### PR TITLE
Fix open relay error message

### DIFF
--- a/DomainDetective.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/DomainDetective.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -80,7 +80,7 @@ namespace DomainDetective.PowerShell {
         private void Logger_OnErrorMessage(object sender, LogEventArgs e) {
             var errorId = GetNextErrorId();
             ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), errorId, ErrorCategory.NotSpecified, null) {
-                ErrorDetails = new ErrorDetails(errorId)
+                ErrorDetails = new ErrorDetails(e.Message)
             };
             WriteError(errorRecord);
         }

--- a/DomainDetective.Tests/TestInternalLoggerPowerShell.cs
+++ b/DomainDetective.Tests/TestInternalLoggerPowerShell.cs
@@ -15,8 +15,10 @@ namespace DomainDetective.Tests {
             logger.WriteError("second");
 
             Assert.Equal(2, records.Count);
-            Assert.Equal("1", records[0].ErrorDetails.Message);
-            Assert.Equal("2", records[1].ErrorDetails.Message);
+            Assert.Equal("1", records[0].FullyQualifiedErrorId);
+            Assert.Equal("first", records[0].ErrorDetails.Message);
+            Assert.Equal("2", records[1].FullyQualifiedErrorId);
+            Assert.Equal("second", records[1].ErrorDetails.Message);
         }
     }
 }


### PR DESCRIPTION
## Summary
- show actual message when logging PowerShell errors

## Testing
- `dotnet build DomainDetective.sln -c Debug`
- `pwsh -NoLogo -NoProfile -Command "& { Import-Module ./Module/DomainDetective.psd1 -Force; Test-OpenRelay -HostName 'gmail-smtp-in.l.google.com' -Port 25 -Verbose }"`
- `pwsh -NoLogo -NoProfile -Command "& { Import-Module ./Module/DomainDetective.psd1 -Force; Set-Location Module/Examples; . ./Example.TestOpenRelay.ps1 }"`

------
https://chatgpt.com/codex/tasks/task_e_685b09356ba8832eb3465697f65f281c