### PR TITLE
Fix cancellation test hanging on Linux

### DIFF
--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -146,7 +146,7 @@ namespace DomainDetective.Tests {
             await Assert.ThrowsAsync<System.OperationCanceledException>(() => analyzeTask);
 
             listener.Stop();
-            try { await serverTask; } catch (System.OperationCanceledException) { }
+            try { await serverTask; } catch (System.Exception) { }
         }
     }
 }

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -19,24 +19,52 @@ namespace DomainDetective {
         private static async Task<bool> TryRelay(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
             using var client = new TcpClient();
             try {
+#if NET6_0_OR_GREATER
+                await client.ConnectAsync(host, port, cancellationToken);
+#else
                 await client.ConnectAsync(host, port);
+                cancellationToken.ThrowIfCancellationRequested();
+#endif
                 using NetworkStream network = client.GetStream();
                 using var reader = new StreamReader(network);
                 using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
 
+#if NET8_0_OR_GREATER
+                await reader.ReadLineAsync(cancellationToken);
+#else
                 await reader.ReadLineAsync();
+                cancellationToken.ThrowIfCancellationRequested();
+#endif
                 cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync($"HELO example.com");
+#if NET8_0_OR_GREATER
+                await reader.ReadLineAsync(cancellationToken);
+#else
                 await reader.ReadLineAsync();
                 cancellationToken.ThrowIfCancellationRequested();
+#endif
+                cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync("MAIL FROM:<test@example.com>");
+#if NET8_0_OR_GREATER
+                var mailResp = await reader.ReadLineAsync(cancellationToken);
+#else
                 var mailResp = await reader.ReadLineAsync();
                 cancellationToken.ThrowIfCancellationRequested();
+#endif
+                cancellationToken.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync("RCPT TO:<test@example.org>");
+#if NET8_0_OR_GREATER
+                var rcptResp = await reader.ReadLineAsync(cancellationToken);
+                await writer.WriteLineAsync("QUIT".AsMemory(), cancellationToken);
+                await writer.FlushAsync(cancellationToken);
+                await reader.ReadLineAsync(cancellationToken);
+#else
                 var rcptResp = await reader.ReadLineAsync();
                 await writer.WriteLineAsync("QUIT");
                 await writer.FlushAsync();
                 await reader.ReadLineAsync();
+                cancellationToken.ThrowIfCancellationRequested();
+#endif
 
                 logger?.WriteVerbose($"MAIL FROM response: {mailResp}");
                 logger?.WriteVerbose($"RCPT TO response: {rcptResp}");


### PR DESCRIPTION
## Summary
- pass cancellation token to `TcpClient.ConnectAsync`
- update open relay read/write ops to support cancellation on .NET 8
- relax server task cleanup in test to avoid SocketException failures

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter "CancelsDuringAnalysis" --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685a93384f70832e99c5258c1b6dfc1d