### PR TITLE
Add version presence and duplicate checks for MTA‑STS

### DIFF
--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -48,6 +48,27 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void MissingVersionInvalidatesPolicy() {
+            var policy = "mode: enforce\nmx: mail.example.com\nmax_age: 86400";
+            var analysis = new MTASTSAnalysis();
+            analysis.AnalyzePolicyText(policy);
+
+            Assert.False(analysis.PolicyValid);
+            Assert.False(analysis.VersionPresent);
+            Assert.False(analysis.ValidVersion);
+        }
+
+        [Fact]
+        public void DuplicateFieldsInvalidatePolicy() {
+            var policy = "version: STSv1\nmode: enforce\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";
+            var analysis = new MTASTSAnalysis();
+            analysis.AnalyzePolicyText(policy);
+
+            Assert.True(analysis.HasDuplicateFields);
+            Assert.False(analysis.PolicyValid);
+        }
+
+        [Fact]
         public async Task FetchPolicyFromServer() {
             using var listener = new HttpListener();
             var port = GetFreePort();


### PR DESCRIPTION
## Summary
- validate that `version` field exists and matches `STSv1`
- detect duplicate policy fields (excluding `mx`)
- expose `VersionPresent` and `HasDuplicateFields` results
- test missing version and duplicate fields

## Testing
- `dotnet test` *(fails: KeyNotFoundException)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_685adeb2c1e8832ea4744d93435c8122