### PR TITLE
Add cancellation token support for HTTP checks

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -367,7 +367,7 @@ namespace DomainDetective {
                         await SmtpTlsAnalysis.AnalyzeServers(smtpTlsHosts, 25, _logger, cancellationToken);
                         break;
                     case HealthCheckType.HTTP:
-                        await HttpAnalysis.AnalyzeUrl($"http://{domainName}", true, _logger);
+                        await HttpAnalysis.AnalyzeUrl($"http://{domainName}", true, _logger, cancellationToken: cancellationToken);
                         break;
                     case HealthCheckType.HPKP:
                         await HPKPAnalysis.AnalyzeUrl($"http://{domainName}", _logger);
@@ -842,7 +842,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            await HttpAnalysis.AnalyzeUrl($"http://{domainName}", false, _logger);
+            await HttpAnalysis.AnalyzeUrl($"http://{domainName}", false, _logger, cancellationToken: cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- pass `CancellationToken` into `HttpAnalysis.AnalyzeUrl`
- allow `VerifyPlainHttp` to accept a token
- forward token when performing HTTP health check

## Testing
- `dotnet test DomainDetective.sln -v minimal` *(fails: Assert.Equal() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b168a74832e83266e89688940fb