### PR TITLE
Add MTA‑STS enforcement check

### DIFF
--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -18,6 +18,7 @@ namespace DomainDetective.Tests {
             Assert.Equal(86400, analysis.MaxAge);
             Assert.Single(analysis.Mx);
             Assert.Equal("mail.example.com", analysis.Mx[0]);
+            Assert.True(analysis.EnforcesMtaSts);
         }
 
         [Fact]
@@ -29,6 +30,18 @@ namespace DomainDetective.Tests {
             Assert.False(analysis.PolicyValid);
             Assert.False(analysis.HasMx);
             Assert.False(analysis.ValidMaxAge);
+            Assert.False(analysis.EnforcesMtaSts);
+        }
+
+        [Fact]
+        public void PolicyNotEnforcedWhenModeTesting() {
+            var policy = "version: STSv1\nmode: testing\nmx: mail.example.com\nmax_age: 86400";
+            var analysis = new MTASTSAnalysis();
+            analysis.AnalyzePolicyText(policy);
+
+            Assert.True(analysis.PolicyValid);
+            Assert.Equal("testing", analysis.Mode);
+            Assert.False(analysis.EnforcesMtaSts);
         }
     }
 }

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -74,12 +74,30 @@ namespace DomainDetective {
         internal InternalLogger Logger { get; set; }
 
         /// <summary>
+        /// Resets analysis state so the instance can be reused.
+        /// </summary>
+        public void Reset() {
+            Domain = null;
+            PolicyPresent = false;
+            PolicyValid = false;
+            ValidVersion = false;
+            ValidMode = false;
+            ValidMaxAge = false;
+            HasMx = false;
+            Mode = null;
+            MaxAge = 0;
+            Mx = new List<string>();
+            Policy = null;
+        }
+
+        /// <summary>
         /// Fetches and analyses the policy for the specified domain using HTTPS.
         /// </summary>
         /// <param name="domainName">The domain to query.</param>
         /// <param name="logger">A logger for warning messages.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task AnalyzePolicy(string domainName, InternalLogger logger) {
+            Reset();
             Logger = logger;
             Domain = domainName;
             string url = $"https://mta-sts.{domainName}/.well-known/mta-sts.txt";
@@ -98,7 +116,10 @@ namespace DomainDetective {
         /// Analyses the supplied policy text.
         /// </summary>
         /// <param name="text">Raw policy contents.</param>
-        public void AnalyzePolicyText(string text) => ParsePolicy(text);
+        public void AnalyzePolicyText(string text) {
+            Reset();
+            ParsePolicy(text);
+        }
 
         /// <summary>
         /// Retrieves the policy contents from the specified URL.

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -4,21 +4,81 @@ using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace DomainDetective {
+    /// <summary>
+    /// Provides functionality for retrieving and analysing MTA-STS policies.
+    /// </summary>
     public class MTASTSAnalysis {
+        /// <summary>
+        /// Gets the domain name that was analysed.
+        /// </summary>
         public string Domain { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the policy was successfully fetched.
+        /// </summary>
         public bool PolicyPresent { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the policy is valid.
+        /// </summary>
         public bool PolicyValid { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the policy version is valid.
+        /// </summary>
         public bool ValidVersion { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the policy mode is valid.
+        /// </summary>
         public bool ValidMode { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the Max-Age value is valid.
+        /// </summary>
         public bool ValidMaxAge { get; private set; }
+
+        /// <summary>
+        /// Gets a value indicating whether at least one MX entry was found.
+        /// </summary>
         public bool HasMx { get; private set; }
+
+        /// <summary>
+        /// Gets the policy mode value.
+        /// </summary>
         public string Mode { get; private set; }
+
+        /// <summary>
+        /// Gets the Max-Age value defined by the policy.
+        /// </summary>
         public int MaxAge { get; private set; }
+
+        /// <summary>
+        /// Gets the list of MX entries found in the policy.
+        /// </summary>
         public List<string> Mx { get; private set; } = new List<string>();
+
+        /// <summary>
+        /// Gets the text of the policy.
+        /// </summary>
         public string Policy { get; private set; }
 
+        /// <summary>
+        /// Gets a value indicating whether the policy enforces MTA-STS.
+        /// </summary>
+        public bool EnforcesMtaSts => PolicyValid && string.Equals(Mode, "enforce", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// Gets or sets the logger instance used for reporting warnings.
+        /// </summary>
         internal InternalLogger Logger { get; set; }
 
+        /// <summary>
+        /// Fetches and analyses the policy for the specified domain using HTTPS.
+        /// </summary>
+        /// <param name="domainName">The domain to query.</param>
+        /// <param name="logger">A logger for warning messages.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         public async Task AnalyzePolicy(string domainName, InternalLogger logger) {
             Logger = logger;
             Domain = domainName;
@@ -34,8 +94,17 @@ namespace DomainDetective {
             ParsePolicy(content);
         }
 
+        /// <summary>
+        /// Analyses the supplied policy text.
+        /// </summary>
+        /// <param name="text">Raw policy contents.</param>
         public void AnalyzePolicyText(string text) => ParsePolicy(text);
 
+        /// <summary>
+        /// Retrieves the policy contents from the specified URL.
+        /// </summary>
+        /// <param name="url">The policy URL.</param>
+        /// <returns>The policy text or <see langword="null"/> if the request failed.</returns>
         private async Task<string> GetPolicy(string url) {
             try {
                 using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
@@ -52,6 +121,10 @@ namespace DomainDetective {
             return null;
         }
 
+        /// <summary>
+        /// Parses the supplied policy text and updates property values.
+        /// </summary>
+        /// <param name="text">Raw policy text.</param>
         private void ParsePolicy(string text) {
             PolicyValid = true;
             ValidVersion = false;


### PR DESCRIPTION
## Summary
- enhance `MTASTSAnalysis` with `EnforcesMtaSts` property to indicate an enforcing policy
- extend unit tests for `MTASTSAnalysis`
- add XML documentation for `MTASTSAnalysis`

## Testing
- `dotnet test` *(fails: Assert.True failures due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_6859098068f4832ea43cf319264f1cee