### PR TITLE
Add DKIM/DMARC validity flags

### DIFF
--- a/DomainDetective.Tests/TestDomainSummary.cs
+++ b/DomainDetective.Tests/TestDomainSummary.cs
@@ -1,0 +1,23 @@
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestDomainSummary {
+        [Fact]
+        public async Task BuildSummaryIncludesValidityFlags() {
+            const string spfRecord = "v=spf1 include:_spf.google.com -all";
+            const string dmarcRecord = "v=DMARC1; p=reject;";
+            const string dkimRecord = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckSPF(spfRecord);
+            await healthCheck.CheckDMARC(dmarcRecord);
+            await healthCheck.CheckDKIM(dkimRecord);
+
+            var summary = healthCheck.BuildSummary();
+
+            Assert.True(summary.SpfValid);
+            Assert.True(summary.DmarcValid);
+            Assert.True(summary.DkimValid);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -819,12 +819,24 @@ namespace DomainDetective {
             var spfValid = SpfAnalysis.SpfRecordExists && SpfAnalysis.StartsCorrectly &&
                             !SpfAnalysis.ExceedsDnsLookups && !SpfAnalysis.MultipleSpfRecords;
 
+            var dmarcValid = DmarcAnalysis.DmarcRecordExists && DmarcAnalysis.StartsCorrectly &&
+                             DmarcAnalysis.HasMandatoryTags && DmarcAnalysis.IsPolicyValid &&
+                             DmarcAnalysis.IsPctValid && !DmarcAnalysis.MultipleRecords &&
+                             !DmarcAnalysis.ExceedsCharacterLimit && DmarcAnalysis.ValidDkimAlignment &&
+                             DmarcAnalysis.ValidSpfAlignment;
+
+            var dkimValid = DKIMAnalysis.AnalysisResults.Values.Any(a =>
+                a.DkimRecordExists && a.StartsCorrectly && a.PublicKeyExists &&
+                a.ValidPublicKey && a.KeyTypeExists && a.ValidKeyType && a.ValidFlags);
+
             return new DomainSummary {
                 HasSpfRecord = SpfAnalysis.SpfRecordExists,
                 SpfValid = spfValid,
                 HasDmarcRecord = DmarcAnalysis.DmarcRecordExists,
                 DmarcPolicy = DmarcAnalysis.Policy,
+                DmarcValid = dmarcValid,
                 HasDkimRecord = DKIMAnalysis.AnalysisResults.Values.Any(a => a.DkimRecordExists),
+                DkimValid = dkimValid,
                 HasMxRecord = MXAnalysis.MxRecordExists,
                 DnsSecValid = DNSSecAnalysis.ChainValid
             };

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -15,8 +15,14 @@ namespace DomainDetective {
         /// <summary>Policy configured in the DMARC record.</summary>
         public string DmarcPolicy { get; init; }
 
+        /// <summary>True when the DMARC record appears valid.</summary>
+        public bool DmarcValid { get; init; }
+
         /// <summary>Indicates whether a DKIM record exists.</summary>
         public bool HasDkimRecord { get; init; }
+
+        /// <summary>True when at least one DKIM record appears valid.</summary>
+        public bool DkimValid { get; init; }
 
         /// <summary>Indicates whether MX records exist.</summary>
         public bool HasMxRecord { get; init; }


### PR DESCRIPTION
## Summary
- add `DmarcValid` and `DkimValid` to `DomainSummary`
- compute new validity flags in `DomainHealthCheck.BuildSummary`
- test that summary builder populates validity flags

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Invalid URI, network issues)*

------
https://chatgpt.com/codex/tasks/task_e_685c32c1a918832eb31ee3765f693bb0