### PR TITLE
Fix default DNS endpoint

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -59,7 +59,7 @@ namespace DomainDetective {
 
         public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
 
-        public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.System, InternalLogger internalLogger = null) {
+        public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.Cloudflare, InternalLogger internalLogger = null) {
             if (internalLogger != null) {
                 _logger = internalLogger;
             }


### PR DESCRIPTION
## Summary
- default to Cloudflare DNS to avoid invalid URI errors when creating `DomainHealthCheck`

## Testing
- `dotnet clean`
- `dotnet test -v n` *(fails: Invalid URI: The hostname could not be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_68542c2583d8832ea693fd880a28bbef