### PR TITLE
Add more cmdlet examples

### DIFF
--- a/Module/Examples/Example.ManageDnsblProviders.ps1
+++ b/Module/Examples/Example.ManageDnsblProviders.ps1
@@ -1,0 +1,15 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Added = Add-DnsblProvider -Domain 'dnsbl.example.com' -Comment 'custom'
+$Added | Format-Table
+
+$Removed = Remove-DnsblProvider -Domain 'dnsbl.example.com'
+$Removed | Format-Table
+
+$Cleared = Clear-DnsblProvider
+$Cleared | Format-Table
+
+$Loaded = Load-DnsblConfig -Path $PSScriptRoot/../../DnsblProviders.sample.json -OverwriteExisting
+$Loaded | Format-Table

--- a/Module/Examples/Example.TestCaaRecord.ps1
+++ b/Module/Examples/Example.TestCaaRecord.ps1
@@ -1,0 +1,12 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Results = Test-CaaRecord -DomainName 'evotec.pl'
+$Results | Format-Table
+
+$Google = Test-CaaRecord -DomainName 'google.com'
+$Google | Format-Table
+
+$VerboseExample = Test-CaaRecord -DomainName 'example.com' -Verbose
+$VerboseExample | Format-Table

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -1,0 +1,12 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Results = Test-DnsPropagation -DomainName 'google.com' -RecordType A -CompareResults
+$Results | Format-Table
+
+$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $PSScriptRoot/../Data/DNS/PublicDNS.json
+$PublicServers | Format-Table
+
+$TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults
+$TxtCheck | Format-Table

--- a/Module/Examples/Example.TestDomainHealth.ps1
+++ b/Module/Examples/Example.TestDomainHealth.ps1
@@ -1,0 +1,12 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Health = Test-DomainHealth -DomainName 'evotec.pl' -Verbose
+$Health | Format-Table
+
+$EmailHealth = Test-DomainHealth -DomainName 'gmail.com' -HealthCheckType SPF, DMARC
+$EmailHealth | Format-Table
+
+$DkimHealth = Test-DomainHealth -DomainName 'example.com' -DnsEndpoint Cloudflare -DkimSelectors 'selector1','selector2' -HealthCheckType DKIM
+$DkimHealth | Format-Table

--- a/Module/Examples/Example.TestNsRecord.ps1
+++ b/Module/Examples/Example.TestNsRecord.ps1
@@ -1,0 +1,12 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Results = Test-NsRecord -DomainName 'google.com' -Verbose
+$Results | Format-Table
+
+$Cloudflare = Test-NsRecord -DomainName 'example.com' -DnsEndpoint Cloudflare
+$Cloudflare | Format-Table
+
+$Evotec = Test-NsRecord -DomainName 'evotec.pl' -Verbose
+$Evotec | Format-Table

--- a/Module/Examples/Example.TestSecurityTXT.ps1
+++ b/Module/Examples/Example.TestSecurityTXT.ps1
@@ -1,0 +1,12 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Results = Test-SecurityTXT -DomainName 'google.com' -Verbose
+$Results | Format-Table
+
+$Github = Test-SecurityTXT -DomainName 'github.com'
+$Github | Format-Table
+
+$Evotec = Test-SecurityTXT -DomainName 'evotec.pl'
+$Evotec | Format-Table

--- a/Module/Examples/Example.TestStartTls.ps1
+++ b/Module/Examples/Example.TestStartTls.ps1
@@ -1,0 +1,12 @@
+﻿# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$Gmail = Test-StartTls -DomainName 'gmail.com' -Verbose
+$Gmail | Format-Table
+
+$Evotec = Test-StartTls -DomainName 'evotec.pl' -Port 25
+$Evotec | Format-Table
+
+$Example = Test-StartTls -DomainName 'example.com' -DnsEndpoint Cloudflare
+$Example | Format-Table


### PR DESCRIPTION
## Summary
- add example scripts for NS record, DNS propagation, CAA records, security.txt checks, STARTTLS, DNSBL management
- include domain health example covering multiple health checks

## Testing
- `dotnet test DomainDetective.sln` *(fails: 13 failed, 103 passed)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6859c76e9b30832ea0a9c3bea79d669e