### PR TITLE
Configure redirect limits

### DIFF
--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -85,7 +85,8 @@ namespace DomainDetective {
 
         private static async Task<string> DownloadIndicator(string url, InternalLogger logger) {
             try {
-                using (HttpClient client = new HttpClient()) {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
+                using (HttpClient client = new HttpClient(handler)) {
                     client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
                     using (var response = await client.GetAsync(url)) {
                         if (!response.IsSuccessStatusCode) {

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -19,7 +19,7 @@ namespace DomainDetective {
         public async Task AnalyzeUrl(string url, int port, InternalLogger logger) {
             var builder = new UriBuilder(url) { Port = port };
             url = builder.ToString();
-            using (var handler = new HttpClientHandler()) {
+            using (var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 }) {
                 handler.ServerCertificateCustomValidationCallback = (HttpRequestMessage requestMessage, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors policyErrors) => {
                     Certificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
                     return true;

--- a/DomainDetective/Protocols/DNSSecAnalysis.cs
+++ b/DomainDetective/Protocols/DNSSecAnalysis.cs
@@ -15,7 +15,8 @@ namespace DomainDetective {
         public bool DsMatch { get; private set; }
 
         public async Task Analyze(string domainName, InternalLogger logger, DnsConfiguration dnsConfiguration = null) {
-            using HttpClient client = new();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
+            using HttpClient client = new(handler);
 
             var dnskeyUri = $"https://cloudflare-dns.com/dns-query?name={domainName}&type=DNSKEY&do=1";
             client.DefaultRequestHeaders.Add("Accept", "application/dns-json");

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -9,9 +9,11 @@ namespace DomainDetective {
         public TimeSpan ResponseTime { get; private set; }
         public bool HstsPresent { get; private set; }
         public bool IsReachable { get; private set; }
+        public int MaxRedirects { get; set; } = 10;
 
         public async Task AnalyzeUrl(string url, bool checkHsts, InternalLogger logger) {
-            using var client = new HttpClient();
+            using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = MaxRedirects };
+            using var client = new HttpClient(handler);
             var sw = Stopwatch.StartNew();
             try {
                 var response = await client.GetAsync(url);

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -38,7 +38,8 @@ namespace DomainDetective {
 
         private async Task<string> GetPolicy(string url) {
             try {
-                using HttpClient client = new();
+                using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
+                using HttpClient client = new(handler);
                 client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
                 var response = await client.GetAsync(url);
                 if (response.IsSuccessStatusCode) {

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -54,7 +54,8 @@ namespace DomainDetective {
 
         private async Task<string> GetSecurityTxt(string url) {
             try {
-                using (HttpClient client = new HttpClient()) {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
+                using (HttpClient client = new HttpClient(handler)) {
                     // Set the User-Agent header to mimic a popular web browser
                     client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537");
 


### PR DESCRIPTION
## Summary
- restrict automatic redirects when using `HttpClient`
- support optional redirect limit for `HttpAnalysis`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Sequence contains no elements)*

------
https://chatgpt.com/codex/tasks/task_e_6857b3c08c7c832e839e723b77e0c096