### PR TITLE
Add enum summaries

### DIFF
--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -1,24 +1,47 @@
-namespace DomainDetective {
-    public enum HealthCheckType {
-        DMARC,
-        SPF,
-        DKIM,
-        MX,
-        CAA,
-        NS,
-        DANE,
-        DNSBL,
-        DNSSEC,
-        MTASTS,
-        TLSRPT,
-        BIMI,
-        CERT,
-        SECURITYTXT,
-        SOA,
-        OPENRELAY,
-        STARTTLS,
-        SMTPTLS,
-        HTTP,
-        HPKP
-    }
+namespace DomainDetective;
+
+/// <summary>
+/// Represents the various health checks that can be performed on a domain.
+/// </summary>
+public enum HealthCheckType {
+    /// <summary>Perform a DMARC policy check.</summary>
+    DMARC,
+    /// <summary>Verify the SPF record.</summary>
+    SPF,
+    /// <summary>Validate DKIM configuration.</summary>
+    DKIM,
+    /// <summary>Check MX records.</summary>
+    MX,
+    /// <summary>Inspect CAA records.</summary>
+    CAA,
+    /// <summary>Verify NS records.</summary>
+    NS,
+    /// <summary>Validate DANE information.</summary>
+    DANE,
+    /// <summary>Check DNSBL listings.</summary>
+    DNSBL,
+    /// <summary>Validate DNSSEC configuration.</summary>
+    DNSSEC,
+    /// <summary>Check MTA-STS policy.</summary>
+    MTASTS,
+    /// <summary>Check TLS-RPT configuration.</summary>
+    TLSRPT,
+    /// <summary>Validate BIMI records.</summary>
+    BIMI,
+    /// <summary>Inspect certificate records.</summary>
+    CERT,
+    /// <summary>Check for security.txt presence.</summary>
+    SECURITYTXT,
+    /// <summary>Inspect SOA records.</summary>
+    SOA,
+    /// <summary>Detect open SMTP relay.</summary>
+    OPENRELAY,
+    /// <summary>Validate STARTTLS support.</summary>
+    STARTTLS,
+    /// <summary>Verify SMTP TLS configuration.</summary>
+    SMTPTLS,
+    /// <summary>Perform HTTP checks.</summary>
+    HTTP,
+    /// <summary>Validate HPKP configuration.</summary>
+    HPKP
 }

--- a/DomainDetective/Definitions/QueryType.cs
+++ b/DomainDetective/Definitions/QueryType.cs
@@ -1,6 +1,11 @@
-namespace DomainDetective {
-    public enum QueryType {
-        Standard,
-        DnsOverHttps,
-    }
+namespace DomainDetective;
+
+/// <summary>
+/// Defines the supported DNS query mechanisms.
+/// </summary>
+public enum QueryType {
+    /// <summary>Standard UDP/TCP DNS query.</summary>
+    Standard,
+    /// <summary>Query using DNS over HTTPS.</summary>
+    DnsOverHttps,
 }

--- a/DomainDetective/Definitions/ServiceType.cs
+++ b/DomainDetective/Definitions/ServiceType.cs
@@ -1,6 +1,11 @@
-namespace DomainDetective {
-    public enum ServiceType {
-        SMTP = 25,
-        HTTPS = 443
-    }
+namespace DomainDetective;
+
+/// <summary>
+/// Enumerates common service ports used in health checks.
+/// </summary>
+public enum ServiceType {
+    /// <summary>SMTP service running on port 25.</summary>
+    SMTP = 25,
+    /// <summary>HTTPS service running on port 443.</summary>
+    HTTPS = 443
 }

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -323,11 +323,19 @@ As an illustration, a CAA record that is set on example.com is also applicable t
         public Dictionary<string, string> Parameters { get; set; } = new Dictionary<string, string>();
     }
 
+    /// <summary>
+    /// Describes the recognized CAA tag types.
+    /// </summary>
     public enum CAATagType {
+        /// <summary>An unrecognized tag.</summary>
         Unknown,
+        /// <summary>Authorizes issuance for a specific CA.</summary>
         Issue,
+        /// <summary>Authorizes wildcard certificate issuance.</summary>
         IssueWildcard,
+        /// <summary>Provides incident report contact information.</summary>
         Iodef,
+        /// <summary>Authorizes issuance for S/MIME certificates.</summary>
         IssueMail
     }
 }


### PR DESCRIPTION
## Summary
- document enum member usage in `HealthCheckType`, `ServiceType`, `QueryType`, and `CAATagType`

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Assert.NotNull and Assert.True failures)*

------
https://chatgpt.com/codex/tasks/task_e_685bc46f707c832e8d688d04b8314bb9