### PR TITLE
Add open relay example

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseOpenRelay.cs
+++ b/DomainDetective.Example/ExampleAnalyseOpenRelay.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseOpenRelay() {
+        var analysis = new OpenRelayAnalysis();
+        await analysis.AnalyzeServer("smtp.gmail.com", 25, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("smtp.gmail.com:25", out var result)) {
+            Console.WriteLine($"Open relay allowed: {result}");
+        }
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -37,6 +37,7 @@ public static partial class Program {
         await ExampleAnalyseByArrayDNSBL();
         await ExampleAnalyseByDomainDNSBL();
         await ExampleManageDnsbl();
+        await ExampleAnalyseOpenRelay();
         await ExampleAnalyseSecurityTXT();
         await ExampleAnalyseDnsPropagation();
 

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -1,0 +1,29 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "OpenRelay", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestOpenRelay : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string HostName;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public int Port = 25;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Checking open relay for {0}:{1}", HostName, Port);
+            await _healthCheck.CheckOpenRelayHost(HostName, Port);
+            WriteObject(_healthCheck.OpenRelayAnalysis.ServerResults[$"{HostName}:{Port}"]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- remove open relay logic from CLI project
- create `ExampleAnalyseOpenRelay` example
- call example from examples `Program`

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0` *(fails: The tests rely on network resources)*

------
https://chatgpt.com/codex/tasks/task_e_6859288fc5d0832e93236efb8eed4b2c