### PR TITLE
Implement Reset methods for analyses

### DIFF
--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -18,12 +18,16 @@ namespace DomainDetective {
         public bool HasInvalidRecords { get; set; }
 
 
-        public async Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
-            // reset all properties so repeated calls don't accumulate data
+        public void Reset() {
             AnalysisResults = new List<DANERecordAnalysis>();
             NumberOfRecords = 0;
             HasDuplicateRecords = false;
             HasInvalidRecords = false;
+        }
+
+
+        public async Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+            Reset();
 
             var daneRecordList = dnsResults.ToList();
 

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -205,9 +205,15 @@ namespace DomainDetective {
 
         internal InternalLogger Logger { get; set; }
 
-        internal async Task AnalyzeDNSBLRecordsMX(string domainName, InternalLogger logger) {
-            Logger = logger;
+        public void Reset() {
+            Results = new Dictionary<string, DNSQueryResult>();
             AllResults = new List<DNSBLRecord>();
+            Logger = null;
+        }
+
+        internal async Task AnalyzeDNSBLRecordsMX(string domainName, InternalLogger logger) {
+            Reset();
+            Logger = logger;
 
             var mxRecords = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX);
 
@@ -245,6 +251,7 @@ namespace DomainDetective {
         }
 
         internal async Task AnalyzeDNSBLRecords(string ipAddressOrHostname, InternalLogger logger) {
+            Reset();
             Logger = logger;
             Logger.WriteVerbose($"Checking {ipAddressOrHostname} against {DNSBLLists.Count} blacklists");
             var results = await QueryDNSBL(DNSBLLists, ipAddressOrHostname);

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -59,8 +59,7 @@ namespace DomainDetective {
         public List<SpfPartAnalysis> SpfPartAnalyses { get; private set; } = new List<SpfPartAnalysis>();
         public List<SpfTestResult> SpfTestResults { get; private set; } = new List<SpfTestResult>();
 
-        public async Task AnalyzeSpfRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
-            // reset all properties so repeated calls don't accumulate data
+        public void Reset() {
             SpfRecord = null;
             SpfRecords = new List<string>();
             SpfRecordExists = false;
@@ -98,6 +97,10 @@ namespace DomainDetective {
             AllMechanism = null;
             SpfPartAnalyses = new List<SpfPartAnalysis>();
             SpfTestResults = new List<SpfTestResult>();
+        }
+
+        public async Task AnalyzeSpfRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+            Reset();
             var spfRecordList = dnsResults.ToList();
             SpfRecordExists = spfRecordList.Any();
             MultipleSpfRecords = spfRecordList.Count > 1;


### PR DESCRIPTION
## Summary
- implement `Reset()` in SpfAnalysis, DANEAnalysis and DNSBLAnalysis
- invoke `Reset()` at the start of each analysis method

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Exceeds lookups should be true, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6857b8f4aa1c832e921287811abcbd8b