### PR TITLE
Add Test-DmarcRecord cmdlet

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -1,0 +1,31 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "DmarcRecord", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestDmarcRecord : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string DomainName;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying DMARC record for domain: {0}", DomainName);
+            await healthCheck.Verify(DomainName, new[] { HealthCheckType.DMARC });
+            WriteObject(healthCheck.DmarcAnalysis);
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord', 'Test-DnsPropagation', 'Test-SecurityTXT')
+    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord', 'Test-DnsPropagation', 'Test-SecurityTXT', 'Test-DmarcRecord')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
## Summary
- add `CmdletTestDmarcRecord` for DMARC analysis
- export new cmdlet in module manifest

## Testing
- `dotnet test` *(fails: TestSpfAnalysis.QueryDomainBySPF etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68596af696f0832e958297cc0d9a0627