### PR TITLE
Implement SMTPTLSAnalysis

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseSMTPTLS.cs
+++ b/DomainDetective.Example/ExampleAnalyseSMTPTLS.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseSmtpTls() {
+        var analysis = new SMTPTLSAnalysis();
+        await analysis.AnalyzeServer("smtp.gmail.com", 465, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("smtp.gmail.com:465", out var result)) {
+            Helpers.ShowPropertiesTable("SMTP TLS", result);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestSMTPTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSMTPTLSAnalysis.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestSMTPTLSAnalysis {
+        [Fact]
+        public async Task DetectsTls12AndInvalidCert() {
+            using var cert = CreateSelfSigned();
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var ssl = new SslStream(client.GetStream());
+                await ssl.AuthenticateAsServerAsync(cert, false, SslProtocols.Tls12, false);
+                await Task.Delay(100);
+            });
+
+            try {
+                var analysis = new SMTPTLSAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var result = analysis.ServerResults[$"localhost:{port}"];
+                Assert.Contains(SslProtocols.Tls12, result.SupportedProtocols);
+                Assert.False(result.CertificateValid);
+                Assert.True(result.DaysToExpire > 0);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        private static X509Certificate2 CreateSelfSigned() {
+            using var ecdsa = ECDsa.Create();
+            var req = new CertificateRequest("CN=localhost", ecdsa, HashAlgorithmName.SHA256);
+            var cert = req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(30));
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx));
+        }
+    }
+}

--- a/DomainDetective/Protocols/SMTPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPTLSAnalysis.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Net.Security;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    public class SMTPTLSAnalysis {
+        public class TlsResult {
+            public bool CertificateValid { get; set; }
+            public int DaysToExpire { get; set; }
+            public List<SslProtocols> SupportedProtocols { get; } = new();
+        }
+
+        public Dictionary<string, TlsResult> ServerResults { get; } = new();
+
+        public async Task AnalyzeServer(string host, int port, InternalLogger logger) {
+            var result = new TlsResult();
+            foreach (var protocol in _protocolsToTest) {
+                if (await CheckProtocol(host, port, protocol, result, logger)) {
+                    result.SupportedProtocols.Add(protocol);
+                }
+            }
+            ServerResults[$"{host}:{port}"] = result;
+        }
+
+        private static readonly SslProtocols[] _protocolsToTest = new[] {
+            SslProtocols.Tls,
+            SslProtocols.Tls11,
+            SslProtocols.Tls12,
+#if NET8_0_OR_GREATER
+            SslProtocols.Tls13,
+#endif
+        };
+
+        private static async Task<bool> CheckProtocol(string host, int port, SslProtocols protocol, TlsResult result, InternalLogger logger) {
+            try {
+                using var client = new TcpClient();
+                await client.ConnectAsync(host, port);
+                using var ssl = new SslStream(client.GetStream(), false, (sender, certificate, chain, errors) => {
+                    result.CertificateValid = errors == SslPolicyErrors.None;
+                    if (certificate is X509Certificate2 cert) {
+                        result.DaysToExpire = (int)(cert.NotAfter - DateTime.Now).TotalDays;
+                    }
+                    return true; // continue even if invalid
+                });
+
+                await ssl.AuthenticateAsClientAsync(host, null, protocol, false);
+                logger?.WriteVerbose($"{host}:{port} supports {protocol}");
+                return true;
+            } catch (Exception ex) {
+                logger?.WriteVerbose($"{host}:{port} does not support {protocol}: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `SMTPTLSAnalysis` to probe SMTP servers over TLS
- demonstrate usage in `ExampleAnalyseSMTPTLS`
- cover TLS analysis with new unit test

## Testing
- `dotnet build DomainDetective.sln --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter TestSMTPTLSAnalysis` *(failed: dotnet exited with code 130)*

------
https://chatgpt.com/codex/tasks/task_e_6857214de124832ea1d2e22baccb07ca