### PR TITLE
Validate ports for DANE verification

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -139,5 +139,19 @@ namespace DomainDetective.Tests {
                 }
             }
         }
+
+        [Fact]
+        public async Task VerifyDaneThrowsIfPortsNull() {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await healthCheck.VerifyDANE("example.com", null!));
+        }
+
+        [Fact]
+        public async Task VerifyDaneThrowsIfPortsEmpty() {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await healthCheck.VerifyDANE("example.com", Array.Empty<int>()));
+        }
     }
 }

--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -144,7 +144,7 @@ namespace DomainDetective.Tests {
         public async Task VerifyDaneThrowsIfPortsNull() {
             var healthCheck = new DomainHealthCheck();
             await Assert.ThrowsAsync<ArgumentException>(async () =>
-                await healthCheck.VerifyDANE("example.com", null!));
+                await healthCheck.VerifyDANE("example.com", (int[])null!));
         }
 
         [Fact]

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -356,6 +356,10 @@ namespace DomainDetective {
         }
 
         public async Task VerifyDANE(string domainName, int[] ports, CancellationToken cancellationToken = default) {
+            if (ports == null || ports.Length == 0) {
+                throw new ArgumentException("No ports provided.", nameof(ports));
+            }
+
             DaneAnalysis = new DANEAnalysis();
             var allDaneRecords = new List<DnsAnswer>();
             foreach (var port in ports) {


### PR DESCRIPTION
## Summary
- add argument check for ports in DANE verification
- test port validation logic

## Testing
- `dotnet test --no-build` *(fails: The argument DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6859545433e4832e8215a0a255cf5da8