### PR TITLE
Add missing security header detection

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -19,6 +19,10 @@ namespace DomainDetective.Tests {
                 ctx.Response.Headers.Add("X-XSS-Protection", "1; mode=block");
                 ctx.Response.Headers.Add("Expect-CT", "max-age=86400, enforce");
                 ctx.Response.Headers.Add("Content-Security-Policy", "default-src 'self'");
+                ctx.Response.Headers.Add("X-Permitted-Cross-Domain-Policies", "none");
+                ctx.Response.Headers.Add("Cross-Origin-Opener-Policy", "same-origin");
+                ctx.Response.Headers.Add("Cross-Origin-Embedder-Policy", "require-corp");
+                ctx.Response.Headers.Add("Cross-Origin-Resource-Policy", "same-origin");
                 var buffer = Encoding.UTF8.GetBytes("ok");
                 await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
                 ctx.Response.Close();
@@ -38,10 +42,15 @@ namespace DomainDetective.Tests {
                 Assert.Equal("1; mode=block", analysis.SecurityHeaders["X-XSS-Protection"]);
                 Assert.Equal("max-age=86400, enforce", analysis.SecurityHeaders["Expect-CT"]);
                 Assert.Equal("max-age=31536000", analysis.SecurityHeaders["Strict-Transport-Security"]);
+                Assert.Equal("none", analysis.SecurityHeaders["X-Permitted-Cross-Domain-Policies"]);
+                Assert.Equal("same-origin", analysis.SecurityHeaders["Cross-Origin-Opener-Policy"]);
+                Assert.Equal("require-corp", analysis.SecurityHeaders["Cross-Origin-Embedder-Policy"]);
+                Assert.Equal("same-origin", analysis.SecurityHeaders["Cross-Origin-Resource-Policy"]);
                 Assert.Equal(31536000, analysis.HstsMaxAge);
                 Assert.False(analysis.HstsIncludesSubDomains);
                 Assert.False(analysis.HstsTooShort);
                 Assert.Equal("ok", analysis.Body);
+                Assert.Empty(analysis.MissingSecurityHeaders);
             } finally {
                 listener.Stop();
                 await serverTask;
@@ -101,6 +110,7 @@ namespace DomainDetective.Tests {
                 var analysis = new HttpAnalysis();
                 await analysis.AnalyzeUrl(prefix, false, new InternalLogger());
                 Assert.True(analysis.SecurityHeaders.Count == 0);
+                Assert.True(analysis.MissingSecurityHeaders.Count == 0);
                 Assert.False(analysis.XssProtectionPresent);
                 Assert.False(analysis.ExpectCtPresent);
             } finally {
@@ -226,6 +236,7 @@ namespace DomainDetective.Tests {
                 Assert.Equal(1000, analysis.HstsMaxAge);
                 Assert.True(analysis.HstsIncludesSubDomains);
                 Assert.True(analysis.HstsTooShort);
+                Assert.Contains("Content-Security-Policy", analysis.MissingSecurityHeaders);
             } finally {
                 listener.Stop();
                 await serverTask;


### PR DESCRIPTION
## Summary
- track which security headers are absent in `HttpAnalysis`
- extend the list of known security headers
- validate missing security headers in HTTP tests

## Testing
- `dotnet build`
- `dotnet test` *(fails: The argument is invalid / network-related test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd40cf04832ea179adc97a5054d1