### PR TITLE
Ensure QUIT cleanup waits for server response

### DIFF
--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -29,6 +29,8 @@ namespace DomainDetective {
                 await writer.WriteLineAsync("RCPT TO:<test@example.org>");
                 var rcptResp = await reader.ReadLineAsync();
                 await writer.WriteLineAsync("QUIT");
+                await writer.FlushAsync();
+                await reader.ReadLineAsync();
 
                 logger?.WriteVerbose($"MAIL FROM response: {mailResp}");
                 logger?.WriteVerbose($"RCPT TO response: {rcptResp}");

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -45,6 +45,8 @@ namespace DomainDetective {
                 }
 
                 await writer.WriteLineAsync("QUIT");
+                await writer.FlushAsync();
+                await reader.ReadLineAsync();
 
                 return capabilities.Exists(c => c.Equals("STARTTLS", System.StringComparison.OrdinalIgnoreCase));
             } catch (System.Exception ex) {


### PR DESCRIPTION
## Summary
- wait for server response after sending QUIT in open relay and STARTTLS checks

## Testing
- `dotnet test` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68586b85ec6c832e9304d7e8b93d3f9b