### PR TITLE
Add DKIM public key validation

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -21,6 +21,7 @@ namespace DomainDetective.PowerShell {
                     DkimRecordExists = result.DkimRecordExists,
                     StartsCorrectly = result.StartsCorrectly,
                     PublicKeyExists = result.PublicKeyExists,
+                    ValidPublicKey = result.ValidPublicKey,
                     KeyTypeExists = result.KeyTypeExists,
                     PublicKey = result.PublicKey,
                     ServiceType = result.ServiceType,
@@ -53,6 +54,9 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Indicates whether the public key was found.</summary>
         public bool PublicKeyExists { get; set; }
+
+        /// <summary>Validation result for the public key.</summary>
+        public bool ValidPublicKey { get; set; }
 
         /// <summary>Indicates whether the key type is present.</summary>
         public bool KeyTypeExists { get; set; }

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -18,6 +18,7 @@ namespace DomainDetective.Tests {
                 Assert.Equal("rsa", healthCheck.DKIMAnalysis.AnalysisResults[selector].KeyType);
                 Assert.Equal("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB", healthCheck.DKIMAnalysis.AnalysisResults[selector].PublicKey);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].PublicKeyExists);
+                Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].ValidPublicKey);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].StartsCorrectly);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].KeyTypeExists);
             }
@@ -39,6 +40,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].StartsCorrectly);
             Assert.Equal("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB", healthCheck.DKIMAnalysis.AnalysisResults["selector1"].PublicKey);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].PublicKeyExists);
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].ValidPublicKey);
 
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].Name == "selector2-evotec-pl._domainkey.evotecpoland.onmicrosoft.com");
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].DkimRecord == "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21OfspkRgPHhdCgu3kWgBX+xLyw7wRqM+Y4KaX82Pul9ikEDfZCJ35siFzV2WMH9Od/yM2TtMnubRqm9QN6paEB0VhNgNURQMmyTVsBO1usTJS9IvkIt3JtTFEinzVJLEaOC/F3d6bJaW9MMKUTBra9RcUf/E6dWAaJX8lrK8SefL9adNTwED8ZgFBnFcoJJn6e1W2WyIZ/8XAk+5Jwc7JMFZsdjFYdBSDPNyEfhNsKahVdRvdCG+OeDHyLSiNuFE27wtXaUI2TySDcfSSzE8k8z/Td9mMb0DQ2qaJ6xxk/5cwzwYSXr3sdGp++mHpGOJm18OwfsJmFCuSEcFGrHAQIDAQAB;");
@@ -48,6 +50,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].KeyType == "rsa");
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].PublicKey == "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21OfspkRgPHhdCgu3kWgBX+xLyw7wRqM+Y4KaX82Pul9ikEDfZCJ35siFzV2WMH9Od/yM2TtMnubRqm9QN6paEB0VhNgNURQMmyTVsBO1usTJS9IvkIt3JtTFEinzVJLEaOC/F3d6bJaW9MMKUTBra9RcUf/E6dWAaJX8lrK8SefL9adNTwED8ZgFBnFcoJJn6e1W2WyIZ/8XAk+5Jwc7JMFZsdjFYdBSDPNyEfhNsKahVdRvdCG+OeDHyLSiNuFE27wtXaUI2TySDcfSSzE8k8z/Td9mMb0DQ2qaJ6xxk/5cwzwYSXr3sdGp++mHpGOJm18OwfsJmFCuSEcFGrHAQIDAQAB");
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].PublicKeyExists);
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].ValidPublicKey);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].StartsCorrectly);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].KeyTypeExists);
 
@@ -91,6 +94,26 @@ namespace DomainDetective.Tests {
             Assert.Single(healthCheck.DKIMAnalysis.AnalysisResults);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults.ContainsKey("selector2"));
             Assert.Equal(record2, healthCheck.DKIMAnalysis.AnalysisResults["selector2"].DkimRecord);
+        }
+
+        [Fact]
+        public async Task InvalidBase64PublicKeyIsFlagged() {
+            const string record = "v=DKIM1; k=rsa; p=@@@badbase64;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
+        }
+
+        [Fact]
+        public async Task ShortPublicKeyIsFlagged() {
+            const string record = "v=DKIM1; k=rsa; p=QUJD;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
         }
     }
 }

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using DomainDetective.Definitions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -55,6 +56,12 @@ namespace DomainDetective {
                     switch (key) {
                         case "p":
                             analysis.PublicKey = value;
+                            try {
+                                var bytes = Convert.FromBase64String(value);
+                                analysis.ValidPublicKey = bytes.Length >= 16;
+                            } catch (FormatException) {
+                                analysis.ValidPublicKey = false;
+                            }
                             break;
                         case "s":
                             analysis.ServiceType = value;
@@ -101,6 +108,7 @@ namespace DomainDetective {
         public bool DkimRecordExists { get; set; }
         public bool StartsCorrectly { get; set; }
         public bool PublicKeyExists { get; set; }
+        public bool ValidPublicKey { get; set; }
         public bool KeyTypeExists { get; set; }
         public string PublicKey { get; set; }
         public string ServiceType { get; set; }


### PR DESCRIPTION
## Summary
- validate DKIM `p` tag base64 and length
- expose `ValidPublicKey` in DKIM record output
- test valid and invalid `p` tag values

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Invalid URI errors)*

------
https://chatgpt.com/codex/tasks/task_e_685bbfca5c30832ea3af94ebee4378a6