### PR TITLE
Add message header analysis tests

### DIFF
--- a/DomainDetective.Tests/Data/sample-headers.txt
+++ b/DomainDetective.Tests/Data/sample-headers.txt
@@ -1,0 +1,7 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Test Message
+Date: Tue, 24 Oct 2023 12:34:56 +0000
+Received: from mail1.example.com (mail1.example.com [192.0.2.1]) by mx.example.net with ESMTP id abc123 for <recipient@example.com>; Tue, 24 Oct 2023 12:35:56 +0000
+Received: from internal.example.com (internal.example.com [192.0.2.2]) by mail1.example.com with ESMTP id def456; Tue, 24 Oct 2023 12:34:56 +0000
+Authentication-Results: mx.example.net; dkim=pass; spf=pass; dmarc=pass; arc=pass

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -35,14 +35,17 @@
     <ProjectReference Include="..\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\Data\DNS\PublicDNS.json">
-      <Link>Data/DNS/PublicDNS.json</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="Data/smime.pem">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\Data\DNS\PublicDNS.json">
+            <Link>Data/DNS/PublicDNS.json</Link>
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="Data/smime.pem">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="Data/sample-headers.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
 </Project>

--- a/DomainDetective.Tests/TestMessageHeaderAnalysis.cs
+++ b/DomainDetective.Tests/TestMessageHeaderAnalysis.cs
@@ -1,0 +1,22 @@
+using System.IO;
+
+namespace DomainDetective.Tests {
+    public class TestMessageHeaderAnalysis {
+        [Fact]
+        public void ParseMessageHeaders() {
+            var raw = File.ReadAllText("Data/sample-headers.txt");
+            var analysis = new MessageHeaderAnalysis();
+            analysis.Parse(raw, new InternalLogger());
+
+            Assert.Equal("sender@example.com", analysis.From);
+            Assert.Equal("recipient@example.com", analysis.To);
+            Assert.Equal("Test Message", analysis.Subject);
+            Assert.NotNull(analysis.Date);
+            Assert.Equal(2, analysis.ReceivedChain.Count);
+            Assert.Equal("pass", analysis.DkimResult);
+            Assert.Equal("pass", analysis.SpfResult);
+            Assert.Equal("pass", analysis.DmarcResult);
+            Assert.Equal("pass", analysis.ArcResult);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add sample message headers
- include header data file in test output
- verify `MessageHeaderAnalysis.Parse`

## Testing
- `dotnet test` *(fails: 13 failed, 189 passed)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb828ea8832e91230cf7269b29ca