### PR TITLE
Fix server results clearing

### DIFF
--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -53,5 +53,58 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task ResultsDoNotAccumulateAcrossCalls() {
+            var listener1 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener1.Start();
+            var port1 = ((System.Net.IPEndPoint)listener1.LocalEndpoint).Port;
+            var serverTask1 = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener1.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost\r\n250-STARTTLS\r\n250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            var analysis = new STARTTLSAnalysis();
+            try {
+                await analysis.AnalyzeServer("localhost", port1, new InternalLogger());
+                Assert.Single(analysis.ServerResults);
+                Assert.True(analysis.ServerResults[$"localhost:{port1}"]);
+            } finally {
+                listener1.Stop();
+                await serverTask1;
+            }
+
+            var listener2 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener2.Start();
+            var port2 = ((System.Net.IPEndPoint)listener2.LocalEndpoint).Port;
+            var serverTask2 = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener2.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250 localhost");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                await analysis.AnalyzeServer("localhost", port2, new InternalLogger());
+                Assert.Single(analysis.ServerResults);
+                Assert.False(analysis.ServerResults.ContainsKey($"localhost:{port1}"));
+                Assert.False(analysis.ServerResults[$"localhost:{port2}"]);
+            } finally {
+                listener2.Stop();
+                await serverTask2;
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -9,6 +9,7 @@ namespace DomainDetective {
         public Dictionary<string, bool> ServerResults { get; private set; } = new();
 
         public async Task AnalyzeServer(string host, int port, InternalLogger logger) {
+            ServerResults.Clear();
             var allows = await TryRelay(host, port, logger);
             ServerResults[$"{host}:{port}"] = allows;
         }

--- a/DomainDetective/Protocols/SMTPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPTLSAnalysis.cs
@@ -18,6 +18,7 @@ namespace DomainDetective {
         public Dictionary<string, TlsResult> ServerResults { get; } = new();
 
         public async Task AnalyzeServer(string host, int port, InternalLogger logger) {
+            ServerResults.Clear();
             var result = new TlsResult();
             foreach (var protocol in _protocolsToTest) {
                 if (await CheckProtocol(host, port, protocol, result, logger)) {

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -9,12 +9,14 @@ namespace DomainDetective {
         public Dictionary<string, bool> ServerResults { get; private set; } = new();
 
         public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+            ServerResults.Clear();
             cancellationToken.ThrowIfCancellationRequested();
             bool supports = await CheckStartTls(host, port, logger, cancellationToken);
             ServerResults[$"{host}:{port}"] = supports;
         }
 
         public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+            ServerResults.Clear();
             foreach (var host in hosts) {
                 cancellationToken.ThrowIfCancellationRequested();
                 await AnalyzeServer(host, port, logger, cancellationToken);


### PR DESCRIPTION
## Summary
- clear result dictionaries in protocol analyses
- ensure results don't accumulate across calls with new tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*


------
https://chatgpt.com/codex/tasks/task_e_6859544bb490832e8c97894884a06c19