### PR TITLE
Fix LoadDNSBL encoding

### DIFF
--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -399,7 +400,7 @@ namespace DomainDetective {
                 throw new FileNotFoundException($"DNSBL list file not found: {filePath}");
             }
 
-            var lines = File.ReadAllLines(filePath);
+            var lines = File.ReadAllLines(filePath, Encoding.UTF8);
 
             if (clearExisting) {
                 ClearDNSBL();


### PR DESCRIPTION
## Summary
- read DNSBL list with UTF-8 encoding

## Testing
- `dotnet test` *(fails: Sequence contains no elements)*

------
https://chatgpt.com/codex/tasks/task_e_6857e476c624832e9e0a3ebd45a6e412