### PR TITLE
Fix Codecov link

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -104,7 +104,7 @@ If you don't need to automate the process, or if you just want to quickly query 
 ## Continuous Integration
 
 This project uses GitHub Actions to run .NET and PowerShell tests on Windows, Linux and macOS.
-Code coverage results are published to [Codecov](https://codecov.io/gh/your-user/DomainDetective).
+Code coverage results are published to [Codecov](https://codecov.io/gh/EvotecIT/DomainDetective).
 
 ## Understanding Results
 


### PR DESCRIPTION
## Summary
- update Codecov link in README

## Testing
- `dotnet test DomainDetective.sln` *(fails: invalid arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685947dc73cc832eb7444fb67f854343