### PR TITLE
Fix progress event percentage

### DIFF
--- a/DomainDetective.Tests/TestInternalLogger.cs
+++ b/DomainDetective.Tests/TestInternalLogger.cs
@@ -1,0 +1,19 @@
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestInternalLogger {
+        [Fact]
+        public void ProgressEventHasCorrectPercentage() {
+            var logger = new InternalLogger();
+            LogEventArgs? eventArgs = null;
+            logger.OnProgressMessage += (_, e) => eventArgs = e;
+
+            logger.WriteProgress("activity", "operation", 42, 2, 5);
+
+            Assert.NotNull(eventArgs);
+            Assert.Equal(42, eventArgs!.ProgressPercentage);
+            Assert.Equal(2, eventArgs.ProgressCurrentSteps);
+            Assert.Equal(5, eventArgs.ProgressTotalSteps);
+        }
+    }
+}

--- a/DomainDetective/Logger/InternalLogger.cs
+++ b/DomainDetective/Logger/InternalLogger.cs
@@ -77,7 +77,7 @@ namespace DomainDetective {
 
         public void WriteProgress(string activity, string currentOperation, int percentCompleted, int? currentSteps = null, int? totalSteps = null) {
             lock (_lock) {
-                OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, totalSteps));
+                OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, percentCompleted));
                 if (IsProgress) {
                     if (currentSteps.HasValue && totalSteps.HasValue) {
                         Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentCompleted, currentSteps, totalSteps);


### PR DESCRIPTION
## Summary
- pass percentCompleted to progress events instead of totalSteps
- add unit test ensuring ProgressPercentage is emitted correctly

## Testing
- `dotnet test` *(fails: TestCAAAnalysis.TestCAARecordByDomain, TestDkimGuess.GuessSelectorsForDomain, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestDkimAnalysis.TestDKIMByDomain, TestSOAAnalysis.VerifySoaByDomain, TestAll.TestAllHealthChecks, TestDMARCAnalysis.TestDMARCByDomain, TestSpfAnalysis.TestSpfOver255, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF)*

------
https://chatgpt.com/codex/tasks/task_e_6857c01f3040832e9e9c0781e3ca06c5