### PR TITLE
Add SecurityTXT check

### DIFF
--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestSecurityTXTAnalysis {
+        [Fact]
+        public async Task ValidSecurityTxtIsParsed() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var expires = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var content = $"Contact: mailto:admin@example.com\nExpires: {expires}";
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "text/plain";
+                var buffer = Encoding.UTF8.GetBytes(content);
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.Verify(prefix.Replace("http://", string.Empty).TrimEnd('/'), new[] { HealthCheckType.SECURITYTXT });
+                Assert.True(healthCheck.SecurityTXTAnalysis.RecordPresent);
+                Assert.True(healthCheck.SecurityTXTAnalysis.RecordValid);
+                Assert.True(healthCheck.SecurityTXTAnalysis.FallbackUsed);
+                Assert.Contains("admin@example.com", healthCheck.SecurityTXTAnalysis.ContactEmail);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task MissingContactMakesRecordInvalid() {
+            var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var expires = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var content = $"Expires: {expires}";
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "text/plain";
+                var buffer = Encoding.UTF8.GetBytes(content);
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.Verify(prefix.Replace("http://", string.Empty).TrimEnd('/'), new[] { HealthCheckType.SECURITYTXT });
+                Assert.True(healthCheck.SecurityTXTAnalysis.RecordPresent);
+                Assert.False(healthCheck.SecurityTXTAnalysis.RecordValid);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        private static int GetFreePort() {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using PgpCore;
 using PgpCore.Models;
-using System.IO;
 
 namespace DomainDetective {
     public class SecurityTXTAnalysis {
@@ -67,7 +66,7 @@ namespace DomainDetective {
                     }
                 }
             } catch (Exception ex) {
-                // Log the exception
+                Logger?.WriteDebug("Failed to download security.txt from {0}: {1}", url, ex.Message);
                 return null;
             }
         }
@@ -113,8 +112,8 @@ namespace DomainDetective {
                     string value = line.Substring(colonIndex + 1).Trim();
 
                     // Add the value to the appropriate list in the record
-                    switch (currentField) {
-                        case "Contact":
+                    switch (currentField.ToLowerInvariant()) {
+                        case "contact":
                             if (value.StartsWith("mailto:")) {
                                 ContactEmail.Add(value.Substring("mailto:".Length));
                             } else if (value.Contains("@")) {
@@ -123,25 +122,25 @@ namespace DomainDetective {
                                 ContactWebsite.Add(value);
                             }
                             break;
-                        case "Acknowledgments":
+                        case "acknowledgments":
                             Acknowledgments.Add(value);
                             break;
-                        case "Preferred-Languages":
+                        case "preferred-languages":
                             PreferredLanguages.Add(value);
                             break;
-                        case "Encryption":
+                        case "encryption":
                             Encryption.Add(value);
                             break;
-                        case "Policy":
+                        case "policy":
                             Policy.Add(value);
                             break;
-                        case "Hiring":
+                        case "hiring":
                             Hiring.Add(value);
                             break;
-                        case "Canonical":
+                        case "canonical":
                             Canonical.Add(value);
                             break;
-                        case "Expires":
+                        case "expires":
                             if (hasSeenExpires) {
                                 Logger.WriteWarning("Multiple Expires fields found");
                                 RecordValid = false;
@@ -149,7 +148,7 @@ namespace DomainDetective {
                             Expires = value;
                             hasSeenExpires = true;
                             break;
-                        case "Signature-Encryption":
+                        case "signature-encryption":
                             if (hasSeenSignatureEncryption) {
                                 Logger.WriteWarning("Multiple Signature-Encryption fields found");
                                 RecordValid = false;


### PR DESCRIPTION
## Summary
- improve SecurityTXTAnalysis to log download failures and parse fields in a case-insensitive way
- add tests for SecurityTXT parser using a local HTTP server

## Testing
- `dotnet build`
- `dotnet test` *(fails: Assert.True() etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6859c78e3040832ea3491bfa27af1fda