### PR TITLE
Add XmlDoc comments to all PowerShell cmdlets

### DIFF
--- a/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
@@ -1,25 +1,27 @@
 using System.Management.Automation;
 
 namespace DomainDetective.PowerShell {
-    /// <summary>
-    ///     Adds a DNSBL provider entry to an existing <see cref="DNSBLAnalysis"/> instance.
-    /// </summary>
+    /// <summary>Adds a DNSBL provider entry to an analysis object.</summary>
+    /// <example>
+    ///   <summary>Add a provider and return the updated analysis.</summary>
+    ///   <code>Add-DnsblProvider -Domain "dnsbl.example.com"</code>
+    /// </example>
     [Cmdlet(VerbsCommon.Add, "DnsblProvider")]
     public sealed class CmdletAddDnsblProvider : PSCmdlet {
-        /// <summary>Domain name of the DNSBL provider.</summary>
+        /// <param name="Domain">Domain name of the DNSBL provider.</param>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Domain { get; set; }
 
-        /// <summary>Sets the provider as enabled on creation.</summary>
+        /// <param name="Enabled">Sets the provider as enabled.</param>
         [Parameter(Mandatory = false)]
         public bool Enabled { get; set; } = true;
 
-        /// <summary>Optional descriptive comment.</summary>
+        /// <param name="Comment">Optional descriptive comment.</param>
         [Parameter(Mandatory = false)]
         public string Comment { get; set; }
 
-        /// <summary>Analysis object to add the provider to.</summary>
+        /// <param name="InputObject">Analysis object to add the provider to.</param>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletClearDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletClearDnsblProvider.cs
@@ -1,8 +1,14 @@
 using System.Management.Automation;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Removes all DNSBL providers from an analysis object.</summary>
+    /// <example>
+    ///   <summary>Clear the provider list.</summary>
+    ///   <code>Clear-DnsblProvider</code>
+    /// </example>
     [Cmdlet(VerbsCommon.Clear, "DnsblProvider")]
     public sealed class CmdletClearDnsblProvider : PSCmdlet {
+        /// <param name="InputObject">Analysis object to modify.</param>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletGetDomainSummary.cs
+++ b/DomainDetective.PowerShell/CmdletGetDomainSummary.cs
@@ -4,13 +4,20 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Returns a summary of domain health checks.</summary>
+    /// <example>
+    ///   <summary>Get basic domain overview.</summary>
+    ///   <code>Get-DomainSummary -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsCommon.Get, "DomainSummary", DefaultParameterSetName = "ServerName")]
     [OutputType(typeof(DomainSummary))]
     public sealed class CmdletGetDomainSummary : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to analyze.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
+++ b/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Retrieves WHOIS information for the specified domain.</summary>
+    /// <example>
+    ///   <summary>Get WHOIS details.</summary>
+    ///   <code>Get-WhoisInfo -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsCommon.Get, "WhoisInfo", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletGetWhoisInfo : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to retrieve WHOIS information for.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletImportDnsblConfig.cs
+++ b/DomainDetective.PowerShell/CmdletImportDnsblConfig.cs
@@ -1,18 +1,27 @@
 using System.Management.Automation;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Imports DNSBL provider configuration from a file.</summary>
+    /// <example>
+    ///   <summary>Load providers from JSON.</summary>
+    ///   <code>Import-DnsblConfig -Path ./DnsblProviders.json -OverwriteExisting</code>
+    /// </example>
     [Cmdlet(VerbsData.Import, "DnsblConfig")]
     public sealed class CmdletImportDnsblConfig : PSCmdlet {
+        /// <param name="Path">Path to the configuration file.</param>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Path { get; set; }
 
+        /// <param name="OverwriteExisting">Replace existing providers.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter OverwriteExisting { get; set; }
 
+        /// <param name="ClearExisting">Remove current providers before import.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter ClearExisting { get; set; }
 
+        /// <param name="InputObject">Analysis object to modify.</param>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
@@ -1,12 +1,19 @@
 using System.Management.Automation;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Removes a DNSBL provider entry from an analysis object.</summary>
+    /// <example>
+    ///   <summary>Remove a provider by domain.</summary>
+    ///   <code>Remove-DnsblProvider -Domain dnsbl.example.com</code>
+    /// </example>
     [Cmdlet(VerbsCommon.Remove, "DnsblProvider")]
     public sealed class CmdletRemoveDnsblProvider : PSCmdlet {
+        /// <param name="Domain">Domain name of the provider to remove.</param>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Domain { get; set; }
 
+        /// <param name="InputObject">Analysis object to modify.</param>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates BIMI record for the specified domain.</summary>
+    /// <example>
+    ///   <summary>Check BIMI configuration.</summary>
+    ///   <code>Test-BimiRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "BimiRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestBimiRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestBlackList.cs
+++ b/DomainDetective.PowerShell/CmdletTestBlackList.cs
@@ -4,15 +4,23 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Queries DNSBL providers to see if domains or IPs are listed.</summary>
+    /// <example>
+    ///   <summary>Check a single host.</summary>
+    ///   <code>Test-DomainBlacklist -NameOrIpAddress example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DomainBlacklist", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestBlackList : AsyncPSCmdlet {
+        /// <param name="NameOrIpAddress">Domain names or IP addresses to check.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string[] NameOrIpAddress;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="FullResponse">Return full analysis result.</param>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 

--- a/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates CAA records for a domain.</summary>
+    /// <example>
+    ///   <summary>Check CAA entries.</summary>
+    ///   <code>Test-CaaRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "CaaRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestCaaRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Enumerates raw DNSBL records for a domain or IP address.</summary>
+    /// <example>
+    ///   <summary>List DNSBL records.</summary>
+    ///   <code>Test-DNSBLRecord -NameOrIpAddress example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DNSBLRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDNSBLRecord : AsyncPSCmdlet {
+        /// <param name="NameOrIpAddress">Domain or IP to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string NameOrIpAddress;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -4,15 +4,23 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates DANE TLSA records for the given domain.</summary>
+    /// <example>
+    ///   <summary>Check DANE records.</summary>
+    ///   <code>Test-DaneRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DaneRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDaneRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="FullResponse">Return full analysis object.</param>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 

--- a/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
@@ -4,22 +4,32 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates DKIM records for the specified selectors.</summary>
+    /// <example>
+    ///   <summary>Verify DKIM selectors.</summary>
+    ///   <code>Test-DkimRecord -DomainName example.com -Selectors selector1</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DkimRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDkimRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="Selectors">Selectors to validate.</param>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string[] Selectors;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 2, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="FullResponse">Return full analysis result.</param>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 
+        /// <param name="Raw">Return raw response objects.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter Raw;
 

--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -3,15 +3,23 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates DMARC record for a domain.</summary>
+    /// <example>
+    ///   <summary>Check DMARC settings.</summary>
+    ///   <code>Test-DmarcRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DmarcRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDmarcRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="Raw">Return raw analysis object.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter Raw;
 

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -5,28 +5,40 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Checks how DNS records propagate across public resolvers.</summary>
+    /// <example>
+    ///   <summary>Test propagation of an A record.</summary>
+    ///   <code>Test-DnsPropagation -DomainName example.com -RecordType A -ServersFile ./PublicDNS.json</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DnsPropagation", DefaultParameterSetName = "ServersFile")]
     public sealed class CmdletTestDnsPropagation : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServersFile")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="RecordType">DNS record type to test.</param>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServersFile")]
         public DnsRecordType RecordType;
 
+        /// <param name="ServersFile">Path to JSON file with DNS servers.</param>
         [Parameter(Mandatory = true, Position = 2, ParameterSetName = "ServersFile")]
         [ValidateNotNullOrEmpty]
         public string ServersFile;
 
+        /// <param name="Country">Filter servers by country.</param>
         [Parameter(Mandatory = false)]
         public string Country;
 
+        /// <param name="Location">Filter servers by location.</param>
         [Parameter(Mandatory = false)]
         public string Location;
 
+        /// <param name="Take">Limit the number of servers queried.</param>
         [Parameter(Mandatory = false)]
         public int? Take;
 
+        /// <param name="CompareResults">Return aggregated comparison of results.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter CompareResults;
 

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -4,15 +4,23 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates DNSSEC configuration for a domain.</summary>
+    /// <example>
+    ///   <summary>Check DNSSEC records.</summary>
+    ///   <code>Test-DnsSec -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DnsSec", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDnsSec : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="Raw">Return raw analysis object.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter Raw;
 

--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -3,21 +3,31 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Runs multiple domain health checks and returns the results.</summary>
+    /// <example>
+    ///   <summary>Perform a full health test.</summary>
+    ///   <code>Test-DomainHealth -DomainName example.com -Verbose</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DomainHealth", DefaultParameterSetName = "ServerName")]
     [OutputType(typeof(DomainHealthCheck))]
     public sealed class CmdletTestDomainHealth : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to analyze.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="HealthCheckType">Specific tests to run.</param>
         [Parameter(Mandatory = false)]
         public HealthCheckType[]? HealthCheckType;
 
+        /// <param name="DkimSelectors">DKIM selectors used when testing DKIM.</param>
         [Parameter(Mandatory = false)]
         public string[]? DkimSelectors;
 
+        /// <param name="DaneServiceType">Service types to check for DANE.</param>
         [Parameter(Mandatory = false)]
         public ServiceType[]? DaneServiceType;
 

--- a/DomainDetective.PowerShell/CmdletTestMxRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestMxRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Retrieves MX records for a domain.</summary>
+    /// <example>
+    ///   <summary>Check MX configuration.</summary>
+    ///   <code>Test-MxRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "MxRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestMxRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestNsRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestNsRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Retrieves NS records for a domain.</summary>
+    /// <example>
+    ///   <summary>Query name servers.</summary>
+    ///   <code>Test-NsRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "NsRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestNsRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -2,12 +2,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Checks if an SMTP server is an open relay.</summary>
+    /// <example>
+    ///   <summary>Test a mail server.</summary>
+    ///   <code>Test-OpenRelay -HostName mail.example.com -Port 25</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "OpenRelay", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestOpenRelay : AsyncPSCmdlet {
+        /// <param name="HostName">SMTP host name to check.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string HostName;
 
+        /// <param name="Port">SMTP port number.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Retrieves security.txt information for a domain.</summary>
+    /// <example>
+    ///   <summary>Get security contacts.</summary>
+    ///   <code>Test-SecurityTXT -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "SecurityTXT", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSecurityTXT : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -2,14 +2,22 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Checks TLS configuration for a specific SMTP host.</summary>
+    /// <example>
+    ///   <summary>Test mail server TLS.</summary>
+    ///   <code>Test-SmtpTls -HostName mail.example.com -Port 587</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "SmtpTls", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSmtpTls : AsyncPSCmdlet {
+        /// <param name="HostName">SMTP host to check.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
+        /// <param name="Port">SMTP port number.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 
+        /// <param name="ShowChain">Output certificate chain information.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 

--- a/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Retrieves the SOA record for a domain.</summary>
+    /// <example>
+    ///   <summary>Query SOA information.</summary>
+    ///   <code>Test-SoaRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "SoaRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSoaRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
@@ -4,12 +4,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates SPF record for a domain.</summary>
+    /// <example>
+    ///   <summary>Check SPF configuration.</summary>
+    ///   <code>Test-SpfRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "SpfRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSpfRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -3,15 +3,23 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Checks SMTP STARTTLS support for a domain.</summary>
+    /// <example>
+    ///   <summary>Verify STARTTLS.</summary>
+    ///   <code>Test-StartTls -DomainName example.com -Port 587</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "StartTls", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestStartTls : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to test.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="Port">SMTP port number.</param>
         [Parameter(Mandatory = false)]
         public int Port = 25;
 

--- a/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
@@ -3,12 +3,19 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates TLS-RPT record for a domain.</summary>
+    /// <example>
+    ///   <summary>Check TLS report policy.</summary>
+    ///   <code>Test-TlsRptRecord -DomainName example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "TlsRptRecord", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestTlsRptRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -2,15 +2,23 @@ using System.Management.Automation;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
+    /// <summary>Validates TLS certificate for a website.</summary>
+    /// <example>
+    ///   <summary>Check HTTPS certificate.</summary>
+    ///   <code>Test-WebsiteCertificate -Url https://example.com</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "WebsiteCertificate", DefaultParameterSetName = "Url")]
     public sealed class CmdletTestWebsiteCertificate : AsyncPSCmdlet {
+        /// <param name="Url">Website URL.</param>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Url")]
         [ValidateNotNullOrEmpty]
         public string Url;
 
+        /// <param name="Port">TCP port used for connection.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Url")]
         public int Port = 443;
 
+        /// <param name="ShowChain">Output certificate chain information.</param>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 


### PR DESCRIPTION
## Summary
- document each cmdlet class and parameters using XmlDoc2CmdletDoc style
- provide basic examples in comments for easy help generation

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: Assert.True/NotNull)*

------
https://chatgpt.com/codex/tasks/task_e_685bc4b3d3ac832eb46ec55da027a8c2