### PR TITLE
Add OCSP/CRL lookup to certificate checks

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -47,5 +47,14 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.DaysValid > 0);
             Assert.Equal(analysis.DaysToExpire < 0, analysis.IsExpired);
         }
+
+        [Fact]
+        public async Task ExtractsRevocationEndpoints() {
+            var logger = new InternalLogger();
+            var analysis = new CertificateAnalysis();
+            await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
+            Assert.NotNull(analysis.OcspUrls);
+            Assert.NotNull(analysis.CrlUrls);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- expand `CertificateAnalysis` to include OCSP/CRL info
- query revocation URLs using BouncyCastle
- expose revocation results when checking certificates
- add unit test coverage for new properties

## Testing
- `dotnet run --project DomainDetective.Example/DomainDetective.Example.csproj` *(fails: reflection-based serialization disabled)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter ExtractsRevocationEndpoints --verbosity minimal`
- `dotnet build DomainDetective.sln -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_685d1bd07e28832e8a4627c04643e300