### PR TITLE
Handle duplicate CAA issuers

### DIFF
--- a/DomainDetective.Tests/TestALL.cs
+++ b/DomainDetective.Tests/TestALL.cs
@@ -51,6 +51,7 @@ namespace DomainDetective.Tests {
             Assert.Empty(healthCheck.CAAAnalysis.CanIssueMail);
             Assert.Equal(5, healthCheck.CAAAnalysis.CanIssueWildcardCertificatesForDomain.Count);
             Assert.Equal(5, healthCheck.CAAAnalysis.CanIssueCertificatesForDomain.Count);
+            Assert.False(healthCheck.CAAAnalysis.HasDuplicateIssuers);
         }
     }
 }

--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -25,12 +25,11 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckCAA(caaRecords);
 
             Assert.Equal(9, healthCheck.CAAAnalysis.AnalysisResults.Count);
-            Assert.Equal(5, healthCheck.CAAAnalysis.CanIssueCertificatesForDomain.Count);
+            Assert.Equal(3, healthCheck.CAAAnalysis.CanIssueCertificatesForDomain.Count);
             Assert.Equal("digicert.com", healthCheck.CAAAnalysis.CanIssueCertificatesForDomain[0]);
             Assert.Equal("letsencrypt.org", healthCheck.CAAAnalysis.CanIssueCertificatesForDomain[1]);
             Assert.Equal("pki.goog", healthCheck.CAAAnalysis.CanIssueCertificatesForDomain[2]);
-            Assert.Equal("letsencrypt.org", healthCheck.CAAAnalysis.CanIssueCertificatesForDomain[3]);
-            Assert.Equal("letsencrypt.org", healthCheck.CAAAnalysis.CanIssueCertificatesForDomain[4]);
+            Assert.True(healthCheck.CAAAnalysis.HasDuplicateIssuers);
 
             Assert.Single(healthCheck.CAAAnalysis.CanIssueWildcardCertificatesForDomain);
             Assert.Equal("letsencrypt.org", healthCheck.CAAAnalysis.CanIssueWildcardCertificatesForDomain[0]);
@@ -189,6 +188,7 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.CAAAnalysis.ConflictingMailIssuance);
             Assert.True(healthCheck.CAAAnalysis.Valid);
             Assert.Empty(healthCheck.CAAAnalysis.CanIssueMail);
+            Assert.False(healthCheck.CAAAnalysis.HasDuplicateIssuers);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- dedupe CAA issuer lists with LINQ
- warn and flag when duplicate CAA issuers are found
- update tests for deduped data

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_68571484011c832eae0287ab9621df23