### PR TITLE
Fix TLSRPT parsing with CNAME answers

### DIFF
--- a/DomainDetective.Tests/TestTLSRPTAnalysis.cs
+++ b/DomainDetective.Tests/TestTLSRPTAnalysis.cs
@@ -1,4 +1,6 @@
 using DomainDetective;
+using DnsClientX;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -21,6 +23,25 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckTLSRPT(record);
             Assert.False(healthCheck.TLSRPTAnalysis.RuaDefined);
             Assert.False(healthCheck.TLSRPTAnalysis.PolicyValid);
+        }
+
+        [Fact]
+        public async Task SkipCnameRecordBeforeParsing() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer {
+                    DataRaw = "alias.example.com",
+                    Type = DnsRecordType.CNAME
+                },
+                new DnsAnswer {
+                    DataRaw = "v=TLSRPTv1;rua=mailto:reports@example.com",
+                    Type = DnsRecordType.TXT
+                }
+            };
+
+            var analysis = new TLSRPTAnalysis();
+            await analysis.AnalyzeTlsRptRecords(answers, new InternalLogger());
+
+            Assert.True(analysis.PolicyValid);
         }
     }
 }

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -35,7 +35,9 @@ namespace DomainDetective {
                 return;
             }
 
-            var recordList = dnsResults.ToList();
+            var recordList = dnsResults
+                .Where(r => r.Type != DnsRecordType.CNAME)
+                .ToList();
             TlsRptRecordExists = recordList.Any();
             if (!TlsRptRecordExists) {
                 logger?.WriteVerbose("No TLSRPT record found.");


### PR DESCRIPTION
## Summary
- filter out CNAME DNS answers when analyzing TLSRPT records
- test TLSRPT parsing with a CNAME DNS answer

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Failed: 13, Passed: 110)*

------
https://chatgpt.com/codex/tasks/task_e_685a556bafcc832e9f71f83381303621