### PR TITLE
Add UnknownTags list for DMARC

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -143,5 +143,17 @@ namespace DomainDetective.Tests {
             Assert.Single(healthCheck.DmarcAnalysis.HttpRuf);
             Assert.Equal("https://reports.example.com", healthCheck.DmarcAnalysis.HttpRuf[0]);
         }
+
+        [Fact]
+        public async Task UnknownTagsAreCollected() {
+            var dmarcRecord = "v=DMARC1; p=none; foo=bar; test; x=y";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckDMARC(dmarcRecord);
+
+            Assert.Contains("foo=bar", healthCheck.DmarcAnalysis.UnknownTags);
+            Assert.Contains("test", healthCheck.DmarcAnalysis.UnknownTags);
+            Assert.Contains("x=y", healthCheck.DmarcAnalysis.UnknownTags);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -47,6 +47,7 @@ namespace DomainDetective {
         public string Ruf { get; private set; }
         public List<string> MailtoRuf { get; private set; } = new List<string>();
         public List<string> HttpRuf { get; private set; } = new List<string>();
+        public List<string> UnknownTags { get; private set; } = new List<string>();
 
         // short versions of the tags
         public string SubPolicyShort { get; private set; }
@@ -75,6 +76,7 @@ namespace DomainDetective {
             Ruf = null;
             MailtoRuf = new List<string>();
             HttpRuf = new List<string>();
+            UnknownTags = new List<string>();
             SubPolicyShort = null;
             PolicyShort = null;
             FoShort = null;
@@ -121,6 +123,8 @@ namespace DomainDetective {
                     var key = keyValue[0].Trim();
                     var value = keyValue[1].Trim();
                     switch (key) {
+                        case "v":
+                            break;
                         case "p":
                             PolicyShort = value;
                             policyTagFound = true;
@@ -179,6 +183,17 @@ namespace DomainDetective {
                             Ruf = value;
                             AddUriToList(value, MailtoRuf, HttpRuf);
                             break;
+                        default:
+                            var tagPair = $"{key}={value}";
+                            if (!UnknownTags.Contains(tagPair)) {
+                                UnknownTags.Add(tagPair);
+                            }
+                            break;
+                    }
+                } else if (!string.IsNullOrWhiteSpace(tag)) {
+                    var unknown = tag.Trim();
+                    if (!UnknownTags.Contains(unknown)) {
+                        UnknownTags.Add(unknown);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- collect unrecognized DMARC tags
- expose UnknownTags property
- test custom tags are recorded

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter UnknownTagsAreCollected -v minimal`
- `dotnet test -v minimal` *(fails: unreachable DNS queries)*

------
https://chatgpt.com/codex/tasks/task_e_685be7533f24832ea5b925c14a0fd4d0