### PR TITLE
Add PGP signature verification

### DIFF
--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -5,10 +5,11 @@
 		<LangVersion>Latest</LangVersion>
 	</PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="DnsClientX" Version="0.4.0" />
-		<PackageReference Include="MailKit" Version="4.12.1" />
-	</ItemGroup>
+        <ItemGroup>
+                <PackageReference Include="DnsClientX" Version="0.4.0" />
+                <PackageReference Include="MailKit" Version="4.12.1" />
+                <PackageReference Include="PgpCore" Version="6.5.2" />
+        </ItemGroup>
 
   <ItemGroup>
           <Folder Include="Dictionaries\" />


### PR DESCRIPTION
## Summary
- add `PgpCore` package to enable PGP support
- detect and verify clear-signed `security.txt` files

## Testing
- `dotnet test` *(fails: Invalid URI and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856cbac7a30832ebf385ccaf8e42c69