### PR TITLE
Handle variable length DANE matching type 0

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -41,5 +41,23 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DaneAnalysis.HasInvalidRecords == true);
             Assert.True(healthCheck.DaneAnalysis.NumberOfRecords == 1);
         }
+
+        [Fact]
+        public async Task TestType0RecordVariableLength() {
+            var daneRecord = "0 0 0 ABCDEF0123";
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false
+            };
+            await healthCheck.CheckDANE(daneRecord);
+
+            Assert.True(healthCheck.DaneAnalysis.HasDuplicateRecords == false);
+            Assert.True(healthCheck.DaneAnalysis.HasInvalidRecords == false);
+            Assert.True(healthCheck.DaneAnalysis.NumberOfRecords == 1);
+
+            var analysis = healthCheck.DaneAnalysis.AnalysisResults[0];
+            Assert.True(analysis.ValidDANERecord);
+            Assert.True(analysis.CorrectLengthOfCertificateAssociationData);
+            Assert.Equal(10, analysis.LengthOfCertificateAssociationData);
+        }
     }
 }

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -74,13 +74,12 @@ namespace DomainDetective {
                 // SHA-512 => 128 hex chars).  For type 0 the data is the full
                 // certificate and length is implementation specific.
                 int expectedLength = matchingTypeValue switch {
-                    0 => 256,
                     1 => 64,
                     2 => 128,
                     _ => 0
                 };
 
-                analysis.CorrectLengthOfCertificateAssociationData = associationData.Length == expectedLength;
+                analysis.CorrectLengthOfCertificateAssociationData = matchingTypeValue == 0 || associationData.Length == expectedLength;
                 analysis.LengthOfCertificateAssociationData = associationData.Length;
                 analysis.ValidMatchingType = matchingTypeValue >= 0 && matchingTypeValue <= 2;
 


### PR DESCRIPTION
## Summary
- relax length check for TLSA matching type 0
- test variable‑length type 0 TLSA record

## Testing
- `dotnet test` *(fails: Invalid URI due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68565b8b6070832e93afc40374466158