### PR TITLE
Add XML documentation

### DIFF
--- a/DomainDetective/DnsResult.cs
+++ b/DomainDetective/DnsResult.cs
@@ -4,9 +4,15 @@ using System.Collections.Generic;
 using System.Linq;
 
 namespace DomainDetective {
+    /// <summary>
+    /// Represents a DNS query result.
+    /// </summary>
     public class DnsResult {
+        /// <summary>Gets or sets the queried name.</summary>
         public string Name { get; set; }
+        /// <summary>Gets or sets the raw data returned.</summary>
         public string[] Data { get; set; }
+        /// <summary>Gets or sets the data joined into a single string.</summary>
         public string DataJoined { get; set; }
 
         internal ServiceType ServiceType { get; set; }

--- a/DomainDetective/DnsblConfiguration.cs
+++ b/DomainDetective/DnsblConfiguration.cs
@@ -2,6 +2,12 @@ namespace DomainDetective;
 
 using System.Collections.Generic;
 
+/// <summary>
+/// Configuration for DNS block list providers.
+/// </summary>
 public class DnsblConfiguration {
+    /// <summary>
+    /// Gets or sets the list of DNSBL providers.
+    /// </summary>
     public List<DnsblEntry> Providers { get; set; } = new();
 }

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -184,25 +184,45 @@ namespace DomainDetective {
         }
     }
 
+    /// <summary>
+    /// Detailed analysis information for a single DANE record.
+    /// </summary>
     public class DANERecordAnalysis {
+        /// <summary>Gets or sets the domain name that provided the record.</summary>
         public string DomainName { get; set; }
 
+        /// <summary>Gets or sets the associated service type.</summary>
         public ServiceType ServiceType { get; set; }
 
+        /// <summary>Gets or sets the raw TLSA record.</summary>
         public string DANERecord { get; set; }
+        /// <summary>Gets or sets a value indicating whether the record passed all validations.</summary>
         public bool ValidDANERecord { get; set; }
+        /// <summary>Gets or sets whether the usage field is valid.</summary>
         public bool ValidUsage { get; set; }
+        /// <summary>Gets or sets whether the selector field is valid.</summary>
         public bool ValidSelector { get; set; }
+        /// <summary>Gets or sets whether the matching type is valid.</summary>
         public bool ValidMatchingType { get; set; }
+        /// <summary>Gets or sets whether the certificate association data is valid hexadecimal.</summary>
         public bool ValidCertificateAssociationData { get; set; }
+        /// <summary>Gets or sets a value indicating whether this configuration is recommended for SMTP.</summary>
         public bool IsValidChoiceForSmtp { get; set; }
+        /// <summary>Gets or sets the textual description of the certificate usage.</summary>
         public string CertificateUsage { get; set; }
+        /// <summary>Gets or sets the textual description of the selector field.</summary>
         public string SelectorField { get; set; }
+        /// <summary>Gets or sets the textual description of the matching type.</summary>
         public string MatchingTypeField { get; set; }
+        /// <summary>Gets or sets the certificate association data.</summary>
         public string CertificateAssociationData { get; set; }
+        /// <summary>Gets or sets a value indicating whether the record contains four fields.</summary>
         public bool CorrectNumberOfFields { get; set; }
+        /// <summary>Gets or sets whether the certificate association data has the expected length.</summary>
         public bool CorrectLengthOfCertificateAssociationData { get; set; }
+        /// <summary>Gets or sets the length of the association data.</summary>
         public int LengthOfCertificateAssociationData { get; set; }
+        /// <summary>Gets or sets the total number of fields in the record.</summary>
         public int NumberOfFields { get; set; }
     }
 }

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -4,13 +4,27 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace DomainDetective {
+    /// <summary>
+    /// Performs basic HTTP checks against a web endpoint.
+    /// </summary>
     public class HttpAnalysis {
+        /// <summary>Gets the HTTP status code of the response.</summary>
         public int? StatusCode { get; private set; }
+        /// <summary>Gets the time taken to receive the response.</summary>
         public TimeSpan ResponseTime { get; private set; }
+        /// <summary>Gets a value indicating whether the HSTS header was present.</summary>
         public bool HstsPresent { get; private set; }
+        /// <summary>Gets a value indicating whether the endpoint was reachable.</summary>
         public bool IsReachable { get; private set; }
+        /// <summary>Gets or sets the maximum number of redirects to follow.</summary>
         public int MaxRedirects { get; set; } = 10;
 
+        /// <summary>
+        /// Performs an HTTP GET request to the specified URL.
+        /// </summary>
+        /// <param name="url">The URL to query.</param>
+        /// <param name="checkHsts">Whether to check for the presence of HSTS.</param>
+        /// <param name="logger">Logger used for error reporting.</param>
         public async Task AnalyzeUrl(string url, bool checkHsts, InternalLogger logger) {
             using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = MaxRedirects };
             using var client = new HttpClient(handler);
@@ -31,6 +45,12 @@ namespace DomainDetective {
             }
         }
 
+        /// <summary>
+        /// Convenience method to check a URL with default logging.
+        /// </summary>
+        /// <param name="url">The URL to check.</param>
+        /// <param name="checkHsts">Whether to check for HSTS.</param>
+        /// <returns>A populated <see cref="HttpAnalysis"/> instance.</returns>
         public static async Task<HttpAnalysis> CheckUrl(string url, bool checkHsts = false) {
             var analysis = new HttpAnalysis();
             await analysis.AnalyzeUrl(url, checkHsts, new InternalLogger());

--- a/DomainDetective/Settings.cs
+++ b/DomainDetective/Settings.cs
@@ -1,35 +1,53 @@
 namespace DomainDetective {
 
+    /// <summary>
+    /// Base settings used across DomainDetective components.
+    /// </summary>
     public class Settings {
         protected static InternalLogger _logger = new InternalLogger();
 
+        /// <summary>
+        /// Gets or sets a value indicating whether error messages are written.
+        /// </summary>
         public bool Error {
             get => _logger.IsError;
             set => _logger.IsError = value;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether verbose messages are written.
+        /// </summary>
         public bool Verbose {
             get => _logger.IsVerbose;
             set => _logger.IsVerbose = value;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether warning messages are written.
+        /// </summary>
         public bool Warning {
             get => _logger.IsWarning;
             set => _logger.IsWarning = value;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether progress messages are written.
+        /// </summary>
         public bool Progress {
             get => _logger.IsProgress;
             set => _logger.IsProgress = value;
         }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether debug messages are written.
+        /// </summary>
         public bool Debug {
             get => _logger.IsDebug;
             set => _logger.IsDebug = value;
         }
 
         /// <summary>
-        /// Number of threads to use for lingering object detection
+        /// Number of threads to use for lingering object detection.
         /// </summary>
         public int NumberOfThreads = 8;
 

--- a/DomainDetective/UnsupportedTldException.cs
+++ b/DomainDetective/UnsupportedTldException.cs
@@ -2,13 +2,21 @@ using System;
 
 namespace DomainDetective;
 
-public class UnsupportedTldException : Exception
-{
+/// <summary>
+/// Exception thrown when a TLD is not supported for WHOIS lookups.
+/// </summary>
+public class UnsupportedTldException : Exception {
+    /// <summary>Gets the domain that was queried.</summary>
     public string Domain { get; }
+    /// <summary>Gets the unsupported top-level domain.</summary>
     public string Tld { get; }
 
-    public UnsupportedTldException(string domain, string tld) : base($"TLD '{tld}' is not supported for WHOIS lookup.")
-    {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsupportedTldException"/> class.
+    /// </summary>
+    /// <param name="domain">The domain name.</param>
+    /// <param name="tld">The unsupported TLD.</param>
+    public UnsupportedTldException(string domain, string tld) : base($"TLD '{tld}' is not supported for WHOIS lookup.") {
         Domain = domain;
         Tld = tld;
     }


### PR DESCRIPTION
## Summary
- add XML docs to Settings and DNS helper classes
- expand HttpAnalysis documentation
- document DANE record analysis types
- document PowerShell async cmdlet base

## Testing
- `dotnet format --no-restore --include DomainDetective.PowerShell/Communication/AsyncPSCmdlet.cs DomainDetective/DnsPropagationAnalysis.cs DomainDetective/DnsResult.cs DomainDetective/DnsblConfiguration.cs DomainDetective/Protocols/DANEAnalysis.cs DomainDetective/Protocols/HttpAnalysis.cs DomainDetective/Settings.cs DomainDetective/UnsupportedTldException.cs`
- `dotnet test` *(fails: "Assert.True() Failure")*

------
https://chatgpt.com/codex/tasks/task_e_6857c158ff6c832ea5eb51054dbf8a5f