### PR TITLE
Add nicer DKIM cmdlet output

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
@@ -20,6 +20,9 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Raw;
+
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
@@ -35,7 +38,12 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DKIM records for domain: {0}", DomainName);
             await healthCheck.VerifyDKIM(DomainName, Selectors);
-            WriteObject(healthCheck.DKIMAnalysis);
+            if (Raw) {
+                WriteObject(healthCheck.DKIMAnalysis);
+            } else {
+                var output = OutputHelper.Convert(healthCheck.DKIMAnalysis);
+                WriteObject(output, true);
+            }
         }
     }
 }

--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.PowerShell {
+    internal static class OutputHelper {
+        public static IEnumerable<DkimRecordInfo> Convert(DkimAnalysis analysis) {
+            foreach (var kvp in analysis.AnalysisResults) {
+                var result = kvp.Value;
+                yield return new DkimRecordInfo {
+                    Selector = kvp.Key,
+                    Name = result.Name,
+                    DkimRecord = result.DkimRecord,
+                    DkimRecordExists = result.DkimRecordExists,
+                    StartsCorrectly = result.StartsCorrectly,
+                    PublicKeyExists = result.PublicKeyExists,
+                    KeyTypeExists = result.KeyTypeExists,
+                    PublicKey = result.PublicKey,
+                    ServiceType = result.ServiceType,
+                    Flags = result.Flags,
+                    KeyType = result.KeyType,
+                    HashAlgorithm = result.HashAlgorithm
+                };
+            }
+        }
+    }
+
+    public class DkimRecordInfo {
+        public string Selector { get; set; }
+        public string Name { get; set; }
+        public string DkimRecord { get; set; }
+        public bool DkimRecordExists { get; set; }
+        public bool StartsCorrectly { get; set; }
+        public bool PublicKeyExists { get; set; }
+        public bool KeyTypeExists { get; set; }
+        public string PublicKey { get; set; }
+        public string ServiceType { get; set; }
+        public string Flags { get; set; }
+        public string KeyType { get; set; }
+        public string HashAlgorithm { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- add `OutputHelper` for PowerShell-friendly DKIM info
- support `-Raw` switch on `Test-DkimRecord`
- show converted results by default

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: Uri creation issues)*
- `dotnet build DomainDetective.sln -c Debug`
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685a54b3985c832eb38853e2b7e384d7