### PR TITLE
fix(ci): ensure test runner restores packages

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -89,6 +89,9 @@ jobs:
           name: windows-build
           path: DomainDetective.Tests
 
+      - name: Restore test project
+        run: dotnet restore DomainDetective.Tests/DomainDetective.Tests.csproj
+
       # yamllint disable rule:line-length
       - name: Run test ${{ matrix.testclass }}
         shell: pwsh
@@ -181,6 +184,9 @@ jobs:
         with:
           name: ubuntu-build
           path: DomainDetective.Tests
+
+      - name: Restore test project
+        run: dotnet restore DomainDetective.Tests/DomainDetective.Tests.csproj
 
       # yamllint disable rule:line-length
       - name: Run test ${{ matrix.testclass }}


### PR DESCRIPTION
## Summary
- restore test packages before running `dotnet test` jobs on Windows and Ubuntu

## Testing
- `dotnet restore DomainDetective.Tests/DomainDetective.Tests.csproj -v minimal`
- `dotnet build DomainDetective.sln -c Release -v minimal`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0 --no-build --verbosity minimal --collect:"XPlat Code Coverage" --results-directory ./testresults` *(fails: SOAAnalysis.VerifySoaByDomain [FAIL])*

------
https://chatgpt.com/codex/tasks/task_e_685a8b7b7360832ebdd2417b2c6e5bbe