### PR TITLE
Handle duplicate headers

### DIFF
--- a/DomainDetective.Tests/Data/sample-headers-duplicate.txt
+++ b/DomainDetective.Tests/Data/sample-headers-duplicate.txt
@@ -1,0 +1,8 @@
+From: sender@example.com
+Subject: First Subject
+Subject: Second Subject
+To: recipient@example.com
+Date: Tue, 24 Oct 2023 12:34:56 +0000
+Received: from mail1.example.com (mail1.example.com [192.0.2.1]) by mx.example.net with ESMTP id abc123 for <recipient@example.com>; Tue, 24 Oct 2023 12:35:56 +0000
+Received: from internal.example.com (internal.example.com [192.0.2.2]) by mail1.example.com with ESMTP id def456; Tue, 24 Oct 2023 12:34:56 +0000
+Authentication-Results: mx.example.net; dkim=pass; spf=pass; dmarc=pass; arc=pass

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -46,6 +46,9 @@
         <None Include="Data/sample-headers.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/sample-headers-duplicate.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/DomainDetective.Tests/TestMessageHeaderDuplicates.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDuplicates.cs
@@ -1,0 +1,18 @@
+using System.IO;
+
+namespace DomainDetective.Tests {
+    public class TestMessageHeaderDuplicates {
+        [Fact]
+        public void ParseHeadersWithDuplicates() {
+            var raw = File.ReadAllText("Data/sample-headers-duplicate.txt");
+            var analysis = new MessageHeaderAnalysis();
+            analysis.Parse(raw, new InternalLogger());
+
+            Assert.Equal("Second Subject", analysis.Headers["Subject"]);
+            Assert.True(analysis.DuplicateHeaders.TryGetValue("Subject", out var list));
+            Assert.Equal(2, list.Count);
+            Assert.Contains("First Subject", list);
+            Assert.Contains("Second Subject", list);
+        }
+    }
+}

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -14,6 +14,8 @@ namespace DomainDetective {
         public string? RawHeaders { get; private set; }
         /// <summary>All parsed headers keyed by header name.</summary>
         public Dictionary<string, string> Headers { get; } = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>Duplicate header values keyed by header name.</summary>
+        public Dictionary<string, List<string>> DuplicateHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
         /// <summary>List of <c>Received</c> header values in order.</summary>
         public List<string> ReceivedChain { get; } = new();
         /// <summary>Total message transit time across all hops.</summary>
@@ -45,6 +47,7 @@ namespace DomainDetective {
         public void Parse(string rawHeaders, InternalLogger? logger = null) {
             RawHeaders = rawHeaders;
             Headers.Clear();
+            DuplicateHeaders.Clear();
             ReceivedChain.Clear();
             SpamHeaders.Clear();
             TotalTransitTime = null;
@@ -66,6 +69,13 @@ namespace DomainDetective {
                 using var stream = new MemoryStream(bytes);
                 var message = MimeMessage.Load(stream);
                 foreach (var header in message.Headers) {
+                    if (Headers.TryGetValue(header.Field, out var existing)) {
+                        if (!DuplicateHeaders.TryGetValue(header.Field, out var list)) {
+                            list = new List<string> { existing };
+                            DuplicateHeaders[header.Field] = list;
+                        }
+                        list.Add(header.Value);
+                    }
                     Headers[header.Field] = header.Value;
                     switch (header.Id) {
                         case HeaderId.Received:


### PR DESCRIPTION
## Summary
- track duplicate message headers separately
- add coverage for duplicate message headers

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b36a398832eb6be611b3317ca29