### PR TITLE
Fix: make analysis properties nullable

### DIFF
--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -14,11 +14,11 @@ namespace DomainDetective {
     /// Analyse BIMI records according to draft specifications.
     /// </summary>
     public class BimiAnalysis {
-        public string BimiRecord { get; private set; }
+        public string? BimiRecord { get; private set; }
         public bool BimiRecordExists { get; private set; }
         public bool StartsCorrectly { get; private set; }
-        public string Location { get; private set; }
-        public string Authority { get; private set; }
+        public string? Location { get; private set; }
+        public string? Authority { get; private set; }
         public bool LocationUsesHttps { get; private set; }
         public bool AuthorityUsesHttps { get; private set; }
         public bool DeclinedToPublish { get; private set; }
@@ -54,9 +54,9 @@ namespace DomainDetective {
             BimiRecord = string.Join(" ", recordList.Select(r => r.Data));
             logger.WriteVerbose($"Analyzing BIMI record {BimiRecord}");
 
-            StartsCorrectly = BimiRecord.StartsWith("v=BIMI1", StringComparison.OrdinalIgnoreCase);
+            StartsCorrectly = BimiRecord?.StartsWith("v=BIMI1", StringComparison.OrdinalIgnoreCase) == true;
 
-            foreach (var part in BimiRecord.Split(';')) {
+            foreach (var part in (BimiRecord ?? string.Empty).Split(';')) {
                 var kv = part.Split(new[] { '=' }, 2);
                 if (kv.Length != 2) {
                     continue;

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace DomainDetective {
 
     public class CAAAnalysis {
-        public string DomainName { get; set; }
+        public string? DomainName { get; set; }
 
         public string Description { get; set; } =
             @"A Certification Authority Authorization (CAA) record allows a domain to specify which certificate authorities (CAs)

--- a/DomainDetective/Protocols/HPKPAnalysis.cs
+++ b/DomainDetective/Protocols/HPKPAnalysis.cs
@@ -8,7 +8,7 @@ namespace DomainDetective {
         public bool HeaderPresent { get; private set; }
         public bool PinsValid { get; private set; }
         public List<string> Pins { get; private set; } = new();
-        public string Header { get; private set; }
+        public string? Header { get; private set; }
 
         public async Task AnalyzeUrl(string url, InternalLogger logger) {
             HeaderPresent = false;
@@ -28,7 +28,7 @@ namespace DomainDetective {
                     return;
                 }
 
-                var parts = Header.Split(';');
+                var parts = (Header ?? string.Empty).Split(';');
                 var valid = true;
                 foreach (var part in parts) {
                     var trimmed = part.Trim();

--- a/DomainDetective/Protocols/SOAAnalysis.cs
+++ b/DomainDetective/Protocols/SOAAnalysis.cs
@@ -5,9 +5,9 @@ using System.Threading.Tasks;
 
 namespace DomainDetective {
     public class SOAAnalysis {
-        public string DomainName { get; private set; }
-        public string PrimaryNameServer { get; private set; }
-        public string ResponsibleMailbox { get; private set; }
+        public string? DomainName { get; private set; }
+        public string? PrimaryNameServer { get; private set; }
+        public string? ResponsibleMailbox { get; private set; }
         public long SerialNumber { get; private set; }
         public int Refresh { get; private set; }
         public int Retry { get; private set; }

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -10,7 +10,7 @@ namespace DomainDetective {
     /// Analyzes SMTP TLS Reporting (TLSRPT) policies according to RFC 8460.
     /// </summary>
     public class TLSRPTAnalysis {
-        public string TlsRptRecord { get; private set; }
+        public string? TlsRptRecord { get; private set; }
         public bool TlsRptRecordExists { get; private set; }
         public bool StartsCorrectly { get; private set; }
         public bool RuaDefined { get; private set; }
@@ -47,9 +47,9 @@ namespace DomainDetective {
             TlsRptRecord = string.Join(" ", recordList.Select(r => r.Data));
             logger?.WriteVerbose($"Analyzing TLSRPT record {TlsRptRecord}");
 
-            StartsCorrectly = TlsRptRecord.StartsWith("v=TLSRPTv1", StringComparison.OrdinalIgnoreCase);
+            StartsCorrectly = TlsRptRecord?.StartsWith("v=TLSRPTv1", StringComparison.OrdinalIgnoreCase) == true;
 
-            foreach (var part in TlsRptRecord.Split(';')) {
+            foreach (var part in (TlsRptRecord ?? string.Empty).Split(';')) {
                 var kv = part.Split(new[] { '=' }, 2);
                 if (kv.Length != 2) {
                     continue;


### PR DESCRIPTION
## Summary
- update property types to nullable strings across analyses
- guard against null BIMI and TLSRPT records
- guard against missing HPKP header

## Testing
- `dotnet test` *(fails: Assert failures)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685ba86b65c4832e9c362eb56d2700a6