### PR TITLE
Implement BIMI health check

### DIFF
--- a/DomainDetective.Tests/TestBimiHealthCheck.cs
+++ b/DomainDetective.Tests/TestBimiHealthCheck.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestBimiHealthCheck {
+        [Fact]
+        public async Task ParseBimiRecordViaHealthCheck() {
+            var record = "v=BIMI1; l=https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckBIMI(record);
+
+            Assert.True(healthCheck.BimiAnalysis.BimiRecordExists);
+            Assert.True(healthCheck.BimiAnalysis.StartsCorrectly);
+            Assert.Equal("https://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg", healthCheck.BimiAnalysis.Location);
+            Assert.True(healthCheck.BimiAnalysis.LocationUsesHttps);
+            Assert.True(healthCheck.BimiAnalysis.SvgFetched);
+            Assert.True(healthCheck.BimiAnalysis.SvgValid);
+        }
+    }
+}

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -11,6 +11,7 @@ namespace DomainDetective {
         DNSSEC,
         MTASTS,
         TLSRPT,
+        BIMI,
         CERT,
         SECURITYTXT,
         SOA,


### PR DESCRIPTION
## Summary
- add BIMI option to health check type enum
- expose BimiAnalysis via DomainHealthCheck
- support BIMI record verification and checking
- test BIMI through DomainHealthCheck

## Testing
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6857ea93c3f8832ead6b99465869b485