### PR TITLE
Fix null DS and DNSKEY loops

### DIFF
--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -14,13 +14,17 @@ namespace DomainDetective {
         /// <returns>Structured representation of the results.</returns>
         public static DnsSecInfo Convert(DNSSecAnalysis analysis) {
             List<DsRecordInfo> dsRecords = new();
-            foreach (string record in analysis.DsRecords) {
-                dsRecords.Add(ParseDsRecord(record));
+            if (analysis.DsRecords != null) {
+                foreach (string record in analysis.DsRecords) {
+                    dsRecords.Add(ParseDsRecord(record));
+                }
             }
 
             List<DnsKeyInfo> dnsKeys = new();
-            foreach (string key in analysis.DnsKeys) {
-                dnsKeys.Add(ParseDnsKey(key));
+            if (analysis.DnsKeys != null) {
+                foreach (string key in analysis.DnsKeys) {
+                    dnsKeys.Add(ParseDnsKey(key));
+                }
             }
 
             return new DnsSecInfo {


### PR DESCRIPTION
## Summary
- avoid null loops in `DnsSecConverter`

## Testing
- `dotnet build --no-restore DomainDetective.sln`
- `dotnet test --no-restore --no-build DomainDetective.sln` *(fails: 13 tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_685d7f0e51b0832e87988799bd277387