### PR TITLE
Fix YAML syntax in PowerShell workflow

### DIFF
--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -158,7 +158,6 @@ jobs:
               run: ./Module/DomainDetective.Tests.ps1
               shell: pwsh
 
-              run: ./Module/DomainDetective.Tests.ps1
 
     test-macos:
         needs: refresh-psd1


### PR DESCRIPTION
## Summary
- fix duplicate `run` definition in `powershell-tests.yml`

## Testing
- `dotnet restore DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --verbosity minimal` *(fails: assets not found)*
- `pwsh ./Module/DomainDetective.Tests.ps1` *(fails: cmdlet not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_6856e17002dc832e8fe80d9413dcd233