### PR TITLE
Fix SPF 'exists' counting and update docs

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -10,7 +10,7 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck6.SpfAnalysis.MultipleSpfRecords);
             Assert.True(healthCheck6.SpfAnalysis.HasNullLookups, "Should have null lookups");
             Assert.True(healthCheck6.SpfAnalysis.ExceedsDnsLookups, "Exceeds lookups should be true, as we expect it over the board");
-            Assert.Equal(13, healthCheck6.SpfAnalysis.DnsLookupsCount);
+            Assert.Equal(14, healthCheck6.SpfAnalysis.DnsLookupsCount);
             Assert.False(healthCheck6.SpfAnalysis.MultipleAllMechanisms);
             Assert.False(healthCheck6.SpfAnalysis.ContainsCharactersAfterAll);
             Assert.False(healthCheck6.SpfAnalysis.HasPtrType);

--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -239,5 +239,28 @@ namespace DomainDetective.Tests {
             Assert.Contains("10.10.10.10", healthCheck.SpfAnalysis.ResolvedIpv4Records);
             Assert.Contains("2001::1", healthCheck.SpfAnalysis.ResolvedIpv6Records);
         }
+
+        [Fact]
+        public async Task ExistsMechanismCountsTowardsDnsLookups() {
+            var spfRecord = "v=spf1 exists:example.com -all";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.Equal(1, healthCheck.SpfAnalysis.DnsLookupsCount);
+            Assert.False(healthCheck.SpfAnalysis.ExceedsDnsLookups);
+        }
+
+        [Fact]
+        public async Task Rfc7208MultipleDomainExample() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["example.com"] = "v=spf1 -all";
+            healthCheck.SpfAnalysis.TestSpfRecords["example.net"] = "v=spf1 -all";
+
+            await healthCheck.CheckSPF("v=spf1 include:example.com include:example.net -all");
+
+            Assert.Equal(2, healthCheck.SpfAnalysis.DnsLookupsCount);
+            Assert.False(healthCheck.SpfAnalysis.ExceedsDnsLookups);
+        }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -216,6 +216,12 @@ namespace DomainDetective {
                             }
                         }
                     }
+                } else if (part.StartsWith("exists:", StringComparison.OrdinalIgnoreCase)) {
+                    var domain = part.Substring("exists:".Length);
+                    if (domain != string.Empty) {
+                        DnsLookups.Add(domain);
+                    }
+                    dnsLookups++;
                 } else if (part.StartsWith("a:", StringComparison.OrdinalIgnoreCase) || part.StartsWith("mx:", StringComparison.OrdinalIgnoreCase) || part.StartsWith("ptr:", StringComparison.OrdinalIgnoreCase)) {
                     var domain = part.Substring(part.IndexOf(":") + 1);
                     if (domain != string.Empty) {

--- a/README.MD
+++ b/README.MD
@@ -135,3 +135,5 @@ Each analysis type returns an object exposing properties that map to fields desc
 Boolean fields indicate whether a particular requirement was met. You can inspect the object returned from `DomainHealthCheck` or the PowerShell cmdlets to review these properties and make decisions in automation.
 
 `SpfAnalysis` exposes additional collections capturing every token discovered through nested `include` and `redirect` records. These `Resolved*` lists mirror the top-level properties but aggregate results from the entire chain (for example `ResolvedARecords`, `ResolvedMxRecords`, `ResolvedIpv4Records` and `ResolvedIpv6Records`).
+
+DNS lookup counting adheres to [RFC&nbsp;7208](https://datatracker.ietf.org/doc/html/rfc7208) Section&nbsp;4.6.4. Queries caused by the `include`, `a`, `mx`, `ptr`, and `exists` mechanisms as well as the `redirect` modifier are tallied, and exceeding ten during evaluation sets `ExceedsDnsLookups`.


### PR DESCRIPTION
## Summary
- count `exists:` mechanism when tallying SPF DNS lookups
- document lookup counting rules from RFC 7208
- add tests for `exists:` and RFC example records

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "TestSpfAnalysis" -v minimal` *(fails: Invalid URI due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_6856cc276048832e8ea5286ad17c508c