### PR TITLE
Throw on empty name list in QueryFullDNS

### DIFF
--- a/DomainDetective.Tests/TestDnsConfiguration.cs
+++ b/DomainDetective.Tests/TestDnsConfiguration.cs
@@ -1,0 +1,21 @@
+using System;
+using DnsClientX;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestDnsConfiguration {
+        [Fact]
+        public async Task QueryFullDNSThrowsIfNamesNull() {
+            var config = new DnsConfiguration();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await config.QueryFullDNS(null!, DnsRecordType.A));
+        }
+
+        [Fact]
+        public async Task QueryFullDNSThrowsIfNamesEmpty() {
+            var config = new DnsConfiguration();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await config.QueryFullDNS(Array.Empty<string>(), DnsRecordType.A));
+        }
+    }
+}

--- a/DomainDetective/DnsConfiguration.cs
+++ b/DomainDetective/DnsConfiguration.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,6 +77,9 @@ namespace DomainDetective {
         /// </summary>
         public async Task<IEnumerable<DnsResponse>> QueryFullDNS(string[] names, DnsRecordType recordType, string filter = "", CancellationToken cancellationToken = default) {
             cancellationToken.ThrowIfCancellationRequested();
+            if (names == null || names.Length == 0) {
+                throw new ArgumentNullException(nameof(names));
+            }
             ClientX client = new(endpoint: DnsEndpoint, DnsSelectionStrategy);
             DnsResponse[] data = filter != string.Empty
                 ? await client.ResolveFilter(names, recordType, filter)


### PR DESCRIPTION
## Summary
- validate input for `QueryFullDNS`
- cover null and empty name lists with unit tests

## Testing
- `dotnet test --no-build` *(fails: Invalid URI, unreachable hosts)*

------
https://chatgpt.com/codex/tasks/task_e_685a58cffae8832eb9464dbd34d9c099