### PR TITLE
Add MTA-STS policy analyzer

### DIFF
--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -1,0 +1,34 @@
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestMTASTSAnalysis {
+        [Fact]
+        public void ParseValidPolicy() {
+            var policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";
+            var analysis = new MTASTSAnalysis();
+            analysis.AnalyzePolicyText(policy);
+
+            Assert.True(analysis.PolicyValid);
+            Assert.True(analysis.ValidVersion);
+            Assert.True(analysis.ValidMode);
+            Assert.True(analysis.ValidMaxAge);
+            Assert.True(analysis.HasMx);
+            Assert.Equal("enforce", analysis.Mode);
+            Assert.Equal(86400, analysis.MaxAge);
+            Assert.Single(analysis.Mx);
+            Assert.Equal("mail.example.com", analysis.Mx[0]);
+        }
+
+        [Fact]
+        public void MissingFieldsInvalidatePolicy() {
+            var policy = "version: STSv1\nmode: enforce";
+            var analysis = new MTASTSAnalysis();
+            analysis.AnalyzePolicyText(policy);
+
+            Assert.False(analysis.PolicyValid);
+            Assert.False(analysis.HasMx);
+            Assert.False(analysis.ValidMaxAge);
+        }
+    }
+}

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -7,6 +7,7 @@ namespace DomainDetective {
         CAA,
         DANE,
         DNSBL,
+        MTASTS,
         CERT,
         SECURITYTXT
     }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -48,6 +48,8 @@ namespace DomainDetective {
 
         public DNSBLAnalysis DNSBLAnalysis { get; private set; }
 
+        public MTASTSAnalysis MTASTSAnalysis { get; private set; } = new MTASTSAnalysis();
+
         public CertificateAnalysis CertificateAnalysis { get; private set; } = new CertificateAnalysis();
 
         public SecurityTXTAnalysis SecurityTXTAnalysis { get; private set; } = new SecurityTXTAnalysis();
@@ -137,6 +139,10 @@ namespace DomainDetective {
                     case HealthCheckType.DNSBL:
                         await DNSBLAnalysis.AnalyzeDNSBLRecordsMX(domainName, _logger);
                         break;
+                    case HealthCheckType.MTASTS:
+                        MTASTSAnalysis = new MTASTSAnalysis();
+                        await MTASTSAnalysis.AnalyzePolicy(domainName, _logger);
+                        break;
                     case HealthCheckType.SECURITYTXT:
                         // lets reset the SecurityTXTAnalysis, so it's overwritten completly on next run
                         SecurityTXTAnalysis = new SecurityTXTAnalysis();
@@ -210,6 +216,11 @@ namespace DomainDetective {
         public async Task VerifySPF(string domainName) {
             var spf = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.TXT, "SPF1");
             await SpfAnalysis.AnalyzeSpfRecords(spf, _logger);
+        }
+
+        public async Task VerifyMTASTS(string domainName) {
+            MTASTSAnalysis = new MTASTSAnalysis();
+            await MTASTSAnalysis.AnalyzePolicy(domainName, _logger);
         }
 
         public async Task VerifyDANE(string domainName, int[] ports) {

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -1,4 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
 namespace DomainDetective {
-    internal class MTASTSAnalysis {
+    public class MTASTSAnalysis {
+        public string Domain { get; private set; }
+        public bool PolicyPresent { get; private set; }
+        public bool PolicyValid { get; private set; }
+        public bool ValidVersion { get; private set; }
+        public bool ValidMode { get; private set; }
+        public bool ValidMaxAge { get; private set; }
+        public bool HasMx { get; private set; }
+        public string Mode { get; private set; }
+        public int MaxAge { get; private set; }
+        public List<string> Mx { get; private set; } = new List<string>();
+        public string Policy { get; private set; }
+
+        internal InternalLogger Logger { get; set; }
+
+        public async Task AnalyzePolicy(string domainName, InternalLogger logger) {
+            Logger = logger;
+            Domain = domainName;
+            string url = $"https://mta-sts.{domainName}/.well-known/mta-sts.txt";
+            string content = await GetPolicy(url);
+            if (content == null) {
+                PolicyPresent = false;
+                return;
+            }
+
+            PolicyPresent = true;
+            Policy = content;
+            ParsePolicy(content);
+        }
+
+        public void AnalyzePolicyText(string text) => ParsePolicy(text);
+
+        private async Task<string> GetPolicy(string url) {
+            try {
+                using HttpClient client = new();
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+                var response = await client.GetAsync(url);
+                if (response.IsSuccessStatusCode) {
+                    return await response.Content.ReadAsStringAsync();
+                }
+            } catch (Exception ex) {
+                Logger?.WriteWarning($"Failed to fetch {url}: {ex.Message}");
+            }
+
+            return null;
+        }
+
+        private void ParsePolicy(string text) {
+            PolicyValid = true;
+            ValidVersion = false;
+            ValidMode = false;
+            ValidMaxAge = false;
+            HasMx = false;
+            Mode = null;
+            MaxAge = 0;
+            Mx = new List<string>();
+
+            var lines = text.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines) {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith("#") || trimmed.Length == 0) {
+                    continue;
+                }
+
+                int colonIndex = trimmed.IndexOf(':');
+                if (colonIndex <= 0) {
+                    PolicyValid = false;
+                    continue;
+                }
+
+                string key = trimmed.Substring(0, colonIndex).Trim();
+                string value = trimmed.Substring(colonIndex + 1).Trim();
+
+                switch (key) {
+                    case "version":
+                        ValidVersion = value == "STSv1";
+                        break;
+                    case "mode":
+                        Mode = value;
+                        ValidMode = value == "enforce" || value == "testing" || value == "none";
+                        break;
+                    case "max_age":
+                        if (int.TryParse(value, out int ma)) {
+                            MaxAge = ma;
+                            ValidMaxAge = ma > 0;
+                        }
+                        break;
+                    case "mx":
+                        Mx.Add(value);
+                        HasMx = true;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            PolicyValid = PolicyValid && ValidVersion && ValidMode && ValidMaxAge && HasMx;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement `MTASTSAnalysis` for downloading and validating `.well-known/mta-sts.txt`
- wire analysis into `DomainHealthCheck`
- add enum entry for `MTASTS`
- test parsing of the policy file

## Testing
- `dotnet test` *(fails: Invalid URI and other network related issues)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1187664832e9a7031c028d5ceff