### PR TITLE
Add failing BIMI, security.txt, DNSSEC, TLSRPT tests

### DIFF
--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -1,4 +1,6 @@
 using DnsClientX;
+using System.Net;
+using System.Text;
 
 namespace DomainDetective.Tests {
     public class TestBimiAnalysis {
@@ -44,6 +46,45 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.SvgFetched);
             Assert.True(analysis.SvgValid);
             Assert.Contains(warnings, w => w.FullMessage.Contains("does not use HTTPS"));
+        }
+
+        [Fact]
+        public async Task InvalidSvgFailsValidation() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "image/svg+xml";
+                var buffer = Encoding.UTF8.GetBytes("<html></html>");
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var record = $"v=BIMI1; l={prefix}logo.svg";
+                var answers = new List<DnsAnswer> {
+                    new DnsAnswer { DataRaw = record, Type = DnsRecordType.TXT }
+                };
+                var analysis = new BimiAnalysis();
+                await analysis.AnalyzeBimiRecords(answers, new InternalLogger());
+
+                Assert.True(analysis.SvgFetched);
+                Assert.False(analysis.SvgValid);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        private static int GetFreePort() {
+            var socket = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            socket.Start();
+            var port = ((IPEndPoint)socket.LocalEndpoint).Port;
+            socket.Stop();
+            return port;
         }
     }
 }

--- a/DomainDetective.Tests/TestDNSSECInvalidDs.cs
+++ b/DomainDetective.Tests/TestDNSSECInvalidDs.cs
@@ -10,5 +10,14 @@ namespace DomainDetective.Tests {
             bool result = (bool)method.Invoke(null, new object[] { dnskey, dsRecord, "example.com" });
             Assert.False(result);
         }
+
+        [Fact]
+        public void MismatchedDsDigestReturnsFalse() {
+            var dnskey = "257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==";
+            var dsRecord = "2371 ECDSAP256SHA256 2 c988ec423e3880eb8dd8a46fe06ca230ee23f35b578d64e78b29c3e1c83d246";
+            var method = typeof(DNSSecAnalysis).GetMethod("VerifyDsMatch", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { dnskey, dsRecord, "example.com" });
+            Assert.False(result);
+        }
     }
 }

--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -92,6 +92,34 @@ namespace DomainDetective.Tests {
             }
         }
 
+        [Fact]
+        public async Task ExpiredDateMakesRecordInvalid() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var expires = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var content = $"Contact: mailto:admin@example.com\nExpires: {expires}";
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "text/plain";
+                var buffer = Encoding.UTF8.GetBytes(content);
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.Verify(prefix.Replace("http://", string.Empty).TrimEnd('/'), new[] { HealthCheckType.SECURITYTXT });
+                Assert.True(healthCheck.SecurityTXTAnalysis.RecordPresent);
+                Assert.False(healthCheck.SecurityTXTAnalysis.RecordValid);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
         private static int GetFreePort() {
             var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
             listener.Start();

--- a/DomainDetective.Tests/TestTLSRPTAnalysis.cs
+++ b/DomainDetective.Tests/TestTLSRPTAnalysis.cs
@@ -43,5 +43,17 @@ namespace DomainDetective.Tests {
 
             Assert.True(analysis.PolicyValid);
         }
+
+        [Fact]
+        public async Task MissingRuaInvalidatesPolicyAnalysis() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "v=TLSRPTv1", Type = DnsRecordType.TXT }
+            };
+            var analysis = new TLSRPTAnalysis();
+            await analysis.AnalyzeTlsRptRecords(answers, new InternalLogger());
+
+            Assert.False(analysis.RuaDefined);
+            Assert.False(analysis.PolicyValid);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- test BIMI with invalid SVG content
- check security.txt with expired Expires value
- verify mismatched DS detection
- ensure TLSRPT analysis fails without rua

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -v n` *(fails: Test Run Failed)*

------
https://chatgpt.com/codex/tasks/task_e_685b9d03e8c0832e9b11fbd65782ac33