### PR TITLE
Improve SPF tokenization handling macros and quotes

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -204,5 +204,25 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.SpfAnalysis.ExceedsCharacterLimit);
             Assert.True(healthCheck.SpfAnalysis.ExceedsTotalCharacterLimit);
         }
+
+        [Fact]
+        public async Task DetectQuotedInclude() {
+            var spfRecord = "v=spf1 include:\"_spf.google.com\" -all";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.Contains("_spf.google.com", healthCheck.SpfAnalysis.IncludeRecords);
+            Assert.Equal("-all", healthCheck.SpfAnalysis.AllMechanism);
+        }
+
+        [Fact]
+        public async Task DetectMacroRedirect() {
+            var spfRecord = "v=spf1 redirect=%{d}.spf.example.com";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.True(healthCheck.SpfAnalysis.HasRedirect);
+            Assert.Equal("%{d}.spf.example.com", healthCheck.SpfAnalysis.RedirectValue);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- parse SPF records with a tokenizer that respects quoted strings
- trim quotes when extracting SPF tokens
- add tests for SPF records containing quoted includes and macro redirects

## Testing
- `dotnet test` *(fails: Invalid URI/ network related errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856ae8af7e4832eb2d26fbcf100a8ed