### PR TITLE
Add SMTP TLS analysis via STARTTLS

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseSMTPTLS.cs
+++ b/DomainDetective.Example/ExampleAnalyseSMTPTLS.cs
@@ -5,8 +5,8 @@ namespace DomainDetective.Example;
 public static partial class Program {
     public static async Task ExampleAnalyseSmtpTls() {
         var analysis = new SMTPTLSAnalysis();
-        await analysis.AnalyzeServer("smtp.gmail.com", 465, new InternalLogger());
-        if (analysis.ServerResults.TryGetValue("smtp.gmail.com:465", out var result)) {
+        await analysis.AnalyzeServer("smtp.gmail.com", 587, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("smtp.gmail.com:587", out var result)) {
             Helpers.ShowPropertiesTable("SMTP TLS", result);
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -1,0 +1,30 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    [Cmdlet(VerbsDiagnostic.Test, "SmtpTls", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestSmtpTls : AsyncPSCmdlet {
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string HostName;
+
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public int Port = 25;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Checking SMTP TLS for {0}:{1}", HostName, Port);
+            await _healthCheck.CheckSmtpTlsHost(HostName, Port);
+            WriteObject(_healthCheck.SmtpTlsAnalysis.ServerResults[$"{HostName}:{Port}"]);
+        }
+    }
+}

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -17,6 +17,7 @@ namespace DomainDetective {
         SOA,
         OPENRELAY,
         STARTTLS,
+        SMTPTLS,
         HTTP
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -67,6 +67,8 @@ namespace DomainDetective {
 
         public STARTTLSAnalysis StartTlsAnalysis { get; private set; } = new STARTTLSAnalysis();
 
+        public SMTPTLSAnalysis SmtpTlsAnalysis { get; private set; } = new SMTPTLSAnalysis();
+
         public TLSRPTAnalysis TLSRPTAnalysis { get; private set; } = new TLSRPTAnalysis();
 
         public BimiAnalysis BimiAnalysis { get; private set; } = new BimiAnalysis();
@@ -206,6 +208,11 @@ namespace DomainDetective {
                         var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
                         await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
                         break;
+                    case HealthCheckType.SMTPTLS:
+                        var mxRecordsForSmtpTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
+                        var smtpTlsHosts = mxRecordsForSmtpTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
+                        await SmtpTlsAnalysis.AnalyzeServers(smtpTlsHosts, 25, _logger, cancellationToken);
+                        break;
                     case HealthCheckType.HTTP:
                         await HttpAnalysis.AnalyzeUrl($"http://{domainName}", true, _logger);
                         break;
@@ -308,6 +315,10 @@ namespace DomainDetective {
             await StartTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
+        public async Task CheckSmtpTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
+            await SmtpTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
         public async Task CheckTLSRPT(string tlsRptRecord, CancellationToken cancellationToken = default) {
             await TLSRPTAnalysis.AnalyzeTlsRptRecords(new List<DnsAnswer> {
                 new DnsAnswer {
@@ -341,6 +352,12 @@ namespace DomainDetective {
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
             await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
+        }
+
+        public async Task VerifySMTPTLS(string domainName, CancellationToken cancellationToken = default) {
+            var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
+            var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
+            await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
         }
 
         public async Task VerifyTLSRPT(string domainName, CancellationToken cancellationToken = default) {

--- a/DomainDetective/Protocols/SMTPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPTLSAnalysis.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Sockets;
 using System.Net.Security;
 using System.Security.Authentication;
@@ -10,58 +11,96 @@ using System.Threading;
 namespace DomainDetective {
     public class SMTPTLSAnalysis {
         public class TlsResult {
+            public bool StartTlsAdvertised { get; set; }
             public bool CertificateValid { get; set; }
             public int DaysToExpire { get; set; }
-            public List<SslProtocols> SupportedProtocols { get; } = new();
+            public SslProtocols Protocol { get; set; }
+            public CipherAlgorithmType CipherAlgorithm { get; set; }
+            public int CipherStrength { get; set; }
         }
 
         public Dictionary<string, TlsResult> ServerResults { get; } = new();
 
-        public async Task AnalyzeServer(string host, int port, InternalLogger logger) {
+        public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
             ServerResults.Clear();
-            var result = new TlsResult();
-            foreach (var protocol in _protocolsToTest) {
-                if (await CheckProtocol(host, port, protocol, result, logger)) {
-                    result.SupportedProtocols.Add(protocol);
-                }
-            }
+            var result = await CheckTls(host, port, logger, cancellationToken);
             ServerResults[$"{host}:{port}"] = result;
         }
 
-        private static readonly SslProtocols[] _protocolsToTest = new[] {
-            SslProtocols.Tls,
-            SslProtocols.Tls11,
-            SslProtocols.Tls12,
-#if NET8_0_OR_GREATER
-            SslProtocols.Tls13,
-#endif
-        };
+        public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+            ServerResults.Clear();
+            foreach (var host in hosts) {
+                cancellationToken.ThrowIfCancellationRequested();
+                ServerResults[$"{host}:{port}"] = await CheckTls(host, port, logger, cancellationToken);
+            }
+        }
 
-        private static async Task<bool> CheckProtocol(string host, int port, SslProtocols protocol, TlsResult result, InternalLogger logger) {
+        private static async Task<TlsResult> CheckTls(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
+            var result = new TlsResult();
             using var client = new TcpClient();
             try {
                 await client.ConnectAsync(host, port);
-                using var ssl = new SslStream(client.GetStream(), false, (sender, certificate, chain, errors) => {
+                using NetworkStream network = client.GetStream();
+                using var reader = new StreamReader(network);
+                using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
+
+                await reader.ReadLineAsync();
+                cancellationToken.ThrowIfCancellationRequested();
+                await writer.WriteLineAsync($"EHLO example.com");
+
+                var capabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                string line;
+                while ((line = await reader.ReadLineAsync()) != null) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    logger?.WriteVerbose($"EHLO response: {line}");
+                    if (line.StartsWith("250")) {
+                        string capabilityLine = line.Substring(4).Trim();
+                        foreach (var part in capabilityLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
+                            capabilities.Add(part);
+                        }
+                        if (!line.StartsWith("250-")) {
+                            break;
+                        }
+                    } else if (line.StartsWith("4") || line.StartsWith("5")) {
+                        break;
+                    }
+                }
+
+                result.StartTlsAdvertised = capabilities.Contains("STARTTLS");
+                if (!result.StartTlsAdvertised) {
+                    await writer.WriteLineAsync("QUIT");
+                    await writer.FlushAsync();
+                    await reader.ReadLineAsync();
+                    return result;
+                }
+
+                await writer.WriteLineAsync("STARTTLS");
+                string resp = await reader.ReadLineAsync();
+                if (resp == null || !resp.StartsWith("220")) {
+                    logger?.WriteVerbose($"{host}:{port} STARTTLS rejected: {resp}");
+                    return result;
+                }
+
+                using var ssl = new SslStream(network, false, (sender, certificate, chain, errors) => {
                     result.CertificateValid = errors == SslPolicyErrors.None;
                     if (certificate is X509Certificate2 cert) {
                         result.DaysToExpire = (int)(cert.NotAfter - DateTime.Now).TotalDays;
                     }
-                    return true; // continue even if invalid
+                    return true;
                 });
 
-                var authTask = ssl.AuthenticateAsClientAsync(host, null, protocol, false);
-                if (await Task.WhenAny(authTask, Task.Delay(TimeSpan.FromSeconds(5))) != authTask) {
-                    client.Close();
-                    logger?.WriteVerbose($"{host}:{port} handshake timed out for {protocol}");
-                    return false;
-                }
-                await authTask; // propagate exceptions
-                logger?.WriteVerbose($"{host}:{port} supports {protocol}");
-                return true;
+                await ssl.AuthenticateAsClientAsync(host);
+                result.Protocol = ssl.SslProtocol;
+                result.CipherAlgorithm = ssl.CipherAlgorithm;
+                result.CipherStrength = ssl.CipherStrength;
+
+                using var secureWriter = new StreamWriter(ssl) { AutoFlush = true, NewLine = "\r\n" };
+                await secureWriter.WriteLineAsync("QUIT");
             } catch (Exception ex) {
-                logger?.WriteVerbose($"{host}:{port} does not support {protocol}: {ex.Message}");
-                return false;
+                logger?.WriteError("SMTP TLS check failed for {0}:{1} - {2}", host, port, ex.Message);
             }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement SMTPTLSAnalysis to issue STARTTLS and record TLS info
- surface results through DomainHealthCheck and new PowerShell cmdlet
- support new SMTPTLS health check type
- update example and unit tests

## Testing
- `dotnet test` *(fails: 13 failed, 95 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6859be2ca0ac832e8eb9ff0fee58d64c