### PR TITLE
Fix DNSBL cancellation handling

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -866,6 +866,7 @@ namespace DomainDetective {
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         public async Task CheckDNSBL(string ipAddress, CancellationToken cancellationToken = default) {
             await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger)) {
+                cancellationToken.ThrowIfCancellationRequested();
                 // enumeration triggers processing
             }
         }
@@ -879,6 +880,7 @@ namespace DomainDetective {
             foreach (var ip in ipAddresses) {
                 cancellationToken.ThrowIfCancellationRequested();
                 await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ip, _logger)) {
+                    cancellationToken.ThrowIfCancellationRequested();
                     // enumeration triggers processing
                 }
             }


### PR DESCRIPTION
## Summary
- check cancellation token for `CheckDNSBL` loops

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: 13 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_685d626e87c4832e8d3a750a28146723