### PR TITLE
Capture TLS chain errors

### DIFF
--- a/DomainDetective.Tests/TestSMTPTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSMTPTLSAnalysis.cs
@@ -27,6 +27,8 @@ namespace DomainDetective.Tests {
                 Assert.False(result.CertificateValid);
                 Assert.True(result.DaysToExpire > 0);
                 Assert.True(result.CipherStrength > 0);
+                Assert.NotEmpty(result.ChainErrors);
+                Assert.Contains(X509ChainStatusFlags.UntrustedRoot, result.ChainErrors);
             } finally {
                 cts.Cancel();
                 listener.Stop();


### PR DESCRIPTION
## Summary
- expose certificate chain validation errors on `TlsResult`
- record chain validation status in `SMTPTLSAnalysis`
- validate chain errors in `TestSMTPTLSAnalysis`

## Testing
- `dotnet build DomainDetective.sln --no-restore --configuration Release --verbosity minimal`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --framework net8.0 --configuration Release --verbosity minimal` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_685adeca3934832e862b968913214dfe