### PR TITLE
Fix IPv6 DNSBL nibble reversal

### DIFF
--- a/DomainDetective.Tests/TestDNSBLIPv6.cs
+++ b/DomainDetective.Tests/TestDNSBLIPv6.cs
@@ -13,7 +13,14 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckDNSBL(address);
 
             var record = healthCheck.DNSBLAnalysis.Results[address].DNSBLRecords.First();
-            var expected = string.Join(".", string.Concat(IPAddress.Parse(address).GetAddressBytes().Select(b => b.ToString("x2"))).Reverse());
+            var expected = string.Join(
+                ".",
+                IPAddress
+                    .Parse(address)
+                    .GetAddressBytes()
+                    .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
+                    .Select(n => n.ToString("x"))
+                    .Reverse());
             Assert.Equal(expected, record.IPAddress);
             Assert.Equal(address, record.OriginalIPAddress);
         }
@@ -27,7 +34,14 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckDNSBL(address);
 
             var record = healthCheck.DNSBLAnalysis.Results[address].DNSBLRecords.First();
-            var nibble = string.Join(".", string.Concat(IPAddress.Parse(address).GetAddressBytes().Select(b => b.ToString("x2"))).Reverse());
+            var nibble = string.Join(
+                ".",
+                IPAddress
+                    .Parse(address)
+                    .GetAddressBytes()
+                    .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
+                    .Select(n => n.ToString("x"))
+                    .Reverse());
             Assert.Equal($"{nibble}.example.test", record.FQDN);
         }
     }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -287,10 +287,11 @@ namespace DomainDetective {
             string name;
             if (IPAddress.TryParse(ipAddressOrHostname, out IPAddress ipAddress)) {
                 if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
-                    var hex = string.Concat(ipAddress
+                    var nibbles = ipAddress
                         .GetAddressBytes()
-                        .Select(b => b.ToString("x2")));
-                    name = string.Join(".", hex.Reverse());
+                        .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
+                        .Select(n => n.ToString("x"));
+                    name = string.Join(".", nibbles.Reverse());
                 } else {
                     // Reverse the IPv4 address and append the DNSBL list
                     name = string.Join(".", ipAddress.ToString().Split('.').Reverse());


### PR DESCRIPTION
## Summary
- handle IPv6 lookups using nibble-reversal
- adjust IPv6 DNSBL tests for the new formatting

## Testing
- `dotnet test --no-build` *(fails: Assert.True() Failure etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6857eab70e38832e875d45c8d081765e