### PR TITLE
Add header analysis command

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -1,0 +1,42 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Parses raw email message headers.</summary>
+    /// <example>
+    ///   <summary>Analyze headers from a file.</summary>
+    ///   <code>Get-Content './headers.txt' -Raw | Test-MessageHeader</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "MessageHeader")]
+    public sealed class CmdletTestMessageHeader : AsyncPSCmdlet {
+        /// <param name="HeaderText">Raw header text.</param>
+        [Parameter(Mandatory = true, Position = 0)]
+        [ValidateNotNullOrEmpty]
+        public string HeaderText;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(
+                _logger,
+                this.WriteVerbose,
+                this.WriteWarning,
+                this.WriteDebug,
+                this.WriteError,
+                this.WriteProgress,
+                this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(DnsEndpoint.System, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override Task ProcessRecordAsync() {
+            var result = _healthCheck.CheckMessageHeaders(HeaderText, CancelToken);
+            WriteObject(result);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate')
+    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -41,6 +41,10 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```powershell
   Test-SmtpTls -HostName "mail.example.com" -Port 587
   ```
+- `Test-MessageHeader` – parses raw email headers.
+  ```powershell
+  Get-Content './headers.txt' -Raw | Test-MessageHeader
+  ```
 - `Add-DnsblProvider`, `Remove-DnsblProvider`, `Clear-DnsblProvider` and `Import-DnsblConfig` manage the list of DNSBL providers.
   ```powershell
   Add-DnsblProvider -Domain 'dnsbl.example.com' -Comment 'custom'

--- a/README.MD
+++ b/README.MD
@@ -109,6 +109,14 @@ through entering domain names, selecting checks and choosing between JSON output
 or a condensed summary. The wizard is built with **Spectre.Console** for a more
 pleasant terminal experience.
 
+### Analyze Message Headers
+
+Parse email headers from a file or raw string:
+
+```bash
+ddcli AnalyzeMessageHeader --file ./headers.txt --json
+```
+
 ### PowerShell Module
 
 Import the module and call any of the testing cmdlets:


### PR DESCRIPTION
## Summary
- add AnalyzeMessageHeader command to CLI
- expose Test-MessageHeader cmdlet in PowerShell module
- document new cmdlet and CLI feature

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -v minimal` *(fails: Assert.True() failures)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685ceb76da60832ea185ed39bf8c6842