### PR TITLE
Fix README duplicate section

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -61,23 +61,6 @@ analysis.ClearDNSBL();
 analysis.LoadDnsblConfig("DnsblProviders.json", overwriteExisting: true);
 ```
 
-Example usage in C#:
-
-```csharp
-var analysis = new DNSBLAnalysis();
-
-// add a provider
-analysis.AddDNSBL("dnsbl.example.com", comment: "custom");
-
-// remove a provider
-analysis.RemoveDNSBL("dnsbl.example.com");
-
-// clear all configured providers
-analysis.ClearDNSBL();
-
-// load providers from JSON configuration
-analysis.LoadDnsblConfig("DnsblProviders.json", overwriteExisting: true);
-```
 
 ## Build and Test
 


### PR DESCRIPTION
## Summary
- remove a duplicate `Example usage in C#` snippet from README

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Invalid URI and KeyNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_68586b5f3c18832e860b07b1ff826667