### PR TITLE
Add IPv6 test coverage

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DnsClientX;
 
 namespace DomainDetective.Tests {
     public class TestDANEnalysis {
@@ -79,6 +80,19 @@ namespace DomainDetective.Tests {
         public async Task HttpsQueriesAandAaaaRecords() {
             var healthCheck = new DomainHealthCheck {
                 Verbose = false
+            };
+            await healthCheck.Verify("ipv6.google.com", [HealthCheckType.DANE], daneServiceType: [ServiceType.HTTPS]);
+
+            Assert.False(healthCheck.DaneAnalysis.HasDuplicateRecords);
+            Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
+            Assert.Equal(0, healthCheck.DaneAnalysis.NumberOfRecords);
+        }
+
+        [Fact]
+        public async Task HttpsQueriesAandAaaaRecordsUsingSystemResolver() {
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false,
+                DnsEndpoint = DnsEndpoint.System
             };
             await healthCheck.Verify("ipv6.google.com", [HealthCheckType.DANE], daneServiceType: [ServiceType.HTTPS]);
 

--- a/DomainDetective.Tests/TestDNSBLIPv6.cs
+++ b/DomainDetective.Tests/TestDNSBLIPv6.cs
@@ -16,5 +16,18 @@ namespace DomainDetective.Tests {
             var expected = string.Join(".", string.Concat(IPAddress.Parse(address).GetAddressBytes().Select(b => b.ToString("x2"))).Reverse());
             Assert.Equal(expected, record.IPAddress);
         }
+
+        [Fact]
+        public async Task Ipv6AddressFormsFqdnCorrectly() {
+            const string address = "2001:db8::2";
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.DNSBLAnalysis.ClearDNSBL();
+            healthCheck.DNSBLAnalysis.AddDNSBL("example.test");
+            await healthCheck.CheckDNSBL(address);
+
+            var record = healthCheck.DNSBLAnalysis.Results[address].DNSBLRecords.First();
+            var nibble = string.Join(".", string.Concat(IPAddress.Parse(address).GetAddressBytes().Select(b => b.ToString("x2"))).Reverse());
+            Assert.Equal($"{nibble}.example.test", record.FQDN);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- cover DNSBL FQDN generation for IPv6
- verify HTTPS DANE lookup when system resolver is used

## Testing
- `dotnet test DomainDetective.sln --verbosity minimal` *(fails: Invalid URI due to DNS restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856e64cefe0832e9c0820529d274297