### PR TITLE
Add abuse contact fields to WHOIS

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -91,5 +91,49 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task ParsesRegistrarAbuseContactInfo() {
+            var response = string.Join("\n", new[] {
+                "Domain Name: example.sample",
+                "Registrar: Example Registrar",
+                "Registrar Abuse Contact Email: abuse@example.com",
+                "Registrar Abuse Contact Phone: +1.1234567890",
+                "Name Server: ns1.example.sample"
+            });
+
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                await reader.ReadLineAsync();
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true };
+                await writer.WriteAsync(response);
+            });
+
+            try {
+                var whois = new WhoisAnalysis();
+                var field = typeof(WhoisAnalysis).GetField("WhoisServers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var servers = (System.Collections.Generic.Dictionary<string, string>?)field?.GetValue(whois);
+                Assert.NotNull(servers);
+                var lockField = typeof(WhoisAnalysis).GetField("_whoisServersLock", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var lockObj = lockField?.GetValue(whois);
+                Assert.NotNull(lockObj);
+                lock (lockObj!) {
+                    servers!["sample"] = $"localhost:{port}";
+                }
+
+                await whois.QueryWhoisServer("example.sample");
+
+                Assert.Equal("abuse@example.com", whois.RegistrarAbuseEmail);
+                Assert.Equal("+1.1234567890", whois.RegistrarAbusePhone);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -31,6 +31,8 @@ public class WhoisAnalysis {
     public string RegistrarTel { get; set; }
     public string RegistrarWebsite { get; set; }
     public string RegistrarEmail { get; set; }
+    public string RegistrarAbuseEmail { get; set; }
+    public string RegistrarAbusePhone { get; set; }
     public string WhoisData { get; set; }
 
     private static readonly InternalLogger _logger = new();
@@ -557,9 +559,13 @@ public class WhoisAnalysis {
             } else if (line.StartsWith("   Name Server:")) {
                 NameServers.Add(line.Substring("   Name Server:".Length).Trim());
             } else if (line.StartsWith("   Registrar Abuse Contact Email:")) {
-                RegistrarEmail = line.Substring("   Registrar Abuse Contact Email:".Length).Trim();
+                var value = line.Substring("   Registrar Abuse Contact Email:".Length).Trim();
+                RegistrarEmail = value;
+                RegistrarAbuseEmail = value;
             } else if (line.StartsWith("   Registrar Abuse Contact Phone:")) {
-                RegistrarTel = line.Substring("   Registrar Abuse Contact Phone:".Length).Trim();
+                var value = line.Substring("   Registrar Abuse Contact Phone:".Length).Trim();
+                RegistrarTel = value;
+                RegistrarAbusePhone = value;
             } else if (line.StartsWith("   DNSSEC:")) {
                 DnsSec = line.Substring("   DNSSEC:".Length).Trim();
             }
@@ -586,9 +592,13 @@ public class WhoisAnalysis {
             } else if (trimmedLine.StartsWith("Name Server:")) {
                 NameServers.Add(trimmedLine.Substring("Name Server:".Length).Trim());
             } else if (trimmedLine.StartsWith("Registrar Abuse Contact Email:")) {
-                RegistrarEmail = trimmedLine.Substring("Registrar Abuse Contact Email:".Length).Trim();
+                var value = trimmedLine.Substring("Registrar Abuse Contact Email:".Length).Trim();
+                RegistrarEmail = value;
+                RegistrarAbuseEmail = value;
             } else if (trimmedLine.StartsWith("Registrar Abuse Contact Phone:")) {
-                RegistrarTel = trimmedLine.Substring("Registrar Abuse Contact Phone:".Length).Trim();
+                var value = trimmedLine.Substring("Registrar Abuse Contact Phone:".Length).Trim();
+                RegistrarTel = value;
+                RegistrarAbusePhone = value;
             } else if (trimmedLine.StartsWith("Registrant Organization:")) {
                 RegisteredTo = trimmedLine.Substring("Registrant Organization:".Length).Trim();
             } else if (trimmedLine.StartsWith("Registrant Country:")) {
@@ -635,9 +645,13 @@ public class WhoisAnalysis {
             } else if (trimmedLine.StartsWith("Registrant Country:")) {
                 Country = trimmedLine.Substring("Registrant Country:".Length).Trim();
             } else if (trimmedLine.StartsWith("Registrar Abuse Contact Email:")) {
-                RegistrarEmail = trimmedLine.Substring("Registrar Abuse Contact Email:".Length).Trim();
+                var value = trimmedLine.Substring("Registrar Abuse Contact Email:".Length).Trim();
+                RegistrarEmail = value;
+                RegistrarAbuseEmail = value;
             } else if (trimmedLine.StartsWith("Registrar Abuse Contact Phone:")) {
-                RegistrarTel = trimmedLine.Substring("Registrar Abuse Contact Phone:".Length).Trim();
+                var value = trimmedLine.Substring("Registrar Abuse Contact Phone:".Length).Trim();
+                RegistrarTel = value;
+                RegistrarAbusePhone = value;
             }
         }
     }


### PR DESCRIPTION
## Summary
- store registrar abuse contact details
- parse abuse contact lines if present in WHOIS data
- test abuse contact parsing

## Testing
- `dotnet test` *(fails: The argument /workspace/... is invalid etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6859c7939b8c832ea84e7bc0d577e5bf