### PR TITLE
Fix WHOIS registered date parsing

### DIFF
--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -538,8 +538,8 @@ public class WhoisAnalysis {
             if (isParsingDomainSection) {
                 if (trimmedLine.StartsWith("domain:")) {
                     DomainName = trimmedLine.Substring("domain:".Length).Trim();
-                } else if (trimmedLine.StartsWith("registrant:")) {
-                    CreationDate = trimmedLine.Substring("registrant:".Length).Trim();
+                } else if (trimmedLine.StartsWith("registered:")) {
+                    CreationDate = trimmedLine.Substring("registered:".Length).Trim();
                 } else if (trimmedLine.StartsWith("expire:")) {
                     ExpiryDate = trimmedLine.Substring("expire:".Length).Trim();
                 } else if (trimmedLine.StartsWith("registrar:")) {


### PR DESCRIPTION
## Summary
- capture `registered:` info for `CreationDate`

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: KeyNotFoundException)*
- `pwsh ./Module/DomainDetective.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685d1b61c43c832e92fe23a8caf5fc04