### PR TITLE
Detect SPF include cycles

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -130,5 +130,17 @@ namespace DomainDetective.Tests {
             Assert.Contains("_spf.google.com", healthCheck.SpfAnalysis.IncludeRecords);
             Assert.Equal("-ALL", healthCheck.SpfAnalysis.AllMechanism);
         }
+
+        [Fact]
+        public async Task DetectCircularInclude() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 include:b.example.com -all";
+            healthCheck.SpfAnalysis.TestSpfRecords["b.example.com"] = "v=spf1 include:a.example.com -all";
+
+            await healthCheck.CheckSPF("v=spf1 include:a.example.com -all");
+
+            Assert.True(healthCheck.SpfAnalysis.CycleDetected);
+            Assert.False(healthCheck.SpfAnalysis.ExceedsDnsLookups);
+        }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -43,6 +43,10 @@ namespace DomainDetective {
         public string RedirectValue { get; private set; }
         public string AllMechanism { get; private set; }
 
+        public Dictionary<string, string> TestSpfRecords { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        public bool CycleDetected { get; private set; }
+        private HashSet<string> _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
 
         public List<SpfPartAnalysis> SpfPartAnalyses { get; private set; } = new List<SpfPartAnalysis>();
         public List<SpfTestResult> SpfTestResults { get; private set; } = new List<SpfTestResult>();
@@ -65,6 +69,8 @@ namespace DomainDetective {
             HasNullLookups = false;
             HasRedirect = false;
             HasExp = false;
+            CycleDetected = false;
+            _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             ARecords = new List<string>();
             Ipv4Records = new List<string>();
             Ipv6Records = new List<string>();
@@ -107,7 +113,7 @@ namespace DomainDetective {
             var parts = SpfRecord.Split(' ');
 
             // check that the SPF record does not exceed 10 DNS lookups
-            int dnsLookups = await CountDnsLookups(parts);
+            int dnsLookups = await CountDnsLookups(parts, _visitedDomains);
             DnsLookupsCount = dnsLookups;
             ExceedsDnsLookups = ExceedsDnsLookups || DnsLookupsCount > 10;
 
@@ -130,50 +136,63 @@ namespace DomainDetective {
         }
 
 
-        private async Task<int> CountDnsLookups(string[] parts) {
+        private async Task<int> CountDnsLookups(string[] parts, HashSet<string> visitedDomains) {
             int dnsLookups = 0;
             foreach (var part in parts) {
                 if (part.StartsWith("include:", StringComparison.OrdinalIgnoreCase)) {
                     var domain = part.Substring("include:".Length);
-                    if (domain != "") {
-                        // Add the domain to the DnsLookups list
-                        DnsLookups.Add(domain);
+                    if (domain != string.Empty) {
+                        if (!visitedDomains.Add(domain)) {
+                            CycleDetected = true;
+                            continue;
+                        }
 
-                        // TODO: change provider/protocol to use DOH or DNS based on user choices
-                        var dnsResults = await DnsConfiguration.QueryDNS(domain, DnsRecordType.TXT, "SPF1");
-                        dnsLookups++; // count the DNS lookup
-                        if (dnsResults != null) {
-                            // recursively analyze the results of the DNS lookup
-                            foreach (var dnsResult in dnsResults) {
-                                var resultParts = dnsResult.Data.Split(' ');
-                                dnsLookups += await CountDnsLookups(resultParts);
+                        DnsLookups.Add(domain);
+                        if (TestSpfRecords.TryGetValue(domain, out var fakeRecord)) {
+                            dnsLookups++;
+                            var resultParts = fakeRecord.Split(' ');
+                            dnsLookups += await CountDnsLookups(resultParts, visitedDomains);
+                        } else {
+                            var dnsResults = await DnsConfiguration.QueryDNS(domain, DnsRecordType.TXT, "SPF1");
+                            dnsLookups++;
+                            if (dnsResults != null) {
+                                foreach (var dnsResult in dnsResults) {
+                                    var resultParts = dnsResult.Data.Split(' ');
+                                    dnsLookups += await CountDnsLookups(resultParts, visitedDomains);
+                                }
                             }
                         }
                     }
                 } else if (part.StartsWith("redirect=", StringComparison.OrdinalIgnoreCase)) {
                     var domain = part.Substring("redirect=".Length);
-                    if (domain != "") {
-                        // Add the domain to the DnsLookups list
-                        DnsLookups.Add(domain);
+                    if (domain != string.Empty) {
+                        if (!visitedDomains.Add(domain)) {
+                            CycleDetected = true;
+                            continue;
+                        }
 
-                        // TODO: change provider/protocol to use DOH or DNS based on user choices
-                        var dnsResults = await DnsConfiguration.QueryDNS(domain, DnsRecordType.TXT, "SPF1");
-                        dnsLookups++; // count the DNS lookup
-                        if (dnsResults != null) {
-                            // recursively analyze the results of the DNS lookup
-                            foreach (var dnsResult in dnsResults) {
-                                var resultParts = dnsResult.Data.Split(' ');
-                                dnsLookups += await CountDnsLookups(resultParts);
+                        DnsLookups.Add(domain);
+                        if (TestSpfRecords.TryGetValue(domain, out var fakeRedirect)) {
+                            dnsLookups++;
+                            var resultParts = fakeRedirect.Split(' ');
+                            dnsLookups += await CountDnsLookups(resultParts, visitedDomains);
+                        } else {
+                            var dnsResults = await DnsConfiguration.QueryDNS(domain, DnsRecordType.TXT, "SPF1");
+                            dnsLookups++;
+                            if (dnsResults != null) {
+                                foreach (var dnsResult in dnsResults) {
+                                    var resultParts = dnsResult.Data.Split(' ');
+                                    dnsLookups += await CountDnsLookups(resultParts, visitedDomains);
+                                }
                             }
                         }
                     }
                 } else if (part.StartsWith("a:", StringComparison.OrdinalIgnoreCase) || part.StartsWith("mx:", StringComparison.OrdinalIgnoreCase) || part.StartsWith("ptr:", StringComparison.OrdinalIgnoreCase)) {
                     var domain = part.Substring(part.IndexOf(":") + 1);
-                    if (domain != "") {
-                        // Add the domain to the DnsLookups list
+                    if (domain != string.Empty) {
                         DnsLookups.Add(domain);
                     }
-                    dnsLookups++; // count the DNS lookup, but don't check the results
+                    dnsLookups++;
                 }
             }
             return dnsLookups;


### PR DESCRIPTION
## Summary
- maintain a visited-domain list when counting SPF DNS lookups
- stop recursion and flag an error on cycles
- expose a testing dictionary for fake SPF records
- add unit test for circular SPF includes

## Testing
- `dotnet test` *(fails: Invalid URI / could not resolve DNS)*

------
https://chatgpt.com/codex/tasks/task_e_6856a006702c832eb4ca14abd0dc828a