### PR TITLE
Fix case-insensitive WHOIS parsing

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -45,5 +45,45 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task QueryFromLocalWhoisServerReadsLargeResponseCaseInsensitive() {
+            var responseBuilder = new System.Text.StringBuilder();
+            responseBuilder.AppendLine("Domain Name: example.local");
+            for (int i = 0; i < 2000; i++) {
+                responseBuilder.AppendLine($"Entry {i}");
+            }
+            var response = responseBuilder.ToString();
+
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                await reader.ReadLineAsync();
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true };
+                await writer.WriteAsync(response);
+            });
+
+            try {
+                var whois = new WhoisAnalysis();
+                var field = typeof(WhoisAnalysis).GetField("WhoisServers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var servers = (System.Collections.Generic.Dictionary<string, string>?)field?.GetValue(whois);
+                Assert.NotNull(servers);
+                servers!["local"] = $"localhost:{port}";
+
+                await whois.QueryWhoisServer("EXAMPLE.LOCAL");
+
+                Assert.Equal("example.local", whois.DomainName);
+                var expected = response.Replace("\r\n", "\n").Replace("\r", "\n");
+                var actual = whois.WhoisData.Replace("\r\n", "\n").Replace("\r", "\n");
+                Assert.Equal(expected, actual);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -13,7 +13,7 @@ public class WhoisAnalysis {
     private string TLD { get; set; }
     private string _domainName;
     public string DomainName {
-        get => _domainName?.ToLower();
+        get => _domainName;
         set => _domainName = value;
     }
     public string Tld => TLD;
@@ -35,7 +35,8 @@ public class WhoisAnalysis {
 
     private static readonly InternalLogger _logger = new();
 
-    private readonly Dictionary<string, string> WhoisServers = new Dictionary<string, string> {
+    private readonly Dictionary<string, string> WhoisServers =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) {
         {"ac", "whois.nic.ac"},
         {"ad", "whois.ripe.net"},
         {"ae", "whois.aeda.net.ae"},
@@ -329,19 +330,20 @@ public class WhoisAnalysis {
     }
 
     private void ParseWhoisData() {
-        if (TLD == "xyz") {
+        if (string.Equals(TLD, "xyz", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataXYZ();
-        } else if (TLD == "pl") {
+        } else if (string.Equals(TLD, "pl", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataPL();
-        } else if (TLD == "com" || TLD == "net") {
+        } else if (string.Equals(TLD, "com", StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(TLD, "net", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataCOM();
-        } else if (TLD == "co.uk") {
+        } else if (string.Equals(TLD, "co.uk", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataCOUK();
-        } else if (TLD == "de") {
+        } else if (string.Equals(TLD, "de", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataDE();
-        } else if (TLD == "cz") {
+        } else if (string.Equals(TLD, "cz", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataCZ();
-        } else if (TLD == "be") {
+        } else if (string.Equals(TLD, "be", StringComparison.OrdinalIgnoreCase)) {
             ParseWhoisDataBE();
         } else {
             ParseWhoisDataDefault();


### PR DESCRIPTION
## Summary
- avoid using `ToLower()` on domain names
- lookup WHOIS servers with case-insensitive keys
- parse TLDs without lowercasing by using `StringComparison.OrdinalIgnoreCase`
- add regression test for uppercase WHOIS lookup

## Testing
- `dotnet test --no-build` *(fails: System.Collections.Generic.Dictionary`2.get_Item ...)*

------
https://chatgpt.com/codex/tasks/task_e_685947d410f8832e93f781203986c954