### PR TITLE
Fix trimming of DNS server fields

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -75,5 +75,22 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, groups.First().Value.Count);
             Assert.Equal(IPAddress.Parse("2001:db8::1").ToString(), groups.Keys.First());
         }
+
+        [Fact]
+        public void LoadServersTrimsWhitespace() {
+            var json = "[{\"Country\":\" Test \",\"IPAddress\":\"1.2.3.4\",\"HostName\":\" example.com \",\"Location\":\" Somewhere \",\"ASN\":\"123\",\"ASNName\":\" Example ASN \"}]";
+
+            var file = Path.GetTempFileName();
+            File.WriteAllText(file, json);
+
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadServers(file, clearExisting: true);
+
+            var server = Assert.Single(analysis.Servers);
+            Assert.Equal("Test", server.Country);
+            Assert.Equal("example.com", server.HostName);
+            Assert.Equal("Somewhere", server.Location);
+            Assert.Equal("Example ASN", server.ASNName);
+        }
     }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -77,9 +77,20 @@ namespace DomainDetective {
             if (servers == null) {
                 return;
             }
+
             foreach (var entry in servers) {
-                if (_servers.All(s => s.IPAddress != entry.IPAddress)) {
-                    _servers.Add(entry);
+                var trimmed = new PublicDnsEntry {
+                    Country = entry.Country?.Trim(),
+                    IPAddress = entry.IPAddress,
+                    HostName = entry.HostName?.Trim(),
+                    Location = entry.Location?.Trim(),
+                    ASN = entry.ASN,
+                    ASNName = entry.ASNName?.Trim(),
+                    Enabled = entry.Enabled
+                };
+
+                if (_servers.All(s => s.IPAddress != trimmed.IPAddress)) {
+                    _servers.Add(trimmed);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- trim public DNS entry fields when loading JSON
- test whitespace trimming

## Testing
- `dotnet test DomainDetective.sln --framework net8.0 --verbosity minimal` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_685a587318c4832e9ca730c5de2d7a92