### PR TITLE
Add TTL mapping for DNS result

### DIFF
--- a/DomainDetective.Tests/TestDnsResult.cs
+++ b/DomainDetective.Tests/TestDnsResult.cs
@@ -1,0 +1,22 @@
+using DnsClientX;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestDnsResult {
+        [Fact]
+        public void ConvertFromDnsAnswerCopiesTtl() {
+            var answer = new DnsAnswer {
+                Name = "example.com",
+                TTL = 3600,
+                DataRaw = "1.1.1.1",
+                Type = DnsRecordType.A
+            };
+
+            var result = DnsResult.FromDnsAnswer(answer);
+
+            Assert.Equal(3600, result.Ttl);
+            Assert.Equal("example.com", result.Name);
+            Assert.Contains("1.1.1.1", result.Data);
+        }
+    }
+}

--- a/DomainDetective/DnsResult.cs
+++ b/DomainDetective/DnsResult.cs
@@ -14,7 +14,21 @@ namespace DomainDetective {
         public string[] Data { get; set; }
         /// <summary>Gets or sets the data joined into a single string.</summary>
         public string DataJoined { get; set; }
+        /// <summary>Gets or sets the time to live value.</summary>
+        public int Ttl { get; set; }
 
         internal ServiceType ServiceType { get; set; }
+
+        /// <summary>
+        ///     Creates a <see cref="DnsResult"/> from a <see cref="DnsAnswer"/>.
+        /// </summary>
+        public static DnsResult FromDnsAnswer(DnsAnswer answer) {
+            return new DnsResult {
+                Name = answer.Name,
+                Data = answer.DataStringsEscaped,
+                DataJoined = answer.Data,
+                Ttl = answer.TTL
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expose TTL on `DnsResult`
- create helper to convert `DnsAnswer` to `DnsResult`
- test conversion retains TTL

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_685af47e8c4c832e8dfe5881a5574cdb