### PR TITLE
Improve numeric parsing

### DIFF
--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -64,8 +64,10 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                 analysis.CAARecord = caaRecord;
 
                 var properties = caaRecord.Split(new[] { ' ' }, 3); // Split into 3 parts at most
-                if (properties.Length == 3) {
-                    var flag = int.Parse(properties[0].Trim());
+                // RFC 6844 section 5 specifies that the flag field must be a
+                // single unsigned octet in the range 0-255.  We validate the
+                // numeric value before processing the remaining parts.
+                if (properties.Length == 3 && int.TryParse(properties[0].Trim(), out var flag)) {
                     var tag = properties[1].Trim();
                     var value = properties[2];
 

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -83,13 +83,22 @@ namespace DomainDetective {
                             SubPolicyShort = value;
                             break;
                         case "ri":
-                            ReportingIntervalShort = int.Parse(value);
+                            // RFC 7489 section 6.3 defines 'ri' as the reporting
+                            // interval in seconds.  It must be a numeric value.
+                            if (int.TryParse(value, out var ri)) {
+                                ReportingIntervalShort = ri;
+                            }
                             break;
                         case "fo":
                             FoShort = value;
                             break;
                         case "pct":
-                            Pct = int.Parse(value);
+                            // RFC 7489 section 6.3 defines 'pct' as the
+                            // percentage of messages to which the DMARC policy
+                            // applies.  It should be a number between 0 and 100.
+                            if (int.TryParse(value, out var pct)) {
+                                Pct = pct;
+                            }
                             break;
                         case "adkim":
                             DkimAShort = value;


### PR DESCRIPTION
## Summary
- avoid multiple numeric conversions and validate field counts for DANE records
- guard DMARC parsing from FormatException
- handle invalid CAA flags safely
- document checks in code comments

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build -v minimal` *(fails: missing frameworks)*
- `dotnet format --no-restore --include DomainDetective/Protocols/CAAAnalysis.cs DomainDetective/Protocols/DANEAnalysis.cs DomainDetective/Protocols/DMARCAnalysis.cs`

------
https://chatgpt.com/codex/tasks/task_e_6853fa3d2c94832eb0f28aea6fbab126