### PR TITLE
feat(bimi): ✨ allow HTTP indicator locations

### DIFF
--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -21,5 +21,29 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.SvgFetched);
             Assert.True(analysis.SvgValid);
         }
+
+        [Fact]
+        public async Task ParseBimiRecordHttp() {
+            var record = "v=BIMI1; l=http://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg";
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer {
+                    DataRaw = record,
+                    Type = DnsRecordType.TXT
+                }
+            };
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var analysis = new BimiAnalysis();
+            await analysis.AnalyzeBimiRecords(answers, logger);
+
+            Assert.True(analysis.BimiRecordExists);
+            Assert.True(analysis.StartsCorrectly);
+            Assert.Equal("http://upload.wikimedia.org/wikipedia/commons/a/a7/React-icon.svg", analysis.Location);
+            Assert.False(analysis.LocationUsesHttps);
+            Assert.True(analysis.SvgFetched);
+            Assert.True(analysis.SvgValid);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("does not use HTTPS"));
+        }
     }
 }

--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -80,11 +80,18 @@ namespace DomainDetective {
 
             DeclinedToPublish = string.IsNullOrEmpty(Location) && string.IsNullOrEmpty(Authority);
 
-            if (!string.IsNullOrEmpty(Location) && LocationUsesHttps) {
+            if (!string.IsNullOrEmpty(Location)) {
+                if (!LocationUsesHttps) {
+                    logger?.WriteWarning("BIMI indicator location does not use HTTPS: {0}", Location);
+                }
+
                 var svg = await DownloadIndicator(Location, logger, cancellationToken);
                 if (svg != null) {
                     SvgFetched = true;
                     SvgValid = ValidateSvg(svg);
+                    logger?.WriteVerbose("Successfully downloaded BIMI indicator from {0}", Location);
+                } else {
+                    logger?.WriteWarning("Failed to download BIMI indicator from {0}", Location);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- fetch BIMI indicator even when HTTP is used
- warn when HTTPS isn't used and log download outcome
- test HTTP BIMI record handling

## Testing
- `dotnet test --no-build`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_685af4866c04832eb59c4dd4540a2f3a