### PR TITLE
Add DMARC alignment validation

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -99,5 +99,16 @@ namespace DomainDetective.Tests {
             Assert.Single(analysis.MailtoRua);
             Assert.Equal("test@example.com", analysis.MailtoRua[0]);
         }
+
+        [Fact]
+        public async Task InvalidAlignmentFlags() {
+            var dmarcRecord = "v=DMARC1; p=none; adkim=x; aspf=y";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDMARC(dmarcRecord);
+            Assert.False(healthCheck.DmarcAnalysis.ValidDkimAlignment);
+            Assert.False(healthCheck.DmarcAnalysis.ValidSpfAlignment);
+            Assert.Equal("x", healthCheck.DmarcAnalysis.DkimAShort);
+            Assert.Equal("y", healthCheck.DmarcAnalysis.SpfAShort);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -31,6 +31,9 @@ namespace DomainDetective {
         public string DkimAlignment => TranslateAlignment(DkimAShort);
         public string FailureReportingOptions => TranslateFailureReportingOptions(FoShort);
 
+        public bool ValidDkimAlignment { get; private set; }
+        public bool ValidSpfAlignment { get; private set; }
+
         public string Rua { get; private set; }
         public List<string> MailtoRua { get; private set; } = new List<string>();
         public List<string> HttpRua { get; private set; } = new List<string>();
@@ -68,6 +71,8 @@ namespace DomainDetective {
             FoShort = null;
             DkimAShort = null;
             SpfAShort = null;
+            ValidDkimAlignment = true;
+            ValidSpfAlignment = true;
             Pct = null;
             ReportingIntervalShort = 0;
 
@@ -141,9 +146,17 @@ namespace DomainDetective {
                             break;
                         case "adkim":
                             DkimAShort = value;
+                            ValidDkimAlignment = value == "s" || value == "r";
+                            if (!ValidDkimAlignment) {
+                                logger?.WriteWarning($"Invalid adkim value '{value}', expected 's' or 'r'");
+                            }
                             break;
                         case "aspf":
                             SpfAShort = value;
+                            ValidSpfAlignment = value == "s" || value == "r";
+                            if (!ValidSpfAlignment) {
+                                logger?.WriteWarning($"Invalid aspf value '{value}', expected 's' or 'r'");
+                            }
                             break;
                         case "rua":
                             Rua = value;


### PR DESCRIPTION
## Summary
- validate `adkim` and `aspf` values
- warn on invalid DMARC alignment
- add unit test for invalid alignment values

## Testing
- `dotnet test` *(fails: Assert errors due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685ade7ef368832e9a363e39173a28f0