### PR TITLE
Fix case sensitivity in DNSBL removal

### DIFF
--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -457,7 +457,8 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="dnsbl">Blacklist host name.</param>
         public void RemoveDNSBL(string dnsbl) {
-            var entry = DnsblEntries.FirstOrDefault(e => e.Domain == dnsbl);
+            var entry = DnsblEntries.FirstOrDefault(e =>
+                string.Equals(e.Domain, dnsbl, StringComparison.OrdinalIgnoreCase));
             if (entry != null) {
                 DnsblEntries.Remove(entry);
             }


### PR DESCRIPTION
## Summary
- use case-insensitive comparison when removing DNSBL entries

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: SOA record not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b122514832ebbf40f8448eec112