### PR TITLE
Handle IPv6 in DNS propagation comparison

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using DomainDetective;
+using System.Net;
 namespace DomainDetective.Tests {
     public class TestDnsPropagation {
         [Fact]
@@ -52,6 +53,27 @@ namespace DomainDetective.Tests {
             var groups = DnsPropagationAnalysis.CompareResults(results);
             Assert.Equal(2, groups.Count);
             Assert.Contains(groups, g => g.Value.Any(s => s.IPAddress == "9.9.9.9"));
+        }
+
+        [Fact]
+        public void CompareResultsHandlesIpv6Variants() {
+            var results = new[] {
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "1.1.1.1" },
+                    Records = new[] { "2001:0db8:0000:0000:0000:0000:0000:0001" },
+                    Success = true
+                },
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "8.8.8.8" },
+                    Records = new[] { "2001:db8::1" },
+                    Success = true
+                }
+            };
+
+            var groups = DnsPropagationAnalysis.CompareResults(results);
+            Assert.Single(groups);
+            Assert.Equal(2, groups.First().Value.Count);
+            Assert.Equal(IPAddress.Parse("2001:db8::1").ToString(), groups.Keys.First());
         }
     }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 using DnsClientX;
@@ -126,7 +127,10 @@ namespace DomainDetective {
         public static Dictionary<string, List<PublicDnsEntry>> CompareResults(IEnumerable<DnsPropagationResult> results) {
             var comparison = new Dictionary<string, List<PublicDnsEntry>>();
             foreach (var res in results.Where(r => r.Success)) {
-                var key = string.Join(",", res.Records.OrderBy(r => r));
+                var normalizedRecords = res.Records
+                    .Select(r => IPAddress.TryParse(r, out var ip) ? ip.ToString() : r)
+                    .OrderBy(r => r);
+                var key = string.Join(",", normalizedRecords);
                 if (!comparison.TryGetValue(key, out var list)) {
                     list = new List<PublicDnsEntry>();
                     comparison[key] = list;


### PR DESCRIPTION
## Summary
- normalize IP addresses when comparing DNS propagation results
- test that IPv6 representations are treated the same

## Testing
- `dotnet test` *(fails: Sequence contains no elements, Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6857b3cc7488832e90025413eaf973e8