### PR TITLE
Stream DNSBL results with async enumeration

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -23,7 +23,7 @@ namespace DomainDetective.PowerShell {
 
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DNSBL records for: {0}", NameOrIpAddress);
-            await foreach (var record in healthCheck.DNSBLAnalysis.AnalyzeDNSBLRecords(NameOrIpAddress, _logger)) {
+            await foreach (var record in healthCheck.EnumerateDNSBLRecords(NameOrIpAddress)) {
                 WriteObject(record);
             }
         }

--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -1,0 +1,31 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "DNSBLRecord", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestDNSBLRecord : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string NameOrIpAddress;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying DNSBL records for: {0}", NameOrIpAddress);
+            await foreach (var record in healthCheck.DNSBLAnalysis.AnalyzeDNSBLRecords(NameOrIpAddress, _logger)) {
+                WriteObject(record);
+            }
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -361,11 +361,17 @@ namespace DomainDetective {
         }
 
         public async Task CheckDNSBL(string ipAddress) {
-            await DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger);
+            await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger)) {
+                // enumeration triggers analysis
+            }
         }
 
         public async Task CheckDNSBL(string[] ipAddresses) {
-            var tasks = ipAddresses.Select(ip => DNSBLAnalysis.AnalyzeDNSBLRecords(ip, _logger));
+            var tasks = ipAddresses.Select(async ip => {
+                await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ip, _logger)) {
+                    // enumeration triggers analysis
+                }
+            });
             await Task.WhenAll(tasks);
         }
 

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Threading;
 
 namespace DomainDetective {
     public partial class DomainHealthCheck : Settings {
@@ -363,6 +365,12 @@ namespace DomainDetective {
         public async Task CheckDNSBL(string ipAddress) {
             await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger)) {
                 // enumeration triggers analysis
+            }
+        }
+
+        public async IAsyncEnumerable<DNSBLRecord> EnumerateDNSBLRecords(string ipAddressOrHostname, [EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            await foreach (var record in DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddressOrHostname, _logger, cancellationToken)) {
+                yield return record;
             }
         }
 


### PR DESCRIPTION
## Summary
- return `IAsyncEnumerable<DNSBLRecord>` from DNSBLAnalysis to avoid large lists
- iterate async records inside DomainHealthCheck
- add `CmdletTestDNSBLRecord` for PowerShell consumption

## Testing
- `dotnet test` *(fails: Exceeds lookups should be true)*

------
https://chatgpt.com/codex/tasks/task_e_6857b3922fac832e9b07efaab6d0a4a9