### PR TITLE
Implement async enumeration for DNSBL records

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -1,0 +1,31 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "DNSBLRecord", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestDNSBLRecord : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string NameOrIpAddress;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying DNSBL records for name/ip address: {0}", NameOrIpAddress);
+            await foreach (var record in healthCheck.DNSBLAnalysis.AnalyzeDNSBLRecords(NameOrIpAddress, _logger)) {
+                WriteObject(record);
+            }
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -367,12 +367,17 @@ namespace DomainDetective {
         }
 
         public async Task CheckDNSBL(string ipAddress, CancellationToken cancellationToken = default) {
-            await DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger);
+            await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger)) {
+                // enumeration triggers processing
+            }
         }
 
         public async Task CheckDNSBL(string[] ipAddresses, CancellationToken cancellationToken = default) {
-            var tasks = ipAddresses.Select(ip => DNSBLAnalysis.AnalyzeDNSBLRecords(ip, _logger));
-            await Task.WhenAll(tasks);
+            foreach (var ip in ipAddresses) {
+                await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ip, _logger)) {
+                    // enumeration triggers processing
+                }
+            }
         }
 
         public async Task CheckWHOIS(string domain, CancellationToken cancellationToken = default) {


### PR DESCRIPTION
## Summary
- return async enumerables from `DNSBLAnalysis.AnalyzeDNSBLRecords`
- stream results in `QueryDNSBL` instead of returning lists
- adapt `DomainHealthCheck.CheckDNSBL` for async enumeration
- add `CmdletTestDNSBLRecord` PowerShell cmdlet for streaming DNSBL records

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6857c0ba033c832e88364545e7fb3fee