### PR TITLE
Normalize IPv6 keys in DNS propagation comparison

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -75,5 +75,26 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, groups.First().Value.Count);
             Assert.Equal(IPAddress.Parse("2001:db8::1").ToString(), groups.Keys.First());
         }
+
+        [Fact]
+        public void CompareResultsConsistentKeyCasing() {
+            var results = new[] {
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "1.1.1.1" },
+                    Records = new[] { "2001:DB8::1" },
+                    Success = true
+                },
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "8.8.8.8" },
+                    Records = new[] { "2001:db8::1" },
+                    Success = true
+                }
+            };
+
+            var groups = DnsPropagationAnalysis.CompareResults(results);
+            Assert.Single(groups);
+            Assert.Equal(2, groups.First().Value.Count);
+            Assert.Equal("2001:db8::1", groups.Keys.First());
+        }
     }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -222,7 +222,12 @@ namespace DomainDetective {
             var comparison = new Dictionary<string, List<PublicDnsEntry>>();
             foreach (var res in results.Where(r => r.Success)) {
                 var normalizedRecords = res.Records
-                    .Select(r => IPAddress.TryParse(r, out var ip) ? ip.ToString() : r)
+                    .Select(r =>
+                        IPAddress.TryParse(r, out var ip)
+                            ? ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
+                                ? ip.ToString().ToLowerInvariant()
+                                : ip.ToString()
+                            : r)
                     .OrderBy(r => r);
                 var key = string.Join(",", normalizedRecords);
                 if (!comparison.TryGetValue(key, out var list)) {


### PR DESCRIPTION
## Summary
- normalize IPv6 addresses to lowercase when comparing results
- ensure consistent keys for IPv6 regardless of casing
- test for IPv6 case consistency

## Testing
- `dotnet test --filter FullyQualifiedName~DomainDetective.Tests.TestDnsPropagation`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_685a58d6a178832ea446c69e80767b36