### PR TITLE
Remove unused Answers property

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -73,7 +73,6 @@ namespace DomainDetective {
 
         public HttpAnalysis HttpAnalysis { get; private set; } = new HttpAnalysis();
 
-        public List<DnsAnswer> Answers;
 
         public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
 


### PR DESCRIPTION
## Summary
- remove unused `Answers` property from `DomainHealthCheck.cs`

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: The tests rely on network resources)*

------
https://chatgpt.com/codex/tasks/task_e_6859479e4d64832ea56d549cfa680fd3