### PR TITLE
Validate TLD before WHOIS lookup

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -7,6 +7,12 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task MissingTldThrows() {
+            var whois = new WhoisAnalysis();
+            await Assert.ThrowsAsync<UnsupportedTldException>(async () => await whois.QueryWhoisServer("example"));
+        }
+
+        [Fact]
         public async Task QueryFromLocalWhoisServerReadsLargeResponse() {
             var responseBuilder = new System.Text.StringBuilder();
             responseBuilder.AppendLine("Domain Name: example.local");

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -298,6 +298,9 @@ public class WhoisAnalysis {
 
     public async Task QueryWhoisServer(string domain) {
         DomainName = domain;
+        if (string.IsNullOrWhiteSpace(domain) || !domain.Contains('.')) {
+            throw new UnsupportedTldException(domain, domain);
+        }
         var whoisServer = GetWhoisServer(domain);
         if (whoisServer == null) {
             throw new UnsupportedTldException(domain, TLD);


### PR DESCRIPTION
## Summary
- validate TLD exists before fetching WHOIS server
- test missing TLD case

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test` *(fails: Failed: 13, Passed: 124)*

------
https://chatgpt.com/codex/tasks/task_e_685abff782d8832e8628c63c881da465