### PR TITLE
Fix CAA tag parsing

### DIFF
--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -190,5 +190,18 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.CAAAnalysis.Valid);
             Assert.Empty(healthCheck.CAAAnalysis.CanIssueMail);
         }
+
+        [Fact]
+        public async Task CaseInsensitiveTagParsing() {
+            var caaRecord = "0 ISSUE \"letsencrypt.org\"";
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.Verbose = false;
+            await healthCheck.CheckCAA(caaRecord);
+
+            Assert.Single(healthCheck.CAAAnalysis.AnalysisResults);
+            Assert.Equal(CAATagType.Issue, healthCheck.CAAAnalysis.AnalysisResults[0].Tag);
+            Assert.False(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidTag);
+            Assert.False(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidFlag);
+        }
     }
 }

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -1,6 +1,7 @@
 using DnsClientX;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -80,7 +81,7 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                 // RFC 6844 section 5 specifies that the flag field must be a
                 // single unsigned octet in the range 0-255.  We validate the
                 // numeric value before processing the remaining parts.
-                if (properties.Length == 3 && int.TryParse(properties[0].Trim(), out var flag)) {
+                if (properties.Length == 3 && int.TryParse(properties[0].Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out var flag)) {
                     var tag = properties[1].Trim();
                     var value = properties[2];
 
@@ -91,7 +92,7 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                     }
 
                     // Validate tag and set the Tag property
-                    var validTags = new Dictionary<string, CAATagType> {
+                    var validTags = new Dictionary<string, CAATagType>(StringComparer.OrdinalIgnoreCase) {
                             { "issue", CAATagType.Issue },
                             { "issuewild", CAATagType.IssueWildcard },
                             { "iodef", CAATagType.Iodef },


### PR DESCRIPTION
## Summary
- handle CAA tags ignoring case
- parse flag using `NumberStyles.None` so it's treated strictly as numeric
- add a unit test verifying case-insensitive tag handling

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: The tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6856e0eb00dc832e8fbe563a28fd7a89