### PR TITLE
Expose parsed DMARC report addresses

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.Dmarc.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.Dmarc.cs
@@ -20,7 +20,12 @@ namespace DomainDetective.PowerShell {
                 SubPolicy = analysis.SubPolicy,
                 Percent = analysis.Percent,
                 Rua = analysis.Rua,
-                Ruf = analysis.Ruf
+                Ruf = analysis.Ruf,
+                MailtoRua = analysis.MailtoRua,
+                HttpRua = analysis.HttpRua,
+                MailtoRuf = analysis.MailtoRuf,
+                HttpRuf = analysis.HttpRuf,
+                ExternalReportAuthorization = analysis.ExternalReportAuthorization
             };
         }
     }
@@ -55,5 +60,20 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Forensic report destination.</summary>
         public string Ruf { get; set; }
+
+        /// <summary>Parsed mailto RUA addresses.</summary>
+        public IReadOnlyList<string> MailtoRua { get; set; }
+
+        /// <summary>Parsed HTTP RUA endpoints.</summary>
+        public IReadOnlyList<string> HttpRua { get; set; }
+
+        /// <summary>Parsed mailto RUF addresses.</summary>
+        public IReadOnlyList<string> MailtoRuf { get; set; }
+
+        /// <summary>Parsed HTTP RUF endpoints.</summary>
+        public IReadOnlyList<string> HttpRuf { get; set; }
+
+        /// <summary>External reporting authorization per domain.</summary>
+        public IReadOnlyDictionary<string, bool> ExternalReportAuthorization { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- expose parsed DMARC report information in PowerShell helper

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Unreachable DNS tests)*

------
https://chatgpt.com/codex/tasks/task_e_685b05080fe0832e9f8ee2c0356fdc98