### PR TITLE
Fix temp file cleanup in tests

### DIFF
--- a/DomainDetective.Tests/TestDNSBLConfig.cs
+++ b/DomainDetective.Tests/TestDNSBLConfig.cs
@@ -4,30 +4,40 @@ namespace DomainDetective.Tests {
         public void LoadConfigWithClear() {
             var json = "{\"providers\":[{\"domain\":\"test.example\"},{\"domain\":\"another.test\",\"enabled\":false}]}";
             var file = Path.GetTempFileName();
-            File.WriteAllText(file, json);
+            try {
+                File.WriteAllText(file, json);
 
-            var analysis = new DNSBLAnalysis();
-            analysis.LoadDnsblConfig(file, clearExisting: true);
+                var analysis = new DNSBLAnalysis();
+                analysis.LoadDnsblConfig(file, clearExisting: true);
 
-            var entries = analysis.GetDNSBL().ToList();
-            Assert.Equal(2, entries.Count);
-            Assert.Contains(entries, e => e.Domain == "test.example");
-            Assert.Contains(entries, e => e.Domain == "another.test" && !e.Enabled);
+                var entries = analysis.GetDNSBL().ToList();
+                Assert.Equal(2, entries.Count);
+                Assert.Contains(entries, e => e.Domain == "test.example");
+                Assert.Contains(entries, e => e.Domain == "another.test" && !e.Enabled);
+            }
+            finally {
+                File.Delete(file);
+            }
         }
 
         [Fact]
         public void LoadConfigAddsMissing() {
             var json = "{\"providers\":[{\"domain\":\"added.test\"}]}";
             var file = Path.GetTempFileName();
-            File.WriteAllText(file, json);
+            try {
+                File.WriteAllText(file, json);
 
-            var analysis = new DNSBLAnalysis();
-            var before = analysis.GetDNSBL().Count;
-            analysis.LoadDnsblConfig(file);
-            var after = analysis.GetDNSBL().Count;
+                var analysis = new DNSBLAnalysis();
+                var before = analysis.GetDNSBL().Count;
+                analysis.LoadDnsblConfig(file);
+                var after = analysis.GetDNSBL().Count;
 
-            Assert.Equal(before + 1, after);
-            Assert.Contains(analysis.GetDNSBL(), e => e.Domain == "added.test");
+                Assert.Equal(before + 1, after);
+                Assert.Contains(analysis.GetDNSBL(), e => e.Domain == "added.test");
+            }
+            finally {
+                File.Delete(file);
+            }
         }
     }
 }

--- a/DomainDetective.Tests/TestDNSBLLoadFile.cs
+++ b/DomainDetective.Tests/TestDNSBLLoadFile.cs
@@ -12,18 +12,23 @@ namespace DomainDetective.Tests {
                 "load3.test ### trailing"
             };
             var file = Path.GetTempFileName();
-            File.WriteAllLines(file, lines);
+            try {
+                File.WriteAllLines(file, lines);
 
-            var analysis = new DNSBLAnalysis();
-            analysis.LoadDNSBL(file, clearExisting: true);
+                var analysis = new DNSBLAnalysis();
+                analysis.LoadDNSBL(file, clearExisting: true);
 
-            var entries = analysis.GetDNSBL().ToList();
-            Assert.Equal(4, entries.Count);
-            Assert.Equal("load1.test", entries[0].Domain);
-            Assert.Equal("load2.test", entries[1].Domain);
-            Assert.Equal("disabled.test", entries[2].Domain);
-            Assert.False(entries[2].Enabled);
-            Assert.Equal("load3.test", entries[3].Domain);
+                var entries = analysis.GetDNSBL().ToList();
+                Assert.Equal(4, entries.Count);
+                Assert.Equal("load1.test", entries[0].Domain);
+                Assert.Equal("load2.test", entries[1].Domain);
+                Assert.Equal("disabled.test", entries[2].Domain);
+                Assert.False(entries[2].Enabled);
+                Assert.Equal("load3.test", entries[3].Domain);
+            }
+            finally {
+                File.Delete(file);
+            }
         }
     }
 }

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -114,16 +114,21 @@ namespace DomainDetective.Tests {
             var json = "[{\"Country\":\" Test \",\"IPAddress\":\"1.2.3.4\",\"HostName\":\" example.com \",\"Location\":\" Somewhere \",\"ASN\":\"123\",\"ASNName\":\" Example ASN \"}]";
 
             var file = Path.GetTempFileName();
-            File.WriteAllText(file, json);
+            try {
+                File.WriteAllText(file, json);
 
-            var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers(file, clearExisting: true);
+                var analysis = new DnsPropagationAnalysis();
+                analysis.LoadServers(file, clearExisting: true);
 
-            var server = Assert.Single(analysis.Servers);
-            Assert.Equal("Test", server.Country);
-            Assert.Equal("example.com", server.HostName);
-            Assert.Equal("Somewhere", server.Location);
-            Assert.Equal("Example ASN", server.ASNName);
+                var server = Assert.Single(analysis.Servers);
+                Assert.Equal("Test", server.Country);
+                Assert.Equal("example.com", server.HostName);
+                Assert.Equal("Somewhere", server.Location);
+                Assert.Equal("Example ASN", server.ASNName);
+            }
+            finally {
+                File.Delete(file);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure temp files are deleted in `TestDnsblLoadFile`
- clean up temp files in `TestDnsblConfig`
- add cleanup for temp files in `TestDnsPropagation`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Invalid URI: The hostname could not be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_685aa8006238832e86a036d1bb58934f