### PR TITLE
Handle null DNS records in comparison

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -110,6 +110,20 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void CompareResultsIgnoresNullRecords() {
+            var results = new[] {
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "1.1.1.1" },
+                    Records = null,
+                    Success = true
+                }
+            };
+
+            var exception = Record.Exception(() => DnsPropagationAnalysis.CompareResults(results));
+            Assert.Null(exception);
+        }
+
+        [Fact]
         public void LoadServersTrimsWhitespace() {
             var json = "[{\"Country\":\" Test \",\"IPAddress\":\"1.2.3.4\",\"HostName\":\" example.com \",\"Location\":\" Somewhere \",\"ASN\":\"123\",\"ASNName\":\" Example ASN \"}]";
 

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -241,7 +241,7 @@ namespace DomainDetective {
         /// <returns>A dictionary keyed by the record returned and listing the servers that returned it.</returns>
         public static Dictionary<string, List<PublicDnsEntry>> CompareResults(IEnumerable<DnsPropagationResult> results) {
             var comparison = new Dictionary<string, List<PublicDnsEntry>>();
-            foreach (var res in results.Where(r => r.Success)) {
+            foreach (var res in results.Where(r => r.Success && r.Records != null)) {
                 var normalizedRecords = res.Records
                     .Select(r =>
                         IPAddress.TryParse(r, out var ip)


### PR DESCRIPTION
## Summary
- skip results with null `Records` before processing in `CompareResults`
- ensure handling of null record sets with unit test

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter CompareResultsIgnoresNullRecords`

------
https://chatgpt.com/codex/tasks/task_e_685aa7efff90832e8ff2ad7867f2f9b3