### PR TITLE
Fix LoadDNSBL comment trimming

### DIFF
--- a/DomainDetective.Tests/TestDNSBLLoadFile.cs
+++ b/DomainDetective.Tests/TestDNSBLLoadFile.cs
@@ -1,0 +1,29 @@
+using System.IO;
+using System.Linq;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblLoadFile {
+        [Fact]
+        public void LoadFileRemovesTrailingComments() {
+            var lines = new[] {
+                "load1.test # comment",
+                "load2.test#",
+                "#disabled.test",
+                "load3.test ### trailing"
+            };
+            var file = Path.GetTempFileName();
+            File.WriteAllLines(file, lines);
+
+            var analysis = new DNSBLAnalysis();
+            analysis.LoadDNSBL(file, clearExisting: true);
+
+            var entries = analysis.GetDNSBL().ToList();
+            Assert.Equal(4, entries.Count);
+            Assert.Equal("load1.test", entries[0].Domain);
+            Assert.Equal("load2.test", entries[1].Domain);
+            Assert.Equal("disabled.test", entries[2].Domain);
+            Assert.False(entries[2].Enabled);
+            Assert.Equal("load3.test", entries[3].Domain);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -425,6 +425,8 @@ namespace DomainDetective {
                     trimmed = trimmed.Substring(0, commentIndex).Trim();
                 }
 
+                trimmed = trimmed.TrimEnd('#').Trim();
+
                 if (!string.IsNullOrWhiteSpace(trimmed)) {
                     AddDNSBL(trimmed, enabled, comment);
                 }


### PR DESCRIPTION
## Summary
- strip trailing `#` when loading DNSBL files
- add regression test for loading DNSBL from file

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -f net8.0` *(fails: Assert.True() Failure, System.InvalidOperationException, KeyNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6857c179d4b0832e9acee83365ccb002