### PR TITLE
Fix DANEAnalysis reuse

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -354,6 +354,7 @@ namespace DomainDetective {
         }
 
         public async Task VerifyDANE(string domainName, int[] ports, CancellationToken cancellationToken = default) {
+            DaneAnalysis = new DANEAnalysis();
             var allDaneRecords = new List<DnsAnswer>();
             foreach (var port in ports) {
                 var dane = await DnsConfiguration.QueryDNS($"_{port}._tcp.{domainName}", DnsRecordType.TLSA, cancellationToken: cancellationToken);
@@ -364,6 +365,7 @@ namespace DomainDetective {
         }
 
         public async Task VerifyDANE(string domainName, ServiceType[] serviceTypes, CancellationToken cancellationToken = default) {
+            DaneAnalysis = new DANEAnalysis();
             if (serviceTypes == null || serviceTypes.Length == 0) {
                 serviceTypes = new[] { ServiceType.SMTP, ServiceType.HTTPS };
             }


### PR DESCRIPTION
## Summary
- reset DANE analysis for every verification run

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --verbosity normal` *(fails: VSTestTask returned false)*

------
https://chatgpt.com/codex/tasks/task_e_68586b7e5364832ea55653f2ddbe2ee6