### PR TITLE
Improve TLD error handling

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -1,0 +1,9 @@
+namespace DomainDetective.Tests {
+    public class TestWhoisAnalysis {
+        [Fact]
+        public async Task UnsupportedTldThrows() {
+            var whois = new WhoisAnalysis();
+            await Assert.ThrowsAsync<UnsupportedTldException>(async () => await whois.QueryWhoisServer("example.unknown"));
+        }
+    }
+}

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -14,6 +14,7 @@ public class WhoisAnalysis {
         get => _domainName?.ToLower();
         set => _domainName = value;
     }
+    public string Tld => TLD;
     public string Registrar { get; set; }
     public string CreationDate { get; set; }
     public string ExpiryDate { get; set; }
@@ -277,6 +278,7 @@ public class WhoisAnalysis {
 
         // If not found, check for single-part TLDs
         tld = domainParts.Last();
+        TLD = tld;
         return WhoisServers.ContainsKey(tld) ? WhoisServers[tld] : null;
     }
 
@@ -284,7 +286,7 @@ public class WhoisAnalysis {
         DomainName = domain;
         var whoisServer = GetWhoisServer(domain);
         if (whoisServer == null) {
-            throw new Exception($"No WHOIS server found for domain {domain}");
+            throw new UnsupportedTldException(domain, TLD);
         }
 
         try {

--- a/DomainDetective/UnsupportedTldException.cs
+++ b/DomainDetective/UnsupportedTldException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace DomainDetective;
+
+public class UnsupportedTldException : Exception
+{
+    public string Domain { get; }
+    public string Tld { get; }
+
+    public UnsupportedTldException(string domain, string tld) : base($"TLD '{tld}' is not supported for WHOIS lookup.")
+    {
+        Domain = domain;
+        Tld = tld;
+    }
+}


### PR DESCRIPTION
## Summary
- raise `UnsupportedTldException` when WHOIS server not found
- expose `Tld` from `WhoisAnalysis`
- add unit test for unsupported TLD

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter TestWhoisAnalysis --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6856c56cb580832e90639cc87c23daf2