### PR TITLE
Add CSP unsafe directive detection

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseCSP.cs
+++ b/DomainDetective.Example/ExampleAnalyseCSP.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleDetectUnsafeCsp() {
+        var analysis = await HttpAnalysis.CheckUrl("https://www.google.com", collectHeaders: true);
+        Console.WriteLine($"Unsafe directives detected: {analysis.CspUnsafeDirectives}");
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -44,6 +44,7 @@ public static partial class Program {
 
         await ExampleAnalyseHTTP();
         await ExampleAnalyseHTTPByHealthCheck();
+        await ExampleDetectUnsafeCsp();
 
 
         await ExampleAnalyseByDomainDANE();


### PR DESCRIPTION
## Summary
- extend HTTP security headers with Content-Security-Policy
- flag unsafe directives in Content-Security-Policy
- test the new CSP parser
- show CSP example in example project

## Testing
- `dotnet build`
- `dotnet test` *(fails: Invalid URI / network errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c225af284832ebe5ac3b04ee219fe