### PR TITLE
Add MessageHeader health check

### DIFF
--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -45,5 +45,7 @@ public enum HealthCheckType {
     /// <summary>Validate HPKP configuration.</summary>
     HPKP,
     /// <summary>Query contact TXT record.</summary>
-    CONTACT
+    CONTACT,
+    /// <summary>Parse message headers.</summary>
+    MESSAGEHEADER
 }

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Represents the results from parsing message headers.
+/// </summary>
+public class MessageHeaderAnalysis {
+    /// <summary>The unparsed raw headers.</summary>
+    public string? RawHeaders { get; internal set; }
+    /// <summary>Parsed header values keyed by header name.</summary>
+    public Dictionary<string, string> Headers { get; } = new(StringComparer.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
## Summary
- extend health check enum with `MESSAGEHEADER`
- support message header analysis in `DomainHealthCheck`
- implement stub `MessageHeaderAnalysis`

## Testing
- `dotnet test` *(fails: DomainDetective.Tests)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_685cdef97998832e83a66ecacf58b5b9