### PR TITLE
Fix progress percentage limit

### DIFF
--- a/DomainDetective.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/DomainDetective.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -96,11 +96,12 @@ namespace DomainDetective.PowerShell {
             var progressMessage = e.ProgressCurrentOperation ?? "Processing...: ";
             var progressRecord = new ProgressRecord(_currentActivityId, e.ProgressActivity, progressMessage);
             if (e.ProgressPercentage.HasValue) {
-                if (e.ProgressPercentage.Value >= 0 && e.ProgressPercentage.Value <= 100) {
-                    progressRecord.PercentComplete = e.ProgressPercentage.Value;
-                } else {
-                    progressRecord.PercentComplete = 100;
+                var percentComplete = e.ProgressPercentage.Value;
+                if (percentComplete > 100) {
+                    percentComplete = 100;
                 }
+
+                progressRecord.PercentComplete = percentComplete;
             } else {
                 progressRecord.PercentComplete = 50;
             }


### PR DESCRIPTION
## Summary
- clamp progress value in PowerShell logger to 100

## Testing
- `dotnet test -v minimal` *(fails: 11 failed, 80 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685928ae52c0832e833bd6a25c70780b