### PR TITLE
Align NativeAOT options with .NET 8

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -4,3 +4,8 @@
 - Initial release of Domain Detective
 - Includes CLI and PowerShell module
 - Supports checks for SPF, DMARC, DKIM, CAA, NS, SOA, DNSSEC and DANE/TLSA records
+
+## 1.0.1
+
+### What's Changed
+- Enabled trimming on CLI and example projects with partial mode to align with .NET 8 NativeAOT guidance

--- a/DomainDetective.CLI/DomainDetective.CLI.csproj
+++ b/DomainDetective.CLI/DomainDetective.CLI.csproj
@@ -6,6 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>partial</TrimMode>
     <InvariantGlobalization>true</InvariantGlobalization>
   </PropertyGroup>
 

--- a/DomainDetective.Example/DomainDetective.Example.csproj
+++ b/DomainDetective.Example/DomainDetective.Example.csproj
@@ -2,10 +2,12 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
-		<ImplicitUsings>disable</ImplicitUsings>
-		<LangVersion>12.0</LangVersion>
-	</PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>disable</ImplicitUsings>
+        <LangVersion>12.0</LangVersion>
+        <PublishTrimmed>true</PublishTrimmed>
+        <TrimMode>partial</TrimMode>
+    </PropertyGroup>
 
 	<ItemGroup>
 	  <PackageReference Include="Spectre.Console" Version="0.50.0" />


### PR DESCRIPTION
## Summary
- enable PublishTrimmed and TrimMode on CLI
- enable PublishTrimmed and TrimMode on example app
- document new AOT defaults

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: Assert.True() etc.)*


------
https://chatgpt.com/codex/tasks/task_e_685c32b1e80c832eae1f6bcd17bccc41