### PR TITLE
Add DMARC URI validation

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.Dmarc.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.Dmarc.cs
@@ -25,7 +25,8 @@ namespace DomainDetective.PowerShell {
                 HttpRua = analysis.HttpRua,
                 MailtoRuf = analysis.MailtoRuf,
                 HttpRuf = analysis.HttpRuf,
-                ExternalReportAuthorization = analysis.ExternalReportAuthorization
+                ExternalReportAuthorization = analysis.ExternalReportAuthorization,
+                InvalidReportUri = analysis.InvalidReportUri
             };
         }
     }
@@ -75,5 +76,8 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>External reporting authorization per domain.</summary>
         public IReadOnlyDictionary<string, bool> ExternalReportAuthorization { get; set; }
+
+        /// <summary>Indicates at least one report URI failed validation.</summary>
+        public bool InvalidReportUri { get; set; }
     }
 }

--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -131,5 +131,17 @@ namespace DomainDetective.Tests {
             Assert.Equal("x", healthCheck.DmarcAnalysis.DkimAShort);
             Assert.Equal("y", healthCheck.DmarcAnalysis.SpfAShort);
         }
+
+        [Fact]
+        public async Task BadUrisSetInvalidFlag() {
+            var dmarcRecord = "v=DMARC1; p=none; rua=mailto:test@example.com,http://bad.example.com,mailto:invalid; ruf=https://reports.example.com";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDMARC(dmarcRecord);
+            Assert.True(healthCheck.DmarcAnalysis.InvalidReportUri);
+            Assert.Single(healthCheck.DmarcAnalysis.MailtoRua);
+            Assert.Equal("test@example.com", healthCheck.DmarcAnalysis.MailtoRua[0]);
+            Assert.Single(healthCheck.DmarcAnalysis.HttpRuf);
+            Assert.Equal("https://reports.example.com", healthCheck.DmarcAnalysis.HttpRuf[0]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate DMARC report URIs
- expose InvalidReportUri flag
- surface flag in PowerShell output helpers
- test invalid DMARC URIs

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0 --no-build --filter BadUrisSetInvalidFlag`
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685bd8c95f2c832e9435377ad24919f4