### PR TITLE
Fix DMARC multi-chunk TXT handling

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -1,3 +1,5 @@
+using DnsClientX;
+
 namespace DomainDetective.Tests {
     public class TestDMARCAnalysis {
 
@@ -40,6 +42,29 @@ namespace DomainDetective.Tests {
             Assert.Equal(
                 "Percentage value must be between 0 and 100.",
                 healthCheck.DmarcAnalysis.Percent);
+        }
+
+        [Fact]
+        public async Task ConcatenateMultipleTxtChunks() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer {
+                    DataRaw = "v=DMARC1; p=none;",
+                    Type = DnsRecordType.TXT
+                },
+                new DnsAnswer {
+                    DataRaw = "rua=mailto:test@example.com",
+                    Type = DnsRecordType.TXT
+                }
+            };
+
+            var analysis = new DmarcAnalysis();
+            await analysis.AnalyzeDmarcRecords(answers, new InternalLogger());
+
+            Assert.True(analysis.DmarcRecordExists);
+            Assert.Equal("v=DMARC1; p=none; rua=mailto:test@example.com", analysis.DmarcRecord);
+            Assert.Equal("none", analysis.PolicyShort);
+            Assert.Single(analysis.MailtoRua);
+            Assert.Equal("test@example.com", analysis.MailtoRua[0]);
         }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -68,11 +68,8 @@ namespace DomainDetective {
             var dmarcRecordList = dnsResults.ToList();
             DmarcRecordExists = dmarcRecordList.Any();
 
-            // create a single string from the list of DnsResult objects
-            // TODO: check this logic for creating a single string from the list of DnsResult objects
-            foreach (var record in dmarcRecordList) {
-                DmarcRecord = record.Data;
-            }
+            // concatenate all TXT chunks into a single string separated by spaces
+            DmarcRecord = string.Join(" ", dmarcRecordList.Select(record => record.Data));
 
             if (DmarcRecord == null) {
                 logger.WriteVerbose("No DMARC record found.");


### PR DESCRIPTION
## Summary
- concatenate DMARC TXT data chunks when parsing
- test that multiple TXT pieces combine correctly

## Testing
- `dotnet test -v minimal` *(fails: Invalid URI during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6856bec3d2c4832e8a2d35923b31901d