### PR TITLE
feat(dmarc): preserve original pct value

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -40,6 +40,7 @@ namespace DomainDetective.Tests {
             var healthCheck = new DomainHealthCheck();
             await healthCheck.CheckDMARC(dmarcRecord);
             Assert.Equal(100, healthCheck.DmarcAnalysis.Pct);
+            Assert.Equal(500, healthCheck.DmarcAnalysis.OriginalPct);
             Assert.False(healthCheck.DmarcAnalysis.IsPctValid);
             Assert.Equal(
                 "Percentage value must be between 0 and 100.",
@@ -52,6 +53,7 @@ namespace DomainDetective.Tests {
             var healthCheck = new DomainHealthCheck();
             await healthCheck.CheckDMARC(dmarcRecord);
             Assert.Equal(0, healthCheck.DmarcAnalysis.Pct);
+            Assert.Equal(-1, healthCheck.DmarcAnalysis.OriginalPct);
             Assert.False(healthCheck.DmarcAnalysis.IsPctValid);
             Assert.Equal(
                 "Percentage value must be between 0 and 100.",

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -52,6 +52,7 @@ namespace DomainDetective {
         public string DkimAShort { get; private set; }
         public string SpfAShort { get; private set; }
         public int? Pct { get; private set; }
+        public int? OriginalPct { get; private set; }
         public bool IsPctValid { get; private set; }
         public int ReportingIntervalShort { get; private set; }
 
@@ -79,6 +80,7 @@ namespace DomainDetective {
             ValidDkimAlignment = true;
             ValidSpfAlignment = true;
             Pct = null;
+            OriginalPct = null;
             ReportingIntervalShort = 0;
             ExternalReportAuthorization = new Dictionary<string, bool>();
 
@@ -138,14 +140,15 @@ namespace DomainDetective {
                             // percentage of messages to which the DMARC policy
                             // applies.  It should be a number between 0 and 100.
                             if (int.TryParse(value, out var pct)) {
+                                OriginalPct = pct;
                                 IsPctValid = pct >= 0 && pct <= 100;
-                                if (pct < 0) {
-                                    pct = 0;
-                                }
-                                if (pct > 100) {
-                                    pct = 100;
-                                }
                                 Pct = pct;
+                                if (Pct < 0) {
+                                    Pct = 0;
+                                }
+                                if (Pct > 100) {
+                                    Pct = 100;
+                                }
                             } else {
                                 IsPctValid = false;
                             }


### PR DESCRIPTION
## Summary
- add `OriginalPct` property
- capture the provided pct value before clamping
- test pct diagnostics with new field

## Testing
- `dotnet build`
- `dotnet test` *(fails: Exceeds lookups should be true, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685b9ccc78ac832e92d5a0b5b5c29d25