### PR TITLE
Log stack traces in CertificateHTTP

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
     public class TestCertificateHTTP {

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -11,6 +11,19 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task UnreachableHostLogsExceptionType() {
+            var logger = new InternalLogger();
+            LogEventArgs? eventArgs = null;
+            logger.OnErrorMessage += (_, e) => eventArgs = e;
+
+            var analysis = new CertificateAnalysis();
+            await analysis.AnalyzeUrl("https://nonexistent.invalid", 443, logger);
+
+            Assert.NotNull(eventArgs);
+            Assert.Contains(nameof(HttpRequestException), eventArgs!.FullMessage);
+        }
+
+        [Fact]
         public async Task ValidHostSetsProtocolVersion() {
             var logger = new InternalLogger();
             var analysis = new CertificateAnalysis();

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -61,7 +61,7 @@ namespace DomainDetective {
                                     Certificate = new X509Certificate2(cert.Export(X509ContentType.Cert));
                                 }
                             } catch (Exception ex) {
-                                logger?.WriteError("Error retrieving certificate for {0}: {1}", url, ex.Message);
+                                logger?.WriteError("Error retrieving certificate for {0}: {1}", url, ex.ToString());
                             }
                         }
                         if (Certificate != null) {
@@ -69,7 +69,7 @@ namespace DomainDetective {
                         }
                     } catch (Exception ex) {
                         IsReachable = false;
-                        logger?.WriteError("Exception reaching {0}: {1}", url, ex.Message);
+                        logger?.WriteError("Exception reaching {0}: {1}", url, ex.ToString());
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- log full exception string for certificate retrieval errors
- log full exception string for HTTP request failures
- test logger to capture exception type when host is unreachable

## Testing
- `dotnet test` *(fails: HttpRequestException due to network)*

------
https://chatgpt.com/codex/tasks/task_e_685954601608832eadfd9bbb4cf2553b