### PR TITLE
Add DNS validation for MTA‑STS

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -221,6 +221,10 @@ namespace DomainDetective {
                 DnsConfiguration = DnsConfiguration
             };
 
+            MTASTSAnalysis = new MTASTSAnalysis() {
+                DnsConfiguration = DnsConfiguration
+            };
+
             _logger.WriteVerbose("DomainHealthCheck initialized.");
             _logger.WriteVerbose("DnsEndpoint: {0}", DnsEndpoint);
             _logger.WriteVerbose("DnsSelectionStrategy: {0}", DnsSelectionStrategy);
@@ -321,7 +325,8 @@ namespace DomainDetective {
                         break;
                     case HealthCheckType.MTASTS:
                         MTASTSAnalysis = new MTASTSAnalysis {
-                            PolicyUrlOverride = MtaStsPolicyUrlOverride
+                            PolicyUrlOverride = MtaStsPolicyUrlOverride,
+                            DnsConfiguration = DnsConfiguration
                         };
                         await MTASTSAnalysis.AnalyzePolicy(domainName, _logger);
                         break;
@@ -645,7 +650,8 @@ namespace DomainDetective {
                 throw new ArgumentNullException(nameof(domainName));
             }
             MTASTSAnalysis = new MTASTSAnalysis {
-                PolicyUrlOverride = MtaStsPolicyUrlOverride
+                PolicyUrlOverride = MtaStsPolicyUrlOverride,
+                DnsConfiguration = DnsConfiguration
             };
             await MTASTSAnalysis.AnalyzePolicy(domainName, _logger);
         }

--- a/README.MD
+++ b/README.MD
@@ -118,6 +118,14 @@ Import-Module ./Module/DomainDetective.psd1 -Force
 Test-SpfRecord -DomainName "example.com"
 ```
 
+### MTA-STS
+
+`VerifyMTASTS` now validates the `_mta-sts.<domain>` TXT record before downloading
+the policy file. If the DNS record is missing or does not contain both `v=STSv1`
+and a valid `id` value, the analysis fails. The parsed identifier is exposed via
+`PolicyId` and the properties `DnsRecordPresent` and `DnsRecordValid` reflect the
+DNS state.
+
 ## Alternatives
 If you don't need to automate the process, or if you just want to quickly query for your domain name, you can use the following web based tools:
 


### PR DESCRIPTION
## Summary
- validate `_mta-sts` TXT records in MTASTSAnalysis
- expose DNS record status and policy ID
- update DomainHealthCheck to use new logic
- test valid and invalid TXT records
- document DNS validation behaviour

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build` *(fails: Invalid URI / network access)*

------
https://chatgpt.com/codex/tasks/task_e_685ce427f73c832e97c4ba7db6319750