### PR TITLE
Fix DNSBL provider lookups

### DIFF
--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -322,7 +322,7 @@ namespace DomainDetective {
             ["127.0.0.4"] = (true, "Blacklisted")
         };
 
-        private static readonly Dictionary<string, Dictionary<string, (bool IsListed, string Meaning)>> _providerReplyCodes = new()
+        private static readonly Dictionary<string, Dictionary<string, (bool IsListed, string Meaning)>> _providerReplyCodes = new(StringComparer.OrdinalIgnoreCase)
         {
             ["hostkarma.junkemailfilter.com"] = new()
             {
@@ -540,7 +540,7 @@ namespace DomainDetective {
             }
 
             foreach (var provider in config.Providers) {
-                var existing = DnsblEntries.FirstOrDefault(e => e.Domain == provider.Domain);
+                var existing = DnsblEntries.FirstOrDefault(e => StringComparer.OrdinalIgnoreCase.Equals(e.Domain, provider.Domain));
                 if (existing == null) {
                     DnsblEntries.Add(new DnsblEntry(provider.Domain, provider.Enabled, provider.Comment));
                 } else if (overwriteExisting) {


### PR DESCRIPTION
## Summary
- ensure DNSBL provider reply codes map is case-insensitive
- use case-insensitive match when loading DNSBL config

## Testing
- `dotnet test` *(fails: The argument ... is invalid)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_685d7f187468832e863d00b1ef129c28