### PR TITLE
Add validation and tests for empty parameters

### DIFF
--- a/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
@@ -4,6 +4,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsCommon.Add, "DnsblProvider")]
     public sealed class CmdletAddDnsblProvider : PSCmdlet {
         [Parameter(Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty]
         public string Domain { get; set; }
 
         [Parameter(Mandatory = false)]

--- a/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
+++ b/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsCommon.Get, "WhoisInfo", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletGetWhoisInfo : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletLoadDnsblConfig.cs
+++ b/DomainDetective.PowerShell/CmdletLoadDnsblConfig.cs
@@ -4,6 +4,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet("Load", "DnsblConfig")]
     public sealed class CmdletLoadDnsblConfig : PSCmdlet {
         [Parameter(Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty]
         public string Path { get; set; }
 
         [Parameter(Mandatory = false)]

--- a/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
@@ -4,6 +4,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsCommon.Remove, "DnsblProvider")]
     public sealed class CmdletRemoveDnsblProvider : PSCmdlet {
         [Parameter(Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty]
         public string Domain { get; set; }
 
         [Parameter(ValueFromPipeline = true)]

--- a/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "BimiRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestBimiRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestBlackList.cs
+++ b/DomainDetective.PowerShell/CmdletTestBlackList.cs
@@ -7,6 +7,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DomainBlacklist", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestBlackList : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string[] NameOrIpAddress;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "CaaRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestCaaRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DNSBLRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDNSBLRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string NameOrIpAddress;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -7,6 +7,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DaneRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDaneRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
@@ -7,9 +7,11 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DkimRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDkimRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string[] Selectors;
 
         [Parameter(Mandatory = false, Position = 2, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DmarcRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDmarcRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -8,12 +8,14 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DnsPropagation", DefaultParameterSetName = "ServersFile")]
     public sealed class CmdletTestDnsPropagation : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServersFile")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServersFile")]
         public DnsRecordType RecordType;
 
         [Parameter(Mandatory = true, Position = 2, ParameterSetName = "ServersFile")]
+        [ValidateNotNullOrEmpty]
         public string ServersFile;
 
         [Parameter(Mandatory = false)]

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DnsSec", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDnsSec : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestMxRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestMxRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "MxRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestMxRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestNsRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestNsRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "NsRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestNsRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -5,6 +5,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "OpenRelay", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestOpenRelay : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string HostName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "SecurityTXT", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSecurityTXT : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "SoaRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSoaRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
@@ -7,6 +7,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "SpfRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSpfRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "StartTls", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestStartTls : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
@@ -6,6 +6,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "TlsRptRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestTlsRptRecord : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
         public string DomainName;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -5,6 +5,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "WebsiteCertificate", DefaultParameterSetName = "Url")]
     public sealed class CmdletTestWebsiteCertificate : AsyncPSCmdlet {
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Url")]
+        [ValidateNotNullOrEmpty]
         public string Url;
 
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Url")]

--- a/Module/Tests/DnsblProviderManagement.Tests.ps1
+++ b/Module/Tests/DnsblProviderManagement.Tests.ps1
@@ -4,6 +4,10 @@ Describe 'Add-DnsblProvider cmdlet' {
         $result = Add-DnsblProvider -Domain 'dnsbl.example.com' -Comment 'test'
         $result | Should -Not -BeNullOrEmpty
     }
+    It 'throws if Domain is empty' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        { Add-DnsblProvider -Domain '' } | Should -Throw
+    }
 }
 
 Describe 'Remove-DnsblProvider cmdlet' {
@@ -12,6 +16,10 @@ Describe 'Remove-DnsblProvider cmdlet' {
         $analysis = Add-DnsblProvider -Domain 'remove.example.com'
         $result = $analysis | Remove-DnsblProvider -Domain 'remove.example.com'
         $result | Should -Not -BeNullOrEmpty
+    }
+    It 'throws if Domain is empty' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        { Remove-DnsblProvider -Domain '' } | Should -Throw
     }
 }
 
@@ -30,5 +38,9 @@ Describe 'Load-DnsblConfig cmdlet' {
         $path = "$PSScriptRoot/../../DnsblProviders.sample.json"
         $result = Load-DnsblConfig -Path $path -OverwriteExisting
         $result | Should -Not -BeNullOrEmpty
+    }
+    It 'throws if Path is empty' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        { Load-DnsblConfig -Path '' } | Should -Throw
     }
 }

--- a/Module/Tests/NsRecord.Tests.ps1
+++ b/Module/Tests/NsRecord.Tests.ps1
@@ -4,5 +4,9 @@ Describe 'Test-NsRecord cmdlet' {
         $result = Test-NsRecord -DomainName 'example.com' -DnsEndpoint CloudflareWireFormat
         $result | Should -Not -BeNullOrEmpty
     }
+    It 'throws if DomainName is empty' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        { Test-NsRecord -DomainName '' } | Should -Throw
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `[ValidateNotNullOrEmpty]` to mandatory cmdlet parameters
- check that empty parameters throw in Pester tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --verbosity minimal` *(fails: The build stopped unexpectedly)*
- `pwsh ./Module/DomainDetective.Tests.ps1` *(fails: several tests not run)*

------
https://chatgpt.com/codex/tasks/task_e_6859c0a712c0832e99dffd0d46b2ed10