### PR TITLE
Add VMC validation

### DIFF
--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -1,6 +1,8 @@
 using DnsClientX;
 using System.Net;
 using System.Text;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 
 namespace DomainDetective.Tests {
     public class TestBimiAnalysis {
@@ -77,6 +79,49 @@ namespace DomainDetective.Tests {
                 listener.Stop();
                 await serverTask;
             }
+        }
+
+        [Fact]
+        public async Task ValidVmcCertificate() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var cert = CreateSelfSigned();
+            var serverTask = Task.Run(async () => {
+                for (var i = 0; i < 2; i++) {
+                    var ctx = await listener.GetContextAsync();
+                    if (ctx.Request.RawUrl!.EndsWith(".svg")) {
+                        var buffer = Encoding.UTF8.GetBytes("<svg></svg>");
+                        ctx.Response.ContentType = "image/svg+xml";
+                        await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                    } else {
+                        var buffer = cert.Export(X509ContentType.Cert);
+                        await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                    }
+                    ctx.Response.Close();
+                }
+            });
+
+            try {
+                var record = $"v=BIMI1; l={prefix}logo.svg; a={prefix}vmc.cer";
+                var answers = new List<DnsAnswer> { new DnsAnswer { DataRaw = record, Type = DnsRecordType.TXT } };
+                var analysis = new BimiAnalysis();
+                await analysis.AnalyzeBimiRecords(answers, new InternalLogger());
+
+                Assert.True(analysis.SvgValid);
+                Assert.True(analysis.ValidVmc);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        private static X509Certificate2 CreateSelfSigned() {
+            using var rsa = System.Security.Cryptography.RSA.Create(2048);
+            var req = new System.Security.Cryptography.X509Certificates.CertificateRequest("CN=example", rsa, System.Security.Cryptography.HashAlgorithmName.SHA256, System.Security.Cryptography.RSASignaturePadding.Pkcs1);
+            var cert = req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(30));
+            return new X509Certificate2(cert.Export(X509ContentType.Pfx));
         }
 
         private static int GetFreePort() {


### PR DESCRIPTION
## Summary
- validate BIMI VMC certificates
- add `ValidVmc` property on `BimiAnalysis`
- test BIMI VMC validation with a mocked certificate download

## Testing
- `dotnet test --filter ValidVmcCertificate --no-build`
- `dotnet test` *(fails: The argument ... invalid)*

------
https://chatgpt.com/codex/tasks/task_e_685bd902d834832e90e137f15b79b257