### PR TITLE
Optimize dotnet workflow

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -13,6 +13,9 @@ on:
         branches:
             - master
 
+permissions:
+    contents: read
+
 env:
     DOTNET_VERSION: '8.x'
     BUILD_CONFIGURATION: 'Release'

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -18,35 +18,27 @@ env:
     BUILD_CONFIGURATION: 'Release'
 
 jobs:
+    generate-matrix:
+        runs-on: ubuntu-latest
+        outputs:
+            testclasses: ${{ steps.collect.outputs.testclasses }}
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Collect test classes
+              id: collect
+              run: |
+                classes=$(grep -h "public class" DomainDetective.Tests/Test*.cs | sed -E 's/.*public class ([A-Za-z0-9_]+).*/\1/' | sort | jq -R -s -c 'split("\n")[:-1]')
+                echo "testclasses=$classes" >> "$GITHUB_OUTPUT"
+
     test-windows:
         name: 'Windows'
         runs-on: windows-latest
         strategy:
             matrix:
-                testclass:
-                    - TestAll
-                    - TestBimiAnalysis
-                    - TestCAAAnalysis
-                    - TestCertificateHTTP
-                    - TestDANEnalysis
-                    - TestDkimAnalysis
-                    - TestDkimGuess
-                    - TestDMARCAnalysis
-                    - TestDnsblConfig
-                    - TestDnsblIpv6
-                    - TestDnsblManual
-                    - TestDnssecAnalysis
-                    - TestDnsPropagation
-                    - TestHTTPAnalysis
-                    - TestMTASTSAnalysis
-                    - TestMXAnalysis
-                    - TestNSAnalysis
-                    - TestOpenRelayAnalysis
-                    - TestSMTPTLSAnalysis
-                    - TestSOAAnalysis
-                    - TestSpfAnalysis
-                    - TestSTARTTLSAnalysis
-                    - TestWhoisAnalysis
+                testclass: ${{ fromJson(needs.generate-matrix.outputs.testclasses) }}
+        needs: generate-matrix
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -91,30 +83,8 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                testclass:
-                    - TestAll
-                    - TestBimiAnalysis
-                    - TestCAAAnalysis
-                    - TestCertificateHTTP
-                    - TestDANEnalysis
-                    - TestDkimAnalysis
-                    - TestDkimGuess
-                    - TestDMARCAnalysis
-                    - TestDnsblConfig
-                    - TestDnsblIpv6
-                    - TestDnsblManual
-                    - TestDnssecAnalysis
-                    - TestDnsPropagation
-                    - TestHTTPAnalysis
-                    - TestMTASTSAnalysis
-                    - TestMXAnalysis
-                    - TestNSAnalysis
-                    - TestOpenRelayAnalysis
-                    - TestSMTPTLSAnalysis
-                    - TestSOAAnalysis
-                    - TestSpfAnalysis
-                    - TestSTARTTLSAnalysis
-                    - TestWhoisAnalysis
+                testclass: ${{ fromJson(needs.generate-matrix.outputs.testclasses) }}
+        needs: generate-matrix
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -32,12 +32,9 @@ jobs:
                 classes=$(grep -h "public class" DomainDetective.Tests/Test*.cs | sed -E 's/.*public class ([A-Za-z0-9_]+).*/\1/' | sort | jq -R -s -c 'split("\n")[:-1]')
                 echo "testclasses=$classes" >> "$GITHUB_OUTPUT"
 
-    test-windows:
-        name: 'Windows'
+    build-windows:
+        name: 'Build Windows'
         runs-on: windows-latest
-        strategy:
-            matrix:
-                testclass: ${{ fromJson(needs.generate-matrix.outputs.testclasses) }}
         needs: generate-matrix
         steps:
             - name: Checkout code
@@ -56,12 +53,45 @@ jobs:
             - name: Build solution
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: windows-build
+                  path: |
+                      DomainDetective.Tests/bin
+                      DomainDetective.Tests/obj
+
+    test-windows:
+        name: 'Windows'
+        runs-on: windows-latest
+        strategy:
+            matrix:
+                testclass: ${{ fromJson(needs.generate-matrix.outputs.testclasses) }}
+        needs: [generate-matrix, build-windows]
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+                  cache: true
+                  cache-dependency-path: '**/*.csproj'
+
+            - name: Download build artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: windows-build
+                  path: DomainDetective.Tests
+
             - name: Run tests
               run: >-
                   dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj
                   --configuration ${{ env.BUILD_CONFIGURATION }}
                   --framework net8.0
                   --no-build
+                  --no-restore
                   --verbosity normal
                   --logger trx
                   --collect:"XPlat Code Coverage"
@@ -88,12 +118,9 @@ jobs:
               with:
                   files: '**/coverage.cobertura.xml'
 
-    test-ubuntu:
-        name: 'Ubuntu'
+    build-ubuntu:
+        name: 'Build Ubuntu'
         runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                testclass: ${{ fromJson(needs.generate-matrix.outputs.testclasses) }}
         needs: generate-matrix
         steps:
             - name: Checkout code
@@ -112,12 +139,45 @@ jobs:
             - name: Build solution
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
+            - name: Upload build artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: ubuntu-build
+                  path: |
+                      DomainDetective.Tests/bin
+                      DomainDetective.Tests/obj
+
+    test-ubuntu:
+        name: 'Ubuntu'
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                testclass: ${{ fromJson(needs.generate-matrix.outputs.testclasses) }}
+        needs: [generate-matrix, build-ubuntu]
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Setup .NET
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: ${{ env.DOTNET_VERSION }}
+                  cache: true
+                  cache-dependency-path: '**/*.csproj'
+
+            - name: Download build artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  name: ubuntu-build
+                  path: DomainDetective.Tests
+
             - name: Run tests
               run: >-
                   dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj
                   --configuration ${{ env.BUILD_CONFIGURATION }}
                   --framework net8.0
                   --no-build
+                  --no-restore
                   --verbosity normal
                   --logger trx
                   --collect:"XPlat Code Coverage"
@@ -193,3 +253,19 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+
+    collect-results:
+        if: always()
+        runs-on: ubuntu-latest
+        needs: [test-windows, test-ubuntu]
+        steps:
+            - name: Download all artifacts
+              uses: actions/download-artifact@v4
+              with:
+                  path: collected
+
+            - name: Upload combined artifacts
+              uses: actions/upload-artifact@v4
+              with:
+                  name: all-test-artifacts
+                  path: collected

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -57,7 +57,17 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~DomainDetective.Tests.${{ matrix.testclass }}"
+              run: >-
+                  dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj
+                  --configuration ${{ env.BUILD_CONFIGURATION }}
+                  --framework net8.0
+                  --no-build
+                  --verbosity normal
+                  --logger trx
+                  --collect:"XPlat Code Coverage"
+                  --blame-hang-timeout 2m
+                  --blame-hang-dump-type none
+                  --filter "FullyQualifiedName~DomainDetective.Tests.${{ matrix.testclass }}"
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -103,7 +113,17 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~DomainDetective.Tests.${{ matrix.testclass }}"
+              run: >-
+                  dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj
+                  --configuration ${{ env.BUILD_CONFIGURATION }}
+                  --framework net8.0
+                  --no-build
+                  --verbosity normal
+                  --logger trx
+                  --collect:"XPlat Code Coverage"
+                  --blame-hang-timeout 2m
+                  --blame-hang-dump-type none
+                  --filter "FullyQualifiedName~DomainDetective.Tests.${{ matrix.testclass }}"
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -144,7 +164,16 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: >-
+                  dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj
+                  --configuration ${{ env.BUILD_CONFIGURATION }}
+                  --framework net8.0
+                  --no-build
+                  --verbosity normal
+                  --logger trx
+                  --collect:"XPlat Code Coverage"
+                  --blame-hang-timeout 2m
+                  --blame-hang-dump-type none
 
             - name: Upload test results
               uses: actions/upload-artifact@v4

--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -21,6 +21,32 @@ jobs:
     test-windows:
         name: 'Windows'
         runs-on: windows-latest
+        strategy:
+            matrix:
+                testclass:
+                    - TestAll
+                    - TestBimiAnalysis
+                    - TestCAAAnalysis
+                    - TestCertificateHTTP
+                    - TestDANEnalysis
+                    - TestDkimAnalysis
+                    - TestDkimGuess
+                    - TestDMARCAnalysis
+                    - TestDnsblConfig
+                    - TestDnsblIpv6
+                    - TestDnsblManual
+                    - TestDnssecAnalysis
+                    - TestDnsPropagation
+                    - TestHTTPAnalysis
+                    - TestMTASTSAnalysis
+                    - TestMXAnalysis
+                    - TestNSAnalysis
+                    - TestOpenRelayAnalysis
+                    - TestSMTPTLSAnalysis
+                    - TestSOAAnalysis
+                    - TestSpfAnalysis
+                    - TestSTARTTLSAnalysis
+                    - TestWhoisAnalysis
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -29,6 +55,8 @@ jobs:
               uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
+                  cache: true
+                  cache-dependency-path: '**/*.csproj'
 
             - name: Restore dependencies
               run: dotnet restore DomainDetective.sln
@@ -37,20 +65,20 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~DomainDetective.Tests.${{ matrix.testclass }}"
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: test-results-windows
+                  name: test-results-windows-${{ matrix.testclass }}
                   path: '**/*.trx'
 
             - name: Upload coverage reports
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: coverage-reports-windows
+                  name: coverage-reports-windows-${{ matrix.testclass }}
                   path: '**/coverage.cobertura.xml'
 
             - name: Upload coverage to Codecov
@@ -61,6 +89,32 @@ jobs:
     test-ubuntu:
         name: 'Ubuntu'
         runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                testclass:
+                    - TestAll
+                    - TestBimiAnalysis
+                    - TestCAAAnalysis
+                    - TestCertificateHTTP
+                    - TestDANEnalysis
+                    - TestDkimAnalysis
+                    - TestDkimGuess
+                    - TestDMARCAnalysis
+                    - TestDnsblConfig
+                    - TestDnsblIpv6
+                    - TestDnsblManual
+                    - TestDnssecAnalysis
+                    - TestDnsPropagation
+                    - TestHTTPAnalysis
+                    - TestMTASTSAnalysis
+                    - TestMXAnalysis
+                    - TestNSAnalysis
+                    - TestOpenRelayAnalysis
+                    - TestSMTPTLSAnalysis
+                    - TestSOAAnalysis
+                    - TestSpfAnalysis
+                    - TestSTARTTLSAnalysis
+                    - TestWhoisAnalysis
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -69,6 +123,8 @@ jobs:
               uses: actions/setup-dotnet@v4
               with:
                   dotnet-version: ${{ env.DOTNET_VERSION }}
+                  cache: true
+                  cache-dependency-path: '**/*.csproj'
 
             - name: Restore dependencies
               run: dotnet restore DomainDetective.sln
@@ -77,20 +133,20 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage" --filter "FullyQualifiedName~DomainDetective.Tests.${{ matrix.testclass }}"
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: test-results-ubuntu
+                  name: test-results-ubuntu-${{ matrix.testclass }}
                   path: '**/*.trx'
 
             - name: Upload coverage reports
               uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: coverage-reports-ubuntu
+                  name: coverage-reports-ubuntu-${{ matrix.testclass }}
                   path: '**/coverage.cobertura.xml'
 
             - name: Upload coverage to Codecov


### PR DESCRIPTION
## Summary
- cache NuGet packages during setup
- split dotnet tests per class using a matrix

## Testing
- `dotnet vstest DomainDetective.Tests/bin/Release/net8.0/DomainDetective.Tests.dll --TestCaseFilter:"FullyQualifiedName~DomainDetective.Tests.TestSOAAnalysis.ParseSoaRecord"`

------
https://chatgpt.com/codex/tasks/task_e_6857a513b1c8832ebb6f0ad9946fc9e3