### PR TITLE
Fix DS record hex validation

### DIFF
--- a/DomainDetective.Tests/TestDNSSECInvalidDs.cs
+++ b/DomainDetective.Tests/TestDNSSECInvalidDs.cs
@@ -1,0 +1,14 @@
+using System.Reflection;
+
+namespace DomainDetective.Tests {
+    public class TestDnssecInvalidDs {
+        [Fact]
+        public void InvalidDsDigestReturnsFalse() {
+            var dnskey = "257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==";
+            var dsRecord = "2371 ECDSAP256SHA256 2 c988ec423e3880eb8dd8a46fe06ca230ee23f35b578d64e78b29c3e1c83d245z";
+            var method = typeof(DNSSecAnalysis).GetMethod("VerifyDsMatch", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { dnskey, dsRecord, "example.com" });
+            Assert.False(result);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSKeyAnalysis.cs
+++ b/DomainDetective/Protocols/DNSKeyAnalysis.cs
@@ -1,10 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 
 namespace DomainDetective.Protocols {
-    internal class DNSKeyAnalysis {
+    internal static class DNSKeyAnalysis {
+        internal static bool IsHexadecimal(string input) {
+            return Regex.IsMatch(input ?? string.Empty, @"\A[0-9a-fA-F]+\z");
+        }
     }
 }

--- a/DomainDetective/Protocols/DNSSecAnalysis.cs
+++ b/DomainDetective/Protocols/DNSSecAnalysis.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
+using DomainDetective.Protocols;
 
 namespace DomainDetective {
     /// <summary>
@@ -121,6 +122,9 @@ namespace DomainDetective {
                 var dsAlgorithm = AlgorithmNumber(dsParts[1]);
                 var digestType = int.Parse(dsParts[2]);
                 var digest = dsParts[3];
+                if (!DNSKeyAnalysis.IsHexadecimal(digest)) {
+                    return false;
+                }
 
                 int computedKeyTag = ComputeKeyTag(rdata);
                 if (computedKeyTag != keyTag || dsAlgorithm != algorithm) {


### PR DESCRIPTION
## Summary
- validate DS record digests contain only hex characters
- expose regex helper in `DNSKeyAnalysis`
- add test for invalid DS record digests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: Assert.True() failure in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_685a50104504832eb354d3ec98aef800