### PR TITLE
Add missing PowerShell cmdlets

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -1,0 +1,53 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "DnsPropagation", DefaultParameterSetName = "ServersFile")]
+    public sealed class CmdletTestDnsPropagation : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServersFile")]
+        public string DomainName;
+
+        [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServersFile")]
+        public DnsRecordType RecordType;
+
+        [Parameter(Mandatory = true, Position = 2, ParameterSetName = "ServersFile")]
+        public string ServersFile;
+
+        [Parameter(Mandatory = false)]
+        public string Country;
+
+        [Parameter(Mandatory = false)]
+        public string Location;
+
+        [Parameter(Mandatory = false)]
+        public int? Take;
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter CompareResults;
+
+        private InternalLogger _logger;
+        private DnsPropagationAnalysis _analysis;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            _analysis = new DnsPropagationAnalysis();
+            _analysis.LoadServers(ServersFile, clearExisting: true);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location, Take);
+            var results = await _analysis.QueryAsync(DomainName, RecordType, servers);
+            if (CompareResults) {
+                var comparison = DnsPropagationAnalysis.CompareResults(results);
+                WriteObject(comparison);
+            } else {
+                WriteObject(results, true);
+            }
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -1,0 +1,30 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "SecurityTXT", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestSecurityTXT : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string DomainName;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying security.txt for domain: {0}", DomainName);
+            await healthCheck.Verify(DomainName, new[] { HealthCheckType.SECURITYTXT });
+            WriteObject(healthCheck.SecurityTXTAnalysis);
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord')
+    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord', 'Test-DnsPropagation', 'Test-SecurityTXT')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
## Summary
- expose new cmdlets for DNS propagation checks and security.txt analysis
- update module manifest with exported cmdlets

## Testing
- `dotnet test DomainDetective.sln` *(fails: Sequence contains no elements, etc.)*
- `pwsh -NoLogo -NoProfile -Command ./Module/DomainDetective.Tests.ps1` *(fails: Invalid URI: The hostname could not be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_68579dccdb7c832e811f8d886f6f8cc3