### PR TITLE
Add contact TXT analysis support

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -19,7 +19,8 @@ internal class Program
         ["ns"] = HealthCheckType.NS,
         ["dane"] = HealthCheckType.DANE,
         ["dnssec"] = HealthCheckType.DNSSEC,
-        ["dnsbl"] = HealthCheckType.DNSBL
+        ["dnsbl"] = HealthCheckType.DNSBL,
+        ["contact"] = HealthCheckType.CONTACT
     };
 
     private static async Task<int> Main(string[] args)
@@ -104,6 +105,7 @@ internal class Program
                     HealthCheckType.DANE => hc.DaneAnalysis,
                     HealthCheckType.DNSBL => hc.DNSBLAnalysis,
                     HealthCheckType.DNSSEC => hc.DNSSecAnalysis,
+                    HealthCheckType.CONTACT => hc.ContactInfoAnalysis,
                     _ => null
                 };
                 if (data != null)
@@ -124,7 +126,7 @@ internal class Program
     {
         AnsiConsole.MarkupLine("[green]DomainDetective CLI[/]");
         Console.WriteLine("Usage: ddcli [options] <domain> [domain...]");
-        Console.WriteLine("--checks=LIST     Comma separated list of checks: dmarc, spf, dkim, mx, caa, ns, dane, dnssec, dnsbl");
+        Console.WriteLine("--checks=LIST     Comma separated list of checks: dmarc, spf, dkim, mx, caa, ns, dane, dnssec, dnsbl, contact");
         Console.WriteLine("--check-http      Perform plain HTTP check");
         Console.WriteLine("--summary         Show condensed summary");
         Console.WriteLine("--json            Output raw JSON");

--- a/DomainDetective.PowerShell/CmdletTestContactRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestContactRecord.cs
@@ -1,0 +1,39 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Retrieves contact TXT information for a domain.</summary>
+    /// <example>
+    ///   <summary>Get contact details.</summary>
+    ///   <code>Test-ContactRecord -DomainName example.com</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "ContactRecord", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestContactRecord : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
+        public string DomainName;
+
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying contact record for domain: {0}", DomainName);
+            await healthCheck.Verify(DomainName, new[] { HealthCheckType.CONTACT });
+            WriteObject(healthCheck.ContactInfoAnalysis);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestContactInfoAnalysis.cs
+++ b/DomainDetective.Tests/TestContactInfoAnalysis.cs
@@ -1,0 +1,16 @@
+using DnsClientX;
+
+namespace DomainDetective.Tests {
+    public class TestContactInfoAnalysis {
+        [Fact]
+        public async Task ParseContactRecord() {
+            var record = "email=admin@example.com; phone=12345";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckContactInfo(record);
+
+            Assert.True(healthCheck.ContactInfoAnalysis.RecordExists);
+            Assert.Equal("admin@example.com", healthCheck.ContactInfoAnalysis.Fields["email"]);
+            Assert.Equal("12345", healthCheck.ContactInfoAnalysis.Fields["phone"]);
+        }
+    }
+}

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -43,5 +43,7 @@ public enum HealthCheckType {
     /// <summary>Perform HTTP checks.</summary>
     HTTP,
     /// <summary>Validate HPKP configuration.</summary>
-    HPKP
+    HPKP,
+    /// <summary>Query contact TXT record.</summary>
+    CONTACT
 }

--- a/DomainDetective/Protocols/ContactInfoAnalysis.cs
+++ b/DomainDetective/Protocols/ContactInfoAnalysis.cs
@@ -1,0 +1,42 @@
+using DnsClientX;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+public class ContactInfoAnalysis {
+    public string? ContactRecord { get; private set; }
+    public bool RecordExists { get; private set; }
+    public Dictionary<string, string> Fields { get; } = new();
+
+    public async Task AnalyzeContactRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        await Task.Yield();
+
+        ContactRecord = null;
+        RecordExists = false;
+        Fields.Clear();
+
+        if (dnsResults == null) {
+            logger?.WriteVerbose("DNS query returned no results.");
+            return;
+        }
+
+        var recordList = dnsResults.ToList();
+        RecordExists = recordList.Any();
+        if (!RecordExists) {
+            logger?.WriteVerbose("No contact record found.");
+            return;
+        }
+
+        ContactRecord = string.Join(" ", recordList.Select(r => r.Data));
+        logger?.WriteVerbose($"Analyzing contact TXT record {ContactRecord}");
+
+        foreach (var part in (ContactRecord ?? string.Empty).Split(';')) {
+            var kv = part.Split(new[] { '=' }, 2);
+            if (kv.Length == 2) {
+                Fields[kv[0].Trim().ToLowerInvariant()] = kv[1].Trim();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support `contact` TXT records
- expose new `ContactInfoAnalysis` in CLI and PowerShell
- test parsing contact records

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Assert.True failures)*

------
https://chatgpt.com/codex/tasks/task_e_685c33200b1c832eae104dfa3d243bed