### PR TITLE
Implement redirect/exp modifiers detection in SPF parsing

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -67,5 +67,25 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck6.SpfAnalysis.StartsCorrectly == true);
             Assert.True(healthCheck6.SpfAnalysis.ExceedsCharacterLimit == false);
         }
+
+        [Fact]
+        public async Task DetectRedirectModifier() {
+            var spfRecord = "v=spf1 redirect=_spf.example.com";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.True(healthCheck.SpfAnalysis.HasRedirect);
+            Assert.Equal("_spf.example.com", healthCheck.SpfAnalysis.RedirectValue);
+        }
+
+        [Fact]
+        public async Task DetectExpModifier() {
+            var spfRecord = "v=spf1 exp=explanation.domain.tld -all";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.True(healthCheck.SpfAnalysis.HasExp);
+            Assert.Equal("explanation.domain.tld", healthCheck.SpfAnalysis.ExpValue);
+        }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -188,8 +188,10 @@ namespace DomainDetective {
                 IncludeRecords.Add(part.Substring(8));
             } else if (part.StartsWith("redirect=")) {
                 RedirectValue = part.Substring(9);
+                HasRedirect = true;
             } else if (part.StartsWith("exp=")) {
                 ExpValue = part.Substring(4);
+                HasExp = true;
             } else if (part.EndsWith("all")) {
                 AllMechanism = part;
             }


### PR DESCRIPTION
## Summary
- detect `redirect=` and `exp=` modifiers during SPF parsing
- unit test new flags in SPFAnalysis

## Testing
- `dotnet test` *(fails: Invalid URI from DnsClientX)*

------
https://chatgpt.com/codex/tasks/task_e_68565b93705c832e911a979fe8e6981a