### PR TITLE
Expose DNSBL provider management cmdlets

### DIFF
--- a/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsCommon.Add, "DnsblProvider")]
+    public sealed class CmdletAddDnsblProvider : PSCmdlet {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Domain { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public bool Enabled { get; set; } = true;
+
+        [Parameter(Mandatory = false)]
+        public string Comment { get; set; }
+
+        [Parameter(ValueFromPipeline = true)]
+        public DNSBLAnalysis InputObject { get; set; }
+
+        protected override void ProcessRecord() {
+            var analysis = InputObject ?? new DNSBLAnalysis();
+            analysis.AddDNSBL(Domain, Enabled, Comment);
+            WriteObject(analysis);
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletClearDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletClearDnsblProvider.cs
@@ -1,0 +1,15 @@
+using System.Management.Automation;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsCommon.Clear, "DnsblProvider")]
+    public sealed class CmdletClearDnsblProvider : PSCmdlet {
+        [Parameter(ValueFromPipeline = true)]
+        public DNSBLAnalysis InputObject { get; set; }
+
+        protected override void ProcessRecord() {
+            var analysis = InputObject ?? new DNSBLAnalysis();
+            analysis.ClearDNSBL();
+            WriteObject(analysis);
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletLoadDnsblConfig.cs
+++ b/DomainDetective.PowerShell/CmdletLoadDnsblConfig.cs
@@ -1,0 +1,24 @@
+using System.Management.Automation;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet("Load", "DnsblConfig")]
+    public sealed class CmdletLoadDnsblConfig : PSCmdlet {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Path { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter OverwriteExisting { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public SwitchParameter ClearExisting { get; set; }
+
+        [Parameter(ValueFromPipeline = true)]
+        public DNSBLAnalysis InputObject { get; set; }
+
+        protected override void ProcessRecord() {
+            var analysis = InputObject ?? new DNSBLAnalysis();
+            analysis.LoadDnsblConfig(Path, overwriteExisting: OverwriteExisting, clearExisting: ClearExisting);
+            WriteObject(analysis);
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
@@ -1,0 +1,18 @@
+using System.Management.Automation;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsCommon.Remove, "DnsblProvider")]
+    public sealed class CmdletRemoveDnsblProvider : PSCmdlet {
+        [Parameter(Mandatory = true, Position = 0)]
+        public string Domain { get; set; }
+
+        [Parameter(ValueFromPipeline = true)]
+        public DNSBLAnalysis InputObject { get; set; }
+
+        protected override void ProcessRecord() {
+            var analysis = InputObject ?? new DNSBLAnalysis();
+            analysis.RemoveDNSBL(Domain);
+            WriteObject(analysis);
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,21 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Test-DomainBlacklist', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-SpfRecord', 'Test-NsRecord', 'Test-DnsPropagation', 'Test-CaaRecord', 'Test-SecurityTXT', 'Test-StartTls')
+    CmdletsToExport      = @(
+        'Test-DomainBlacklist',
+        'Test-DaneRecord',
+        'Test-DkimRecord',
+        'Test-SpfRecord',
+        'Test-NsRecord',
+        'Test-DnsPropagation',
+        'Test-CaaRecord',
+        'Test-SecurityTXT',
+        'Test-StartTls',
+        'Add-DnsblProvider',
+        'Remove-DnsblProvider',
+        'Clear-DnsblProvider',
+        'Load-DnsblConfig'
+    )
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/Tests/Import.Tests.ps1
+++ b/Module/Tests/Import.Tests.ps1
@@ -7,4 +7,9 @@ Describe 'DomainDetective module' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
         Get-Command Test-SpfRecord -ErrorAction Stop | Should -Not -BeNullOrEmpty
     }
+
+    It 'exposes Add-DnsblProvider cmdlet' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        Get-Command Add-DnsblProvider -ErrorAction Stop | Should -Not -BeNullOrEmpty
+    }
 }

--- a/README.MD
+++ b/README.MD
@@ -61,6 +61,15 @@ analysis.ClearDNSBL();
 analysis.LoadDnsblConfig("DnsblProviders.json", overwriteExisting: true);
 ```
 
+Same actions are available from PowerShell using dedicated cmdlets:
+
+```powershell
+Add-DnsblProvider -Domain 'dnsbl.example.com' -Comment 'custom'
+Remove-DnsblProvider -Domain 'dnsbl.example.com'
+Clear-DnsblProvider
+Load-DnsblConfig -Path './DnsblProviders.json' -OverwriteExisting
+```
+
 ### Verifying Website Certificates
 `VerifyWebsiteCertificate` can be called with or without a URL scheme. When the scheme is omitted, `https://` is used automatically before checking the certificate.
 


### PR DESCRIPTION
## Summary
- add `Add-DnsblProvider`, `Remove-DnsblProvider`, `Clear-DnsblProvider`, `Load-DnsblConfig` cmdlets
- export new cmdlets in module manifest
- document PowerShell usage
- test presence of new cmdlet in Pester tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0 --verbosity minimal` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*
- `pwsh -NoProfile -Command "./Module/DomainDetective.Tests.ps1" | tail -n 20` *(fails: Invalid URI in NsRecord.Tests.ps1)*

------
https://chatgpt.com/codex/tasks/task_e_68599591dddc832e95bd49a071b77ed9