### PR TITLE
Add FilterAnalyses method and use it in domain health cmdlet

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -42,7 +42,8 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying domain health for domain: {0}", DomainName);
             await _healthCheck.Verify(DomainName, HealthCheckType, DkimSelectors, DaneServiceType);
-            WriteObject(_healthCheck);
+            var result = _healthCheck.FilterAnalyses(HealthCheckType);
+            WriteObject(result);
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -561,7 +561,9 @@ namespace DomainDetective {
         }
 
         public DomainHealthCheck FilterAnalyses(IEnumerable<HealthCheckType> healthCheckTypes) {
-            var active = healthCheckTypes == null ? new HashSet<HealthCheckType>() : healthCheckTypes.ToHashSet();
+            var active = healthCheckTypes != null
+                ? new HashSet<HealthCheckType>(healthCheckTypes)
+                : new HashSet<HealthCheckType>();
             var clone = (DomainHealthCheck)MemberwiseClone();
 
             if (!active.Contains(HealthCheckType.DMARC)) {

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -559,5 +559,73 @@ namespace DomainDetective {
             options ??= new JsonSerializerOptions { WriteIndented = true };
             return JsonSerializer.Serialize(this, options);
         }
+
+        public DomainHealthCheck FilterAnalyses(IEnumerable<HealthCheckType> healthCheckTypes) {
+            var active = healthCheckTypes == null ? new HashSet<HealthCheckType>() : healthCheckTypes.ToHashSet();
+            var clone = (DomainHealthCheck)MemberwiseClone();
+
+            if (!active.Contains(HealthCheckType.DMARC)) {
+                clone.DmarcAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.SPF)) {
+                clone.SpfAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.DKIM)) {
+                clone.DKIMAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.MX)) {
+                clone.MXAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.CAA)) {
+                clone.CAAAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.NS)) {
+                clone.NSAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.DANE)) {
+                clone.DaneAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.DNSBL)) {
+                clone.DNSBLAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.DNSSEC)) {
+                clone.DNSSecAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.MTASTS)) {
+                clone.MTASTSAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.TLSRPT)) {
+                clone.TLSRPTAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.BIMI)) {
+                clone.BimiAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.CERT)) {
+                clone.CertificateAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.SECURITYTXT)) {
+                clone.SecurityTXTAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.SOA)) {
+                clone.SOAAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.OPENRELAY)) {
+                clone.OpenRelayAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.STARTTLS)) {
+                clone.StartTlsAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.SMTPTLS)) {
+                clone.SmtpTlsAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.HTTP)) {
+                clone.HttpAnalysis = null;
+            }
+            if (!active.Contains(HealthCheckType.HPKP)) {
+                clone.HPKPAnalysis = null;
+            }
+
+            return clone;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- added `FilterAnalyses` helper on `DomainHealthCheck` to clear unused analysis results
- updated PowerShell cmdlet to output filtered results

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid. Please use the /help option to check the list of valid arguments.)*

------
https://chatgpt.com/codex/tasks/task_e_685b06af7da0832ebc878bfd04411c84