### PR TITLE
Add DNSSEC record validation

### DIFF
--- a/DomainDetective.Tests/TestDNSSECRecordValidation.cs
+++ b/DomainDetective.Tests/TestDNSSECRecordValidation.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using DnsClientX;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnssecRecordValidation {
+        [Theory]
+        [InlineData("cloudflare.com", DnsRecordType.A, true)]
+        [InlineData("dnssec-failed.org", DnsRecordType.A, false)]
+        public async Task ValidateRecordForZone(string domain, DnsRecordType type, bool expected) {
+            var analysis = new DNSSecAnalysis();
+            bool result = await analysis.ValidateRecord(domain, type);
+            Assert.Equal(expected, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ValidateRecord` method to `DNSSecAnalysis`
- test DNSSEC validation for signed/failed zones

## Testing
- `dotnet build`
- `dotnet test` *(fails: Assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_685a554eaa60832ea67880df0248bcb2