### PR TITLE
Fix logging in SecurityTXTAnalysis

### DIFF
--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -145,9 +145,9 @@ namespace DomainDetective {
 
                     }
                 }
-                if (!RecordValid) {
-                    Logger.WriteWarning("Invalid security.txt file");
-                }
+            }
+            if (!RecordValid) {
+                Logger.WriteWarning("Invalid security.txt file");
             }
         }
 


### PR DESCRIPTION
## Summary
- log security.txt validity once after parsing, not within the loop

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -v minimal` *(fails: System.UriFormatException)*

------
https://chatgpt.com/codex/tasks/task_e_6856beefcd9c832e83182af9086e0a8f