### PR TITLE
Validate DKIM key type and flags

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -23,9 +23,12 @@ namespace DomainDetective.PowerShell {
                     PublicKeyExists = result.PublicKeyExists,
                     ValidPublicKey = result.ValidPublicKey,
                     KeyTypeExists = result.KeyTypeExists,
+                    ValidKeyType = result.ValidKeyType,
                     PublicKey = result.PublicKey,
                     ServiceType = result.ServiceType,
                     Flags = result.Flags,
+                    ValidFlags = result.ValidFlags,
+                    UnknownFlagCharacters = result.UnknownFlagCharacters,
                     KeyType = result.KeyType,
                     HashAlgorithm = result.HashAlgorithm
                 };
@@ -60,6 +63,8 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Indicates whether the key type is present.</summary>
         public bool KeyTypeExists { get; set; }
+        /// <summary>Validation result for the key type.</summary>
+        public bool ValidKeyType { get; set; }
 
         /// <summary>Public key in base64 format.</summary>
         public string PublicKey { get; set; }
@@ -69,6 +74,10 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Any flags specified in the record.</summary>
         public string Flags { get; set; }
+        /// <summary>Indicates whether all flag characters are valid.</summary>
+        public bool ValidFlags { get; set; }
+        /// <summary>Unexpected characters found in the flags.</summary>
+        public string UnknownFlagCharacters { get; set; }
 
         /// <summary>Key type value.</summary>
         public string KeyType { get; set; }

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -115,5 +115,26 @@ namespace DomainDetective.Tests {
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
         }
+
+        [Fact]
+        public async Task InvalidKeyTypeIsFlagged() {
+            const string record = "v=DKIM1; k=hmac; p=QUJD;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidKeyType);
+        }
+
+        [Fact]
+        public async Task UnexpectedFlagCharactersDetected() {
+            const string record = "v=DKIM1; t=yz; k=rsa; p=QUJD;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidFlags);
+            Assert.Contains("z", healthCheck.DKIMAnalysis.AnalysisResults["default"].UnknownFlagCharacters);
+        }
     }
 }

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -33,6 +33,8 @@ namespace DomainDetective {
             var dkimRecordList = dnsResults.ToList();
             var analysis = new DkimRecordAnalysis {
                 DkimRecordExists = dkimRecordList.Any(),
+                ValidKeyType = true,
+                ValidFlags = true
             };
 
             // create a single string from the list of DnsResult objects
@@ -76,9 +78,13 @@ namespace DomainDetective {
                             break;
                         case "t":
                             analysis.Flags = value;
+                            analysis.UnknownFlagCharacters = new string(value.ToLowerInvariant().Where(c => c != 'y' && c != 's').ToArray());
+                            analysis.ValidFlags = analysis.UnknownFlagCharacters.Length == 0;
                             break;
                         case "k":
                             analysis.KeyType = value;
+                            analysis.ValidKeyType = string.Equals(value, "rsa", StringComparison.OrdinalIgnoreCase) ||
+                                string.Equals(value, "ed25519", StringComparison.OrdinalIgnoreCase);
                             break;
                         case "h":
                             analysis.HashAlgorithm = value;
@@ -132,12 +138,18 @@ namespace DomainDetective {
         /// <summary>Gets or sets a value indicating whether a key type was specified.</summary>
         public bool ValidPublicKey { get; set; }
         public bool KeyTypeExists { get; set; }
+        /// <summary>Gets or sets a value indicating whether the key type is recognized.</summary>
+        public bool ValidKeyType { get; set; }
         /// <summary>Gets or sets the public key.</summary>
         public string PublicKey { get; set; }
         /// <summary>Gets or sets the service type flag.</summary>
         public string ServiceType { get; set; }
         /// <summary>Gets or sets any flags defined for the record.</summary>
         public string Flags { get; set; }
+        /// <summary>Gets unrecognized flag characters if <see cref="ValidFlags"/> is <c>false</c>.</summary>
+        public string UnknownFlagCharacters { get; set; }
+        /// <summary>Gets or sets a value indicating whether all flag characters are valid.</summary>
+        public bool ValidFlags { get; set; }
         /// <summary>Gets or sets the key type.</summary>
         public string KeyType { get; set; }
         /// <summary>Gets or sets the hash algorithm type.</summary>


### PR DESCRIPTION
## Summary
- validate DKIM key types and flag letters
- surface validation results through new properties
- test invalid key type and flag characters

## Testing
- `dotnet build DomainDetective.sln --verbosity minimal`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685be7586938832e863b0720bc84efb1