### PR TITLE
Fix module import typo

### DIFF
--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -1,4 +1,4 @@
-﻿Import-Moddule PSPublishModule -Force
+﻿Import-Module PSPublishModule -Force
 
 Build-Module -ModuleName 'DomainDetective' {
     # Usual defaults as per standard module


### PR DESCRIPTION
## Summary
- fix an incorrect cmdlet name in `Build-Module.ps1`

## Testing
- `dotnet test` *(fails: missing frameworks)*

------
https://chatgpt.com/codex/tasks/task_e_6854041c99d4832e81615f6b5bb537b2