### PR TITLE
Fix exception type in DomainHealthCheck.Verify

### DIFF
--- a/DomainDetective.Tests/TestUnknownHealthCheckType.cs
+++ b/DomainDetective.Tests/TestUnknownHealthCheckType.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
@@ -5,7 +6,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task VerifyUnknownHealthCheckTypeThrows() {
             var healthCheck = new DomainHealthCheck();
-            await Assert.ThrowsAsync<System.Exception>(async () =>
+            await Assert.ThrowsAsync<NotSupportedException>(async () =>
                 await healthCheck.Verify("example.com", new[] { (HealthCheckType)999 }));
         }
     }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -230,7 +230,7 @@ namespace DomainDetective {
                         break;
                     default:
                         _logger.WriteError("Unknown health check type: {0}", healthCheckType);
-                        throw new System.Exception("Health check type not implemented.");
+                        throw new NotSupportedException("Health check type not implemented.");
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace `System.Exception` with `NotSupportedException` when encountering an unknown health check type
- update the test to expect `NotSupportedException`

## Testing
- `dotnet build`
- `dotnet test --no-build -v minimal` *(fails: SOA, DKIM, SPF, CertificateHTTP, DANE, DMARC, DKIM guess, CAA, All)*

------
https://chatgpt.com/codex/tasks/task_e_685abfd3e3a8832e8b7d1facc4ffc057