### PR TITLE
Implement protocol version retrieval

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -7,5 +7,13 @@ namespace DomainDetective.Tests {
             await analysis.AnalyzeUrl("https://nonexistent.invalid", 443, logger);
             Assert.False(analysis.IsReachable);
         }
+
+        [Fact]
+        public async Task ValidHostSetsProtocolVersion() {
+            var logger = new InternalLogger();
+            var analysis = new CertificateAnalysis();
+            await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
+            Assert.True(analysis.ProtocolVersion?.Major >= 1);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- record negotiated HTTP protocol version when analyzing certificates
- test HTTP protocol detection with a valid host

## Testing
- `dotnet test --filter ValidHostSetsProtocolVersion --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68571bb18314832e965fe4b81ab35f1b