### PR TITLE
Default DNS server data for propagation checks

### DIFF
--- a/Module/README.MD
+++ b/Module/README.MD
@@ -23,9 +23,10 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```
 - `Test-DnsPropagation` – checks how DNS records propagate across public resolvers.
   ```powershell
-  Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile './Data/DNS/PublicDNS.json' -CompareResults
+  Test-DnsPropagation -DomainName "example.com" -RecordType A -CompareResults
   ```
-- `Test-CaaRecord` – validates CAA entries.
+  The cmdlet uses a built-in list of public resolvers when `-ServersFile` is not provided.
+ - `Test-CaaRecord` – validates CAA entries.
   ```powershell
   Test-CaaRecord -DomainName "example.com"
   ```


### PR DESCRIPTION
## Summary
- default to the built-in PublicDNS.json file in `Test-DnsPropagation`
- document optional `ServersFile` usage

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Assert errors)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685b0541c58c832eb56d4eb7a8979d2c