### PR TITLE
Add DMARC alignment evaluation

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -1,5 +1,5 @@
 using System;
-using System.IO;
+using System.Linq;
 using DnsClientX;
 
 namespace DomainDetective.Tests {
@@ -173,7 +173,10 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task AlignmentStrictVsRelaxed() {
-            string GetOrg(string domain) => string.Join('.', domain.Split('.').TakeLast(2));
+            string GetOrg(string domain) {
+                var parts = domain.Split('.');
+                return string.Join('.', parts.Skip(Math.Max(0, parts.Length - 2)));
+            }
 
             var strictRecord = new List<DnsAnswer> {
                 new DnsAnswer { DataRaw = "v=DMARC1; p=reject; adkim=s; aspf=s", Type = DnsRecordType.TXT }

--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -175,7 +175,7 @@ namespace DomainDetective.Tests {
         public async Task AlignmentStrictVsRelaxed() {
             string GetOrg(string domain) {
                 var parts = domain.Split('.');
-                return string.Join('.', parts.Skip(Math.Max(0, parts.Length - 2)));
+                return string.Join(".", parts.Skip(Math.Max(0, parts.Length - 2)));
             }
 
             var strictRecord = new List<DnsAnswer> {


### PR DESCRIPTION
## Summary
- evaluate DMARC SPF/DKIM alignment via new method
- expose alignment results and add tests for strict vs relaxed policies

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: TestSpfAnalysis.TestSpfOver255, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestCertificateHTTP.UnreachableHostLogsExceptionType, TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps, TestSOAAnalysis.VerifySoaByDomain, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAaandAaaaRecordsUsingSystemResolver, TestDkimAnalysis.TestDKIMByDomain, TestDMARCAnalysis.TestDMARCByDomain, TestAll.TestAllHealthChecks, TestCAAAnalysis.TestCAARecordByDomain, TestDkimGuess.GuessSelectorsForDomain)*

------
https://chatgpt.com/codex/tasks/task_e_685db567d6a8832e97863da41f28e874