### PR TITLE
Fix enum name to match file

### DIFF
--- a/DomainDetective/Definitions/QueryType.cs
+++ b/DomainDetective/Definitions/QueryType.cs
@@ -1,5 +1,5 @@
 namespace DomainDetective {
-    public enum DnsProvider {
+    public enum QueryType {
         Standard,
         DnsOverHttps,
     }


### PR DESCRIPTION
## Summary
- rename `DnsProvider` enum to `QueryType`

## Testing
- `dotnet test` *(fails: Sequence contains no elements)*

------
https://chatgpt.com/codex/tasks/task_e_6857b922f0b4832e8c2a66f2355207bd