### PR TITLE
Handle unreachable hosts

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -1,0 +1,11 @@
+namespace DomainDetective.Tests {
+    public class TestCertificateHTTP {
+        [Fact]
+        public async Task UnreachableHostSetsIsReachableFalse() {
+            var logger = new InternalLogger();
+            var analysis = new CertificateAnalysis();
+            await analysis.AnalyzeUrl("https://nonexistent.invalid", 443, logger);
+            Assert.False(analysis.IsReachable);
+        }
+    }
+}

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -23,11 +23,20 @@ namespace DomainDetective {
                     return true;
                 };
                 using (var client = new HttpClient(handler)) {
-                    var response = await client.GetAsync(url);
-                    if (response.IsSuccessStatusCode) {
-                        IsReachable = true;
+                    try {
+                        HttpResponseMessage response = await client.GetAsync(url);
+                        if (response.IsSuccessStatusCode) {
+                            IsReachable = true;
+                        } else {
+                            IsReachable = false;
+                        }
+                        if (Certificate != null) {
+                            DaysToExpire = (int)(Certificate.NotAfter - DateTime.Now).TotalDays;
+                        }
+                    } catch (Exception ex) {
+                        IsReachable = false;
+                        logger?.WriteError("Exception reaching {0}: {1}", url, ex.Message);
                     }
-                    DaysToExpire = (int)(Certificate.NotAfter - DateTime.Now).TotalDays;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- wrap `HttpClient.GetAsync` in a try/catch and log failures
- add test that checks `IsReachable` on unreachable host

## Testing
- `dotnet test` *(fails: Invalid URI, DNS lookup errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856bf278e60832e96637341a8db2bc4