### PR TITLE
Add certificate chain support

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -10,6 +10,9 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 
+        [Parameter(Mandatory = false)]
+        public SwitchParameter ShowChain;
+
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
@@ -24,7 +27,11 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking SMTP TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckSmtpTlsHost(HostName, Port);
-            WriteObject(_healthCheck.SmtpTlsAnalysis.ServerResults[$"{HostName}:{Port}"]);
+            var result = _healthCheck.SmtpTlsAnalysis.ServerResults[$"{HostName}:{Port}"];
+            WriteObject(result);
+            if (ShowChain && result.Chain.Count > 0) {
+                WriteObject(result.Chain, true);
+            }
         }
     }
 }

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -11,6 +11,9 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Url")]
         public int Port = 443;
 
+        [Parameter(Mandatory = false)]
+        public SwitchParameter ShowChain;
+
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
@@ -26,6 +29,9 @@ namespace DomainDetective.PowerShell {
             _logger.WriteVerbose("Verifying website certificate for {0}", Url);
             await _healthCheck.VerifyWebsiteCertificate(Url, Port);
             WriteObject(_healthCheck.CertificateAnalysis);
+            if (ShowChain && _healthCheck.CertificateAnalysis.Chain.Count > 0) {
+                WriteObject(_healthCheck.CertificateAnalysis.Chain, true);
+            }
         }
     }
 }

--- a/DomainDetective/Protocols/SMTPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPTLSAnalysis.cs
@@ -17,6 +17,7 @@ namespace DomainDetective {
             public SslProtocols Protocol { get; set; }
             public CipherAlgorithmType CipherAlgorithm { get; set; }
             public int CipherStrength { get; set; }
+            public List<X509Certificate2> Chain { get; } = new();
         }
 
         public Dictionary<string, TlsResult> ServerResults { get; } = new();
@@ -85,6 +86,12 @@ namespace DomainDetective {
                             result.CertificateValid = errors == SslPolicyErrors.None;
                             if (certificate is X509Certificate2 cert) {
                                 result.DaysToExpire = (int)(cert.NotAfter - DateTime.Now).TotalDays;
+                                result.Chain.Clear();
+                                if (chain != null) {
+                                    foreach (var element in chain.ChainElements) {
+                                        result.Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
+                                    }
+                                }
                             }
                             return true;
                         });


### PR DESCRIPTION
## Summary
- expose certificate chain for HTTP and SMTP TLS analysis
- include chain output in optional PowerShell parameters

## Testing
- `dotnet test` *(fails: The tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7c77cc0832eaf3a41b8bb863212