### PR TITLE
Improve IPv6 PTR formatting and add tests

### DIFF
--- a/DomainDetective.Tests/TestDNSBLIPv6.cs
+++ b/DomainDetective.Tests/TestDNSBLIPv6.cs
@@ -44,5 +44,24 @@ namespace DomainDetective.Tests {
                     .Reverse());
             Assert.Equal($"{nibble}.example.test", record.FQDN);
         }
+
+        [Fact]
+        public async Task Ipv6LoopbackAddressChecks() {
+            var address = IPAddress.IPv6Loopback.ToString();
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.DNSBLAnalysis.ClearDNSBL();
+            healthCheck.DNSBLAnalysis.AddDNSBL("example.test");
+            await healthCheck.CheckDNSBL(address);
+
+            var record = healthCheck.DNSBLAnalysis.Results[address].DNSBLRecords.First();
+            var expected = string.Join(
+                ".",
+                IPAddress.IPv6Loopback
+                    .GetAddressBytes()
+                    .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
+                    .Select(n => n.ToString("x"))
+                    .Reverse());
+            Assert.Equal(expected, record.IPAddress);
+        }
     }
 }

--- a/DomainDetective.Tests/TestIPAddressExtensions.cs
+++ b/DomainDetective.Tests/TestIPAddressExtensions.cs
@@ -12,7 +12,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public void Ipv6PtrFormat() {
-            var ip = IPAddress.Parse("2001:db8::1");
+            var ip = IPAddress.IPv6Loopback;
             var expected = string.Join(
                 ".",
                 ip

--- a/DomainDetective/IPAddressExtensions.cs
+++ b/DomainDetective/IPAddressExtensions.cs
@@ -16,11 +16,20 @@ public static class IPAddressExtensions {
     /// <returns>The reversed nibble or byte representation suitable for PTR queries.</returns>
     public static string ToPtrFormat(this IPAddress ipAddress) {
         if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
-            var nibbles = ipAddress
-                .GetAddressBytes()
-                .SelectMany(b => new[] { (b >> 4) & 0xF, b & 0xF })
-                .Select(n => n.ToString("x"));
-            return string.Join(".", nibbles.Reverse());
+            var bytes = ipAddress.GetAddressBytes();
+            var result = new char[bytes.Length * 4 - 1];
+            var pos = 0;
+            for (int i = bytes.Length - 1; i >= 0; i--) {
+                var b = bytes[i];
+                result[pos++] = GetHex(b & 0xF);
+                result[pos++] = '.';
+                result[pos++] = GetHex(b >> 4);
+                if (i != 0) {
+                    result[pos++] = '.';
+                }
+            }
+
+            return new string(result, 0, pos);
         }
 
         return string.Join(".", ipAddress.GetAddressBytes().Reverse());
@@ -43,5 +52,10 @@ public static class IPAddressExtensions {
         return string.Join(":",
             Enumerable.Range(0, 3)
                 .Select(i => $"{bytes[i * 2]:x2}{bytes[i * 2 + 1]:x2}"));
+    }
+
+    private static char GetHex(int value) {
+        const string hex = "0123456789abcdef";
+        return hex[value & 0xF];
     }
 }


### PR DESCRIPTION
## Summary
- speed up IPv6 PTR formatting
- test IPv6 loopback conversion
- test DNSBL IPv6 loopback handling

## Testing
- `dotnet build -c Debug`
- `dotnet test --no-build` *(fails: Invalid URI when running DNS dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_685c21cdedc8832e97fab14686392074