### PR TITLE
Add user-friendly PS output

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -12,6 +12,9 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Raw;
+
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
@@ -26,7 +29,12 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DMARC record for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.DMARC });
-            WriteObject(healthCheck.DmarcAnalysis);
+            if (Raw) {
+                WriteObject(healthCheck.DmarcAnalysis);
+            } else {
+                var output = OutputHelper.Convert(healthCheck.DmarcAnalysis);
+                WriteObject(output);
+            }
         }
     }
 }

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -12,6 +12,9 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        [Parameter(Mandatory = false)]
+        public SwitchParameter Raw;
+
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
@@ -26,7 +29,12 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DNSSEC for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.DNSSEC });
-            WriteObject(healthCheck.DNSSecAnalysis);
+            if (Raw) {
+                WriteObject(healthCheck.DNSSecAnalysis);
+            } else {
+                var output = OutputHelper.Convert(healthCheck.DNSSecAnalysis);
+                WriteObject(output);
+            }
         }
     }
 }

--- a/DomainDetective.PowerShell/Helpers/OutputHelper.Dmarc.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.Dmarc.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.PowerShell {
+    internal static partial class OutputHelper {
+        public static DmarcRecordInfo Convert(DmarcAnalysis analysis) {
+            return new DmarcRecordInfo {
+                DmarcRecord = analysis.DmarcRecord,
+                DmarcRecordExists = analysis.DmarcRecordExists,
+                StartsCorrectly = analysis.StartsCorrectly,
+                IsPolicyValid = analysis.IsPolicyValid,
+                Policy = analysis.Policy,
+                SubPolicy = analysis.SubPolicy,
+                Percent = analysis.Percent,
+                Rua = analysis.Rua,
+                Ruf = analysis.Ruf
+            };
+        }
+    }
+
+    public class DmarcRecordInfo {
+        public string DmarcRecord { get; set; }
+        public bool DmarcRecordExists { get; set; }
+        public bool StartsCorrectly { get; set; }
+        public bool IsPolicyValid { get; set; }
+        public string Policy { get; set; }
+        public string SubPolicy { get; set; }
+        public string Percent { get; set; }
+        public string Rua { get; set; }
+        public string Ruf { get; set; }
+    }
+}

--- a/DomainDetective.PowerShell/Helpers/OutputHelper.DnsSec.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.DnsSec.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.PowerShell {
+    internal static partial class OutputHelper {
+        public static DnsSecInfo Convert(DNSSecAnalysis analysis) {
+            return new DnsSecInfo {
+                DsRecords = analysis.DsRecords,
+                DnsKeys = analysis.DnsKeys,
+                Signatures = analysis.Signatures,
+                AuthenticData = analysis.AuthenticData,
+                DsAuthenticData = analysis.DsAuthenticData,
+                DsMatch = analysis.DsMatch,
+                ChainValid = analysis.ChainValid
+            };
+        }
+    }
+
+    public class DnsSecInfo {
+        public IReadOnlyList<string> DsRecords { get; set; }
+        public IReadOnlyList<string> DnsKeys { get; set; }
+        public IReadOnlyList<string> Signatures { get; set; }
+        public bool AuthenticData { get; set; }
+        public bool DsAuthenticData { get; set; }
+        public bool DsMatch { get; set; }
+        public bool ChainValid { get; set; }
+    }
+}

--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 
 namespace DomainDetective.PowerShell {
-    internal static class OutputHelper {
+    internal static partial class OutputHelper {
         public static IEnumerable<DkimRecordInfo> Convert(DkimAnalysis analysis) {
             foreach (var kvp in analysis.AnalysisResults) {
                 var result = kvp.Value;


### PR DESCRIPTION
## Summary
- add new helper types for DMARC and DNSSEC results
- enable `-Raw` switch for DMARC and DNSSEC cmdlets
- expose partial OutputHelper class

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: The given key 'selector1' was not present in the dictionary)*
- `pwsh ./Module/DomainDetective.Tests.ps1` *(fails: cmdlets not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a583e0100832e88c3a2a83ad577ed