### PR TITLE
Fix NXDOMAIN handling for MX host analysis

### DIFF
--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -83,8 +83,13 @@ namespace DomainDetective {
                 var aaaaResults = await QueryDns(host, DnsRecordType.AAAA);
                 var noA = aResults == null || !aResults.Any();
                 var noAAAA = aaaaResults == null || !aaaaResults.Any();
-                PointsToNonExistentDomain = PointsToNonExistentDomain || (noA && noAAAA);
-                PointsToDomainWithoutAOrAaaaRecord = PointsToDomainWithoutAOrAaaaRecord || (noA && noAAAA);
+
+                if (noA && noAAAA) {
+                    var nsResults = await QueryDns(host, DnsRecordType.NS);
+                    var nonExistent = nsResults == null || !nsResults.Any();
+                    PointsToNonExistentDomain = PointsToNonExistentDomain || nonExistent;
+                    PointsToDomainWithoutAOrAaaaRecord = PointsToDomainWithoutAOrAaaaRecord || !nonExistent;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- handle NXDOMAIN separately when MX hosts lack `A` or `AAAA`

## Testing
- `dotnet test -v minimal` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_685af48c36f8832e91fcbab97b537718