### PR TITLE
Fix cancellation handling in OpenRelayAnalysis

### DIFF
--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -70,6 +70,8 @@ namespace DomainDetective {
                 logger?.WriteVerbose($"RCPT TO response: {rcptResp}");
 
                 return mailResp != null && mailResp.StartsWith("250") && rcptResp != null && rcptResp.StartsWith("250");
+            } catch (TaskCanceledException ex) {
+                throw new OperationCanceledException(ex.Message, ex, cancellationToken);
             } catch (OperationCanceledException) {
                 throw;
             } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- convert `TaskCanceledException` to `OperationCanceledException` when cancelling open relay checks

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --filter FullyQualifiedName~DomainDetective.Tests.TestOpenRelayAnalysis`

------
https://chatgpt.com/codex/tasks/task_e_685a9a424394832ea413fb9f7daa0d39