### PR TITLE
Collect SPF tokens from include chain

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -224,5 +224,20 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.SpfAnalysis.HasRedirect);
             Assert.Equal("%{d}.spf.example.com", healthCheck.SpfAnalysis.RedirectValue);
         }
+
+        [Fact]
+        public async Task NestedIncludesPopulateResolvedCollections() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 include:b.example.com a:host.test ip4:10.10.10.10 mx:mx.test -all";
+            healthCheck.SpfAnalysis.TestSpfRecords["b.example.com"] = "v=spf1 a:sub.test ip6:2001::1 -all";
+
+            await healthCheck.CheckSPF("v=spf1 include:a.example.com -all");
+
+            Assert.Contains("host.test", healthCheck.SpfAnalysis.ResolvedARecords);
+            Assert.Contains("sub.test", healthCheck.SpfAnalysis.ResolvedARecords);
+            Assert.Contains("mx.test", healthCheck.SpfAnalysis.ResolvedMxRecords);
+            Assert.Contains("10.10.10.10", healthCheck.SpfAnalysis.ResolvedIpv4Records);
+            Assert.Contains("2001::1", healthCheck.SpfAnalysis.ResolvedIpv6Records);
+        }
     }
 }

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -8,6 +8,8 @@ Test-SpfRecord -DomainName "example.com" -Verbose
 Test-DaneRecord -DomainName "example.com" -Verbose
 ```
 
+`Test-SpfRecord` returns a `SpfAnalysis` object. Besides the original token lists it now includes `Resolved*` collections that contain tokens discovered while following nested `include` or `redirect` directives.
+
 To execute the PowerShell test suite run:
 
 ```powershell

--- a/README.MD
+++ b/README.MD
@@ -132,3 +132,5 @@ Code coverage results are published to [Codecov](https://codecov.io/gh/your-user
 Each analysis type returns an object exposing properties that map to fields described in the relevant RFCs. For example, SPF checks follow [RFC&nbsp;7208](https://datatracker.ietf.org/doc/html/rfc7208) and DMARC analysis references [RFC&nbsp;7489](https://datatracker.ietf.org/doc/html/rfc7489). DKIM validations follow [RFC&nbsp;6376](https://datatracker.ietf.org/doc/html/rfc6376) and DANE TLSA lookups follow [RFC&nbsp;6698](https://datatracker.ietf.org/doc/html/rfc6698).
 
 Boolean fields indicate whether a particular requirement was met. You can inspect the object returned from `DomainHealthCheck` or the PowerShell cmdlets to review these properties and make decisions in automation.
+
+`SpfAnalysis` exposes additional collections capturing every token discovered through nested `include` and `redirect` records. These `Resolved*` lists mirror the top-level properties but aggregate results from the entire chain (for example `ResolvedARecords`, `ResolvedMxRecords`, `ResolvedIpv4Records` and `ResolvedIpv6Records`).


### PR DESCRIPTION
## Summary
- track SPF tokens discovered in nested include/redirect records
- expose `Resolved*` collections in `SpfAnalysis`
- test nested includes
- document the new properties in README and PowerShell module README

## Testing
- `dotnet test` *(fails: invalid URI / DNS lookup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6856b8bab334832e89a10159b99b8ac0