### PR TITLE
Handle DANE service type defaults

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -113,6 +113,19 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task EmptyServiceTypesDefaultsToSmtpHttps() {
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false
+            };
+
+            await healthCheck.VerifyDANE("ietf.org", Array.Empty<ServiceType>());
+
+            Assert.False(healthCheck.DaneAnalysis.HasDuplicateRecords);
+            Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
+            Assert.Equal(1, healthCheck.DaneAnalysis.NumberOfRecords);
+        }
+
+        [Fact]
         public async Task AllCombinationsAreConsideredValid() {
             var healthCheck = new DomainHealthCheck {
                 Verbose = false

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -393,6 +393,9 @@ namespace DomainDetective {
             }
 
             serviceTypes = serviceTypes.Distinct().ToArray();
+            if (serviceTypes.Length == 0) {
+                serviceTypes = new[] { ServiceType.SMTP, ServiceType.HTTPS };
+            }
 
             var allDaneRecords = new List<DnsAnswer>();
             foreach (var serviceType in serviceTypes) {


### PR DESCRIPTION
## Summary
- ensure `VerifyDANE` uses SMTP/HTTPS when given an empty service type list
- add regression test for empty service type array

## Testing
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6859545a9ae0832e880f8513b8b2a61c