### PR TITLE
Validate DMARC pct range

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -31,5 +31,15 @@
             Assert.True(healthCheck.DmarcAnalysis.DkimAShort == "s");
             Assert.True(healthCheck.DmarcAnalysis.SpfAShort == "s");
         }
+
+        [Fact]
+        public async void TestPercentOutOfRange() {
+            var dmarcRecord = "v=DMARC1; p=none; pct=150";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDMARC(dmarcRecord);
+            Assert.Equal(
+                "Percentage value must be between 0 and 100.",
+                healthCheck.DmarcAnalysis.Percent);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -167,10 +167,14 @@ namespace DomainDetective {
         private string TranslatePercentage(string pct) {
             int pctValue;
             if (int.TryParse(pct, out pctValue)) {
+                if (pctValue < 0 || pctValue > 100) {
+                    return "Percentage value must be between 0 and 100.";
+                }
+
                 return $"{pctValue}% of messages are subjected to filtering.";
-            } else {
-                return "Invalid percentage value.";
             }
+
+            return "Invalid percentage value.";
         }
 
         private string TranslateReportingInterval(int interval) {


### PR DESCRIPTION
## Summary
- ensure TranslatePercentage validates the DMARC pct tag
- add unit test for pct outside the allowed range

## Testing
- `dotnet test --framework net8.0` *(fails: Invalid URI / DNS lookups)*

------
https://chatgpt.com/codex/tasks/task_e_6853fa4cd9f0832ead3e5587ab163d72