### PR TITLE
Fix DNS name validation

### DIFF
--- a/DomainDetective.Tests/TestDnsConfiguration.cs
+++ b/DomainDetective.Tests/TestDnsConfiguration.cs
@@ -17,5 +17,19 @@ namespace DomainDetective.Tests {
             await Assert.ThrowsAsync<ArgumentNullException>(async () =>
                 await config.QueryFullDNS(Array.Empty<string>(), DnsRecordType.A));
         }
+
+        [Fact]
+        public async Task QueryDNSThrowsIfNameNull() {
+            var config = new DnsConfiguration();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await config.QueryDNS((string)null!, DnsRecordType.A));
+        }
+
+        [Fact]
+        public async Task QueryDNSThrowsIfNameEmpty() {
+            var config = new DnsConfiguration();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await config.QueryDNS(string.Empty, DnsRecordType.A));
+        }
     }
 }

--- a/DomainDetective/DnsConfiguration.cs
+++ b/DomainDetective/DnsConfiguration.cs
@@ -40,6 +40,9 @@ namespace DomainDetective {
         /// </summary>
         public async Task<DnsAnswer[]> QueryDNS(string name, DnsRecordType recordType, string filter = "", CancellationToken cancellationToken = default) {
             cancellationToken.ThrowIfCancellationRequested();
+            if (string.IsNullOrEmpty(name)) {
+                throw new ArgumentNullException(nameof(name));
+            }
             ClientX client = new(endpoint: DnsEndpoint, DnsSelectionStrategy);
             if (filter != string.Empty) {
                 var data = await client.ResolveFilter(name, recordType, filter);


### PR DESCRIPTION
## Summary
- validate `name` parameter in `DnsConfiguration.QueryDNS`
- add DNS name validation tests for `QueryDNS`

## Testing
- `dotnet test --filter TestDnsConfiguration --no-build`
- `dotnet test` *(fails: 13 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685c21c34f24832ea26b2b9ec56b8ee2