### PR TITLE
Add Original IP to DNSBL record

### DIFF
--- a/DomainDetective.Tests/TestDNSBLIPv6.cs
+++ b/DomainDetective.Tests/TestDNSBLIPv6.cs
@@ -15,6 +15,7 @@ namespace DomainDetective.Tests {
             var record = healthCheck.DNSBLAnalysis.Results[address].DNSBLRecords.First();
             var expected = string.Join(".", string.Concat(IPAddress.Parse(address).GetAddressBytes().Select(b => b.ToString("x2"))).Reverse());
             Assert.Equal(expected, record.IPAddress);
+            Assert.Equal(address, record.OriginalIPAddress);
         }
 
         [Fact]

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 namespace DomainDetective {
     public class DNSBLRecord {
         public string IPAddress { get; set; }
+        public string OriginalIPAddress { get; set; }
         public string FQDN { get; set; }
         public string BlackList { get; set; }
         //public string BlackListReason { get; set; }
@@ -308,6 +309,7 @@ namespace DomainDetective {
                 if (pair.Value.Count == 0) {
                     var dnsblRecord = new DNSBLRecord {
                         IPAddress = name,
+                        OriginalIPAddress = ipAddressOrHostname,
                         FQDN = pair.Key,
                         BlackList = pair.Key.Substring(name.Length + 1), // Extract the blacklist name from the FQDN
                         IsBlackListed = false,
@@ -318,6 +320,7 @@ namespace DomainDetective {
                     foreach (var record in pair.Value) {
                         var dnsblRecord = new DNSBLRecord {
                             IPAddress = name,
+                            OriginalIPAddress = ipAddressOrHostname,
                             FQDN = record.Name,
                             BlackList = record.Name.Substring(name.Length + 1), // Extract the blacklist name from the FQDN
                             IsBlackListed = true,


### PR DESCRIPTION
## Summary
- extend `DNSBLRecord` with `OriginalIPAddress`
- keep the reversed IP used for DNS queries in `IPAddress`
- verify the original IP is tracked in DNSBL IPv6 tests

## Testing
- `dotnet test --no-build` *(fails: Sequence contains no elements)*

------
https://chatgpt.com/codex/tasks/task_e_6857b8da3ab4832e90d4d137b43ded48