### PR TITLE
Add HTTP analysis

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseHTTP.cs
+++ b/DomainDetective.Example/ExampleAnalyseHTTP.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseHTTP() {
+        var analysis = await HttpAnalysis.CheckUrl("https://www.google.com", true);
+        Helpers.ShowPropertiesTable("HTTP Analysis for google.com", analysis);
+    }
+
+    public static async Task ExampleAnalyseHTTPByHealthCheck() {
+        var healthCheck = new DomainHealthCheck();
+        healthCheck.Verbose = false;
+        await healthCheck.Verify("google.com", new[] { HealthCheckType.HTTP });
+        Helpers.ShowPropertiesTable("HTTP Analysis via HealthCheck", healthCheck.HttpAnalysis);
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -26,6 +26,9 @@ public static partial class Program {
         await ExampleCertificateVerification();
         await ExampleCertificateVerificationByHealthCheck();
 
+        await ExampleAnalyseHTTP();
+        await ExampleAnalyseHTTPByHealthCheck();
+
 
         await ExampleAnalyseByDomainDANE();
         await ExampleAnalyseByStringDANE();

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -16,7 +16,7 @@ namespace DomainDetective.Tests {
                 ctx.Response.StatusCode = 200;
                 ctx.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
                 var buffer = Encoding.UTF8.GetBytes("ok");
-                await ctx.Response.OutputStream.WriteAsync(buffer);
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
                 ctx.Response.Close();
             });
 

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -14,6 +14,7 @@ namespace DomainDetective {
         SECURITYTXT,
         SOA,
         OPENRELAY,
-        STARTTLS
+        STARTTLS,
+        HTTP
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -66,6 +66,8 @@ namespace DomainDetective {
 
         public STARTTLSAnalysis StartTlsAnalysis { get; private set; } = new STARTTLSAnalysis();
 
+        public HttpAnalysis HttpAnalysis { get; private set; } = new HttpAnalysis();
+
         public List<DnsAnswer> Answers;
 
         public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
@@ -186,6 +188,9 @@ namespace DomainDetective {
                         var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX);
                         var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
                         await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger);
+                        break;
+                    case HealthCheckType.HTTP:
+                        await HttpAnalysis.AnalyzeUrl($"http://{domainName}", true, _logger);
                         break;
                 }
             }

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    public class HttpAnalysis {
+        public int? StatusCode { get; private set; }
+        public TimeSpan ResponseTime { get; private set; }
+        public bool HstsPresent { get; private set; }
+        public bool IsReachable { get; private set; }
+
+        public async Task AnalyzeUrl(string url, bool checkHsts, InternalLogger logger) {
+            using var client = new HttpClient();
+            var sw = Stopwatch.StartNew();
+            try {
+                var response = await client.GetAsync(url);
+                sw.Stop();
+                StatusCode = (int)response.StatusCode;
+                ResponseTime = sw.Elapsed;
+                IsReachable = true;
+                if (checkHsts) {
+                    HstsPresent = response.Headers.Contains("Strict-Transport-Security");
+                }
+            } catch (Exception ex) {
+                sw.Stop();
+                IsReachable = false;
+                logger?.WriteError("HTTP check failed for {0}: {1}", url, ex.Message);
+            }
+        }
+
+        public static async Task<HttpAnalysis> CheckUrl(string url, bool checkHsts = false) {
+            var analysis = new HttpAnalysis();
+            await analysis.AnalyzeUrl(url, checkHsts, new InternalLogger());
+            return analysis;
+        }
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -23,9 +23,9 @@ Current capabilities include:
   - [ ] Verify HTTP/2
   - [ ] Verify HTTP/3
   - [ ] Verify Certificate
-  - [ ] Verify Response Time
+  - [x] Verify Response Time
   - [ ] Verify Headers
-  - [ ] Verify HSTS
+  - [x] Verify HSTS
   - [ ] Verify HPKP
 - [ ] Verify SecurityTXT
 - [ ] Verify Open Relay (SMTP)


### PR DESCRIPTION
## Summary
- implement `HttpAnalysis` for verifying HTTP status codes, measuring response time and checking HSTS
- support the new analysis in `DomainHealthCheck`
- add tests for HTTP analysis
- update health check types and docs

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: 11 failed, 63 passed)*
- `dotnet build DomainDetective.sln`

------
https://chatgpt.com/codex/tasks/task_e_6857214479f8832eb748eac86abb44ae