### PR TITLE
Add DS chain TTL tracking

### DIFF
--- a/DomainDetective.Tests/TestDNSSECAnalysis.cs
+++ b/DomainDetective.Tests/TestDNSSECAnalysis.cs
@@ -10,6 +10,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DNSSecAnalysis.DsAuthenticData);
             Assert.True(healthCheck.DNSSecAnalysis.DsMatch);
             Assert.True(healthCheck.DNSSecAnalysis.ChainValid);
+            Assert.NotEmpty(healthCheck.DNSSecAnalysis.DsTtls);
         }
 
         [Fact]

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -31,6 +31,7 @@ namespace DomainDetective {
                 DsAuthenticData = analysis.DsAuthenticData,
                 DsMatch = analysis.DsMatch,
                 ChainValid = analysis.ChainValid,
+                DsTtls = analysis.DsTtls,
             };
         }
 
@@ -99,6 +100,9 @@ namespace DomainDetective {
 
         /// <summary>True when the entire DNSSEC chain validated.</summary>
         public bool ChainValid { get; set; }
+
+        /// <summary>TTL values for each DS lookup in the validation chain.</summary>
+        public IReadOnlyList<int> DsTtls { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- include TTL collection for each DS lookup when validating DNSSEC
- expose recorded TTL values via `DsTtls`
- verify TTLs exist in DNSSEC analysis tests

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build -c Release` *(fails: Unable to reach external network)*

------
https://chatgpt.com/codex/tasks/task_e_685b9cbaa1f0832e9ce7b5a95305be2a