### PR TITLE
Fix redirect loop detection

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -148,6 +148,18 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task DetectCircularRedirect() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 redirect=b.example.com";
+            healthCheck.SpfAnalysis.TestSpfRecords["b.example.com"] = "v=spf1 redirect=a.example.com";
+
+            await healthCheck.CheckSPF("v=spf1 redirect=a.example.com");
+
+            Assert.True(healthCheck.SpfAnalysis.CycleDetected);
+            Assert.Equal("a.example.com -> b.example.com -> a.example.com", healthCheck.SpfAnalysis.CyclePath);
+        }
+
+        [Fact]
         public async Task DomainEndingWithAllWithoutAllMechanism() {
             var spfRecord = "v=spf1 a:firewall";
             var healthCheck = new DomainHealthCheck();


### PR DESCRIPTION
## Summary
- check redirect loops before recursion in SPF analysis
- surface offending cycle via `CyclePath`
- test for redirect loop scenario

## Testing
- `dotnet test` *(fails: Argument invalid and network-related test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd297e38832eaf131c3b8d8e4408