### PR TITLE
feat(dnsbl): add reply code map

### DIFF
--- a/DomainDetective.Tests/TestDNSBLReplyCodes.cs
+++ b/DomainDetective.Tests/TestDNSBLReplyCodes.cs
@@ -1,0 +1,16 @@
+using System.Reflection;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblReplyCodes {
+        [Fact]
+        public void HostkarmaMapping() {
+            var method = typeof(DNSBLAnalysis).GetMethod("GetReplyCodeMeaning", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var result = (ValueTuple<bool, string>)method.Invoke(null, new object[] { "hostkarma.junkemailfilter.com", "127.0.0.2" });
+            Assert.True(result.Item1);
+            Assert.Equal("Blacklisted", result.Item2);
+            var result2 = (ValueTuple<bool, string>)method.Invoke(null, new object[] { "hostkarma.junkemailfilter.com", "127.0.0.1" });
+            Assert.False(result2.Item1);
+            Assert.Equal("Whitelisted", result2.Item2);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map DNSBL reply codes to meanings
- interpret DNSBL results using the new map
- test reply code mapping for Hostkarma

## Testing
- `dotnet build -v minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: Should exceed DNS lookups due to many includes)*

------
https://chatgpt.com/codex/tasks/task_e_685af47446fc832ea31bcaf4a7966fe0