### PR TITLE
Add Permissions-Policy parsing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,7 @@ Current capabilities include:
   - [x] Verify Certificate
   - [x] Verify Response Time
   - [x] Verify Headers
+  - [x] Verify HTTP Security Headers (CSP, Referrer-Policy, X-Frame-Options, Permissions-Policy)
   - [x] Verify HSTS
   - [x] Verify HPKP
 - [x] Verify SecurityTXT
@@ -75,6 +76,9 @@ Import-DnsblConfig -Path './DnsblProviders.json' -OverwriteExisting
 
 ### Verifying Website Certificates
 `VerifyWebsiteCertificate` can be called with or without a URL scheme. When the scheme is omitted, `https://` is used automatically before checking the certificate.
+
+### HTTP Security Headers
+`HttpAnalysis.DefaultSecurityHeaders` lists security headers that are inspected when header collection is enabled. The list includes `Content-Security-Policy`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy` and several Cross-Origin policies. You can modify the list to capture additional headers.
 
 
 ## Build and Test


### PR DESCRIPTION
## Summary
- parse modern HTTP headers in `HttpAnalysis`
- expose parsed Permissions-Policy directives
- test new header parsing
- document default HTTP security headers

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_685db5882018832e8fdddc1d4c5e9561