### PR TITLE
Fix header decoding

### DIFF
--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -62,9 +62,17 @@ namespace DomainDetective {
             }
 
             try {
-                var bytes = Encoding.ASCII.GetBytes(rawHeaders + "\r\n");
-                using var stream = new MemoryStream(bytes);
-                var message = MimeMessage.Load(stream);
+                var utf8Bytes = Encoding.UTF8.GetBytes(rawHeaders + "\r\n");
+                using var utf8Stream = new MemoryStream(utf8Bytes);
+                MimeMessage message;
+                try {
+                    message = MimeMessage.Load(utf8Stream);
+                } catch (FormatException) {
+                    utf8Stream.Dispose();
+                    var asciiBytes = Encoding.ASCII.GetBytes(rawHeaders + "\r\n");
+                    using var asciiStream = new MemoryStream(asciiBytes);
+                    message = MimeMessage.Load(asciiStream);
+                }
                 foreach (var header in message.Headers) {
                     Headers[header.Field] = header.Value;
                     switch (header.Id) {


### PR DESCRIPTION
## Summary
- decode email headers in UTF-8 first with ASCII fallback

## Testing
- `dotnet build --nologo`
- `dotnet test --no-build --nologo` *(fails: Specified argument was out of the range of valid values)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b4e688c832eb84eb3b86b5a60a7