### PR TITLE
Add MultipleRecords flag to DMARCAnalysis

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -155,5 +155,18 @@ namespace DomainDetective.Tests {
             Assert.Contains("test", healthCheck.DmarcAnalysis.UnknownTags);
             Assert.Contains("x=y", healthCheck.DmarcAnalysis.UnknownTags);
         }
+
+        [Fact]
+        public async Task DetectMultipleRecords() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "v=DMARC1; p=none", Type = DnsRecordType.TXT },
+                new DnsAnswer { DataRaw = "v=DMARC1; p=quarantine", Type = DnsRecordType.TXT }
+            };
+
+            var analysis = new DmarcAnalysis();
+            await analysis.AnalyzeDmarcRecords(answers, new InternalLogger());
+
+            Assert.True(analysis.MultipleRecords);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -23,6 +23,7 @@ namespace DomainDetective {
         public Dictionary<string, bool> ExternalReportAuthorization { get; private set; } = new();
         public string DmarcRecord { get; private set; }
         public bool DmarcRecordExists { get; private set; } // should be true
+        public bool MultipleRecords { get; private set; }
         public bool StartsCorrectly { get; private set; } // should be true
         public bool ExceedsCharacterLimit { get; private set; } // should be false
         public bool HasMandatoryTags { get; private set; }
@@ -65,6 +66,7 @@ namespace DomainDetective {
             DnsConfiguration ??= new DnsConfiguration();
             DmarcRecord = null;
             DmarcRecordExists = false;
+            MultipleRecords = false;
             StartsCorrectly = false;
             ExceedsCharacterLimit = false;
             HasMandatoryTags = false;
@@ -97,6 +99,7 @@ namespace DomainDetective {
 
             var dmarcRecordList = dnsResults.ToList();
             DmarcRecordExists = dmarcRecordList.Any();
+            MultipleRecords = dmarcRecordList.Count > 1;
 
             // concatenate all TXT chunks into a single string separated by spaces
             DmarcRecord = string.Join(" ", dmarcRecordList.Select(record => record.Data));


### PR DESCRIPTION
## Summary
- track when multiple DMARC records are returned
- test DMARC analysis with two TXT records

## Testing
- `dotnet test` *(fails: The argument ... invalid)*
- `dotnet test` *(fails: several tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd0ed41c832eba42377c04b446a9