### PR TITLE
Configure Dependabot for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-    - package-ecosystem: "nuget" # See documentation for possible values
-        directory: "/" # Location of package manifests
-        schedule:
-            interval: "weekly"
+    - package-ecosystem: nuget
+      directory: "/"
+      schedule:
+          interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "weekly"
+    - package-ecosystem: "nuget" # See documentation for possible values
+        directory: "/" # Location of package manifests
+        schedule:
+            interval: "weekly"


### PR DESCRIPTION
## Summary
- enable Dependabot for NuGet packages

## Testing
- `dotnet test` *(fails: required .NET runtimes 6.0/7.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853d597e8ec832e94043f940f8f81ab