### PR TITLE
Fix BIMI analysis token usage

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -338,7 +338,7 @@ namespace DomainDetective {
                     case HealthCheckType.BIMI:
                         BimiAnalysis = new BimiAnalysis();
                         var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
-                        await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken);
+                        await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken: cancellationToken);
                         break;
                     case HealthCheckType.SECURITYTXT:
                         // lets reset the SecurityTXTAnalysis, so it's overwritten completly on next run
@@ -578,7 +578,7 @@ namespace DomainDetective {
                     DataRaw = bimiRecord,
                     Type = DnsRecordType.TXT
                 }
-            }, _logger, cancellationToken);
+            }, _logger, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -693,7 +693,7 @@ namespace DomainDetective {
             }
             BimiAnalysis = new BimiAnalysis();
             var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
-            await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken);
+            await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken: cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- pass cancellation token explicitly when analyzing BIMI records

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln` *(fails: DNS-related tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b594c6c832ebd4046934f4e1a65