### PR TITLE
Fix CertificateHTTP token handling

### DIFF
--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -111,7 +111,12 @@ namespace DomainDetective {
                                 await tcp.ConnectAsync(uri.Host, port).WaitWithCancellation(timeoutCts.Token);
 #endif
                                 using var ssl = new SslStream(tcp.GetStream(), false, static (_, _, _, errors) => errors == SslPolicyErrors.None);
+#if NET5_0_OR_GREATER
+                                var authOptions = new SslClientAuthenticationOptions { TargetHost = uri.Host };
+                                await ssl.AuthenticateAsClientAsync(authOptions, timeoutCts.Token);
+#else
                                 await ssl.AuthenticateAsClientAsync(uri.Host).WaitWithCancellation(timeoutCts.Token);
+#endif
                                 if (ssl.RemoteCertificate is X509Certificate2 cert) {
                                     Certificate = new X509Certificate2(cert.Export(X509ContentType.Cert));
                                     var xchain = new X509Chain();


### PR DESCRIPTION
## Summary
- pass cancellation tokens to `SslStream.AuthenticateAsClientAsync`

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685d6294e3cc832ea171a12ac69d23b1