### PR TITLE
Add NS subnet diversity check

### DIFF
--- a/DomainDetective/IPAddressExtensions.cs
+++ b/DomainDetective/IPAddressExtensions.cs
@@ -25,4 +25,23 @@ public static class IPAddressExtensions {
 
         return string.Join(".", ipAddress.GetAddressBytes().Reverse());
     }
+
+    /// <summary>
+    /// Returns a string representing the network prefix for grouping.
+    /// </summary>
+    /// <param name="ipAddress">The IP address.</param>
+    /// <returns>
+    /// The /24 prefix for IPv4 or /48 prefix for IPv6 formatted as a string.
+    /// </returns>
+    public static string GetSubnetKey(this IPAddress ipAddress) {
+        var bytes = ipAddress.GetAddressBytes();
+        if (ipAddress.AddressFamily == AddressFamily.InterNetwork) {
+            return $"{bytes[0]}.{bytes[1]}.{bytes[2]}";
+        }
+
+        // IPv6 uses first 48 bits (six bytes)
+        return string.Join(":",
+            Enumerable.Range(0, 3)
+                .Select(i => $"{bytes[i * 2]:x2}{bytes[i * 2 + 1]:x2}"));
+    }
 }


### PR DESCRIPTION
## Summary
- add GetSubnetKey helper for IPv4 / IPv6 prefixes
- check name server subnet diversity
- test diverse and single subnet scenarios

## Testing
- `dotnet build`
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*
- `dotnet test --filter FullyQualifiedName~DomainDetective.Tests.TestNSAnalysis`

------
https://chatgpt.com/codex/tasks/task_e_685bd8f2d06c832e8550cbd61b8df54f