### PR TITLE
Add verbose messages for DNSBL queries

### DIFF
--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -295,6 +295,7 @@ namespace DomainDetective {
             List<string> queries = new List<string>();
             foreach (var dnsbl in dnsblList) {
                 string query = $"{name}.{dnsbl}";
+                Logger?.WriteVerbose($"Querying blacklist domain {dnsbl} with query {query}");
                 queries.Add(query);
             }
 


### PR DESCRIPTION
## Summary
- add verbose logging for each DNSBL query

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_685954395740832eb0d05d732fb0c50e