### PR TITLE
Implement DKIM selector guessing

### DIFF
--- a/DomainDetective.Tests/TestDKIMGuess.cs
+++ b/DomainDetective.Tests/TestDKIMGuess.cs
@@ -1,0 +1,12 @@
+namespace DomainDetective.Tests {
+    public class TestDkimGuess {
+        [Fact]
+        public async Task GuessSelectorsForDomain() {
+            var healthCheck = new DomainHealthCheck { Verbose = false };
+            await healthCheck.Verify("evotec.pl", new[] { HealthCheckType.DKIM });
+
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults.ContainsKey("selector1"));
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults.ContainsKey("selector2"));
+        }
+    }
+}

--- a/DomainDetective/Definitions/DKIMSelectors.cs
+++ b/DomainDetective/Definitions/DKIMSelectors.cs
@@ -1,47 +1,40 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DomainDetective.Definitions {
-    internal class DKIMSelectors {
-        //Google
-        // 
-        //     google
-        // 
-        // 
-        // Microsoft
-        // 
-        //     selector1
-        // 
-        //     selector2
-        // 
-        //     
-        // 
-        // Everlytic
-        // 
-        //     everlytickey1
-        // 
-        //     everlytickey2
-        // 
-        //     eversrv (OLD selector)
-        // 
-        //     
-        // 
-        // MailChimp / Mandrill
-        // 
-        //     k1
-        // 
-        //     
-        // 
-        // Global Micro 
-        // 
-        //     mxvault
-        // 
-        // 
-        // Hetzner
-        // 
-        //     dkim
+    internal static class DKIMSelectors {
+        internal static readonly string[] Google = new[] { "google" };
+
+        internal static readonly string[] Microsoft = new[] { "selector1", "selector2" };
+
+        internal static readonly string[] Everlytic = new[] { "everlytickey1", "everlytickey2", "eversrv" };
+
+        internal static readonly string[] MailChimp = new[] { "k1" };
+
+        internal static readonly string[] GlobalMicro = new[] { "mxvault" };
+
+        internal static readonly string[] Hetzner = new[] { "dkim" };
+
+        internal static readonly string[] SendGrid = new[] { "s1", "s2" };
+
+        internal static readonly string[] CPanel = new[] { "default", "mail" };
+
+        internal static readonly string[] Fastmail = new[] { "fm1", "fm2", "fm3" };
+
+        internal static readonly string[] AmazonSes = new[] { "amazonses" };
+
+        internal static IEnumerable<string> GuessSelectors() {
+            return Google
+                .Concat(Microsoft)
+                .Concat(Everlytic)
+                .Concat(MailChimp)
+                .Concat(GlobalMicro)
+                .Concat(Hetzner)
+                .Concat(SendGrid)
+                .Concat(CPanel)
+                .Concat(Fastmail)
+                .Concat(AmazonSes)
+                .Distinct();
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -113,14 +113,14 @@ namespace DomainDetective {
                         await SpfAnalysis.AnalyzeSpfRecords(spf, _logger);
                         break;
                     case HealthCheckType.DKIM:
-                        if (dkimSelectors != null) {
-                            foreach (var selector in dkimSelectors) {
-                                var dkim = await DnsConfiguration.QueryDNS($"{selector}._domainkey.{domainName}", DnsRecordType.TXT, "DKIM1");
-                                await DKIMAnalysis.AnalyzeDkimRecords(selector, dkim, _logger);
-                            }
-                        } else {
-                            // lets guess DKIM selectors based on common ones - first lets create a list of common selectors
-                            // TODO: Add more common selectors, and maybe guess based on MX/SPF records
+                        var selectors = dkimSelectors;
+                        if (selectors == null || selectors.Length == 0) {
+                            selectors = Definitions.DKIMSelectors.GuessSelectors().ToArray();
+                        }
+
+                        foreach (var selector in selectors) {
+                            var dkim = await DnsConfiguration.QueryDNS($"{selector}._domainkey.{domainName}", DnsRecordType.TXT, "DKIM1");
+                            await DKIMAnalysis.AnalyzeDkimRecords(selector, dkim, _logger);
                         }
                         break;
                     case HealthCheckType.MX:


### PR DESCRIPTION
## Summary
- implement `DKIMSelectors` with lists for common providers
- add helper method to guess selectors
- use guessing in `DomainHealthCheck.Verify`
- add unit test for guessing logic

## Testing
- `dotnet test -c Release` *(fails: Invalid URI: The hostname could not be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_6856c599f344832ea26d3da33690bea1