### PR TITLE
Add DNS null checks to analysis classes

### DIFF
--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -38,6 +38,11 @@ namespace DomainDetective {
             SvgFetched = false;
             SvgValid = false;
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var recordList = dnsResults.ToList();
             BimiRecordExists = recordList.Any();
             if (!BimiRecordExists) {

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -68,7 +68,17 @@ As an illustration, a CAA record that is set on example.com is also applicable t
             HasDuplicateIssuers = false;
             AnalysisResults = new List<CAARecordAnalysis>();
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var caaRecordList = dnsResults.ToList();
+
+            if (!caaRecordList.Any()) {
+                logger?.WriteVerbose("No CAA record found.");
+                return;
+            }
 
             DomainName = caaRecordList.First().Name;
 

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -29,6 +29,11 @@ namespace DomainDetective {
         public async Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             Reset();
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var daneRecordList = dnsResults.ToList();
 
             // Group by the correct data property for duplicate detection

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -71,6 +71,11 @@ namespace DomainDetective {
             Pct = null;
             ReportingIntervalShort = 0;
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var dmarcRecordList = dnsResults.ToList();
             DmarcRecordExists = dmarcRecordList.Any();
 

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -10,6 +10,11 @@ namespace DomainDetective {
         public async Task AnalyzeDkimRecords(string selector, IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             await Task.Yield(); // To avoid warning about lack of 'await'
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var dkimRecordList = dnsResults.ToList();
             var analysis = new DkimRecordAnalysis {
                 DkimRecordExists = dkimRecordList.Any(),

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -47,6 +47,11 @@ namespace DomainDetective {
             PrioritiesInOrder = true;
             HasBackupServers = false;
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var mxRecordList = dnsResults.ToList();
             MxRecordExists = mxRecordList.Any();
 

--- a/DomainDetective/Protocols/NSAnalysis.cs
+++ b/DomainDetective/Protocols/NSAnalysis.cs
@@ -31,6 +31,11 @@ namespace DomainDetective {
             AllHaveAOrAaaa = true;
             PointsToCname = false;
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var nsList = dnsResults.ToList();
             NsRecordExists = nsList.Any();
             AtLeastTwoRecords = nsList.Count >= 2;

--- a/DomainDetective/Protocols/SOAAnalysis.cs
+++ b/DomainDetective/Protocols/SOAAnalysis.cs
@@ -28,6 +28,11 @@ namespace DomainDetective {
             Minimum = 0;
             RecordExists = false;
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var soaRecordList = dnsResults.ToList();
             RecordExists = soaRecordList.Any();
             if (!RecordExists) {

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -101,6 +101,10 @@ namespace DomainDetective {
 
         public async Task AnalyzeSpfRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             Reset();
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
             var spfRecordList = dnsResults.ToList();
             SpfRecordExists = spfRecordList.Any();
             MultipleSpfRecords = spfRecordList.Count > 1;

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -28,6 +28,11 @@ namespace DomainDetective {
             MailtoRua = new List<string>();
             HttpRua = new List<string>();
 
+            if (dnsResults == null) {
+                logger?.WriteVerbose("DNS query returned no results.");
+                return;
+            }
+
             var recordList = dnsResults.ToList();
             TlsRptRecordExists = recordList.Any();
             if (!TlsRptRecordExists) {


### PR DESCRIPTION
## Summary
- handle null DNS results in various analysis classes
- add early exit logging when DNS results are missing

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Assert.Equal/True failures)*

------
https://chatgpt.com/codex/tasks/task_e_6857e4685e34832eb3883439a3e05f21