### PR TITLE
Handle disconnect after QUIT

### DIFF
--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -133,5 +133,34 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task StartTlsDisconnectAfterQuitReturnsTrue() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost\r\n250-STARTTLS\r\n250 OK");
+                var line = await reader.ReadLineAsync();
+                if (line?.StartsWith("QUIT", System.StringComparison.OrdinalIgnoreCase) == true) {
+                    client.Close();
+                }
+            });
+
+            try {
+                var analysis = new STARTTLSAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                Assert.True(analysis.ServerResults[$"localhost:{port}"]);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -55,7 +55,11 @@ namespace DomainDetective {
 
                 await writer.WriteLineAsync("QUIT");
                 await writer.FlushAsync();
-                await reader.ReadLineAsync();
+                try {
+                    await reader.ReadLineAsync();
+                } catch (IOException) {
+                    // swallow disconnect after QUIT
+                }
 
                 return capabilities.Contains("STARTTLS");
             } catch (System.Exception ex) {


### PR DESCRIPTION
## Summary
- swallow IOException when server disconnects after QUIT
- test STARTTLS when server drops the connection immediately

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Invalid URI)*

------
https://chatgpt.com/codex/tasks/task_e_6859be4dcdd0832ebc7c1c1809c9301d