### PR TITLE
Remove unused using directive

### DIFF
--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -1,4 +1,3 @@
-using Org.BouncyCastle.Tls.Crypto;
 using System;
 using System.Collections.Generic;
 using System.IO;


### PR DESCRIPTION
## Summary
- remove BouncyCastle using from `WhoisAnalysis` that wasn't used

## Testing
- `dotnet test` *(fails: Invalid URI & network lookup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf0b5a08832eb9207eb38c53f9dd