### PR TITLE
Improve STARTTLS EHLO parsing

### DIFF
--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -106,5 +106,32 @@ namespace DomainDetective.Tests {
                 await serverTask2;
             }
         }
+
+        [Fact]
+        public async Task ParsesCapabilitiesCaseInsensitive() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost\r\n250-SIZE 35882577\r\n250-starttls\r\n250 HELP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new STARTTLSAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                Assert.True(analysis.ServerResults[$"localhost:{port}"]);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -35,14 +35,16 @@ namespace DomainDetective {
                 cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync($"EHLO example.com");
 
-                var capabilities = new List<string>();
+                var capabilities = new HashSet<string>(System.StringComparer.OrdinalIgnoreCase);
                 string line;
                 while ((line = await reader.ReadLineAsync()) != null) {
                     cancellationToken.ThrowIfCancellationRequested();
                     logger?.WriteVerbose($"EHLO response: {line}");
                     if (line.StartsWith("250")) {
-                        string capability = line.Substring(4).Trim();
-                        capabilities.Add(capability);
+                        string capabilityLine = line.Substring(4).Trim();
+                        foreach (var part in capabilityLine.Split(new[] { ' ' }, System.StringSplitOptions.RemoveEmptyEntries)) {
+                            capabilities.Add(part);
+                        }
                         if (!line.StartsWith("250-")) {
                             break;
                         }
@@ -55,7 +57,7 @@ namespace DomainDetective {
                 await writer.FlushAsync();
                 await reader.ReadLineAsync();
 
-                return capabilities.Exists(c => c.Equals("STARTTLS", System.StringComparison.OrdinalIgnoreCase));
+                return capabilities.Contains("STARTTLS");
             } catch (System.Exception ex) {
                 logger?.WriteError("STARTTLS check failed for {0}:{1} - {2}", host, port, ex.Message);
                 return false;


### PR DESCRIPTION
## Summary
- parse SMTP EHLO capabilities into a case-insensitive `HashSet`
- update detection logic
- test case-insensitive parsing of EHLO capabilities

## Testing
- `dotnet test --filter TestSTARTTLSAnalysis`
- `dotnet test` *(fails: Assert.True() Failure in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_68595a447bcc832ea6e64bc77baac5a0