### PR TITLE
Add HTTP/2 & HTTP/3 detection

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace DomainDetective.Tests {
     public class TestCertificateHTTP {
         [Fact]
@@ -14,6 +16,10 @@ namespace DomainDetective.Tests {
             var analysis = new CertificateAnalysis();
             await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
             Assert.True(analysis.ProtocolVersion?.Major >= 1);
+            Assert.Equal(analysis.ProtocolVersion >= new Version(2, 0), analysis.Http2Supported);
+            if (analysis.ProtocolVersion >= new Version(3, 0)) {
+                Assert.True(analysis.Http3Supported);
+            }
         }
     }
 }

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 using System.Net.Http;
 using System.Text;
@@ -27,6 +28,7 @@ namespace DomainDetective.Tests {
                 Assert.Equal(200, analysis.StatusCode);
                 Assert.True(analysis.ResponseTime > TimeSpan.Zero);
                 Assert.True(analysis.HstsPresent);
+                Assert.Equal(analysis.ProtocolVersion >= new Version(2, 0), analysis.Http2Supported);
             } finally {
                 listener.Stop();
                 await serverTask;

--- a/README.MD
+++ b/README.MD
@@ -20,8 +20,8 @@ Current capabilities include:
 - [ ] Verify MTA-STS
 - [ ] Verify SMTP TLS
 - [ ] Verify Website Connectivity
-  - [ ] Verify HTTP/2
-  - [ ] Verify HTTP/3
+  - [x] Verify HTTP/2
+  - [x] Verify HTTP/3
   - [ ] Verify Certificate
   - [x] Verify Response Time
   - [ ] Verify Headers


### PR DESCRIPTION
## Summary
- detect HTTP protocol version and HTTP/2 or HTTP/3 support
- expose protocol version info for certificate checks
- mark HTTP/2 and HTTP/3 support in README
- validate protocol information in tests

## Testing
- `dotnet test` *(fails: TestCAAAnalysis.TestCAARecordByDomain, TestAll.TestAllHealthChecks, TestDMARCAnalysis.TestDMARCByDomain, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestDkimAnalysis.TestDKIMByDomain, TestDkimGuess.GuessSelectorsForDomain, TestSOAAnalysis.VerifySoaByDomain, TestSpfAnalysis.TestSpfOver255, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF)*

------
https://chatgpt.com/codex/tasks/task_e_685909780c68832eb76f2f8d39b4f6a0