### PR TITLE
Add TLSRPT record checks

### DIFF
--- a/DomainDetective.Tests/TestTLSRPTAnalysis.cs
+++ b/DomainDetective.Tests/TestTLSRPTAnalysis.cs
@@ -55,5 +55,28 @@ namespace DomainDetective.Tests {
             Assert.False(analysis.RuaDefined);
             Assert.False(analysis.PolicyValid);
         }
+
+        [Fact]
+        public async Task InvalidSchemeRecorded() {
+            var record = "v=TLSRPTv1;rua=ftp://reports.example.com";
+            var analysis = new TLSRPTAnalysis();
+            await analysis.AnalyzeTlsRptRecords(new[] { new DnsAnswer { DataRaw = record, Type = DnsRecordType.TXT } }, new InternalLogger());
+
+            Assert.Single(analysis.InvalidRua);
+            Assert.Equal("ftp://reports.example.com", analysis.InvalidRua[0]);
+        }
+
+        [Fact]
+        public async Task DetectMultipleRecords() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "v=TLSRPTv1;rua=mailto:a@example.com", Type = DnsRecordType.TXT },
+                new DnsAnswer { DataRaw = "v=TLSRPTv1;rua=mailto:b@example.com", Type = DnsRecordType.TXT }
+            };
+            var analysis = new TLSRPTAnalysis();
+            await analysis.AnalyzeTlsRptRecords(answers, new InternalLogger());
+
+            Assert.True(analysis.MultipleRecords);
+            Assert.True(analysis.PolicyValid);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- detect invalid RUA schemes
- detect multiple TLSRPT records
- test invalid scheme and duplicate records

## Testing
- `dotnet format --no-restore --include DomainDetective/Protocols/TLSRPTAnalysis.cs --include DomainDetective.Tests/TestTLSRPTAnalysis.cs`
- `dotnet test --no-build --verbosity minimal` *(fails: TestSOAAnalysis.VerifySoaByDomain, TestCAAAnalysis.TestCAARecordByDomain, TestSpfAnalysis.TestSpfOver255, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestCertificateHTTP.UnreachableHostLogsExceptionType, TestDMARCAnalysis.TestDMARCByDomain, TestDkimAnalysis.TestDKIMByDomain, TestAll.TestAllHealthChecks, TestDkimGuess.GuessSelectorsForDomain)*

------
https://chatgpt.com/codex/tasks/task_e_685bd8db03f0832eb5a68863ef3df7a2