### PR TITLE
Implement duplicate tag detection

### DIFF
--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -63,6 +63,35 @@ namespace DomainDetective.Tests {
             }
         }
 
+        [Fact]
+        public async Task DuplicateTagsMakeRecordInvalid() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var expires = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var content = $"Contact: mailto:admin@example.com\nExpires: {expires}\nExpires: {expires}";
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "text/plain";
+                var buffer = Encoding.UTF8.GetBytes(content);
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.Verify(prefix.Replace("http://", string.Empty).TrimEnd('/'), new[] { HealthCheckType.SECURITYTXT });
+                Assert.True(healthCheck.SecurityTXTAnalysis.RecordPresent);
+                Assert.False(healthCheck.SecurityTXTAnalysis.RecordValid);
+                Assert.Contains("expires", healthCheck.SecurityTXTAnalysis.DuplicateTags, StringComparer.OrdinalIgnoreCase);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
         private static int GetFreePort() {
             var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
             listener.Start();

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -13,6 +13,7 @@ namespace DomainDetective {
         public bool PGPSigned { get; set; }
         public bool FallbackUsed { get; set; }
         public string Url { get; set; }
+        public List<string> DuplicateTags { get; private set; } = new List<string>();
         // Fields that can appear multiple times as List<string>
         public List<string> ContactEmail { get; set; } = new List<string>();
         public List<string> ContactWebsite { get; set; } = new List<string>();
@@ -96,6 +97,8 @@ namespace DomainDetective {
             var lines = txt.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
 
             RecordValid = true;
+            DuplicateTags = new List<string>();
+            var seenTags = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             bool hasSeenExpires = false;
             bool hasSeenSignatureEncryption = false;
 
@@ -110,6 +113,11 @@ namespace DomainDetective {
                 if (colonIndex > 0) {
                     string currentField = line.Substring(0, colonIndex).Trim();
                     string value = line.Substring(colonIndex + 1).Trim();
+
+                    if (!seenTags.Add(currentField) && !DuplicateTags.Contains(currentField)) {
+                        DuplicateTags.Add(currentField);
+                        RecordValid = false;
+                    }
 
                     // Add the value to the appropriate list in the record
                     switch (currentField.ToLowerInvariant()) {


### PR DESCRIPTION
## Summary
- track security.txt tags and record duplicates
- mark record invalid when a tag repeats
- test duplicate tag detection

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid. Please use the /help option to check the list of valid arguments.)*
- `dotnet test` *(fails: tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_685af460b0bc832eaf060a898a68fb43