### PR TITLE
Handle scheme-less URLs for certificates

### DIFF
--- a/DomainDetective.Example/ExampleCertficateHTTP.cs
+++ b/DomainDetective.Example/ExampleCertficateHTTP.cs
@@ -18,7 +18,8 @@ public static partial class Program {
     public static async Task ExampleCertificateVerificationByHealthCheck() {
         var healthCheck = new DomainHealthCheck();
         healthCheck.Verbose = false;
-        await healthCheck.VerifyWebsiteCertificate("https://evotec.pl");
+        // URL can omit the scheme, https:// will be used by default
+        await healthCheck.VerifyWebsiteCertificate("evotec.pl");
         Helpers.ShowPropertiesTable("Certificate for evotec.pl ", healthCheck.CertificateAnalysis);
         Helpers.ShowPropertiesTable("Certificate for evotec.pl ", healthCheck.CertificateAnalysis.Certificate);
     }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -408,7 +408,17 @@ namespace DomainDetective {
             await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger);
         }
 
+        /// <summary>
+        /// Verifies the certificate for a website. If no scheme is provided in <paramref name="url"/>, "https://" is assumed.
+        /// </summary>
+        /// <param name="url">Website address. If missing a scheme, "https://" will be prepended.</param>
+        /// <param name="port">Port to use for the connection.</param>
+        /// <param name="cancellationToken">Optional cancellation token.</param>
         public async Task VerifyWebsiteCertificate(string url, int port = 443, CancellationToken cancellationToken = default) {
+            if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) {
+                url = $"https://{url}";
+            }
             await CertificateAnalysis.AnalyzeUrl(url, port, _logger, cancellationToken);
         }
 

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -47,10 +47,14 @@ namespace DomainDetective {
         /// <summary>
         /// Standalone version to check the website certificate.
         /// </summary>
-        /// <param name="url">The URL.</param>
+        /// <param name="url">The URL. If no scheme is provided, "https://" will be prepended.</param>
         /// <param name="port">The port.</param>
         /// <returns></returns>
         public static async Task<CertificateAnalysis> CheckWebsiteCertificate(string url, int port = 443, CancellationToken cancellationToken = default) {
+            if (!url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+                !url.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) {
+                url = $"https://{url}";
+            }
             var analysis = new CertificateAnalysis();
             await analysis.AnalyzeUrl(url, port, new InternalLogger(), cancellationToken);
             return analysis;

--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,9 @@ analysis.ClearDNSBL();
 analysis.LoadDnsblConfig("DnsblProviders.json", overwriteExisting: true);
 ```
 
+### Verifying Website Certificates
+`VerifyWebsiteCertificate` can be called with or without a URL scheme. When the scheme is omitted, `https://` is used automatically before checking the certificate.
+
 
 ## Build and Test
 


### PR DESCRIPTION
## Summary
- default to HTTPS when verifying certificates
- update example to show scheme-less URL
- document scheme handling in README

## Testing
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6859094c82b8832eb7e9c3c7fb92fb34