### PR TITLE
chore: 🔧 update target frameworks and package versions

### DIFF
--- a/DomainDetective.PowerShell/DomainDetective.PowerShell.csproj
+++ b/DomainDetective.PowerShell/DomainDetective.PowerShell.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-            netstandard2.0;net472;net6.0;net7.0;net8.0
+            netstandard2.0;net472;net8.0
         </TargetFrameworks>
         <TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))'  Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-            net6.0;net7.0;net8.0
+            net8.0
         </TargetFrameworks>
         <Description>PowerShell Module to analyze Domain Health</Description>
         <AssemblyName>DomainDetective.PowerShell</AssemblyName>

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -2,10 +2,10 @@
 
 	<PropertyGroup>
 		<TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`Windows`))' ">
-			net472;net48;net6.0;net7.0;net8.0
+			net472;net8.0
 		</TargetFrameworks>
 		<TargetFrameworks Condition=" '$([MSBuild]::IsOsPlatform(`OSX`))' Or '$([MSBuild]::IsOsPlatform(`Linux`))' ">
-			net6.0;net7.0;net8.0
+			net8.0
 		</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
@@ -16,13 +16,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-		<PackageReference Include="xunit" Version="2.7.1" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.8">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net472;netstandard2.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
 		<LangVersion>Latest</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="DnsClientX" Version="0.2.1" />
+		<PackageReference Include="DnsClientX" Version="0.4.0" />
 		<PackageReference Include="MailKit" Version="4.12.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
* Removed `net6.0` and `net7.0` from target frameworks in the project files.
* Updated `DnsClientX` package version to `0.4.0`.
* Ensured compatibility with `net8.0` across all projects.