### PR TITLE
Add DKIM selector probe heuristic

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -112,8 +112,10 @@ namespace DomainDetective {
 
         public async Task VerifyDKIM(string domainName, string[] selectors, CancellationToken cancellationToken = default) {
             if (selectors == null || selectors.Length == 0) {
-                throw new ArgumentException("No DKIM selectors provided.", nameof(selectors));
+                await DKIMAnalysis.QueryWellKnownSelectors(domainName, DnsConfiguration, _logger, cancellationToken);
+                return;
             }
+
             foreach (var selector in selectors) {
                 var dkim = await DnsConfiguration.QueryDNS(name: $"{selector}._domainkey.{domainName}", recordType: DnsRecordType.TXT, filter: "DKIM1", cancellationToken: cancellationToken);
                 await DKIMAnalysis.AnalyzeDkimRecords(selector, dkim, logger: _logger);

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -1,11 +1,17 @@
 using DnsClientX;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using DomainDetective.Definitions;
 
 namespace DomainDetective {
     public class DkimAnalysis {
         public Dictionary<string, DkimRecordAnalysis> AnalysisResults { get; private set; } = new Dictionary<string, DkimRecordAnalysis>();
+
+        public void Reset() {
+            AnalysisResults = new Dictionary<string, DkimRecordAnalysis>();
+        }
 
         public async Task AnalyzeDkimRecords(string selector, IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             await Task.Yield(); // To avoid warning about lack of 'await'
@@ -72,6 +78,20 @@ namespace DomainDetective {
             analysis.KeyTypeExists = !string.IsNullOrEmpty(analysis.KeyType);
 
             AnalysisResults[selector] = analysis;
+        }
+
+        public async Task<string?> QueryWellKnownSelectors(string domainName, DnsConfiguration dnsConfiguration, InternalLogger logger, CancellationToken cancellationToken = default) {
+            Reset();
+
+            foreach (var selector in DKIMSelectors.GuessSelectors()) {
+                var dkim = await dnsConfiguration.QueryDNS($"{selector}._domainkey.{domainName}", DnsRecordType.TXT, "DKIM1", cancellationToken);
+                if (dkim.Any()) {
+                    await AnalyzeDkimRecords(selector, dkim, logger);
+                    return selector;
+                }
+            }
+
+            return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- add `QueryWellKnownSelectors` helper to probe DKIM selectors sequentially
- use the new helper in `DomainHealthCheck.VerifyDKIM` when selectors are not provided

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_685a44a86b48832e9797dae5c0532d7f