### PR TITLE
Add ToJson and CLI JSON output

### DIFF
--- a/DomainDetective.CLI/DomainDetective.CLI.csproj
+++ b/DomainDetective.CLI/DomainDetective.CLI.csproj
@@ -9,8 +9,4 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/DomainDetective.CLI/DomainDetective.CLI.csproj
+++ b/DomainDetective.CLI/DomainDetective.CLI.csproj
@@ -9,4 +9,8 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -1,23 +1,2 @@
-using DomainDetective;
-using System.Text.Json;
-
-if (args.Length == 0 || args.All(a => a.StartsWith("-")))
-{
-    Console.WriteLine("Usage: DomainDetective.CLI <domain> [--json]");
-    return;
-}
-
-var outputJson = args.Contains("--json");
-var domain = args.First(a => !a.StartsWith("-"));
-
-var healthCheck = new DomainHealthCheck();
-await healthCheck.Verify(domain);
-
-if (outputJson)
-{
-    Console.WriteLine(healthCheck.ToJson());
-}
-else
-{
-    Console.WriteLine($"Health check completed for {domain}");
-}
+// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -1,2 +1,23 @@
-// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using DomainDetective;
+using System.Text.Json;
+
+if (args.Length == 0 || args.All(a => a.StartsWith("-")))
+{
+    Console.WriteLine("Usage: DomainDetective.CLI <domain> [--json]");
+    return;
+}
+
+var outputJson = args.Contains("--json");
+var domain = args.First(a => !a.StartsWith("-"));
+
+var healthCheck = new DomainHealthCheck();
+await healthCheck.Verify(domain);
+
+if (outputJson)
+{
+    Console.WriteLine(healthCheck.ToJson());
+}
+else
+{
+    Console.WriteLine($"Health check completed for {domain}");
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -1,9 +1,24 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using DomainDetective;
 
 namespace DomainDetective.Example;
 
 public static partial class Program {
-    public static async Task Main() {
+    public static async Task Main(string[] args) {
+        if (args.Length > 0 && args.Any(a => !a.StartsWith("-"))) {
+            var outputJson = args.Contains("--json");
+            var domain = args.First(a => !a.StartsWith("-"));
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.Verify(domain);
+            if (outputJson) {
+                Console.WriteLine(healthCheck.ToJson());
+            } else {
+                Console.WriteLine($"Health check completed for {domain}");
+            }
+            return;
+        }
         await ExampleAnalyseByDnsSPF();
         await ExampleAnalyseByStringSPF();
 

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Text.Json;
 
 namespace DomainDetective {
     public partial class DomainHealthCheck : Settings {
@@ -499,6 +500,11 @@ namespace DomainDetective {
             WhoisAnalysis = new WhoisAnalysis();
             var tasks = WhoisAnalysis.QueryWhoisServer(domain);
             await Task.WhenAll(tasks);
+        }
+
+        public string ToJson(JsonSerializerOptions options = null) {
+            options ??= new JsonSerializerOptions { WriteIndented = true };
+            return JsonSerializer.Serialize(this, options);
         }
     }
 }

--- a/README.MD
+++ b/README.MD
@@ -93,6 +93,15 @@ PowerShell specific tests can be run with:
 pwsh ./Module/DomainDetective.Tests.ps1
 ```
 
+### Command Line Interface
+
+Run the `DomainDetective.CLI` project to check a domain. Use `--json` to output
+all analysis details in JSON format:
+
+```bash
+dotnet run --project DomainDetective.CLI example.com --json
+```
+
 ### PowerShell Module
 
 Import the module and call any of the testing cmdlets:

--- a/README.MD
+++ b/README.MD
@@ -93,13 +93,13 @@ PowerShell specific tests can be run with:
 pwsh ./Module/DomainDetective.Tests.ps1
 ```
 
-### Command Line Interface
+### Command Line Example
 
-Run the `DomainDetective.CLI` project to check a domain. Use `--json` to output
+Run the `DomainDetective.Example` project to check a domain. Use `--json` to output
 all analysis details in JSON format:
 
 ```bash
-dotnet run --project DomainDetective.CLI example.com --json
+dotnet run --project DomainDetective.Example example.com --json
 ```
 
 ### PowerShell Module


### PR DESCRIPTION
## Summary
- add `ToJson` method to `DomainHealthCheck`
- allow CLI to output JSON via `--json`
- hook CLI project to main library
- document CLI usage

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Exceeds lookups should be true, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685aa813e658832e8b15282010d8a109