### PR TITLE
Add IP syntax validation for SPF

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -15,6 +15,7 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck6.SpfAnalysis.ContainsCharactersAfterAll);
             Assert.False(healthCheck6.SpfAnalysis.HasPtrType);
             Assert.True(healthCheck6.SpfAnalysis.StartsCorrectly);
+            Assert.True(healthCheck6.SpfAnalysis.InvalidIpSyntax);
         }
 
         [Fact]
@@ -32,6 +33,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck6.SpfAnalysis.ContainsCharactersAfterAll == false);
             Assert.True(healthCheck6.SpfAnalysis.HasPtrType == false);
             Assert.True(healthCheck6.SpfAnalysis.StartsCorrectly == true);
+            Assert.False(healthCheck6.SpfAnalysis.InvalidIpSyntax);
 
         }
 
@@ -50,6 +52,7 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck6.SpfAnalysis.HasPtrType);
             Assert.True(healthCheck6.SpfAnalysis.StartsCorrectly);
             Assert.True(healthCheck6.SpfAnalysis.ExceedsCharacterLimit, "Should exceed character limit due to long record");
+            Assert.False(healthCheck6.SpfAnalysis.InvalidIpSyntax);
         }
 
         [Fact]
@@ -67,6 +70,7 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck6.SpfAnalysis.HasPtrType);
             Assert.True(healthCheck6.SpfAnalysis.StartsCorrectly);
             Assert.True(healthCheck6.SpfAnalysis.ExceedsCharacterLimit, "Should exceed character limit due to long record");
+            Assert.False(healthCheck6.SpfAnalysis.InvalidIpSyntax);
         }
 
         [Fact]
@@ -238,6 +242,7 @@ namespace DomainDetective.Tests {
             Assert.Contains("mx.test", healthCheck.SpfAnalysis.ResolvedMxRecords);
             Assert.Contains("10.10.10.10", healthCheck.SpfAnalysis.ResolvedIpv4Records);
             Assert.Contains("2001::1", healthCheck.SpfAnalysis.ResolvedIpv6Records);
+            Assert.False(healthCheck.SpfAnalysis.InvalidIpSyntax);
         }
 
         [Fact]
@@ -294,6 +299,17 @@ namespace DomainDetective.Tests {
 
             Assert.Contains("192.0.2.1", healthCheck.SpfAnalysis.Ipv4Records);
             Assert.Equal("-all", healthCheck.SpfAnalysis.AllMechanism);
+            Assert.False(healthCheck.SpfAnalysis.InvalidIpSyntax);
+        }
+
+        [Fact]
+        public async Task InvalidCidrMasksTriggerFlag() {
+            var spfRecord = "v=spf1 ip4:192.0.2.1/33 ip6:2001::1/129 -all";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.True(healthCheck.SpfAnalysis.InvalidIpSyntax);
         }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -2,6 +2,8 @@ using DnsClientX;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace DomainDetective {
@@ -32,6 +34,7 @@ namespace DomainDetective {
         public bool HasNullLookups { get; private set; }
         public bool HasRedirect { get; private set; }
         public bool HasExp { get; private set; }
+        public bool InvalidIpSyntax { get; private set; }
         public List<string> ARecords { get; private set; } = new List<string>();
         public List<string> Ipv4Records { get; private set; } = new List<string>();
         public List<string> Ipv6Records { get; private set; } = new List<string>();
@@ -76,6 +79,7 @@ namespace DomainDetective {
             HasNullLookups = false;
             HasRedirect = false;
             HasExp = false;
+            InvalidIpSyntax = false;
             CycleDetected = false;
             _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             ARecords = new List<string>();
@@ -277,9 +281,17 @@ namespace DomainDetective {
             } else if (token.StartsWith("exists:", StringComparison.OrdinalIgnoreCase)) {
                 ExistsRecords.Add(token.Substring(7).Trim('"'));
             } else if (token.StartsWith("ip4:", StringComparison.OrdinalIgnoreCase)) {
-                Ipv4Records.Add(token.Substring(4).Trim('"'));
+                var value = token.Substring(4).Trim('"');
+                Ipv4Records.Add(value);
+                if (!TryParseCidr(value, 32)) {
+                    InvalidIpSyntax = true;
+                }
             } else if (token.StartsWith("ip6:", StringComparison.OrdinalIgnoreCase)) {
-                Ipv6Records.Add(token.Substring(4).Trim('"'));
+                var value = token.Substring(4).Trim('"');
+                Ipv6Records.Add(value);
+                if (!TryParseCidr(value, 128)) {
+                    InvalidIpSyntax = true;
+                }
             } else if (token.StartsWith("include:", StringComparison.OrdinalIgnoreCase)) {
                 IncludeRecords.Add(token.Substring(8).Trim('"'));
             } else if (token.StartsWith("redirect=", StringComparison.OrdinalIgnoreCase)) {
@@ -312,6 +324,29 @@ namespace DomainDetective {
             } else if (token.StartsWith("include:", StringComparison.OrdinalIgnoreCase)) {
                 ResolvedIncludeRecords.Add(token.Substring(8).Trim('"'));
             }
+        }
+
+        private static bool TryParseCidr(string value, int maxPrefixLength) {
+            var segments = value.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            if (segments.Length == 0 || segments.Length > 2) {
+                return false;
+            }
+
+            if (!IPAddress.TryParse(segments[0], out _)) {
+                return false;
+            }
+
+            if (segments.Length == 2) {
+                if (!int.TryParse(segments[1], NumberStyles.None, CultureInfo.InvariantCulture, out var mask)) {
+                    return false;
+                }
+
+                if (mask > maxPrefixLength) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool IsAllMechanism(string part) {


### PR DESCRIPTION
## Summary
- check SPF ip tokens with `IPAddress` and CIDR parsing
- flag invalid ip syntax via new `InvalidIpSyntax` property
- test ip validation in SPF analysis

## Testing
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685bd8cf8a38832eb32d22c7be65cc7a