### PR TITLE
Fix HttpListener disposal in tests

### DIFF
--- a/DomainDetective.Tests/TestHPKPAnalysis.cs
+++ b/DomainDetective.Tests/TestHPKPAnalysis.cs
@@ -9,7 +9,7 @@ namespace DomainDetective.Tests {
     public class TestHPKPAnalysis {
         [Fact]
         public async Task DetectsHeaderAndValidPins() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
@@ -40,7 +40,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task InvalidPinFormat() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
@@ -63,7 +63,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task HeaderMissing() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();

--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.Tests {
     public class TestHPKPHealthCheck {
         [Fact]
         public async Task VerifyViaHealthCheck() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.Tests {
     public class TestHTTPAnalysis {
         [Fact]
         public async Task DetectStatusCodeAndHsts() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
@@ -40,7 +40,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task NotFoundStatusSetsIsReachableFalse() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
@@ -74,7 +74,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DoesNotCollectHeadersWhenDisabled() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
@@ -97,12 +97,12 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task FollowsRedirectsWhenUsingHttp3() {
-            var listener1 = new HttpListener();
+            using var listener1 = new HttpListener();
             var prefix1 = $"http://localhost:{GetFreePort()}/";
             listener1.Prefixes.Add(prefix1);
             listener1.Start();
 
-            var listener2 = new HttpListener();
+            using var listener2 = new HttpListener();
             var prefix2 = $"http://localhost:{GetFreePort()}/";
             listener2.Prefixes.Add(prefix2);
             listener2.Start();
@@ -136,7 +136,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task ThrowsWhenMaxRedirectsExceeded() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();

--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -49,7 +49,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task FetchPolicyFromServer() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var port = GetFreePort();
             var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);

--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Tests {
     public class TestSecurityTXTAnalysis {
         [Fact]
         public async Task ValidSecurityTxtIsParsed() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
@@ -37,7 +37,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task MissingContactMakesRecordInvalid() {
-            var listener = new HttpListener();
+            using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();


### PR DESCRIPTION
## Summary
- dispose HttpListener instances using `using` across HTTP-based tests

## Testing
- `dotnet test -c Release` *(fails: DomainDetective.Tests.dll)*

------
https://chatgpt.com/codex/tasks/task_e_685a58a845dc832ea3c5c86d61aac32e