### PR TITLE
Update STARTTLS detection logic

### DIFF
--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -53,5 +53,32 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task StartTlsWithCaseInsensitiveDetection() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost\r\n250 sTaRtTlS 8BITMIME\r\n250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new STARTTLSAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                Assert.True(analysis.ServerResults[$"localhost:{port}"]);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -33,14 +33,16 @@ namespace DomainDetective {
                 cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync($"EHLO example.com");
 
-                var capabilities = new List<string>();
+                var capabilities = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
                 string line;
                 while ((line = await reader.ReadLineAsync()) != null) {
                     cancellationToken.ThrowIfCancellationRequested();
                     logger?.WriteVerbose($"EHLO response: {line}");
                     if (line.StartsWith("250")) {
-                        string capability = line.Substring(4).Trim();
-                        capabilities.Add(capability);
+                        var tokens = line.Substring(4).Trim().Split(new[] { ' ' }, System.StringSplitOptions.RemoveEmptyEntries);
+                        foreach (var token in tokens) {
+                            capabilities.Add(token);
+                        }
                         if (!line.StartsWith("250-")) {
                             break;
                         }
@@ -53,7 +55,7 @@ namespace DomainDetective {
                 await writer.FlushAsync();
                 await reader.ReadLineAsync();
 
-                return capabilities.Exists(c => c.Equals("STARTTLS", System.StringComparison.OrdinalIgnoreCase));
+                return capabilities.Contains("STARTTLS");
             } catch (System.Exception ex) {
                 logger?.WriteError("STARTTLS check failed for {0}:{1} - {2}", host, port, ex.Message);
                 return false;


### PR DESCRIPTION
## Summary
- store EHLO keywords in a case-insensitive `HashSet`
- split EHLO lines on spaces when parsing STARTTLS capabilities
- ensure case-insensitive detection via new test

## Testing
- `dotnet test --filter FullyQualifiedName~DomainDetective.Tests.TestSTARTTLSAnalysis`

------
https://chatgpt.com/codex/tasks/task_e_685954433818832e9c1719834bdd6acd