### PR TITLE
Expand CLI with domain analysis

### DIFF
--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -1,0 +1,89 @@
+using Spectre.Console;
+using System;
+using System.Collections;
+using System.Linq;
+
+namespace DomainDetective.CLI;
+
+internal static class CliHelpers
+{
+    private static void AddProperties(Table table, object obj, bool listAsString = false)
+    {
+        if (obj == null)
+        {
+            return;
+        }
+        var properties = obj.GetType().GetProperties();
+        foreach (var property in properties)
+        {
+            var value = property.GetValue(obj);
+            if (value is IList listValue)
+            {
+                if (listAsString || value is byte[])
+                {
+                    var listString = string.Join(", ", listValue.Cast<object>());
+                    table.AddRow(property.Name, listString);
+                }
+                else
+                {
+                    var nested = new Table().Border(TableBorder.Rounded);
+                    nested.AddColumn("Index");
+                    nested.AddColumn("Value");
+                    for (var i = 0; i < listValue.Count; i++)
+                    {
+                        nested.AddRow(i.ToString(), Markup.Escape(listValue[i]?.ToString() ?? "null"));
+                    }
+                    table.AddRow(new Markup(property.Name), nested);
+                }
+            }
+            else if (value is IDictionary dictionaryValue)
+            {
+                var nested = new Table().Border(TableBorder.Rounded);
+                nested.AddColumn("Key");
+                nested.AddColumn("Value");
+                foreach (DictionaryEntry entry in dictionaryValue)
+                {
+                    var key = Markup.Escape(entry.Key.ToString());
+                    var val = Markup.Escape(entry.Value?.ToString() ?? "null");
+                    nested.AddRow(key, val);
+                }
+                table.AddRow(new Markup(property.Name), nested);
+            }
+            else
+            {
+                table.AddRow(Markup.Escape(property.Name), Markup.Escape(value?.ToString() ?? "null"));
+            }
+        }
+    }
+
+    public static void ShowPropertiesTable(string title, object data)
+    {
+        var table = new Table().Border(TableBorder.Rounded);
+        table.AddColumn("Property");
+        table.AddColumn("Value");
+        if (data is IDictionary dictionary)
+        {
+            foreach (DictionaryEntry entry in dictionary)
+            {
+                AddProperties(table, entry.Value, true);
+            }
+        }
+        else if (data is IList list)
+        {
+            foreach (var item in list)
+            {
+                AddProperties(table, item);
+            }
+        }
+        else
+        {
+            AddProperties(table, data);
+        }
+        var panel = new Panel(table)
+        {
+            Header = new PanelHeader(title),
+            Expand = true
+        };
+        AnsiConsole.Write(panel);
+    }
+}

--- a/DomainDetective.CLI/DomainDetective.CLI.csproj
+++ b/DomainDetective.CLI/DomainDetective.CLI.csproj
@@ -9,4 +9,10 @@
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Spectre.Console" Version="0.50.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
+  </ItemGroup>
 </Project>

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -1,2 +1,112 @@
-// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using DomainDetective;
+using Spectre.Console;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective.CLI;
+
+internal class Program
+{
+    private static readonly Dictionary<string, HealthCheckType> _options = new()
+    {
+        ["dmarc"] = HealthCheckType.DMARC,
+        ["spf"] = HealthCheckType.SPF,
+        ["dkim"] = HealthCheckType.DKIM,
+        ["mx"] = HealthCheckType.MX,
+        ["caa"] = HealthCheckType.CAA,
+        ["ns"] = HealthCheckType.NS,
+        ["dane"] = HealthCheckType.DANE,
+        ["dnssec"] = HealthCheckType.DNSSEC,
+        ["dnsbl"] = HealthCheckType.DNSBL
+    };
+
+    private static async Task<int> Main(string[] args)
+    {
+        if (args.Length == 0 || args.Contains("--help") || args.Contains("-h"))
+        {
+            ShowHelp();
+            return 0;
+        }
+
+        var outputJson = args.Contains("--json");
+        var summaryOnly = args.Contains("--summary");
+
+        var checksOption = args.FirstOrDefault(a => a.StartsWith("--checks="));
+        var selectedChecks = new List<HealthCheckType>();
+        if (checksOption != null)
+        {
+            var parts = checksOption.Substring("--checks=".Length)
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            foreach (var part in parts)
+            {
+                if (_options.TryGetValue(part.ToLowerInvariant(), out var type))
+                {
+                    selectedChecks.Add(type);
+                }
+            }
+        }
+
+        var domains = args.Where(a => !a.StartsWith("--")).ToArray();
+        if (domains.Length == 0)
+        {
+            AnsiConsole.MarkupLine("[red]No domain provided.[/]");
+            return 1;
+        }
+
+        var checks = selectedChecks.Count > 0 ? selectedChecks.ToArray() : null;
+
+        foreach (var domain in domains)
+        {
+            var hc = new DomainHealthCheck { Verbose = false };
+            await hc.Verify(domain, checks);
+
+            if (outputJson)
+            {
+                Console.WriteLine(hc.ToJson());
+                continue;
+            }
+
+            if (summaryOnly)
+            {
+                var summary = hc.BuildSummary();
+                CliHelpers.ShowPropertiesTable($"Summary for {domain}", summary);
+                continue;
+            }
+
+            var activeChecks = checks ?? _options.Values.ToArray();
+            foreach (var check in activeChecks)
+            {
+                object? data = check switch
+                {
+                    HealthCheckType.DMARC => hc.DmarcAnalysis,
+                    HealthCheckType.SPF => hc.SpfAnalysis,
+                    HealthCheckType.DKIM => hc.DKIMAnalysis,
+                    HealthCheckType.MX => hc.MXAnalysis,
+                    HealthCheckType.CAA => hc.CAAAnalysis,
+                    HealthCheckType.NS => hc.NSAnalysis,
+                    HealthCheckType.DANE => hc.DaneAnalysis,
+                    HealthCheckType.DNSBL => hc.DNSBLAnalysis,
+                    HealthCheckType.DNSSEC => hc.DNSSecAnalysis,
+                    _ => null
+                };
+                if (data != null)
+                {
+                    CliHelpers.ShowPropertiesTable($"{check} for {domain}", data);
+                }
+            }
+        }
+
+        return 0;
+    }
+
+    private static void ShowHelp()
+    {
+        AnsiConsole.MarkupLine("[green]DomainDetective CLI[/]");
+        Console.WriteLine("Usage: ddcli [options] <domain> [domain...]");
+        Console.WriteLine("--checks=LIST     Comma separated list of checks: dmarc, spf, dkim, mx, caa, ns, dane, dnssec, dnsbl");
+        Console.WriteLine("--summary         Show condensed summary");
+        Console.WriteLine("--json            Output raw JSON");
+    }
+}


### PR DESCRIPTION
## Summary
- add Spectre.Console and project reference
- implement DomainDetective CLI using Spectre.Console
- helper for rendering result tables

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln` *(fails: Invalid URI errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b9cfa1c7c832eb50bd0d308fc2a47