### PR TITLE
Convert tests to async Task

### DIFF
--- a/DomainDetective.Tests/TestALL.cs
+++ b/DomainDetective.Tests/TestALL.cs
@@ -1,7 +1,7 @@
 ﻿namespace DomainDetective.Tests {
     public class TestAll {
         [Fact]
-        public async void TestAllHealthChecks() {
+        public async Task TestAllHealthChecks() {
             var healthCheck = new DomainHealthCheck {
                 Verbose = false
             };

--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace DomainDetective.Tests {
     public class TestCAAAnalysis {
         [Fact]
-        public async void TestCAARecordByList() {
+        public async Task TestCAARecordByList() {
             List<string> caaRecords = new List<string> {
                 // Test CAA record one by one
                 "0 issue \"digicert.com; cansignhttpexchanges=yes\"",
@@ -143,7 +143,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async void TestCAARecordByString() {
+        public async Task TestCAARecordByString() {
             var caaRecord = "128 issue letsencrypt.org";
             var healthCheck = new DomainHealthCheck();
             healthCheck.Verbose = false;
@@ -175,7 +175,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async void TestCAARecordByDomain() {
+        public async Task TestCAARecordByDomain() {
             var healthCheck = new DomainHealthCheck();
             healthCheck.Verbose = false;
             await healthCheck.Verify("evotec.pl", new[] { HealthCheckType.CAA });

--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace DomainDetective.Tests {
     public class TestDANEnalysis {
         [Fact]
-        public async void TestDANERecordByDomain() {
+        public async Task TestDANERecordByDomain() {
             var healthCheck = new DomainHealthCheck {
                 Verbose = false
             };
@@ -30,7 +30,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async void TestDANERecordByString() {
+        public async Task TestDANERecordByString() {
             var daneRecord = "3 1 1 0C72AC70B745AC19998811B131D662C9AC69DBDBE7CB23E5B514B566 64C5D3D6";
             var healthCheck = new DomainHealthCheck {
                 Verbose = false

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -1,7 +1,7 @@
 ﻿namespace DomainDetective.Tests {
     public class TestDkimAnalysis {
         [Fact]
-        public async void TestDKIMRecord() {
+        public async Task TestDKIMRecord() {
             var dkimRecord = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
             var healthCheck = new DomainHealthCheck();
             healthCheck.Verbose = true;
@@ -22,7 +22,7 @@
         }
 
         [Fact]
-        public async void TestDKIMByDomain() {
+        public async Task TestDKIMByDomain() {
             var healthCheck = new DomainHealthCheck {
                 Verbose = true
             };

--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -2,7 +2,7 @@
     public class TestDMARCAnalysis {
 
         [Fact]
-        public async void TestDMARCByString() {
+        public async Task TestDMARCByString() {
             var dmarcRecord = "v=DMARC1; p=reject; rua=mailto:1012c7e7df7b474cb85c1c8d00cc1c1a@dmarc-reports.cloudflare.net,mailto:7kkoc19n@ag.eu.dmarcian.com,mailto:dmarc@evotec.pl; adkim=s; aspf=s;";
             var healthCheck = new DomainHealthCheck();
             healthCheck.Verbose = true;
@@ -18,7 +18,7 @@
         }
 
         [Fact]
-        public async void TestDMARCByDomain() {
+        public async Task TestDMARCByDomain() {
             var healthCheck = new DomainHealthCheck();
             healthCheck.Verbose = true;
             await healthCheck.Verify("evotec.pl", [HealthCheckType.DMARC]);
@@ -33,7 +33,7 @@
         }
 
         [Fact]
-        public async void TestPercentOutOfRange() {
+        public async Task TestPercentOutOfRange() {
             var dmarcRecord = "v=DMARC1; p=none; pct=150";
             var healthCheck = new DomainHealthCheck();
             await healthCheck.CheckDMARC(dmarcRecord);

--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -1,7 +1,7 @@
 namespace DomainDetective.Tests {
     public class TestSpfAnalysis {
         [Fact]
-        public async void TestSpfNullsAndExceedDnsLookups() {
+        public async Task TestSpfNullsAndExceedDnsLookups() {
             var spfRecord3 = "v=spf1 ip4: include: test.example.pl a:google.com a:test.com ip4: include: test.example.pl include:_spf.salesforce.com include:_spf.google.com include:spf.protection.outlook.com include:_spf-a.example.com include:_spf-b.example.com include:_spf-c.example.com include:_spf-ssg-a.example.com include:spf-a.anotherexample.com ip4:131.107.115.215 ip4:131.107.115.214 ip4:205.248.106.64 ip4:205.248.106.30 ip4:205.248.106.32 ~all";
             var healthCheck6 = new DomainHealthCheck();
             await healthCheck6.CheckSPF(spfRecord3);
@@ -18,7 +18,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async void TestSpfConstruct() {
+        public async Task TestSpfConstruct() {
             //%{i}._spf.corp.salesforce.com	Pass	This mechanism is used to construct an arbitrary host name that is used for a DNS 'A' record query.
             var spfRecord3 = "v=spf1 include:_spf.google.com include:_spf.salesforce.com exists:%{i}._spf.corp.salesforce.com ~all";
             var healthCheck6 = new DomainHealthCheck();
@@ -36,7 +36,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async void TestSpfOver255() {
+        public async Task TestSpfOver255() {
             var spfRecord3 = "v=spf1 ip4:64.20.227.128/28 ip4:208.123.79.32 ip4:208.123.79.1 ip4:208.123.79.2 ip4:208.123.79.3 ip4:208.123.79.4 ip4:208.123.79.5 ip4:208.123.79.6 ip4:208.123.79.7 ip4:208.123.79.8 ip4:208.123.79.15 ip4:208.123.79.14 ip4:208.123.79.13 ip4:208.123.79.12 ip4:208.123.79.11 ip4:208.123.79.10 ip4:208.123.79.9 ip4:208.123.79.16 ip4:208.123.79.17 include:_spf.google.com include:_spf.ladesk.com -all";
             var healthCheck6 = new DomainHealthCheck();
             await healthCheck6.CheckSPF(spfRecord3);
@@ -53,7 +53,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async void QueryDomainBySPF() {
+        public async Task QueryDomainBySPF() {
             var healthCheck6 = new DomainHealthCheck();
             await healthCheck6.Verify("evotec.pl", [HealthCheckType.SPF]);
 


### PR DESCRIPTION
## Summary
- switch all DomainDetective.Tests test methods to return `Task`
- keep `[Fact]` usage the same

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -f net8.0 --no-build -v minimal` *(fails: Test Run Failed)*

------
https://chatgpt.com/codex/tasks/task_e_6854045abf4c832e8d6660ce1970bc3d