### PR TITLE
Use IPAddress extension for PTR format

### DIFF
--- a/DomainDetective.Tests/TestIPAddressExtensions.cs
+++ b/DomainDetective.Tests/TestIPAddressExtensions.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using System.Net;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestIPAddressExtensions {
+        [Fact]
+        public void Ipv4PtrFormat() {
+            var ip = IPAddress.Parse("1.2.3.4");
+            Assert.Equal("4.3.2.1", ip.ToPtrFormat());
+        }
+
+        [Fact]
+        public void Ipv6PtrFormat() {
+            var ip = IPAddress.Parse("2001:db8::1");
+            var expected = string.Join(
+                '.',
+                ip
+                    .GetAddressBytes()
+                    .SelectMany(b => new[] { (b >> 4) & 0xF, b & 0xF })
+                    .Select(n => n.ToString("x"))
+                    .Reverse());
+            Assert.Equal(expected, ip.ToPtrFormat());
+        }
+    }
+}

--- a/DomainDetective.Tests/TestIPAddressExtensions.cs
+++ b/DomainDetective.Tests/TestIPAddressExtensions.cs
@@ -14,7 +14,7 @@ namespace DomainDetective.Tests {
         public void Ipv6PtrFormat() {
             var ip = IPAddress.Parse("2001:db8::1");
             var expected = string.Join(
-                '.',
+                ".",
                 ip
                     .GetAddressBytes()
                     .SelectMany(b => new[] { (b >> 4) & 0xF, b & 0xF })

--- a/DomainDetective/IPAddressExtensions.cs
+++ b/DomainDetective/IPAddressExtensions.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Helper extensions for working with <see cref="IPAddress"/> instances.
+/// </summary>
+public static class IPAddressExtensions {
+    /// <summary>
+    /// Converts an <see cref="IPAddress"/> to its PTR format.
+    /// </summary>
+    /// <param name="ipAddress">The IP address to convert.</param>
+    /// <returns>The reversed nibble or byte representation suitable for PTR queries.</returns>
+    public static string ToPtrFormat(this IPAddress ipAddress) {
+        if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
+            var nibbles = ipAddress
+                .GetAddressBytes()
+                .SelectMany(b => new[] { (b >> 4) & 0xF, b & 0xF })
+                .Select(n => n.ToString("x"));
+            return string.Join(".", nibbles.Reverse());
+        }
+
+        return string.Join(".", ipAddress.GetAddressBytes().Reverse());
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -286,16 +286,7 @@ namespace DomainDetective {
             // Check if the input is an IP address or a hostname
             string name;
             if (IPAddress.TryParse(ipAddressOrHostname, out IPAddress ipAddress)) {
-                if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
-                    var nibbles = ipAddress
-                        .GetAddressBytes()
-                        .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
-                        .Select(n => n.ToString("x"));
-                    name = string.Join(".", nibbles.Reverse());
-                } else {
-                    // Reverse the IPv4 address and append the DNSBL list
-                    name = string.Join(".", ipAddress.ToString().Split('.').Reverse());
-                }
+                name = ipAddress.ToPtrFormat();
             } else {
                 // Use the hostname and append the DNSBL list
                 name = ipAddressOrHostname;


### PR DESCRIPTION
## Summary
- add `IPAddressExtensions.ToPtrFormat` helper
- use the helper in DNSBLAnalysis
- test PTR format for IPv4 and IPv6

## Testing
- `dotnet build DomainDetective.sln -v minimal`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter TestIPAddressExtensions --no-build`
- `dotnet test DomainDetective.sln` *(fails: Assert.True failures)*

------
https://chatgpt.com/codex/tasks/task_e_6859478fcfd8832e94ce7d89954b6240