### PR TITLE
Implement TLSRPT analysis

### DIFF
--- a/DomainDetective.Tests/TestTLSRPTAnalysis.cs
+++ b/DomainDetective.Tests/TestTLSRPTAnalysis.cs
@@ -1,0 +1,27 @@
+using DomainDetective;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestTLSRPTAnalysis {
+        [Fact]
+        public async Task ParseValidTlsRptPolicy() {
+            var record = "v=TLSRPTv1;rua=mailto:reports@example.com";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckTLSRPT(record);
+            Assert.True(healthCheck.TLSRPTAnalysis.PolicyValid);
+            Assert.Single(healthCheck.TLSRPTAnalysis.MailtoRua);
+            Assert.Equal("reports@example.com", healthCheck.TLSRPTAnalysis.MailtoRua[0]);
+        }
+
+        [Fact]
+        public async Task MissingRuaInvalidatesPolicy() {
+            var record = "v=TLSRPTv1";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckTLSRPT(record);
+            Assert.False(healthCheck.TLSRPTAnalysis.RuaDefined);
+            Assert.False(healthCheck.TLSRPTAnalysis.PolicyValid);
+        }
+    }
+}
+

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -10,6 +10,7 @@ namespace DomainDetective {
         DNSBL,
         DNSSEC,
         MTASTS,
+        TLSRPT,
         CERT,
         SECURITYTXT,
         SOA,

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -1,4 +1,71 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace DomainDetective {
-    internal class TLSRPTAnalysis {
+    /// <summary>
+    /// Analyzes SMTP TLS Reporting (TLSRPT) policies according to RFC 8460.
+    /// </summary>
+    public class TLSRPTAnalysis {
+        public string TlsRptRecord { get; private set; }
+        public bool TlsRptRecordExists { get; private set; }
+        public bool StartsCorrectly { get; private set; }
+        public bool RuaDefined { get; private set; }
+        public List<string> MailtoRua { get; private set; } = new();
+        public List<string> HttpRua { get; private set; } = new();
+
+        public bool PolicyValid => TlsRptRecordExists && StartsCorrectly && RuaDefined;
+
+        public async Task AnalyzeTlsRptRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+            await Task.Yield();
+
+            TlsRptRecord = null;
+            TlsRptRecordExists = false;
+            StartsCorrectly = false;
+            RuaDefined = false;
+            MailtoRua = new List<string>();
+            HttpRua = new List<string>();
+
+            var recordList = dnsResults.ToList();
+            TlsRptRecordExists = recordList.Any();
+            if (!TlsRptRecordExists) {
+                logger?.WriteVerbose("No TLSRPT record found.");
+                return;
+            }
+
+            TlsRptRecord = string.Join(" ", recordList.Select(r => r.Data));
+            logger?.WriteVerbose($"Analyzing TLSRPT record {TlsRptRecord}");
+
+            StartsCorrectly = TlsRptRecord.StartsWith("v=TLSRPTv1", StringComparison.OrdinalIgnoreCase);
+
+            foreach (var part in TlsRptRecord.Split(';')) {
+                var kv = part.Split(new[] { '=' }, 2);
+                if (kv.Length != 2) {
+                    continue;
+                }
+
+                var key = kv[0].Trim();
+                var value = kv[1].Trim();
+                switch (key) {
+                    case "rua":
+                        RuaDefined = true;
+                        AddUriToList(value, MailtoRua, HttpRua);
+                        break;
+                }
+            }
+        }
+
+        private void AddUriToList(string uri, List<string> mailtoList, List<string> httpList) {
+            var uris = uri.Split(',');
+            foreach (var u in uris) {
+                if (u.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) {
+                    mailtoList.Add(u.Substring(7));
+                } else if (u.StartsWith("https://", StringComparison.OrdinalIgnoreCase) || u.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) {
+                    httpList.Add(u);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement `TLSRPTAnalysis` according to RFC 8460
- integrate TLSRPT checks into `DomainHealthCheck`
- add `TLSRPT` enum option
- unit tests for TLSRPT analysis

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: The tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6857c034cc20832ebcca9576d48c559e