### PR TITLE
Add shared RNG for server selection

### DIFF
--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -51,6 +51,14 @@ namespace DomainDetective {
     /// </summary>
     public class DnsPropagationAnalysis {
         private readonly List<PublicDnsEntry> _servers = new();
+        /// <summary>
+        /// Random number generator used for selecting a subset of servers.
+        /// </summary>
+        /// <remarks>
+        /// <para>This instance is shared and not thread-safe. Callers must
+        /// synchronize access when <see cref="FilterServers"/> is used concurrently.</para>
+        /// </remarks>
+        private static readonly Random _rnd = new();
 
         /// <summary>
         /// Gets the collection of configured DNS servers.
@@ -165,8 +173,7 @@ namespace DomainDetective {
                 query = query.Where(s => s.Location != null && s.Location.IndexOf(location, StringComparison.OrdinalIgnoreCase) >= 0);
             }
             if (take.HasValue) {
-                var rnd = new Random();
-                query = query.OrderBy(_ => rnd.Next()).Take(take.Value);
+                query = query.OrderBy(_ => _rnd.Next()).Take(take.Value);
             }
             return query.ToList();
         }


### PR DESCRIPTION
## Summary
- centralize RNG instance for selecting DNS servers
- document thread-safety considerations

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln --no-build -c Release` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685a589d2604832ea65dd85640f96384