### PR TITLE
Handle redirects with HTTP/3

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -120,6 +120,8 @@ namespace DomainDetective.Tests {
                         ctx = await listener.GetContextAsync();
                     } catch (HttpListenerException) {
                         break;
+                    } catch (ObjectDisposedException) {
+                        break;
                     }
                     ctx.Response.StatusCode = 302;
                     ctx.Response.RedirectLocation = prefix;

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -67,6 +67,75 @@ namespace DomainDetective.Tests {
             Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
         }
 
+        [Fact]
+        public async Task FollowsRedirectsWhenUsingHttp3() {
+            var listener1 = new HttpListener();
+            var prefix1 = $"http://localhost:{GetFreePort()}/";
+            listener1.Prefixes.Add(prefix1);
+            listener1.Start();
+
+            var listener2 = new HttpListener();
+            var prefix2 = $"http://localhost:{GetFreePort()}/";
+            listener2.Prefixes.Add(prefix2);
+            listener2.Start();
+
+            var task1 = Task.Run(async () => {
+                var ctx = await listener1.GetContextAsync();
+                ctx.Response.StatusCode = 302;
+                ctx.Response.RedirectLocation = prefix2;
+                ctx.Response.Close();
+            });
+
+            var task2 = Task.Run(async () => {
+                var ctx = await listener2.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                var buffer = Encoding.UTF8.GetBytes("ok");
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var analysis = new HttpAnalysis();
+                await analysis.AnalyzeUrl(prefix1, false, new InternalLogger());
+                Assert.True(analysis.IsReachable);
+                Assert.Equal(200, analysis.StatusCode);
+            } finally {
+                listener1.Stop();
+                listener2.Stop();
+                await Task.WhenAll(task1, task2);
+            }
+        }
+
+        [Fact]
+        public async Task ThrowsWhenMaxRedirectsExceeded() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+
+            var serverTask = Task.Run(async () => {
+                while (true) {
+                    HttpListenerContext ctx;
+                    try {
+                        ctx = await listener.GetContextAsync();
+                    } catch (HttpListenerException) {
+                        break;
+                    }
+                    ctx.Response.StatusCode = 302;
+                    ctx.Response.RedirectLocation = prefix;
+                    ctx.Response.Close();
+                }
+            });
+
+            try {
+                var analysis = new HttpAnalysis { MaxRedirects = 2 };
+                await Assert.ThrowsAsync<InvalidOperationException>(() => analysis.AnalyzeUrl(prefix, false, new InternalLogger()));
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
         private static int GetFreePort() {
             var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
             listener.Start();

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -103,7 +103,7 @@ namespace DomainDetective {
                 IsReachable = false;
                 FailureReason = $"Timeout: {ex.Message}";
                 logger?.WriteError("HTTP request timed out for {0}: {1}", url, ex.Message);
-            } catch (Exception ex) {
+            } catch (Exception ex) when (ex is not InvalidOperationException) {
                 sw.Stop();
                 IsReachable = false;
                 FailureReason = $"HTTP check failed: {ex.Message}";


### PR DESCRIPTION
## Summary
- track redirects manually when using HTTP/3
- stop and throw if MaxRedirects is exceeded
- add redirect tests with local server

## Testing
- `dotnet build`
- `dotnet test` *(fails: Could not access remote domains)*

------
https://chatgpt.com/codex/tasks/task_e_68595487b994832eb125736d3e1f8d40