### PR TITLE
Support escaped characters in SPF tokens

### DIFF
--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -323,7 +323,37 @@ namespace DomainDetective {
 
             var current = new System.Text.StringBuilder();
             var inQuotes = false;
+            var escapeNext = false;
+            var commentDepth = 0;
+
             foreach (var c in record) {
+                if (escapeNext) {
+                    if (commentDepth == 0) {
+                        current.Append(c);
+                    }
+                    escapeNext = false;
+                    continue;
+                }
+
+                if (c == '\\') {
+                    escapeNext = true;
+                    continue;
+                }
+
+                if (commentDepth > 0) {
+                    if (c == '(') {
+                        commentDepth++;
+                    } else if (c == ')') {
+                        commentDepth--;
+                    }
+                    continue;
+                }
+
+                if (!inQuotes && c == '(') {
+                    commentDepth = 1;
+                    continue;
+                }
+
                 if (c == '"') {
                     if (inQuotes) {
                         tokens.Add(current.ToString());


### PR DESCRIPTION
## Summary
- handle escaped spaces and parentheses when tokenizing SPF records
- add tests covering escaped characters and comments

## Testing
- `dotnet test` *(fails: The argument DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6857c0124910832eb0fc3754e6a09758