### PR TITLE
Add CancellationToken support for STARTTLS, TLSRPT, BIMI verification

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -179,12 +179,12 @@ namespace DomainDetective {
                     case HealthCheckType.TLSRPT:
                         TLSRPTAnalysis = new TLSRPTAnalysis();
                         var tlsrpt = await DnsConfiguration.QueryDNS("_smtp._tls." + domainName, DnsRecordType.TXT, cancellationToken: cancellationToken);
-                        await TLSRPTAnalysis.AnalyzeTlsRptRecords(tlsrpt, _logger);
+                        await TLSRPTAnalysis.AnalyzeTlsRptRecords(tlsrpt, _logger, cancellationToken);
                         break;
                     case HealthCheckType.BIMI:
                         BimiAnalysis = new BimiAnalysis();
                         var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
-                        await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger);
+                        await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken);
                         break;
                     case HealthCheckType.SECURITYTXT:
                         // lets reset the SecurityTXTAnalysis, so it's overwritten completly on next run
@@ -205,7 +205,7 @@ namespace DomainDetective {
                     case HealthCheckType.STARTTLS:
                         var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
                         var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
-                        await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger);
+                        await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
                         break;
                     case HealthCheckType.HTTP:
                         await HttpAnalysis.AnalyzeUrl($"http://{domainName}", true, _logger);
@@ -306,7 +306,7 @@ namespace DomainDetective {
         }
 
         public async Task CheckStartTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
-            await StartTlsAnalysis.AnalyzeServer(host, port, _logger);
+            await StartTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
         public async Task CheckTLSRPT(string tlsRptRecord, CancellationToken cancellationToken = default) {
@@ -315,7 +315,7 @@ namespace DomainDetective {
                     DataRaw = tlsRptRecord,
                     Type = DnsRecordType.TXT
                 }
-            }, _logger);
+            }, _logger, cancellationToken);
         }
 
         public async Task CheckBIMI(string bimiRecord, CancellationToken cancellationToken = default) {
@@ -324,7 +324,7 @@ namespace DomainDetective {
                     DataRaw = bimiRecord,
                     Type = DnsRecordType.TXT
                 }
-            }, _logger);
+            }, _logger, cancellationToken);
         }
 
 
@@ -341,19 +341,19 @@ namespace DomainDetective {
         public async Task VerifySTARTTLS(string domainName, CancellationToken cancellationToken = default) {
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
-            await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger);
+            await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
         }
 
         public async Task VerifyTLSRPT(string domainName, CancellationToken cancellationToken = default) {
             TLSRPTAnalysis = new TLSRPTAnalysis();
             var tlsrpt = await DnsConfiguration.QueryDNS("_smtp._tls." + domainName, DnsRecordType.TXT, cancellationToken: cancellationToken);
-            await TLSRPTAnalysis.AnalyzeTlsRptRecords(tlsrpt, _logger);
+            await TLSRPTAnalysis.AnalyzeTlsRptRecords(tlsrpt, _logger, cancellationToken);
         }
 
         public async Task VerifyBIMI(string domainName, CancellationToken cancellationToken = default) {
             BimiAnalysis = new BimiAnalysis();
             var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
-            await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger);
+            await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken);
         }
 
         public async Task VerifyDANE(string domainName, int[] ports, CancellationToken cancellationToken = default) {

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Threading;
 
 namespace DomainDetective {
     /// <summary>
@@ -18,8 +19,9 @@ namespace DomainDetective {
 
         public bool PolicyValid => TlsRptRecordExists && StartsCorrectly && RuaDefined;
 
-        public async Task AnalyzeTlsRptRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        public async Task AnalyzeTlsRptRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger, CancellationToken cancellationToken = default) {
             await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
 
             TlsRptRecord = null;
             TlsRptRecordExists = false;


### PR DESCRIPTION
## Summary
- pass CancellationToken through STARTTLS/TLSRPT/BIMI verification APIs
- update analyses to accept optional CancellationToken

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*


------
https://chatgpt.com/codex/tasks/task_e_68594797b8ec832e963c228b4d1de863