### PR TITLE
Add IPv6 DNSBL support

### DIFF
--- a/DomainDetective.Tests/TestDNSBLIPv6.cs
+++ b/DomainDetective.Tests/TestDNSBLIPv6.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblIpv6 {
+        [Fact]
+        public async Task Ipv6AddressReversedNibble() {
+            const string address = "2001:db8::1";
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.DNSBLAnalysis.ClearDNSBL();
+            healthCheck.DNSBLAnalysis.AddDNSBL("example.test");
+            await healthCheck.CheckDNSBL(address);
+
+            var record = healthCheck.DNSBLAnalysis.Results[address].DNSBLRecords.First();
+            var expected = string.Join(".", string.Concat(IPAddress.Parse(address).GetAddressBytes().Select(b => b.ToString("x2"))).Reverse());
+            Assert.Equal(expected, record.IPAddress);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using System.Text.Json;
 
@@ -262,8 +263,15 @@ namespace DomainDetective {
             // Check if the input is an IP address or a hostname
             string name;
             if (IPAddress.TryParse(ipAddressOrHostname, out IPAddress ipAddress)) {
-                // Reverse the IP address and append the DNSBL list
-                name = string.Join(".", ipAddress.ToString().Split('.').Reverse());
+                if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
+                    var hex = string.Concat(ipAddress
+                        .GetAddressBytes()
+                        .Select(b => b.ToString("x2")));
+                    name = string.Join(".", hex.Reverse());
+                } else {
+                    // Reverse the IPv4 address and append the DNSBL list
+                    name = string.Join(".", ipAddress.ToString().Split('.').Reverse());
+                }
             } else {
                 // Use the hostname and append the DNSBL list
                 name = ipAddressOrHostname;


### PR DESCRIPTION
## Summary
- handle IPv6 addresses when building DNSBL queries
- test IPv6 query generation

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -v minimal` *(fails: Invalid URI)*

------
https://chatgpt.com/codex/tasks/task_e_6856becfbca0832e84a27756ee750161