### PR TITLE
Fix DANE association length

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -56,5 +56,23 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.CorrectLengthOfCertificateAssociationData);
             Assert.Equal(10, analysis.LengthOfCertificateAssociationData);
         }
+
+        [Fact]
+        public async Task TestRecordWithTrailingSpaceTrimmed() {
+            var daneRecord = $"3 1 1 {new string('A', 64)} ";
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false
+            };
+            await healthCheck.CheckDANE(daneRecord);
+
+            Assert.False(healthCheck.DaneAnalysis.HasDuplicateRecords);
+            Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
+            Assert.Equal(1, healthCheck.DaneAnalysis.NumberOfRecords);
+
+            var analysis = healthCheck.DaneAnalysis.AnalysisResults[0];
+            Assert.True(analysis.ValidDANERecord);
+            Assert.True(analysis.CorrectLengthOfCertificateAssociationData);
+            Assert.Equal(64, analysis.LengthOfCertificateAssociationData);
+        }
     }
 }

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -59,7 +59,7 @@ namespace DomainDetective {
                 var usagePart = components[0];
                 var selectorPart = components[1];
                 var matchingPart = components[2];
-                var associationData = components[3];
+                var associationData = components[3].Trim();
 
                 bool usageParsed = int.TryParse(usagePart, out int usageValue);
                 bool selectorParsed = int.TryParse(selectorPart, out int selectorValue);


### PR DESCRIPTION
## Summary
- trim the certificate association string before validation
- cover trailing spaces with a new test

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Invalid URI / cannot access network)*

------
https://chatgpt.com/codex/tasks/task_e_6856c566c318832eb509a33f8b7c81dc