### PR TITLE
Fix protocol version assignment

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -10,6 +10,7 @@ namespace DomainDetective.Tests {
             var analysis = new CertificateAnalysis();
             await analysis.AnalyzeUrl("https://nonexistent.invalid", 443, logger);
             Assert.False(analysis.IsReachable);
+            Assert.Null(analysis.ProtocolVersion);
         }
 
         [Fact]
@@ -23,6 +24,7 @@ namespace DomainDetective.Tests {
 
             Assert.NotNull(eventArgs);
             Assert.Contains(nameof(HttpRequestException), eventArgs!.FullMessage);
+            Assert.Null(analysis.ProtocolVersion);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -55,6 +55,7 @@ namespace DomainDetective.Tests {
                 await analysis.AnalyzeUrl(prefix, false, new InternalLogger());
                 Assert.False(analysis.IsReachable);
                 Assert.Equal(404, analysis.StatusCode);
+                Assert.Null(analysis.ProtocolVersion);
             } finally {
                 listener.Stop();
                 await serverTask;
@@ -68,6 +69,7 @@ namespace DomainDetective.Tests {
             await analysis.AnalyzeUrl(url, false, new InternalLogger());
             Assert.False(analysis.IsReachable);
             Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
+            Assert.Null(analysis.ProtocolVersion);
         }
 
         [Fact]

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -48,17 +48,22 @@ namespace DomainDetective {
                             VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
                         };
                         using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
-                        ProtocolVersion = response.Version;
-                        Http3Supported = response.Version >= HttpVersion.Version30;
-                        Http2Supported = response.Version >= HttpVersion.Version20;
+                        IsReachable = response.IsSuccessStatusCode;
+                        if (IsReachable) {
+                            ProtocolVersion = response.Version;
+                            Http3Supported = response.Version >= HttpVersion.Version30;
+                            Http2Supported = response.Version >= HttpVersion.Version20;
+                        }
 #else
                         var request = new HttpRequestMessage(HttpMethod.Get, url);
                         using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
-                        ProtocolVersion = response.Version;
-                        Http2Supported = response.Version.Major >= 2;
-                        Http3Supported = false;
-#endif
                         IsReachable = response.IsSuccessStatusCode;
+                        if (IsReachable) {
+                            ProtocolVersion = response.Version;
+                            Http2Supported = response.Version.Major >= 2;
+                            Http3Supported = false;
+                        }
+#endif
                         if (Certificate == null && Http3Supported) {
                             try {
                                 var uri = new Uri(url);

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -89,15 +89,17 @@ namespace DomainDetective {
                 sw.Stop();
                 StatusCode = (int)response.StatusCode;
                 ResponseTime = sw.Elapsed;
-                ProtocolVersion = response.Version;
                 IsReachable = response.IsSuccessStatusCode;
+                if (IsReachable) {
+                    ProtocolVersion = response.Version;
 #if NET6_0_OR_GREATER
-                Http3Supported = response.Version >= HttpVersion.Version30;
-                Http2Supported = response.Version >= HttpVersion.Version20;
+                    Http3Supported = response.Version >= HttpVersion.Version30;
+                    Http2Supported = response.Version >= HttpVersion.Version20;
 #else
-                Http2Supported = response.Version.Major >= 2;
-                Http3Supported = false;
+                    Http2Supported = response.Version.Major >= 2;
+                    Http3Supported = false;
 #endif
+                }
                 if (checkHsts) {
                     HstsPresent = response.Headers.Contains("Strict-Transport-Security");
                 }


### PR DESCRIPTION
## Summary
- ensure ProtocolVersion is only set when a response succeeds
- update failing tests to expect null ProtocolVersion on failure

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_685a50330f78832eb49bc9501bcc40c2