### PR TITLE
Fix DKIM analysis reset

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -74,5 +74,23 @@ namespace DomainDetective.Tests {
                 "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;",
                 analysis.AnalysisResults["default"].DkimRecord);
         }
+
+        [Fact]
+        public async Task ResetsBetweenRuns() {
+            const string record1 = "v=DKIM1; k=rsa; p=AAAABBBB;";
+            const string record2 = "v=DKIM1; k=rsa; p=CCCCDDDD;";
+
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckDKIM(record1, "selector1");
+            Assert.Single(healthCheck.DKIMAnalysis.AnalysisResults);
+            Assert.Equal(record1, healthCheck.DKIMAnalysis.AnalysisResults["selector1"].DkimRecord);
+
+            await healthCheck.CheckDKIM(record2, "selector2");
+
+            Assert.Single(healthCheck.DKIMAnalysis.AnalysisResults);
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults.ContainsKey("selector2"));
+            Assert.Equal(record2, healthCheck.DKIMAnalysis.AnalysisResults["selector2"].DkimRecord);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -112,6 +112,7 @@ namespace DomainDetective {
         }
 
         public async Task VerifyDKIM(string domainName, string[] selectors, CancellationToken cancellationToken = default) {
+            DKIMAnalysis.Reset();
             if (selectors == null || selectors.Length == 0) {
                 await DKIMAnalysis.QueryWellKnownSelectors(domainName, DnsConfiguration, _logger, cancellationToken);
                 return;
@@ -254,6 +255,7 @@ namespace DomainDetective {
         }
 
         public async Task CheckDKIM(string dkimRecord, string selector = "default", CancellationToken cancellationToken = default) {
+            DKIMAnalysis.Reset();
             await DKIMAnalysis.AnalyzeDkimRecords(selector, new List<DnsAnswer> {
                 new DnsAnswer {
                     DataRaw = dkimRecord,


### PR DESCRIPTION
## Summary
- reset `DKIMAnalysis` when verifying or checking DKIM records
- test that DKIM results don't persist across runs

## Testing
- `dotnet test` *(fails: invalid argument / network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685abfff7388832eacbda8c814b0a065