### PR TITLE
Ensure DnsAnswer fully populated for manual record checks

### DIFF
--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -189,6 +189,17 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.CAAAnalysis.ConflictingMailIssuance == false);
             Assert.True(healthCheck.CAAAnalysis.Valid == true);
             Assert.True(healthCheck.CAAAnalysis.CanIssueMail.Count == 0);
+        }
+
+        [Fact]
+        public async Task TestCAARecordByString() {
+            var caaRecord = "0 issue \"letsencrypt.org\"";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckCAA(caaRecord);
+
+            Assert.True(healthCheck.CAAAnalysis.AnalysisResults.Count == 1);
+            Assert.True(healthCheck.CAAAnalysis.CanIssueCertificatesForDomain.Count == 1);
+            Assert.True(healthCheck.CAAAnalysis.CanIssueCertificatesForDomain[0] == "letsencrypt.org");
         }
     }
 }

--- a/DomainDetective.Tests/TestMXAnalysis.cs
+++ b/DomainDetective.Tests/TestMXAnalysis.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestMXAnalysis {
+        [Fact]
+        public async Task TestMXRecordByString() {
+            var mxRecord = "10 mail.example.com";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckMX(mxRecord);
+
+            Assert.True(healthCheck.MXAnalysis.MxRecordExists);
+            Assert.True(healthCheck.MXAnalysis.MxRecords.Count == 1);
+            Assert.True(healthCheck.MXAnalysis.MxRecords[0] == mxRecord);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -150,7 +150,9 @@ namespace DomainDetective {
         public async Task CheckDMARC(string dmarcRecord) {
             await DmarcAnalysis.AnalyzeDmarcRecords(new List<DnsAnswer> {
                 new DnsAnswer {
+                    Data = dmarcRecord,
                     DataRaw = dmarcRecord,
+                    DataStringsEscaped = new[] { dmarcRecord },
                 }
             }, _logger);
         }
@@ -158,7 +160,9 @@ namespace DomainDetective {
         public async Task CheckSPF(string spfRecord) {
             await SpfAnalysis.AnalyzeSpfRecords(new List<DnsAnswer> {
                 new DnsAnswer {
-                    DataRaw = spfRecord
+                    Data = spfRecord,
+                    DataRaw = spfRecord,
+                    DataStringsEscaped = new[] { spfRecord }
                 }
             }, _logger);
         }
@@ -166,7 +170,9 @@ namespace DomainDetective {
         public async Task CheckDKIM(string dkimRecord, string selector = "default") {
             await DKIMAnalysis.AnalyzeDkimRecords(selector, new List<DnsAnswer> {
                 new DnsAnswer {
-                    DataRaw = dkimRecord
+                    Data = dkimRecord,
+                    DataRaw = dkimRecord,
+                    DataStringsEscaped = new[] { dkimRecord }
                 }
             }, _logger);
         }
@@ -174,7 +180,9 @@ namespace DomainDetective {
         public async Task CheckMX(string mxRecord) {
             await MXAnalysis.AnalyzeMxRecords(new List<DnsAnswer> {
                 new DnsAnswer {
-                    DataRaw = mxRecord
+                    Data = mxRecord,
+                    DataRaw = mxRecord,
+                    DataStringsEscaped = new[] { mxRecord }
                 }
             }, _logger);
         }
@@ -182,13 +190,17 @@ namespace DomainDetective {
         public async Task CheckCAA(string caaRecord) {
             await CAAAnalysis.AnalyzeCAARecords(new List<DnsAnswer> {
                 new DnsAnswer {
-                    DataRaw = caaRecord
+                    Data = caaRecord,
+                    DataRaw = caaRecord,
+                    DataStringsEscaped = new[] { caaRecord }
                 }
             }, _logger);
         }
         public async Task CheckCAA(List<string> caaRecords) {
             var dnsResults = caaRecords.Select(record => new DnsAnswer {
+                Data = record,
                 DataRaw = record,
+                DataStringsEscaped = new[] { record },
             }).ToList();
 
             await CAAAnalysis.AnalyzeCAARecords(dnsResults, _logger);
@@ -197,7 +209,9 @@ namespace DomainDetective {
         public async Task CheckDANE(string daneRecord) {
             await DaneAnalysis.AnalyzeDANERecords(new List<DnsAnswer> {
                 new DnsAnswer {
-                    DataRaw = daneRecord
+                    Data = daneRecord,
+                    DataRaw = daneRecord,
+                    DataStringsEscaped = new[] { daneRecord }
                 }
             }, _logger);
         }


### PR DESCRIPTION
## Summary
- set `Data`, `DataRaw` and `DataStringsEscaped` when creating `DnsAnswer` objects for manual record checks
- test CAA analysis with a single record string
- add MX analysis test using a raw MX record string

## Testing
- `dotnet test --no-build -v minimal` *(fails: System.UriFormatException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685661fc47ac832eb4f5a703d857d91d