### PR TITLE
Normalize DNS textual record casing

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -110,6 +110,27 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void CompareResultsGroupsTextRecordsCaseInsensitive() {
+            var results = new[] {
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "1.1.1.1" },
+                    Records = new[] { "Example" },
+                    Success = true
+                },
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry { IPAddress = "8.8.8.8" },
+                    Records = new[] { "example" },
+                    Success = true
+                }
+            };
+
+            var groups = DnsPropagationAnalysis.CompareResults(results);
+            Assert.Single(groups);
+            Assert.Equal(2, groups.First().Value.Count);
+            Assert.Equal("example", groups.Keys.First());
+        }
+
+        [Fact]
         public void CompareResultsIgnoresNullRecords() {
             var results = new[] {
                 new DnsPropagationResult {

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -262,7 +262,7 @@ namespace DomainDetective {
                             ? ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
                                 ? ip.ToString().ToLowerInvariant()
                                 : ip.ToString()
-                            : r)
+                            : r.ToLowerInvariant())
                     .OrderBy(r => r);
                 var key = string.Join(",", normalizedRecords);
                 if (!comparison.TryGetValue(key, out var list)) {


### PR DESCRIPTION
## Summary
- normalize textual DNS records before comparing
- ensure mixed-case text records group together

## Testing
- `dotnet test` *(fails: CertificateHTTP.UnreachableHostLogsExceptionType, TestSpfAnalysis, TestDMARCAnalysis, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685cdda90418832ea4174ab25d6b0752