### PR TITLE
Add DNS propagation analysis feature

### DIFF
--- a/DomainDetective.Example/DomainDetective.Example.csproj
+++ b/DomainDetective.Example/DomainDetective.Example.csproj
@@ -11,8 +11,15 @@
 	  <PackageReference Include="Spectre.Console" Version="0.50.0" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Data\DNS\PublicDNS.json">
+      <Link>Data/DNS/PublicDNS.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,10 +1,17 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
-    internal class ExampleAnalyseDnsPropagation {
+    internal class ExampleAnalyseDnsPropagationClass {
+        public static async Task Run() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            var servers = analysis.FilterServers(country: "United States", take: 3);
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
+            foreach (var result in results) {
+                Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{string.Join(',', result.Records)} Time:{result.Duration.TotalMilliseconds}ms");
+            }
+        }
     }
 }

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using DnsClientX;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationClass {
@@ -11,6 +12,11 @@ namespace DomainDetective.Example {
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {
                 Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{string.Join(',', result.Records)} Time:{result.Duration.TotalMilliseconds}ms");
+            }
+
+            var comparison = DnsPropagationAnalysis.CompareResults(results);
+            foreach (var kvp in comparison) {
+                Console.WriteLine($"Record set: {kvp.Key} seen by {kvp.Value.Count} servers");
             }
         }
     }

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -40,7 +40,7 @@ public static partial class Program {
         //await ExampleQueryDNS();
         //await ExampleAnalyseByStringWHOIS();
     }
-}
+
     public static async Task ExampleAnalyseDnsPropagation() {
         await ExampleAnalyseDnsPropagationClass.Run();
     }

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -35,8 +35,13 @@ public static partial class Program {
         await ExampleAnalyseByDomainDNSBL();
         await ExampleManageDnsbl();
         await ExampleAnalyseSecurityTXT();
+        await ExampleAnalyseDnsPropagation();
 
         //await ExampleQueryDNS();
         //await ExampleAnalyseByStringWHOIS();
+    }
+}
+    public static async Task ExampleAnalyseDnsPropagation() {
+        await ExampleAnalyseDnsPropagationClass.Run();
     }
 }

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -32,4 +32,11 @@
     <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="..\Data\DNS\PublicDNS.json">
+      <Link>Data/DNS/PublicDNS.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -1,0 +1,32 @@
+using DnsClientX;
+using DomainDetective;
+namespace DomainDetective.Tests {
+    public class TestDnsPropagation {
+        [Fact]
+        public void LoadServersAddsEntries() {
+            var file = "Data/DNS/PublicDNS.json";
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadServers(file, clearExisting: true);
+            Assert.NotEmpty(analysis.Servers);
+        }
+
+        [Fact]
+        public void AddAndRemoveServerWorks() {
+            var analysis = new DnsPropagationAnalysis();
+            var entry = new PublicDnsEntry { IPAddress = "1.1.1.1", Country = "Test" };
+            analysis.AddServer(entry);
+            Assert.Contains(analysis.Servers, s => s.IPAddress == "1.1.1.1");
+            analysis.RemoveServer("1.1.1.1");
+            Assert.DoesNotContain(analysis.Servers, s => s.IPAddress == "1.1.1.1");
+        }
+
+        [Fact]
+        public async Task QueryHandlesDownServer() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.AddServer(new PublicDnsEntry { IPAddress = "192.0.2.1", Country = "Test" });
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers);
+            Assert.Single(results);
+            Assert.False(results[0].Success);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -28,5 +28,30 @@ namespace DomainDetective.Tests {
             Assert.Single(results);
             Assert.False(results[0].Success);
         }
+
+        [Fact]
+        public void CompareResultsGroupsByRecordSet() {
+            var results = new[] {
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "1.1.1.1" },
+                    Records = new[] { "1.1.1.1" },
+                    Success = true
+                },
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "8.8.8.8" },
+                    Records = new[] { "1.1.1.1" },
+                    Success = true
+                },
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "9.9.9.9" },
+                    Records = new[] { "2.2.2.2" },
+                    Success = true
+                }
+            };
+
+            var groups = DnsPropagationAnalysis.CompareResults(results);
+            Assert.Equal(2, groups.Count);
+            Assert.Contains(groups, g => g.Value.Any(s => s.IPAddress == "9.9.9.9"));
+        }
     }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -122,5 +122,18 @@ namespace DomainDetective {
             }
             return result;
         }
+
+        public static Dictionary<string, List<PublicDnsEntry>> CompareResults(IEnumerable<DnsPropagationResult> results) {
+            var comparison = new Dictionary<string, List<PublicDnsEntry>>();
+            foreach (var res in results.Where(r => r.Success)) {
+                var key = string.Join(",", res.Records.OrderBy(r => r));
+                if (!comparison.TryGetValue(key, out var list)) {
+                    list = new List<PublicDnsEntry>();
+                    comparison[key] = list;
+                }
+                list.Add(res.Server);
+            }
+            return comparison;
+        }
     }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DnsClientX;
+
+namespace DomainDetective {
+    public class PublicDnsEntry {
+        public string Country { get; set; }
+        public string IPAddress { get; set; }
+        public string HostName { get; set; }
+        public string Location { get; set; }
+        public string ASN { get; set; }
+        public string ASNName { get; set; }
+        public bool Enabled { get; set; } = true;
+    }
+
+    public class DnsPropagationResult {
+        public PublicDnsEntry Server { get; set; }
+        public IEnumerable<string> Records { get; set; }
+        public TimeSpan Duration { get; set; }
+        public bool Success { get; set; }
+        public string Error { get; set; }
+    }
+
+    public class DnsPropagationAnalysis {
+        private readonly List<PublicDnsEntry> _servers = new();
+
+        public IReadOnlyList<PublicDnsEntry> Servers => _servers;
+
+        public void LoadServers(string filePath, bool clearExisting = false) {
+            if (!File.Exists(filePath)) {
+                throw new FileNotFoundException($"DNS server list file not found: {filePath}");
+            }
+
+            if (clearExisting) {
+                _servers.Clear();
+            }
+
+            var json = File.ReadAllText(filePath);
+            var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+            var servers = JsonSerializer.Deserialize<List<PublicDnsEntry>>(json, options);
+            if (servers == null) {
+                return;
+            }
+            foreach (var entry in servers) {
+                if (_servers.All(s => s.IPAddress != entry.IPAddress)) {
+                    _servers.Add(entry);
+                }
+            }
+        }
+
+        public void AddServer(PublicDnsEntry entry) {
+            if (entry == null || string.IsNullOrWhiteSpace(entry.IPAddress)) {
+                return;
+            }
+            if (_servers.All(s => s.IPAddress != entry.IPAddress)) {
+                _servers.Add(entry);
+            }
+        }
+
+        public void RemoveServer(string ipAddress) {
+            var existing = _servers.FirstOrDefault(s => s.IPAddress == ipAddress);
+            if (existing != null) {
+                _servers.Remove(existing);
+            }
+        }
+
+        public void DisableServer(string ipAddress) {
+            var existing = _servers.FirstOrDefault(s => s.IPAddress == ipAddress);
+            if (existing != null) {
+                existing.Enabled = false;
+            }
+        }
+
+        public void EnableServer(string ipAddress) {
+            var existing = _servers.FirstOrDefault(s => s.IPAddress == ipAddress);
+            if (existing != null) {
+                existing.Enabled = true;
+            }
+        }
+
+        public IEnumerable<PublicDnsEntry> FilterServers(string country = null, string location = null, int? take = null) {
+            IEnumerable<PublicDnsEntry> query = _servers.Where(s => s.Enabled);
+            if (!string.IsNullOrWhiteSpace(country)) {
+                query = query.Where(s => string.Equals(s.Country, country, StringComparison.OrdinalIgnoreCase));
+            }
+            if (!string.IsNullOrWhiteSpace(location)) {
+                query = query.Where(s => s.Location != null && s.Location.IndexOf(location, StringComparison.OrdinalIgnoreCase) >= 0);
+            }
+            if (take.HasValue) {
+                var rnd = new Random();
+                query = query.OrderBy(_ => rnd.Next()).Take(take.Value);
+            }
+            return query.ToList();
+        }
+
+        public async Task<List<DnsPropagationResult>> QueryAsync(string domain, DnsRecordType recordType, IEnumerable<PublicDnsEntry> servers) {
+            var results = new List<DnsPropagationResult>();
+            var tasks = servers.Select(server => QueryServerAsync(domain, recordType, server));
+            results.AddRange(await Task.WhenAll(tasks));
+            return results;
+        }
+
+        private static async Task<DnsPropagationResult> QueryServerAsync(string domain, DnsRecordType recordType, PublicDnsEntry server) {
+            var result = new DnsPropagationResult { Server = server, Success = false, Records = Array.Empty<string>() };
+            var sw = Stopwatch.StartNew();
+            try {
+                var client = new ClientX(server.IPAddress, DnsRequestFormat.DnsOverUDP, 53);
+                var response = await client.Resolve(domain, recordType);
+                sw.Stop();
+                result.Duration = sw.Elapsed;
+                result.Records = response.Answers.Select(a => a.Data);
+                result.Success = true;
+            } catch (Exception ex) {
+                sw.Stop();
+                result.Duration = sw.Elapsed;
+                result.Error = ex.Message;
+            }
+            return result;
+        }
+    }
+}

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -114,7 +114,7 @@ namespace DomainDetective {
                 sw.Stop();
                 result.Duration = sw.Elapsed;
                 result.Records = response.Answers.Select(a => a.Data);
-                result.Success = true;
+                result.Success = response.Answers.Any();
             } catch (Exception ex) {
                 sw.Stop();
                 result.Duration = sw.Elapsed;


### PR DESCRIPTION
## Summary
- implement `DnsPropagationAnalysis` for multi-server DNS queries
- add example on how to use propagation analysis
- call the example from the runner
- include tests for server list management

## Testing
- `dotnet test` *(fails: Exceeds lookups should be true, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68571b673290832ea837265565a7ab2a