### PR TITLE
Add multi-port STARTTLS and open relay scanning

### DIFF
--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -124,6 +124,60 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task AnalyzeServersMultiplePorts() {
+            var listener1 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener1.Start();
+            var port1 = ((System.Net.IPEndPoint)listener1.LocalEndpoint).Port;
+            var serverTask1 = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener1.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250 hello");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            var listener2 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener2.Start();
+            var port2 = ((System.Net.IPEndPoint)listener2.LocalEndpoint).Port;
+            var serverTask2 = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener2.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250 hello");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("550 relay denied");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new OpenRelayAnalysis();
+                await analysis.AnalyzeServers(new[] { "localhost" }, new[] { port1, port2 }, new InternalLogger());
+                Assert.Equal(2, analysis.ServerResults.Count);
+                Assert.True(analysis.ServerResults[$"localhost:{port1}"]);
+                Assert.False(analysis.ServerResults[$"localhost:{port2}"]);
+            } finally {
+                listener1.Stop();
+                listener2.Stop();
+                await serverTask1;
+                await serverTask2;
+            }
+        }
+
+        [Fact]
         public async Task CancelsDuringAnalysis() {
             var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
             listener.Start();

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -339,7 +339,7 @@ namespace DomainDetective {
                     case HealthCheckType.STARTTLS:
                         var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
                         var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
-                        await StartTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
+                        await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { 25 }, _logger, cancellationToken);
                         break;
                     case HealthCheckType.SMTPTLS:
                         var mxRecordsForSmtpTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
@@ -594,7 +594,7 @@ namespace DomainDetective {
             }
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
-            await StartTlsAnalysis.AnalyzeServers(tlsHosts, port, _logger, cancellationToken);
+            await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { port }, _logger, cancellationToken);
         }
 
         /// <summary>

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -17,6 +17,17 @@ namespace DomainDetective {
             ServerResults[$"{host}:{port}"] = allows;
         }
 
+        public async Task AnalyzeServers(IEnumerable<string> hosts, IEnumerable<int> ports, InternalLogger logger, CancellationToken cancellationToken = default) {
+            ServerResults.Clear();
+            foreach (var host in hosts) {
+                foreach (var port in ports) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var allows = await TryRelay(host, port, logger, cancellationToken);
+                    ServerResults[$"{host}:{port}"] = allows;
+                }
+            }
+        }
+
         private async Task<bool> TryRelay(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
             using var client = new TcpClient();
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -17,11 +17,14 @@ namespace DomainDetective {
             ServerResults[$"{host}:{port}"] = supports;
         }
 
-        public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+        public async Task AnalyzeServers(IEnumerable<string> hosts, IEnumerable<int> ports, InternalLogger logger, CancellationToken cancellationToken = default) {
             ServerResults.Clear();
             foreach (var host in hosts) {
-                cancellationToken.ThrowIfCancellationRequested();
-                await AnalyzeServer(host, port, logger, cancellationToken);
+                foreach (var port in ports) {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    bool supports = await CheckStartTls(host, port, logger, cancellationToken);
+                    ServerResults[$"{host}:{port}"] = supports;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow `STARTTLSAnalysis.AnalyzeServers` to scan multiple ports
- extend `OpenRelayAnalysis` with an `AnalyzeServers` helper
- update `DomainHealthCheck` for new API
- add tests verifying multi-port support

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: DNS/HTTP tests without network)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd34c65c832e90ee0a17a0329988