### PR TITLE
Fix error messages for Test-SmtpTls

### DIFF
--- a/DomainDetective.PowerShell/Communication/InternalLoggerPowerShell.cs
+++ b/DomainDetective.PowerShell/Communication/InternalLoggerPowerShell.cs
@@ -79,8 +79,9 @@ namespace DomainDetective.PowerShell {
         }
         private void Logger_OnErrorMessage(object sender, LogEventArgs e) {
             var errorId = GetNextErrorId();
-            ErrorRecord errorRecord = new ErrorRecord(new Exception(e.Message), errorId, ErrorCategory.NotSpecified, null) {
-                ErrorDetails = new ErrorDetails(errorId)
+            var detailsMessage = string.IsNullOrEmpty(e.FullMessage) ? e.Message : e.FullMessage;
+            ErrorRecord errorRecord = new ErrorRecord(new Exception(detailsMessage), errorId, ErrorCategory.NotSpecified, null) {
+                ErrorDetails = new ErrorDetails(detailsMessage)
             };
             WriteError(errorRecord);
         }


### PR DESCRIPTION
## Summary
- show full SMTP TLS error message in `InternalLoggerPowerShell`

## Testing
- `dotnet build DomainDetective.sln -c Debug`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Network is unreachable)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685b09ae686c832ea3e687b4d81a5328