### PR TITLE
Add HTTP timeout handling test

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -172,9 +172,10 @@ namespace DomainDetective.Tests {
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            var tcs = new TaskCompletionSource<object?>();
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
-                await Task.Delay(3000);
+                await tcs.Task;
                 ctx.Response.StatusCode = 200;
                 ctx.Response.Close();
             });
@@ -185,6 +186,7 @@ namespace DomainDetective.Tests {
                 Assert.False(analysis.IsReachable);
                 Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
             } finally {
+                tcs.TrySetResult(null);
                 listener.Stop();
                 await serverTask;
             }

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -33,6 +33,9 @@ namespace DomainDetective {
         /// <summary>Gets or sets the maximum number of redirects to follow.</summary>
         public int MaxRedirects { get; set; } = 10;
 
+        /// <summary>Gets or sets the HTTP request timeout.</summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(100);
+
         private static readonly string[] _securityHeaderNames = new[] {
             "Content-Security-Policy",
             "X-Content-Type-Options",
@@ -57,7 +60,7 @@ namespace DomainDetective {
 #else
             using var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = MaxRedirects };
 #endif
-            using var client = new HttpClient(handler);
+            using var client = new HttpClient(handler) { Timeout = Timeout };
             var sw = Stopwatch.StartNew();
             FailureReason = null;
             Body = null;


### PR DESCRIPTION
## Summary
- allow configurable timeout for `HttpAnalysis`
- test HTTP timeout behavior

## Testing
- `dotnet build DomainDetective.sln -c Debug`
- `dotnet test` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_685aa7fa8004832ead9e5d344bae697f