### PR TITLE
Update AddDNSBL logic

### DIFF
--- a/DomainDetective.Tests/TestDNSBLCaseInsensitive.cs
+++ b/DomainDetective.Tests/TestDNSBLCaseInsensitive.cs
@@ -10,7 +10,11 @@ namespace DomainDetective.Tests {
             analysis.AddDNSBL("Case.Test");
             analysis.AddDNSBL("case.test");
 
-            var entries = analysis.GetDNSBL().Where(e => e.Domain == "case.test").ToList();
+            var entries = analysis
+                .GetDNSBL()
+                .Where(e => string.Equals(e.Domain, "case.test", StringComparison.OrdinalIgnoreCase))
+                .ToList();
+
             Assert.Single(entries);
             Assert.Equal(before + 1, analysis.GetDNSBL().Count);
         }

--- a/DomainDetective.Tests/TestDNSBLCaseInsensitive.cs
+++ b/DomainDetective.Tests/TestDNSBLCaseInsensitive.cs
@@ -1,0 +1,18 @@
+using System.Linq;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblCaseInsensitive {
+        [Fact]
+        public void AddDnsblDoesNotAddCaseInsensitiveDuplicates() {
+            var analysis = new DNSBLAnalysis();
+            var before = analysis.GetDNSBL().Count;
+
+            analysis.AddDNSBL("Case.Test");
+            analysis.AddDNSBL("case.test");
+
+            var entries = analysis.GetDNSBL().Where(e => e.Domain == "case.test").ToList();
+            Assert.Single(entries);
+            Assert.Equal(before + 1, analysis.GetDNSBL().Count);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -365,7 +365,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(dnsbl))
                 return;
 
-            if (!DnsblEntries.Any(e => e.Domain == dnsbl)) {
+            if (!DnsblEntries.Any(e => string.Equals(e.Domain, dnsbl, StringComparison.OrdinalIgnoreCase))) {
                 DnsblEntries.Add(new DnsblEntry(dnsbl, enabled, comment));
             }
         }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -365,7 +365,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(dnsbl))
                 return;
 
-            if (!DnsblEntries.Any(e => string.Equals(e.Domain, dnsbl, StringComparison.OrdinalIgnoreCase))) {
+            if (!DnsblEntries.Any(e => StringComparer.OrdinalIgnoreCase.Equals(e.Domain, dnsbl))) {
                 DnsblEntries.Add(new DnsblEntry(dnsbl, enabled, comment));
             }
         }


### PR DESCRIPTION
## Summary
- ensure `AddDNSBL` checks for existing entries using `StringComparer.OrdinalIgnoreCase`
- add test for case-insensitive DNSBL duplicates

## Testing
- `dotnet build --no-incremental`
- `dotnet vstest DomainDetective.Tests/bin/Release/net8.0/DomainDetective.Tests.dll --Settings:.runsettings` *(fails: Data collection could not find 'Code Coverage')*

------
https://chatgpt.com/codex/tasks/task_e_6859be765e4c832e9d18ffa5a1b1b801