### PR TITLE
Document ShowPropertiesTable helpers

### DIFF
--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -7,6 +7,12 @@ namespace DomainDetective.CLI;
 
 internal static class CliHelpers
 {
+    /// <summary>
+    ///     Adds property rows for <paramref name="obj"/> to <paramref name="table"/>.
+    /// </summary>
+    /// <param name="table">Target table instance.</param>
+    /// <param name="obj">Object to inspect.</param>
+    /// <param name="listAsString">Renders list values as comma separated strings when true.</param>
     private static void AddProperties(Table table, object obj, bool listAsString = false)
     {
         if (obj == null)
@@ -56,6 +62,11 @@ internal static class CliHelpers
         }
     }
 
+    /// <summary>
+    ///     Renders the properties of <paramref name="data"/> inside a panel titled with <paramref name="title"/>.
+    /// </summary>
+    /// <param name="title">Panel header text.</param>
+    /// <param name="data">Object, list or dictionary to display.</param>
     public static void ShowPropertiesTable(string title, object data)
     {
         var table = new Table().Border(TableBorder.Rounded);

--- a/DomainDetective.Example/Helpers.cs
+++ b/DomainDetective.Example/Helpers.cs
@@ -22,6 +22,12 @@ namespace DomainDetective.Example {
             }
         }
 
+        /// <summary>
+        ///     Adds the properties of <paramref name="obj"/> to <paramref name="table"/>.
+        /// </summary>
+        /// <param name="table">Table instance to add rows to.</param>
+        /// <param name="obj">Object whose properties will be read.</param>
+        /// <param name="listAsString">When true, list values are rendered as comma separated strings.</param>
         private static void AddPropertiesTable(Table table, object obj, bool listAsString = false) {
             if (obj == null) {
                 return;
@@ -64,6 +70,12 @@ namespace DomainDetective.Example {
             }
         }
 
+        /// <summary>
+        ///     Displays a table of property names and values for the supplied object or list.
+        /// </summary>
+        /// <param name="analysisOf">Title shown in the output panel.</param>
+        /// <param name="objs">Object, dictionary or list to inspect.</param>
+        /// <param name="perProperty">Currently unused.</param>
         public static void ShowPropertiesTable(string analysisOf, object objs, bool perProperty = false) {
             var table = new Table();
             table.Border(TableBorder.Rounded);


### PR DESCRIPTION
## Summary
- document internal helper methods for CLI output
- add summary and parameter docs for ShowPropertiesTable

## Testing
- `dotnet restore DomainDetective.sln`
- `dotnet build DomainDetective.sln --configuration Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685bc4aac708832e8f9bbe38d44c3108