### PR TITLE
Add embedded DNS server list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,4 @@ build/*
 /Ignore/*
 dotnet-install.sh
 packages-microsoft-prod.deb
+*.gz

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            analysis.LoadBuiltInServers();
             var servers = analysis.FilterServers(country: "United States", take: 3);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationRegionsClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            analysis.LoadBuiltInServers();
 
             var servers = analysis.FilterServers(take: 8);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -13,6 +13,13 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void LoadBuiltInServersAddsEntries() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltInServers(clearExisting: true);
+            Assert.NotEmpty(analysis.Servers);
+        }
+
+        [Fact]
         public void AddAndRemoveServerWorks() {
             var analysis = new DnsPropagationAnalysis();
             var entry = new PublicDnsEntry { IPAddress = "1.1.1.1", Country = "Test" };

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -17,4 +17,16 @@
   <ItemGroup>
       <!-- DNSBL list is built into the code. Use LoadDNSBL to load external files if required. -->
   </ItemGroup>
+
+  <ItemGroup>
+    <PublicDnsJson Include="..\Data\DNS\PublicDNS.json" />
+  </ItemGroup>
+
+
+  <Target Name="EmbedPublicDns" BeforeTargets="PrepareResources">
+    <Exec Command="gzip -c &quot;%(PublicDnsJson.FullPath)&quot; > &quot;$(IntermediateOutputPath)PublicDNS.json.gz&quot;" />
+    <ItemGroup>
+      <EmbeddedResource Include="$(IntermediateOutputPath)PublicDNS.json.gz" LogicalName="Data.PublicDNS.json.gz" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -5,8 +5,10 @@ Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 $Results = Test-DnsPropagation -DomainName 'google.com' -RecordType A -CompareResults
 $Results | Format-Table
 
-$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $PSScriptRoot/../Data/DNS/PublicDNS.json
+$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX
+$UpdatedServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersUri 'https://raw.githubusercontent.com/EvotecIT/DomainDetective/refs/heads/master/Data/DNS/PublicDNS.json'
 $PublicServers | Format-Table
+$UpdatedServers | Format-Table
 
 $TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults
 $TxtCheck | Format-Table

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -23,7 +23,7 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```
 - `Test-DnsPropagation` – checks how DNS records propagate across public resolvers.
   ```powershell
-  Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile './Data/DNS/PublicDNS.json' -CompareResults
+  Test-DnsPropagation -DomainName "example.com" -RecordType A -CompareResults
   ```
 - `Test-CaaRecord` – validates CAA entries.
   ```powershell


### PR DESCRIPTION
## Summary
- embed PublicDNS.json in the library and load it by default
- allow downloading a server list from URI
- update the DNS propagation cmdlet to use the embedded data or external sources
- adjust examples and docs to new defaults
- ignore generated gzip files

## Testing
- `dotnet test` *(fails: Assert.NotEmpty() Collection was empty)*

------
https://chatgpt.com/codex/tasks/task_e_685b8af644f4832e80a85b7a72d16b8c