### PR TITLE
Fix health check duplication

### DIFF
--- a/DomainDetective.Tests/TestDuplicateHealthChecks.cs
+++ b/DomainDetective.Tests/TestDuplicateHealthChecks.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestDuplicateHealthChecks {
+        [Fact]
+        public async Task DuplicatesExecuteOnce() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var pin = Convert.ToBase64String(Enumerable.Repeat((byte)5, 32).ToArray());
+            var header = $"pin-sha256=\"{pin}\"; pin-sha256=\"{pin}\"; max-age=123";
+            var count = 0;
+            var serverTask = Task.Run(async () => {
+                while (true) {
+                    HttpListenerContext ctx;
+                    try {
+                        ctx = await listener.GetContextAsync();
+                    } catch (HttpListenerException) {
+                        break;
+                    } catch (ObjectDisposedException) {
+                        break;
+                    }
+                    count++;
+                    ctx.Response.Headers.Add("Public-Key-Pins", header);
+                    var buffer = Encoding.UTF8.GetBytes("ok");
+                    await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                    ctx.Response.Close();
+                }
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.Verify(prefix.TrimEnd('/').Replace("http://", string.Empty), new[] { HealthCheckType.HPKP, HealthCheckType.HPKP });
+                Assert.True(healthCheck.HPKPAnalysis.HeaderPresent);
+                Assert.Equal(1, count);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        private static int GetFreePort() {
+            var socket = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            socket.Start();
+            var port = ((IPEndPoint)socket.LocalEndpoint).Port;
+            socket.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -261,6 +261,8 @@ namespace DomainDetective {
                 };
             }
 
+            healthCheckTypes = healthCheckTypes.Distinct().ToArray();
+
             foreach (var healthCheckType in healthCheckTypes) {
                 switch (healthCheckType) {
                     case HealthCheckType.DMARC:


### PR DESCRIPTION
## Summary
- deduplicate health check types in Verify
- add regression test to ensure duplicates don't run twice

## Testing
- `dotnet build`
- `dotnet test` *(fails: Exceeds lookups should be true)*

------
https://chatgpt.com/codex/tasks/task_e_685c21e515cc832e80dddae30761ae3f