### PR TITLE
Validate DNS server addresses

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -144,5 +144,29 @@ namespace DomainDetective.Tests {
                 File.Delete(file);
             }
         }
+
+        [Theory]
+        [InlineData("300.1.1.1")]
+        [InlineData("not.an.ip")]
+        [InlineData("1.2.3")]
+        public void AddServerThrowsForInvalidAddress(string address) {
+            var analysis = new DnsPropagationAnalysis();
+            var entry = new PublicDnsEntry { IPAddress = address };
+            Assert.Throws<FormatException>(() => analysis.AddServer(entry));
+        }
+
+        [Fact]
+        public void LoadServersThrowsForInvalidAddress() {
+            var json = "[{\"IPAddress\":\"bad.ip\"}]";
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, json);
+                var analysis = new DnsPropagationAnalysis();
+                Assert.Throws<FormatException>(() => analysis.LoadServers(file, clearExisting: true));
+            }
+            finally {
+                File.Delete(file);
+            }
+        }
     }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -90,6 +90,11 @@ namespace DomainDetective {
             }
 
             foreach (var entry in servers) {
+                if (!System.Net.IPAddress.TryParse(entry.IPAddress, out var parsed) ||
+                    !string.Equals(parsed.ToString(), entry.IPAddress, StringComparison.OrdinalIgnoreCase)) {
+                    throw new FormatException($"Invalid IP address '{entry.IPAddress}'");
+                }
+
                 var trimmed = new PublicDnsEntry {
                     Country = entry.Country?.Trim(),
                     IPAddress = entry.IPAddress,
@@ -115,6 +120,12 @@ namespace DomainDetective {
             if (entry == null || string.IsNullOrWhiteSpace(entry.IPAddress)) {
                 return;
             }
+
+            if (!System.Net.IPAddress.TryParse(entry.IPAddress, out var parsed) ||
+                !string.Equals(parsed.ToString(), entry.IPAddress, StringComparison.OrdinalIgnoreCase)) {
+                throw new FormatException($"Invalid IP address '{entry.IPAddress}'");
+            }
+
             if (_servers.All(s => s.IPAddress != entry.IPAddress)) {
                 _servers.Add(entry);
             }


### PR DESCRIPTION
## Summary
- validate IP addresses when loading or adding public DNS servers
- test bad DNS server addresses

## Testing
- `dotnet test` *(fails: The given key 'selector1' was not present...)*

------
https://chatgpt.com/codex/tasks/task_e_685c2211f6c0832eb9029a3223f65e16