### PR TITLE
Implement detection for unknown SPF mechanisms

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -295,5 +295,15 @@ namespace DomainDetective.Tests {
             Assert.Contains("192.0.2.1", healthCheck.SpfAnalysis.Ipv4Records);
             Assert.Equal("-all", healthCheck.SpfAnalysis.AllMechanism);
         }
+
+        [Fact]
+        public async Task UnrecognizedTokenCaptured() {
+            var spfRecord = "v=spf1 unknown:example.com -all";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.Contains("unknown:example.com", healthCheck.SpfAnalysis.UnknownMechanisms);
+        }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -51,6 +51,8 @@ namespace DomainDetective {
         public List<string> ResolvedIncludeRecords { get; private set; } = new List<string>();
         public List<string> ResolvedExistsRecords { get; private set; } = new List<string>();
 
+        public List<string> UnknownMechanisms { get; private set; } = new List<string>();
+
         public Dictionary<string, string> TestSpfRecords { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public bool CycleDetected { get; private set; }
         private HashSet<string> _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -92,6 +94,7 @@ namespace DomainDetective {
             ResolvedPtrRecords = new List<string>();
             ResolvedIncludeRecords = new List<string>();
             ResolvedExistsRecords = new List<string>();
+            UnknownMechanisms = new List<string>();
             ExpValue = null;
             RedirectValue = null;
             AllMechanism = null;
@@ -268,6 +271,7 @@ namespace DomainDetective {
 
         private void AddPartToList(string part) {
             var token = part.Trim('"');
+            var normalized = token.TrimStart('+', '-', '~', '?');
             if (token.StartsWith("a:", StringComparison.OrdinalIgnoreCase)) {
                 ARecords.Add(token.Substring(2).Trim('"'));
             } else if (token.StartsWith("mx:", StringComparison.OrdinalIgnoreCase)) {
@@ -290,6 +294,10 @@ namespace DomainDetective {
                 HasExp = true;
             } else if (IsAllMechanism(token)) {
                 AllMechanism = token.Trim('"');
+            } else if (!IsAllowedMechanismOrModifier(normalized)) {
+                if (!UnknownMechanisms.Contains(token)) {
+                    UnknownMechanisms.Add(token);
+                }
             }
 
             AddPartToResolvedLists(part);
@@ -297,6 +305,7 @@ namespace DomainDetective {
 
         private void AddPartToResolvedLists(string part) {
             var token = part.Trim('"');
+            var normalized = token.TrimStart('+', '-', '~', '?');
             if (token.StartsWith("a:", StringComparison.OrdinalIgnoreCase)) {
                 ResolvedARecords.Add(token.Substring(2).Trim('"'));
             } else if (token.StartsWith("mx:", StringComparison.OrdinalIgnoreCase)) {
@@ -311,7 +320,24 @@ namespace DomainDetective {
                 ResolvedIpv6Records.Add(token.Substring(4).Trim('"'));
             } else if (token.StartsWith("include:", StringComparison.OrdinalIgnoreCase)) {
                 ResolvedIncludeRecords.Add(token.Substring(8).Trim('"'));
+            } else if (!IsAllowedMechanismOrModifier(normalized) && !IsAllMechanism(normalized)) {
+                if (!UnknownMechanisms.Contains(token)) {
+                    UnknownMechanisms.Add(token);
+                }
             }
+        }
+
+        private static bool IsAllowedMechanismOrModifier(string token) {
+            return token.StartsWith("a:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("mx:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("ip4:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("ip6:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("include:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("exists:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("ptr:", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("redirect=", StringComparison.OrdinalIgnoreCase)
+                   || token.StartsWith("exp=", StringComparison.OrdinalIgnoreCase)
+                   || IsAllMechanism(token);
         }
 
         private static bool IsAllMechanism(string part) {


### PR DESCRIPTION
## Summary
- track invalid SPF mechanisms via `UnknownMechanisms`
- detect allowed mechanisms/modifiers when parsing tokens
- test that unknown tokens are captured

## Testing
- `dotnet test` *(fails: Invalid URI hostname could not be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_685bd8d3f5f0832eb845122e61a3e178