### PR TITLE
Implement writer-based serialization

### DIFF
--- a/DomainDetective.Tests/TestToJsonPerformance.cs
+++ b/DomainDetective.Tests/TestToJsonPerformance.cs
@@ -1,0 +1,26 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace DomainDetective.Tests {
+    public class TestToJsonPerformance {
+        [Fact]
+        public void ToJson_MatchesJsonSerializerPerformance() {
+            var healthCheck = new DomainHealthCheck();
+            var options = new JsonSerializerOptions { WriteIndented = false };
+            var swSerializer = Stopwatch.StartNew();
+            for (int i = 0; i < 100; i++) {
+                JsonSerializer.Serialize(healthCheck, options);
+            }
+            swSerializer.Stop();
+            var baseline = swSerializer.ElapsedTicks;
+
+            var swMethod = Stopwatch.StartNew();
+            for (int i = 0; i < 100; i++) {
+                healthCheck.ToJson(options);
+            }
+            swMethod.Stop();
+
+            Assert.InRange(swMethod.ElapsedTicks, 0, baseline * 2);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.IO;
+using System.Text;
 using System.Text.Json;
 
 namespace DomainDetective {
@@ -922,7 +924,11 @@ namespace DomainDetective {
         /// </returns>
         public string ToJson(JsonSerializerOptions options = null) {
             options ??= new JsonSerializerOptions { WriteIndented = true };
-            return JsonSerializer.Serialize(this, options);
+            using MemoryStream stream = new MemoryStream();
+            using Utf8JsonWriter writer = new Utf8JsonWriter(stream);
+            JsonSerializer.Serialize(writer, this, options);
+            writer.Flush();
+            return Encoding.UTF8.GetString(stream.ToArray());
         }
 
         /// <summary>Creates a copy with only the specified analyses included.</summary>


### PR DESCRIPTION
## Summary
- switch DomainHealthCheck JSON serialization to `Utf8JsonWriter`
- add a performance test for the new `ToJson` method

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Assert failures on network-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_685cf3c75e30832eb02f95f635624790