### PR TITLE
Fix redundant using statement

### DIFF
--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System;
 using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;


### PR DESCRIPTION
## Summary
- remove duplicate `using System` directive

## Testing
- `dotnet test` *(fails: missing frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_6853d5b8e1a4832e873390aa70905f9c