### PR TITLE
Fix filePath validation

### DIFF
--- a/DomainDetective.Tests/TestLoadServersArgument.cs
+++ b/DomainDetective.Tests/TestLoadServersArgument.cs
@@ -1,0 +1,13 @@
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestLoadServersArgument {
+        [Fact]
+        public void LoadServersThrowsIfPathNullOrWhitespace() {
+            var analysis = new DnsPropagationAnalysis();
+
+            Assert.Throws<ArgumentException>(() => analysis.LoadServers(" ")); 
+        }
+    }
+}
+

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -71,6 +71,9 @@ namespace DomainDetective {
         /// <param name="filePath">Path to the JSON file.</param>
         /// <param name="clearExisting">Whether to clear any existing servers before loading.</param>
         public void LoadServers(string filePath, bool clearExisting = false) {
+            if (string.IsNullOrWhiteSpace(filePath)) {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(filePath));
+            }
             if (!File.Exists(filePath)) {
                 throw new FileNotFoundException($"DNS server list file not found: {filePath}");
             }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -392,6 +392,9 @@ namespace DomainDetective {
         }
 
         public void LoadDNSBL(string filePath, bool clearExisting = false) {
+            if (string.IsNullOrWhiteSpace(filePath)) {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(filePath));
+            }
             if (!File.Exists(filePath)) {
                 throw new FileNotFoundException($"DNSBL list file not found: {filePath}");
             }
@@ -429,6 +432,9 @@ namespace DomainDetective {
         }
 
         public void LoadDnsblConfig(string filePath, bool overwriteExisting = false, bool clearExisting = false) {
+            if (string.IsNullOrWhiteSpace(filePath)) {
+                throw new ArgumentException("File path cannot be null or whitespace.", nameof(filePath));
+            }
             if (!File.Exists(filePath)) {
                 throw new FileNotFoundException($"DNSBL config file not found: {filePath}");
             }


### PR DESCRIPTION
## Summary
- throw `ArgumentException` when filePath is empty for DNS lookups
- cover null/whitespace filePath path with a unit test

## Testing
- `dotnet test --filter FullyQualifiedName~TestLoadServersArgument`
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_685aa7f43f7c832e99ca610824c8005a