### PR TITLE
Fix SPF all detection

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -130,5 +130,27 @@ namespace DomainDetective.Tests {
             Assert.Contains("_spf.google.com", healthCheck.SpfAnalysis.IncludeRecords);
             Assert.Equal("-ALL", healthCheck.SpfAnalysis.AllMechanism);
         }
+
+        [Fact]
+        public async Task DomainEndingWithAllWithoutAllMechanism() {
+            var spfRecord = "v=spf1 a:firewall";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.Null(healthCheck.SpfAnalysis.AllMechanism);
+            Assert.False(healthCheck.SpfAnalysis.MultipleAllMechanisms);
+            Assert.False(healthCheck.SpfAnalysis.ContainsCharactersAfterAll);
+        }
+
+        [Fact]
+        public async Task DomainEndingWithAllWithAllMechanism() {
+            var spfRecord = "v=spf1 include:firewall -all";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.Equal("-all", healthCheck.SpfAnalysis.AllMechanism);
+            Assert.False(healthCheck.SpfAnalysis.MultipleAllMechanisms);
+            Assert.False(healthCheck.SpfAnalysis.ContainsCharactersAfterAll);
+        }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -120,7 +120,9 @@ namespace DomainDetective {
             }
 
             // check if the SPF record contains characters after "all"
-            ContainsCharactersAfterAll = parts.Any(part => part.EndsWith("all", StringComparison.OrdinalIgnoreCase) && !part.Equals(parts.Last()) && !part.StartsWith("+all", StringComparison.OrdinalIgnoreCase) && !part.StartsWith("-all", StringComparison.OrdinalIgnoreCase) && !part.StartsWith("~all", StringComparison.OrdinalIgnoreCase) && !part.StartsWith("?all", StringComparison.OrdinalIgnoreCase));
+            ContainsCharactersAfterAll = parts
+                .Where(part => IsAllMechanism(part))
+                .Any(part => !part.Equals(parts.Last(), StringComparison.OrdinalIgnoreCase));
 
             // check if the SPF record contains a PTR type
             HasPtrType = PtrRecords.Any();
@@ -180,7 +182,7 @@ namespace DomainDetective {
         }
 
         private int CountAllMechanisms(string[] parts) {
-            return parts.Count(part => part.EndsWith("all", StringComparison.OrdinalIgnoreCase));
+            return parts.Count(part => IsAllMechanism(part));
         }
 
         private void CheckForNullDnsLookups(string[] parts) {
@@ -221,9 +223,17 @@ namespace DomainDetective {
             } else if (part.StartsWith("exp=", StringComparison.OrdinalIgnoreCase)) {
                 ExpValue = part.Substring(4);
                 HasExp = true;
-            } else if (part.EndsWith("all", StringComparison.OrdinalIgnoreCase)) {
+            } else if (IsAllMechanism(part)) {
                 AllMechanism = part;
             }
+        }
+
+        private static bool IsAllMechanism(string part) {
+            return part.Equals("all", StringComparison.OrdinalIgnoreCase)
+                   || part.Equals("+all", StringComparison.OrdinalIgnoreCase)
+                   || part.Equals("~all", StringComparison.OrdinalIgnoreCase)
+                   || part.Equals("?all", StringComparison.OrdinalIgnoreCase)
+                   || part.Equals("-all", StringComparison.OrdinalIgnoreCase);
         }
     }
 


### PR DESCRIPTION
## Summary
- use explicit equality checks for SPF `all` tokens
- update `CountAllMechanisms`, `ContainsCharactersAfterAll`, and `AddPartToList`
- cover domains ending with `all` that aren't the `all` mechanism

## Testing
- `dotnet test DomainDetective.sln -v minimal` *(fails: Invalid URI)*

------
https://chatgpt.com/codex/tasks/task_e_68569ff2ddc0832e85fa62aa66de3ecc