### PR TITLE
Fix PublicDNS.gz build conflict

### DIFF
--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -24,12 +24,15 @@
   </ItemGroup>
 
 
-  <Target Name="EmbedPublicDns" BeforeTargets="CoreCompile">
+  <Target Name="EmbedPublicDns"
+          Inputs="@(PublicDnsJson)"
+          Outputs="$(ProjectDir)PublicDNS.json.gz"
+          BeforeTargets="CoreCompile">
     <!-- Use gzip on Unix-like systems -->
-    <Exec Condition=" '$(OS)' != 'Windows_NT' and !Exists('$(ProjectDir)PublicDNS.json.gz') "
+    <Exec Condition=" '$(OS)' != 'Windows_NT' "
           Command="gzip -c &quot;%(PublicDnsJson.FullPath)&quot; > &quot;$(ProjectDir)PublicDNS.json.gz&quot;" />
     <!-- Use PowerShell on Windows to create gzip archive -->
-    <Exec Condition=" '$(OS)' == 'Windows_NT' and !Exists('$(ProjectDir)PublicDNS.json.gz') "
+    <Exec Condition=" '$(OS)' == 'Windows_NT' "
           Command="powershell -NoProfile -Command &quot;$in=[IO.File]::OpenRead('%(PublicDnsJson.FullPath)'); $out=[IO.File]::Create('$(ProjectDir)PublicDNS.json.gz'); $gzip=[IO.Compression.GzipStream]::new($out,[IO.Compression.CompressionLevel]::Optimal); $in.CopyTo($gzip); $gzip.Dispose(); $in.Dispose(); $out.Dispose();&quot;" />
     <Touch Files="$(ProjectDir)PublicDNS.json.gz" />
   </Target>


### PR DESCRIPTION
## Summary
- tweak `EmbedPublicDns` target to run once per build
- ensure gzip generation doesn't collide when multi-targeting

## Testing
- `dotnet restore DomainDetective.sln`
- `dotnet build DomainDetective.sln --configuration Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685babc49dcc832eb701b60d4caab17a