### PR TITLE
Add cancellation support to OpenRelay

### DIFF
--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -122,5 +122,31 @@ namespace DomainDetective.Tests {
                 await serverTask2;
             }
         }
+
+        [Fact]
+        public async Task CancelsDuringAnalysis() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            using var cts = new System.Threading.CancellationTokenSource();
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await System.Threading.Tasks.Task.Delay(System.Threading.Timeout.Infinite, cts.Token).ContinueWith(_ => { });
+            }, cts.Token);
+
+            var analysis = new OpenRelayAnalysis();
+            var analyzeTask = analysis.AnalyzeServer("localhost", port, new InternalLogger(), cts.Token);
+            cts.Cancel();
+
+            await Assert.ThrowsAsync<System.OperationCanceledException>(() => analyzeTask);
+
+            listener.Stop();
+            try { await serverTask; } catch (System.OperationCanceledException) { }
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -208,7 +208,7 @@ namespace DomainDetective {
                         var mxRecordsForRelay = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
                         var hosts = mxRecordsForRelay.Select(r => r.Data.Split(' ')[1].Trim('.'));
                         foreach (var host in hosts) {
-                            await OpenRelayAnalysis.AnalyzeServer(host, 25, _logger);
+                            await OpenRelayAnalysis.AnalyzeServer(host, 25, _logger, cancellationToken);
                         }
                         break;
                     case HealthCheckType.STARTTLS:
@@ -319,7 +319,7 @@ namespace DomainDetective {
         }
 
         public async Task CheckOpenRelayHost(string host, int port = 25, CancellationToken cancellationToken = default) {
-            await OpenRelayAnalysis.AnalyzeServer(host, port, _logger);
+            await OpenRelayAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
         public async Task CheckStartTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -2,19 +2,21 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DomainDetective {
     public class OpenRelayAnalysis {
         public Dictionary<string, bool> ServerResults { get; private set; } = new();
 
-        public async Task AnalyzeServer(string host, int port, InternalLogger logger) {
+        public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
             ServerResults.Clear();
-            var allows = await TryRelay(host, port, logger);
+            cancellationToken.ThrowIfCancellationRequested();
+            var allows = await TryRelay(host, port, logger, cancellationToken);
             ServerResults[$"{host}:{port}"] = allows;
         }
 
-        private static async Task<bool> TryRelay(string host, int port, InternalLogger logger) {
+        private static async Task<bool> TryRelay(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
             using var client = new TcpClient();
             try {
                 await client.ConnectAsync(host, port);
@@ -23,10 +25,13 @@ namespace DomainDetective {
                 using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
 
                 await reader.ReadLineAsync();
+                cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync($"HELO example.com");
                 await reader.ReadLineAsync();
+                cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync("MAIL FROM:<test@example.com>");
                 var mailResp = await reader.ReadLineAsync();
+                cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync("RCPT TO:<test@example.org>");
                 var rcptResp = await reader.ReadLineAsync();
                 await writer.WriteLineAsync("QUIT");
@@ -37,6 +42,8 @@ namespace DomainDetective {
                 logger?.WriteVerbose($"RCPT TO response: {rcptResp}");
 
                 return mailResp != null && mailResp.StartsWith("250") && rcptResp != null && rcptResp.StartsWith("250");
+            } catch (OperationCanceledException) {
+                throw;
             } catch (Exception ex) {
                 logger?.WriteError("Open relay check failed for {0}:{1} - {2}", host, port, ex.Message);
                 return false;


### PR DESCRIPTION
## Summary
- propagate cancellation tokens to OpenRelayAnalysis
- forward cancellation in DomainHealthCheck
- add unit test for cancellation behaviour

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: TestSOAAnalysis.VerifySoaByDomain, TestDMARCAnalysis.TestDMARCByDomain, TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestSpfAnalysis.TestSpfOver255, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestDkimAnalysis.TestDKIMByDomain, TestCertificateHTTP.UnreachableHostLogsExceptionType, TestAll.TestAllHealthChecks, TestCAAAnalysis.TestCAARecordByDomain, TestDkimGuess.GuessSelectorsForDomain)*


------
https://chatgpt.com/codex/tasks/task_e_685a5574ebfc832e97d061d0d36e19cc