### PR TITLE
Fix duplicates in DNSBL results

### DIFF
--- a/DomainDetective.Tests/TestDNSBLDuplicates.cs
+++ b/DomainDetective.Tests/TestDNSBLDuplicates.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblDuplicates {
+        [Fact]
+        public void ConvertToResultsReplacesExistingEntry() {
+            var analysis = new DNSBLAnalysis();
+            var method = typeof(DNSBLAnalysis).GetMethod("ConvertToResults", BindingFlags.NonPublic | BindingFlags.Instance);
+            var first = new[] { new DNSBLRecord { IPAddress = "1.2.3.4", FQDN = "1.2.3.4.test", BlackList = "first", IsBlackListed = true, Answer = "127.0.0.2" } };
+            method.Invoke(analysis, new object[] { "1.2.3.4", first });
+            var second = new[] { new DNSBLRecord { IPAddress = "1.2.3.4", FQDN = "1.2.3.4.test2", BlackList = "second", IsBlackListed = false, Answer = string.Empty } };
+            method.Invoke(analysis, new object[] { "1.2.3.4", second });
+
+            Assert.Single(analysis.Results);
+            Assert.Equal("second", analysis.Results["1.2.3.4"].DNSBLRecords.First().BlackList);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -269,6 +269,9 @@ namespace DomainDetective {
                 Host = ipAddressOrHostname,
                 DNSBLRecords = results,
             };
+            if (Results.ContainsKey(ipAddressOrHostname)) {
+                Results.Remove(ipAddressOrHostname);
+            }
             Results[ipAddressOrHostname] = queryResult;
             AllResults.AddRange(results);
         }


### PR DESCRIPTION
## Summary
- remove existing entry from `DNSBLAnalysis.Results` before adding
- add regression test for duplicate prevention

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid. Please use the /help option to check the list of valid arguments.)*
- `dotnet test` *(fails: 11 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68595475bf28832e91e0a1b06ff467ed