### PR TITLE
Add Test-WebsiteCertificate cmdlet

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -1,0 +1,30 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "WebsiteCertificate", DefaultParameterSetName = "Url")]
+    public sealed class CmdletTestWebsiteCertificate : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Url")]
+        public string Url;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Url")]
+        public int Port = 443;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Verifying website certificate for {0}", Url);
+            await _healthCheck.VerifyWebsiteCertificate(Url, Port);
+            WriteObject(_healthCheck.CertificateAnalysis);
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord', 'Test-DnsPropagation', 'Test-CaaRecord', 'Test-SecurityTXT')
+    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord', 'Test-DnsPropagation', 'Test-CaaRecord', 'Test-SecurityTXT', 'Test-WebsiteCertificate')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
## Summary
- add `CmdletTestWebsiteCertificate` to expose website certificate analysis
- export new cmdlet in `DomainDetective.psd1`

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build -v minimal` *(fails: The argument ... is invalid)*
- `pwsh -NoLogo -NoProfile -Command Invoke-Pester -Path Module/Tests` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_685975a87134832ebe3fbc71f3d38e59