### PR TITLE
Improve MXAnalysis priority checks

### DIFF
--- a/DomainDetective.Tests/TestMXAnalysis.cs
+++ b/DomainDetective.Tests/TestMXAnalysis.cs
@@ -1,0 +1,50 @@
+using DnsClientX;
+using System.Collections.Generic;
+
+namespace DomainDetective.Tests {
+    public class TestMXAnalysis {
+        private static MXAnalysis CreateAnalysis() {
+            return new MXAnalysis {
+                DnsConfiguration = new DnsConfiguration(),
+                QueryDnsOverride = (_, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+            };
+        }
+
+        [Fact]
+        public async Task DetectProperOrder() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "10 mail1.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "20 mail2.example.com", Type = DnsRecordType.MX }
+            };
+            var analysis = CreateAnalysis();
+            await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+
+            Assert.True(analysis.PrioritiesInOrder);
+            Assert.True(analysis.HasBackupServers);
+        }
+
+        [Fact]
+        public async Task DetectOutOfOrder() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "20 mail2.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "10 mail1.example.com", Type = DnsRecordType.MX }
+            };
+            var analysis = CreateAnalysis();
+            await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+
+            Assert.False(analysis.PrioritiesInOrder);
+        }
+
+        [Fact]
+        public async Task DetectNoBackup() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "10 mail1.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "10 mail2.example.com", Type = DnsRecordType.MX }
+            };
+            var analysis = CreateAnalysis();
+            await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+
+            Assert.False(analysis.HasBackupServers);
+        }
+    }
+}

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -16,41 +17,69 @@ namespace DomainDetective {
     /// 5.	The MX record should not point to a domain that doesn't have an A or AAAA record.
     /// </summary>
     public class MXAnalysis {
-        internal DnsConfiguration DnsConfiguration { get; set; }
+        public DnsConfiguration DnsConfiguration { get; set; }
+        public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
         public List<string> MxRecords { get; private set; } = new List<string>();
         public bool MxRecordExists { get; private set; } // should be true
         public bool PointsToCname { get; private set; } // should be false
         public bool PointsToIpAddress { get; private set; } // should be false
         public bool PointsToNonExistentDomain { get; private set; } // should be false
         public bool PointsToDomainWithoutAOrAaaaRecord { get; private set; } // should be false
+        public bool PrioritiesInOrder { get; private set; } // RFC 5321 section 5.1
+        public bool HasBackupServers { get; private set; }
+
+        private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {
+            if (QueryDnsOverride != null) {
+                return await QueryDnsOverride(name, type);
+            }
+
+            return await DnsConfiguration.QueryDNS(name, type);
+        }
 
         public async Task AnalyzeMxRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+            // reset properties for repeated calls
+            MxRecords = new List<string>();
+            MxRecordExists = false;
+            PointsToCname = false;
+            PointsToIpAddress = false;
+            PointsToNonExistentDomain = false;
+            PointsToDomainWithoutAOrAaaaRecord = false;
+            PrioritiesInOrder = true;
+            HasBackupServers = false;
+
             var mxRecordList = dnsResults.ToList();
             MxRecordExists = mxRecordList.Any();
 
-            // create a list of strings from the list of DnsResult objects
+            var parsed = new List<(int Preference, string Host)>();
             foreach (var record in mxRecordList) {
                 MxRecords.Add(record.Data);
+                var parts = record.Data.Split(new[] { ' ' }, 2, System.StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length == 2 && int.TryParse(parts[0], out var pref)) {
+                    parsed.Add((pref, parts[1].Trim('.')));
+                }
             }
 
             logger.WriteVerbose($"Analyzing MX records {string.Join(", ", MxRecords)}");
 
-            // loop through the MX records for remaining checks
-            foreach (var mxRecord in MxRecords) {
-                // check if the MX record points to a CNAME
-                var cnameResults = await DnsConfiguration.QueryDNS(mxRecord, DnsRecordType.CNAME);
-                PointsToCname = cnameResults != null && cnameResults.Any();
+            var preferences = parsed.Select(p => p.Preference).ToList();
+            if (preferences.Count > 1) {
+                var sorted = preferences.OrderBy(p => p).ToList();
+                PrioritiesInOrder = preferences.SequenceEqual(sorted);
+                HasBackupServers = preferences.Distinct().Count() > 1;
+            }
 
-                // check if the MX record points to an IP address
-                PointsToIpAddress = IPAddress.TryParse(mxRecord, out _);
+            foreach (var (_, host) in parsed) {
+                var cnameResults = await QueryDns(host, DnsRecordType.CNAME);
+                PointsToCname = PointsToCname || (cnameResults != null && cnameResults.Any());
 
-                // check if the MX record points to a non-existent domain
-                var aResults = await DnsConfiguration.QueryDNS(mxRecord, DnsRecordType.A);
-                var aaaaResults = await DnsConfiguration.QueryDNS(mxRecord, DnsRecordType.AAAA);
-                PointsToNonExistentDomain = (aResults == null || !aResults.Any()) && (aaaaResults == null || !aaaaResults.Any());
+                PointsToIpAddress = PointsToIpAddress || IPAddress.TryParse(host, out _);
 
-                // check if the MX record points to a domain without an A or AAAA record
-                PointsToDomainWithoutAOrAaaaRecord = (aResults == null || !aResults.Any()) && (aaaaResults == null || !aaaaResults.Any());
+                var aResults = await QueryDns(host, DnsRecordType.A);
+                var aaaaResults = await QueryDns(host, DnsRecordType.AAAA);
+                var noA = aResults == null || !aResults.Any();
+                var noAAAA = aaaaResults == null || !aaaaResults.Any();
+                PointsToNonExistentDomain = PointsToNonExistentDomain || (noA && noAAAA);
+                PointsToDomainWithoutAOrAaaaRecord = PointsToDomainWithoutAOrAaaaRecord || (noA && noAAAA);
             }
         }
     }


### PR DESCRIPTION
## Summary
- extend `MXAnalysis` with priority order and backup server validation
- add DNS query override to facilitate testing
- test MX analysis logic for ordered and backup records

## Testing
- `dotnet test` *(fails: Invalid URI / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6856cb6206a8832e87a0a6c3679936d1