### PR TITLE
Add port range validation

### DIFF
--- a/DomainDetective.Tests/TestPortValidation.cs
+++ b/DomainDetective.Tests/TestPortValidation.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestPortValidation {
+        [Fact]
+        public async Task CheckOpenRelayHostThrowsForTooHighPort() {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await healthCheck.CheckOpenRelayHost("example.com", 65536));
+        }
+
+        [Fact]
+        public async Task VerifyWebsiteCertificateThrowsForTooHighPort() {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                await healthCheck.VerifyWebsiteCertificate("example.com", 70000));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate port ranges in DomainHealthCheck
- document allowed port range in XML comments
- test validation logic

## Testing
- `dotnet test` *(fails: ArgumentOutOfRangeException due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b203da0832e9e048c1fd99eb1ad