### PR TITLE
Add HPKP max-age and includeSubDomains parsing

### DIFF
--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -29,6 +29,8 @@ namespace DomainDetective.Tests {
                 Assert.True(healthCheck.HPKPAnalysis.HeaderPresent);
                 Assert.True(healthCheck.HPKPAnalysis.PinsValid);
                 Assert.Equal(2, healthCheck.HPKPAnalysis.Pins.Count);
+                Assert.Equal(500, healthCheck.HPKPAnalysis.MaxAge);
+                Assert.False(healthCheck.HPKPAnalysis.IncludesSubDomains);
             } finally {
                 listener.Stop();
                 await task;


### PR DESCRIPTION
## Summary
- parse HPKP `max-age` and `includeSubDomains`
- expose `MaxAge` and `IncludesSubDomains`
- require at least two pins
- update HPKP tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln --no-build -v minimal` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685bd9133ff4832e90698a24055aa7ad