### PR TITLE
Fix DANE usage validation

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -86,5 +86,33 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
             Assert.Equal(0, healthCheck.DaneAnalysis.NumberOfRecords);
         }
+
+        [Fact]
+        public async Task AllCombinationsAreConsideredValid() {
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false
+            };
+
+            var sha256 = new string('A', 64);
+            var sha512 = new string('A', 128);
+
+            for (var usage = 0; usage <= 3; usage++) {
+                for (var selector = 0; selector <= 1; selector++) {
+                    for (var matching = 0; matching <= 2; matching++) {
+                        var data = matching switch {
+                            0 => "ABCD",
+                            1 => sha256,
+                            2 => sha512,
+                            _ => ""
+                        };
+
+                        var record = $"{usage} {selector} {matching} {data}";
+                        await healthCheck.CheckDANE(record);
+                        var analysis = healthCheck.DaneAnalysis.AnalysisResults[0];
+                        Assert.True(analysis.ValidDANERecord, record);
+                    }
+                }
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -95,17 +95,8 @@ namespace DomainDetective {
                 analysis.MatchingTypeField = TranslateMatchingType(matchingTypeValue);
                 analysis.CertificateAssociationData = associationData; // This is typically a hex string, so no translation is needed
 
-                // Check for correct usage of the Cert and SPKI selectors
-                if ((analysis.SelectorField == "Cert" && (analysis.CertificateUsage != "PKIX-TA" && analysis.CertificateUsage != "PKIX-EE")) ||
-                    (analysis.SelectorField == "SPKI" && (analysis.CertificateUsage != "DANE-TA" && analysis.CertificateUsage != "DANE-EE"))) {
-                    analysis.ValidSelector = false;
-                }
-
-                // Check for correct usage of the Full, SHA-256, and SHA-512 matching types
-                if ((analysis.MatchingTypeField == "Full" && (analysis.CertificateUsage != "PKIX-TA" && analysis.CertificateUsage != "PKIX-EE")) ||
-                    ((analysis.MatchingTypeField == "SHA-256" || analysis.MatchingTypeField == "SHA-512") && (analysis.CertificateUsage != "DANE-TA" && analysis.CertificateUsage != "DANE-EE"))) {
-                    analysis.ValidMatchingType = false;
-                }
+                // RFC 6698 does not restrict selector or matching type based on
+                // certificate usage, so all combinations are considered valid.
 
                 // Check if the DANE record is appropriate for SMTP
                 // For SMTP, the recommended configuration is:


### PR DESCRIPTION
## Summary
- drop selector & matching type restrictions in DANE analysis
- verify every usage/matching/selector combination in tests

## Testing
- `dotnet test` *(fails: Invalid URI / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6856e1261d60832e8b992b74b8b8d58b