### PR TITLE
Add MTASTS policy fetch and unit test

### DIFF
--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -1,4 +1,7 @@
 using DomainDetective;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DomainDetective.Tests {
@@ -42,6 +45,50 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.PolicyValid);
             Assert.Equal("testing", analysis.Mode);
             Assert.False(analysis.EnforcesMtaSts);
+        }
+
+        [Fact]
+        public async Task FetchPolicyFromServer() {
+            var listener = new HttpListener();
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+
+            const string policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                if (ctx.Request.Url.AbsolutePath == "/.well-known/mta-sts.txt") {
+                    var data = Encoding.UTF8.GetBytes(policy);
+                    ctx.Response.StatusCode = 200;
+                    await ctx.Response.OutputStream.WriteAsync(data, 0, data.Length);
+                } else {
+                    ctx.Response.StatusCode = 404;
+                }
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck { MtaStsPolicyUrlOverride = prefix + ".well-known/mta-sts.txt" };
+                await healthCheck.Verify("example.com", [HealthCheckType.MTASTS]);
+
+                Assert.True(healthCheck.MTASTSAnalysis.PolicyPresent);
+                Assert.True(healthCheck.MTASTSAnalysis.PolicyValid);
+                Assert.Equal("enforce", healthCheck.MTASTSAnalysis.Mode);
+                Assert.Single(healthCheck.MTASTSAnalysis.Mx);
+                Assert.Equal("mail.example.com", healthCheck.MTASTSAnalysis.Mx[0]);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        private static int GetFreePort() {
+            var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            l.Start();
+            var p = ((IPEndPoint)l.LocalEndpoint).Port;
+            l.Stop();
+            return p;
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -55,6 +55,8 @@ namespace DomainDetective {
 
         public MTASTSAnalysis MTASTSAnalysis { get; private set; } = new MTASTSAnalysis();
 
+        public string MtaStsPolicyUrlOverride { get; set; }
+
         public CertificateAnalysis CertificateAnalysis { get; private set; } = new CertificateAnalysis();
 
         public SecurityTXTAnalysis SecurityTXTAnalysis { get; private set; } = new SecurityTXTAnalysis();
@@ -172,7 +174,9 @@ namespace DomainDetective {
                         await DNSBLAnalysis.AnalyzeDNSBLRecordsMX(domainName, _logger);
                         break;
                     case HealthCheckType.MTASTS:
-                        MTASTSAnalysis = new MTASTSAnalysis();
+                        MTASTSAnalysis = new MTASTSAnalysis {
+                            PolicyUrlOverride = MtaStsPolicyUrlOverride
+                        };
                         await MTASTSAnalysis.AnalyzePolicy(domainName, _logger);
                         break;
                     case HealthCheckType.TLSRPT:
@@ -333,7 +337,9 @@ namespace DomainDetective {
         }
 
         public async Task VerifyMTASTS(string domainName, CancellationToken cancellationToken = default) {
-            MTASTSAnalysis = new MTASTSAnalysis();
+            MTASTSAnalysis = new MTASTSAnalysis {
+                PolicyUrlOverride = MtaStsPolicyUrlOverride
+            };
             await MTASTSAnalysis.AnalyzePolicy(domainName, _logger);
         }
 

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -74,6 +74,13 @@ namespace DomainDetective {
         internal InternalLogger Logger { get; set; }
 
         /// <summary>
+        /// Gets or sets a policy URL override. When set, this URL is used
+        /// instead of constructing one from the domain name. Primarily
+        /// intended for testing.
+        /// </summary>
+        public string PolicyUrlOverride { get; set; }
+
+        /// <summary>
         /// Resets analysis state so the instance can be reused.
         /// </summary>
         public void Reset() {
@@ -100,7 +107,9 @@ namespace DomainDetective {
             Reset();
             Logger = logger;
             Domain = domainName;
-            string url = $"https://mta-sts.{domainName}/.well-known/mta-sts.txt";
+
+            string url = PolicyUrlOverride ?? $"https://mta-sts.{domainName}/.well-known/mta-sts.txt";
+
             string content = await GetPolicy(url);
             if (content == null) {
                 PolicyPresent = false;


### PR DESCRIPTION
## Summary
- add PolicyUrlOverride to MTASTSAnalysis
- allow DomainHealthCheck to set policy URL override when verifying MTASTS
- add local HTTP server test for fetching an mta-sts policy

## Testing
- `dotnet test --filter TestMTASTSAnalysis`

------
https://chatgpt.com/codex/tasks/task_e_6859be27b53c832eba94169a8a46e3df