### PR TITLE
Add HPKP header check

### DIFF
--- a/DomainDetective.Tests/TestHPKPAnalysis.cs
+++ b/DomainDetective.Tests/TestHPKPAnalysis.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestHPKPAnalysis {
+        [Fact]
+        public async Task DetectsHeaderAndValidPins() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)1, 32).ToArray());
+            var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)2, 32).ToArray());
+            var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=1000";
+            var task = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.Headers.Add("Public-Key-Pins", header);
+                var buffer = Encoding.UTF8.GetBytes("ok");
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var analysis = new HPKPAnalysis();
+                await analysis.AnalyzeUrl(prefix, new InternalLogger());
+                Assert.True(analysis.HeaderPresent);
+                Assert.True(analysis.PinsValid);
+                Assert.Equal(2, analysis.Pins.Count);
+                Assert.Contains(pin1, analysis.Pins);
+                Assert.Contains(pin2, analysis.Pins);
+            } finally {
+                listener.Stop();
+                await task;
+            }
+        }
+
+        [Fact]
+        public async Task InvalidPinFormat() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var header = "pin-sha256=\"invalidbase64\"; max-age=1000";
+            var task = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.Headers.Add("Public-Key-Pins", header);
+                ctx.Response.Close();
+            });
+            try {
+                var analysis = new HPKPAnalysis();
+                await analysis.AnalyzeUrl(prefix, new InternalLogger());
+                Assert.True(analysis.HeaderPresent);
+                Assert.False(analysis.PinsValid);
+            } finally {
+                listener.Stop();
+                await task;
+            }
+        }
+
+        [Fact]
+        public async Task HeaderMissing() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var task = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.Close();
+            });
+            try {
+                var analysis = new HPKPAnalysis();
+                await analysis.AnalyzeUrl(prefix, new InternalLogger());
+                Assert.False(analysis.HeaderPresent);
+            } finally {
+                listener.Stop();
+                await task;
+            }
+        }
+
+        private static int GetFreePort() {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestHPKPHealthCheck {
+        [Fact]
+        public async Task VerifyViaHealthCheck() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)3, 32).ToArray());
+            var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)4, 32).ToArray());
+            var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=500";
+            var task = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.Headers.Add("Public-Key-Pins", header);
+                var buffer = Encoding.UTF8.GetBytes("ok");
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.Verify(prefix.TrimEnd('/').Replace("http://", string.Empty), [HealthCheckType.HPKP]);
+                Assert.True(healthCheck.HPKPAnalysis.HeaderPresent);
+                Assert.True(healthCheck.HPKPAnalysis.PinsValid);
+                Assert.Equal(2, healthCheck.HPKPAnalysis.Pins.Count);
+            } finally {
+                listener.Stop();
+                await task;
+            }
+        }
+
+        private static int GetFreePort() {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -17,6 +17,7 @@ namespace DomainDetective {
         SOA,
         OPENRELAY,
         STARTTLS,
-        HTTP
+        HTTP,
+        HPKP
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -73,6 +73,8 @@ namespace DomainDetective {
 
         public HttpAnalysis HttpAnalysis { get; private set; } = new HttpAnalysis();
 
+        public HPKPAnalysis HPKPAnalysis { get; private set; } = new HPKPAnalysis();
+
 
         public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
 
@@ -208,6 +210,9 @@ namespace DomainDetective {
                         break;
                     case HealthCheckType.HTTP:
                         await HttpAnalysis.AnalyzeUrl($"http://{domainName}", true, _logger);
+                        break;
+                    case HealthCheckType.HPKP:
+                        await HPKPAnalysis.AnalyzeUrl($"http://{domainName}", _logger);
                         break;
                     default:
                         _logger.WriteError("Unknown health check type: {0}", healthCheckType);

--- a/DomainDetective/Protocols/HPKPAnalysis.cs
+++ b/DomainDetective/Protocols/HPKPAnalysis.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    public class HPKPAnalysis {
+        public bool HeaderPresent { get; private set; }
+        public bool PinsValid { get; private set; }
+        public List<string> Pins { get; private set; } = new();
+        public string Header { get; private set; }
+
+        public async Task AnalyzeUrl(string url, InternalLogger logger) {
+            HeaderPresent = false;
+            PinsValid = false;
+            Pins = new List<string>();
+            Header = null;
+
+            try {
+                using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 };
+                using var client = new HttpClient(handler);
+                using var response = await client.GetAsync(url);
+                if (response.Headers.TryGetValues("Public-Key-Pins", out var values)) {
+                    Header = string.Join(";", values);
+                }
+                HeaderPresent = !string.IsNullOrEmpty(Header);
+                if (!HeaderPresent) {
+                    return;
+                }
+
+                var parts = Header.Split(';');
+                var valid = true;
+                foreach (var part in parts) {
+                    var trimmed = part.Trim();
+                    if (trimmed.StartsWith("pin-sha256=\"", StringComparison.OrdinalIgnoreCase) && trimmed.EndsWith("\"")) {
+                        var b64 = trimmed.Substring(12, trimmed.Length - 13);
+                        Pins.Add(b64);
+                        try {
+                            var bytes = Convert.FromBase64String(b64);
+                            if (bytes.Length != 32) {
+                                valid = false;
+                            }
+                        } catch (FormatException) {
+                            valid = false;
+                        }
+                    }
+                }
+                PinsValid = valid && Pins.Count > 0;
+            } catch (Exception ex) {
+                logger?.WriteError("HPKP check failed for {0}: {1}", url, ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- check Public-Key-Pins header via `HPKPAnalysis`
- hook `HPKPAnalysis` into health checks via `HealthCheckType.HPKP`
- test HPKP analysis with mock HTTP server

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: Failed:    13, Passed:    99)*

------
https://chatgpt.com/codex/tasks/task_e_6859be32e968832eaeedcbb023cf4858