### PR TITLE
Add custom TLSA lookup support

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -102,6 +102,17 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task CustomServiceNamesAreSupported() {
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false
+            };
+
+            await healthCheck.VerifyDANE([new ServiceDefinition("example.com", 443)]);
+
+            Assert.NotNull(healthCheck.DaneAnalysis);
+        }
+
+        [Fact]
         public async Task AllCombinationsAreConsideredValid() {
             var healthCheck = new DomainHealthCheck {
                 Verbose = false

--- a/DomainDetective/Definitions/ServiceDefinition.cs
+++ b/DomainDetective/Definitions/ServiceDefinition.cs
@@ -1,0 +1,11 @@
+namespace DomainDetective {
+    public readonly struct ServiceDefinition {
+        public ServiceDefinition(string host, int port) {
+            Host = host;
+            Port = port;
+        }
+
+        public string Host { get; }
+        public int Port { get; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ServiceDefinition` struct for describing a service host and port
- extend `VerifyDANE` with overload accepting custom `ServiceDefinition[]`
- test that custom service names work

## Testing
- `dotnet build DomainDetective/DomainDetective.csproj -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --framework net8.0` *(fails: CAA, SOA, DMARC, DANE, SPF, DKIM, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6859288a7d44832e86955c01f7206574