### PR TITLE
Fix DNSSEC algorithm parsing

### DIFF
--- a/DomainDetective.Tests/TestDNSSECUnknownAlgorithm.cs
+++ b/DomainDetective.Tests/TestDNSSECUnknownAlgorithm.cs
@@ -1,0 +1,13 @@
+using System.Reflection;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnssecUnknownAlgorithm {
+        [Fact]
+        public void UnknownAlgorithmNumberIsParsed() {
+            var method = typeof(DNSSecAnalysis).GetMethod("AlgorithmNumber", BindingFlags.NonPublic | BindingFlags.Static)!;
+            int value = (int)method.Invoke(null, new object[] { "99" })!;
+            Assert.Equal(99, value);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSSecAnalysis.cs
+++ b/DomainDetective/Protocols/DNSSecAnalysis.cs
@@ -222,26 +222,36 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="name">Algorithm name.</param>
         /// <returns>Numeric algorithm identifier.</returns>
-        private static int AlgorithmNumber(string name) => name.ToUpperInvariant() switch {
-            "RSAMD5" => 1,
-            "DH" => 2,
-            "DSA" => 3,
-            "ECC" => 4,
-            "RSASHA1" => 5,
-            "DSANSEC3SHA1" => 6,
-            "RSASHA1NSEC3SHA1" => 7,
-            "RSASHA256" => 8,
-            "RSASHA512" => 10,
-            "ECCGOST" => 12,
-            "ECDSAP256SHA256" => 13,
-            "ECDSAP384SHA384" => 14,
-            "ED25519" => 15,
-            "ED448" => 16,
-            "INDIRECT" => 252,
-            "PRIVATEDNS" => 253,
-            "PRIVATEOID" => 254,
-            _ => 0,
-        };
+        private static int AlgorithmNumber(string name) {
+            if (string.IsNullOrWhiteSpace(name)) {
+                return 0;
+            }
+
+            if (int.TryParse(name, out int numeric)) {
+                return numeric;
+            }
+
+            return name.ToUpperInvariant() switch {
+                "RSAMD5" => 1,
+                "DH" => 2,
+                "DSA" => 3,
+                "ECC" => 4,
+                "RSASHA1" => 5,
+                "DSANSEC3SHA1" => 6,
+                "RSASHA1NSEC3SHA1" => 7,
+                "RSASHA256" => 8,
+                "RSASHA512" => 10,
+                "ECCGOST" => 12,
+                "ECDSAP256SHA256" => 13,
+                "ECDSAP384SHA384" => 14,
+                "ED25519" => 15,
+                "ED448" => 16,
+                "INDIRECT" => 252,
+                "PRIVATEDNS" => 253,
+                "PRIVATEOID" => 254,
+                _ => 0,
+            };
+        }
 
         /// <summary>
         /// Validates that the specified record has a valid DNSSEC signature.


### PR DESCRIPTION
## Summary
- parse numeric DNSSEC algorithm identifiers
- add test for unknown algorithm parsing

## Testing
- `dotnet test` *(fails: Invalid URI due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685af49f8f98832eab13aaf95c5a3630