### PR TITLE
Add plain HTTP verification

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -32,6 +32,7 @@ internal class Program
 
         var outputJson = args.Contains("--json");
         var summaryOnly = args.Contains("--summary");
+        var checkHttp = args.Contains("--check-http");
 
         var checksOption = args.FirstOrDefault(a => a.StartsWith("--checks="));
         var selectedChecks = new List<HealthCheckType>();
@@ -61,6 +62,10 @@ internal class Program
         {
             var hc = new DomainHealthCheck { Verbose = false };
             await hc.Verify(domain, checks);
+            if (checkHttp)
+            {
+                await hc.VerifyPlainHttp(domain);
+            }
 
             if (outputJson)
             {
@@ -96,6 +101,10 @@ internal class Program
                     CliHelpers.ShowPropertiesTable($"{check} for {domain}", data);
                 }
             }
+            if (checkHttp)
+            {
+                CliHelpers.ShowPropertiesTable($"PLAIN HTTP for {domain}", hc.HttpAnalysis);
+            }
         }
 
         return 0;
@@ -106,6 +115,7 @@ internal class Program
         AnsiConsole.MarkupLine("[green]DomainDetective CLI[/]");
         Console.WriteLine("Usage: ddcli [options] <domain> [domain...]");
         Console.WriteLine("--checks=LIST     Comma separated list of checks: dmarc, spf, dkim, mx, caa, ns, dane, dnssec, dnsbl");
+        Console.WriteLine("--check-http      Perform plain HTTP check");
         Console.WriteLine("--summary         Show condensed summary");
         Console.WriteLine("--json            Output raw JSON");
     }

--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestPlainHttpHealthCheck {
+        [Fact]
+        public async Task VerifyPlainHttpDetectsStatusWithoutHsts() {
+            using var listener = new HttpListener();
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.Headers.Add("Strict-Transport-Security", "max-age=31536000");
+                ctx.Response.Close();
+            });
+
+            try {
+                var healthCheck = new DomainHealthCheck();
+                await healthCheck.VerifyPlainHttp($"localhost:{port}");
+
+                Assert.True(healthCheck.HttpAnalysis.IsReachable);
+                Assert.Equal(200, healthCheck.HttpAnalysis.StatusCode);
+                Assert.False(healthCheck.HttpAnalysis.HstsPresent);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public async Task VerifyPlainHttpThrowsIfDomainNullOrWhitespace(string domain) {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await healthCheck.VerifyPlainHttp(domain));
+        }
+
+        private static int GetFreePort() {
+            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -763,6 +763,18 @@ namespace DomainDetective {
         }
 
         /// <summary>
+        /// Performs a basic HTTP check without enforcing HTTPS.
+        /// </summary>
+        /// <param name="domainName">Domain or host to query.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task VerifyPlainHttp(string domainName, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                throw new ArgumentNullException(nameof(domainName));
+            }
+            await HttpAnalysis.AnalyzeUrl($"http://{domainName}", false, _logger);
+        }
+
+        /// <summary>
         /// Checks an IP address against configured DNS block lists.
         /// </summary>
         /// <param name="ipAddress">IP address to query.</param>


### PR DESCRIPTION
## Summary
- add `VerifyPlainHttp` to `DomainHealthCheck`
- support `--check-http` CLI flag to run new check
- test `VerifyPlainHttp`

## Testing
- `dotnet test` *(fails: Assert errors)*
- `dotnet build -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685c22800adc832eb33fdbf89e39b81d