### PR TITLE
Add documentation for ServiceDefinition

### DIFF
--- a/DomainDetective/Definitions/ServiceDefinition.cs
+++ b/DomainDetective/Definitions/ServiceDefinition.cs
@@ -1,11 +1,26 @@
-namespace DomainDetective {
-    public readonly struct ServiceDefinition {
-        public ServiceDefinition(string host, int port) {
-            Host = host;
-            Port = port;
-        }
+namespace DomainDetective;
 
-        public string Host { get; }
-        public int Port { get; }
+/// <summary>
+/// Defines a target host and port for service checks.
+/// </summary>
+/// <remarks>
+/// <para>Instances describe endpoints that <see cref="DomainHealthCheck"/> can
+/// verify.</para>
+/// </remarks>
+public readonly struct ServiceDefinition {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ServiceDefinition"/> struct.
+    /// </summary>
+    /// <param name="host">The host name to query.</param>
+    /// <param name="port">The port used by the service.</param>
+    public ServiceDefinition(string host, int port) {
+        Host = host;
+        Port = port;
     }
+
+    /// <summary>Gets the host name.</summary>
+    public string Host { get; }
+
+    /// <summary>Gets the service port.</summary>
+    public int Port { get; }
 }


### PR DESCRIPTION
## Summary
- document ServiceDefinition struct and constructor
- add remarks and property documentation

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685bc46ee5e4832ea4cab9b298c3afed