### PR TITLE
Add body capture option to HttpAnalysis

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -24,13 +24,14 @@ namespace DomainDetective.Tests {
 
             try {
                 var analysis = new HttpAnalysis();
-                await analysis.AnalyzeUrl(prefix, true, new InternalLogger(), collectHeaders: true);
+                await analysis.AnalyzeUrl(prefix, true, new InternalLogger(), collectHeaders: true, captureBody: true);
                 Assert.True(analysis.IsReachable);
                 Assert.Equal(200, analysis.StatusCode);
                 Assert.True(analysis.ResponseTime > TimeSpan.Zero);
                 Assert.True(analysis.HstsPresent);
                 Assert.Equal(analysis.ProtocolVersion >= new Version(2, 0), analysis.Http2Supported);
                 Assert.Equal("default-src 'self'", analysis.SecurityHeaders["Content-Security-Policy"]);
+                Assert.Equal("ok", analysis.Body);
             } finally {
                 listener.Stop();
                 await serverTask;


### PR DESCRIPTION
## Summary
- support capturing the HTTP response body in `HttpAnalysis`
- verify body capture in unit tests

## Testing
- `dotnet test` *(fails: DNS/network dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7d0d804832e8ebbd7ba7619af1b