### PR TITLE
Add Autodiscover analysis

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -24,6 +24,7 @@ internal class Program
         ["dane"] = HealthCheckType.DANE,
         ["dnssec"] = HealthCheckType.DNSSEC,
         ["dnsbl"] = HealthCheckType.DNSBL,
+        ["autodiscover"] = HealthCheckType.AUTODISCOVER,
         ["contact"] = HealthCheckType.CONTACT
     };
 
@@ -215,6 +216,7 @@ internal class Program
                     HealthCheckType.DANE => hc.DaneAnalysis,
                     HealthCheckType.DNSBL => hc.DNSBLAnalysis,
                     HealthCheckType.DNSSEC => hc.DNSSecAnalysis,
+                    HealthCheckType.AUTODISCOVER => hc.AutodiscoverAnalysis,
                     HealthCheckType.CONTACT => hc.ContactInfoAnalysis,
                     _ => null
                 };

--- a/DomainDetective.PowerShell/CmdletTestAutodiscover.cs
+++ b/DomainDetective.PowerShell/CmdletTestAutodiscover.cs
@@ -1,0 +1,39 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Checks Autodiscover related DNS records.</summary>
+    /// <example>
+    ///   <summary>Verify Autodiscover setup.</summary>
+    ///   <code>Test-Autodiscover -DomainName example.com</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "Autodiscover", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestAutodiscover : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
+        public string DomainName;
+
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying Autodiscover for domain: {0}", DomainName);
+            await _healthCheck.VerifyAutodiscover(DomainName);
+            WriteObject(_healthCheck.AutodiscoverAnalysis);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestAutodiscoverAnalysis.cs
+++ b/DomainDetective.Tests/TestAutodiscoverAnalysis.cs
@@ -1,0 +1,41 @@
+using DnsClientX;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestAutodiscoverAnalysis {
+        [Fact]
+        public async Task ParseAutodiscoverRecords() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "0 0 443 autodiscover.example.com", Type = DnsRecordType.SRV },
+            };
+            var cnames = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "mail.example.com", Type = DnsRecordType.CNAME }
+            };
+            var analysis = new AutodiscoverAnalysis();
+            analysis.QueryDnsOverride = (name, type) => {
+                if (type == DnsRecordType.SRV) return Task.FromResult(answers.ToArray());
+                if (type == DnsRecordType.CNAME) return Task.FromResult(cnames.ToArray());
+                return Task.FromResult(Array.Empty<DnsAnswer>());
+            };
+            await analysis.Analyze("example.com", new DnsConfiguration(), new InternalLogger());
+
+            Assert.True(analysis.SrvRecordExists);
+            Assert.Equal("autodiscover.example.com", analysis.SrvTarget);
+            Assert.Equal(443, analysis.SrvPort);
+            Assert.True(analysis.AutoconfigCnameExists);
+            Assert.Equal("mail.example.com", analysis.AutoconfigTarget);
+        }
+
+        [Fact]
+        public async Task NoRecordsPresent() {
+            var analysis = new AutodiscoverAnalysis();
+            analysis.QueryDnsOverride = (_, _) => Task.FromResult(Array.Empty<DnsAnswer>());
+            await analysis.Analyze("example.com", new DnsConfiguration(), new InternalLogger());
+            Assert.False(analysis.SrvRecordExists);
+            Assert.False(analysis.AutoconfigCnameExists);
+            Assert.False(analysis.AutodiscoverCnameExists);
+        }
+
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -56,6 +56,10 @@ public static class CheckDescriptions {
                 "Validate BIMI records.",
                 null,
                 "Provide a valid BIMI record and hosted logo."),
+            [HealthCheckType.AUTODISCOVER] = new(
+                "Check Autodiscover configuration.",
+                null,
+                "Publish SRV and CNAME records for Autodiscover."),
             [HealthCheckType.CERT] = new(
                 "Inspect certificate records.",
                 null,

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -28,6 +28,8 @@ public enum HealthCheckType {
     TLSRPT,
     /// <summary>Validate BIMI records.</summary>
     BIMI,
+    /// <summary>Check Autodiscover configuration.</summary>
+    AUTODISCOVER,
     /// <summary>Inspect certificate records.</summary>
     CERT,
     /// <summary>Check for security.txt presence.</summary>

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -169,6 +169,12 @@ namespace DomainDetective {
         public BimiAnalysis BimiAnalysis { get; private set; } = new BimiAnalysis();
 
         /// <summary>
+        /// Gets the Autodiscover analysis.
+        /// </summary>
+        /// <value>Results of Autodiscover related checks.</value>
+        public AutodiscoverAnalysis AutodiscoverAnalysis { get; private set; } = new AutodiscoverAnalysis();
+
+        /// <summary>
         /// Gets the HTTP analysis.
         /// </summary>
         /// <value>HTTP endpoint validation results.</value>
@@ -358,6 +364,10 @@ namespace DomainDetective {
                         BimiAnalysis = new BimiAnalysis();
                         var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
                         await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken: cancellationToken);
+                        break;
+                    case HealthCheckType.AUTODISCOVER:
+                        AutodiscoverAnalysis = new AutodiscoverAnalysis();
+                        await AutodiscoverAnalysis.Analyze(domainName, DnsConfiguration, _logger, cancellationToken);
                         break;
                     case HealthCheckType.SECURITYTXT:
                         // lets reset the SecurityTXTAnalysis, so it's overwritten completly on next run
@@ -742,6 +752,20 @@ namespace DomainDetective {
         }
 
         /// <summary>
+        /// Queries Autodiscover related records for a domain.
+        /// </summary>
+        /// <param name="domainName">Domain to verify.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task VerifyAutodiscover(string domainName, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                throw new ArgumentNullException(nameof(domainName));
+            }
+            UpdateIsPublicSuffix(domainName);
+            AutodiscoverAnalysis = new AutodiscoverAnalysis();
+            await AutodiscoverAnalysis.Analyze(domainName, DnsConfiguration, _logger, cancellationToken);
+        }
+
+        /// <summary>
         /// Queries TLSA records for specific ports on a domain.
         /// </summary>
         /// <param name="domainName">Domain to query.</param>
@@ -1005,6 +1029,7 @@ namespace DomainDetective {
             filtered.MTASTSAnalysis = active.Contains(HealthCheckType.MTASTS) ? CloneAnalysis(MTASTSAnalysis) : null;
             filtered.TLSRPTAnalysis = active.Contains(HealthCheckType.TLSRPT) ? CloneAnalysis(TLSRPTAnalysis) : null;
             filtered.BimiAnalysis = active.Contains(HealthCheckType.BIMI) ? CloneAnalysis(BimiAnalysis) : null;
+            filtered.AutodiscoverAnalysis = active.Contains(HealthCheckType.AUTODISCOVER) ? CloneAnalysis(AutodiscoverAnalysis) : null;
             filtered.CertificateAnalysis = active.Contains(HealthCheckType.CERT) ? CloneAnalysis(CertificateAnalysis) : null;
             filtered.SecurityTXTAnalysis = active.Contains(HealthCheckType.SECURITYTXT) ? CloneAnalysis(SecurityTXTAnalysis) : null;
             filtered.SOAAnalysis = active.Contains(HealthCheckType.SOA) ? CloneAnalysis(SOAAnalysis) : null;

--- a/DomainDetective/Protocols/AutodiscoverAnalysis.cs
+++ b/DomainDetective/Protocols/AutodiscoverAnalysis.cs
@@ -1,0 +1,67 @@
+using DnsClientX;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    /// <summary>
+    /// Analyzes Autodiscover related DNS records.
+    /// </summary>
+    public class AutodiscoverAnalysis {
+        public DnsConfiguration DnsConfiguration { get; set; }
+        public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+        /// <summary>Gets a value indicating whether the _autodiscover._tcp SRV record exists.</summary>
+        public bool SrvRecordExists { get; private set; }
+        /// <summary>Gets the SRV target host if present.</summary>
+        public string? SrvTarget { get; private set; }
+        /// <summary>Gets the SRV port if present.</summary>
+        public int SrvPort { get; private set; }
+        /// <summary>Gets a value indicating whether autoconfig CNAME exists.</summary>
+        public bool AutoconfigCnameExists { get; private set; }
+        /// <summary>Gets the autoconfig CNAME target.</summary>
+        public string? AutoconfigTarget { get; private set; }
+        /// <summary>Gets a value indicating whether autodiscover CNAME exists.</summary>
+        public bool AutodiscoverCnameExists { get; private set; }
+        /// <summary>Gets the autodiscover CNAME target.</summary>
+        public string? AutodiscoverTarget { get; private set; }
+
+        /// <summary>
+        /// Queries DNS for Autodiscover related records.
+        /// </summary>
+        private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type, DnsConfiguration config) {
+            if (QueryDnsOverride != null) {
+                return await QueryDnsOverride(name, type);
+            }
+            return await config.QueryDNS(name, type);
+        }
+
+        public async Task Analyze(string domainName, DnsConfiguration config, InternalLogger logger, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                throw new ArgumentNullException(nameof(domainName));
+            }
+
+            var srv = await QueryDns($"_autodiscover._tcp.{domainName}", DnsRecordType.SRV, config);
+            SrvRecordExists = srv != null && srv.Any();
+            if (SrvRecordExists) {
+                var parts = srv.First().Data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 4 && int.TryParse(parts[2], out var port)) {
+                    SrvPort = port;
+                    SrvTarget = parts[3].TrimEnd('.');
+                }
+            }
+
+            var ac = await QueryDns($"autoconfig.{domainName}", DnsRecordType.CNAME, config);
+            AutoconfigCnameExists = ac != null && ac.Any();
+            if (AutoconfigCnameExists) {
+                AutoconfigTarget = ac.First().Data.TrimEnd('.');
+            }
+
+            var ad = await QueryDns($"autodiscover.{domainName}", DnsRecordType.CNAME, config);
+            AutodiscoverCnameExists = ad != null && ad.Any();
+            if (AutodiscoverCnameExists) {
+                AutodiscoverTarget = ad.First().Data.TrimEnd('.');
+            }
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate')
+    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate', 'Test-Autodiscover')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -41,6 +41,10 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```powershell
   Test-SmtpTls -HostName "mail.example.com" -Port 587
   ```
+- `Test-Autodiscover` – checks SRV and CNAME records used by mail clients.
+  ```powershell
+  Test-Autodiscover -DomainName "example.com"
+  ```
 - `Test-MessageHeader` – parses raw email headers.
   ```powershell
   Get-Content './headers.txt' -Raw | Test-MessageHeader

--- a/README.MD
+++ b/README.MD
@@ -21,6 +21,7 @@ Current capabilities include:
 - [x] Verify SMTP TLS
 - [x] Verify TLS-RPT
 - [x] Verify BIMI
+- [x] Verify Autodiscover
 - [x] Verify Website Connectivity
   - [x] Verify HTTP/2
   - [x] Verify HTTP/3
@@ -101,6 +102,10 @@ all analysis details in JSON format:
 ```bash
 dotnet run --project DomainDetective.Example example.com --json
 ```
+To verify Autodiscover records only:
+```bash
+ddcli example.com --checks autodiscover
+```
 
 ### Interactive CLI Wizard
 
@@ -124,6 +129,7 @@ Import the module and call any of the testing cmdlets:
 ```powershell
 Import-Module ./Module/DomainDetective.psd1 -Force
 Test-SpfRecord -DomainName "example.com"
+Test-Autodiscover -DomainName "example.com"
 ```
 
 ### MTA-STS


### PR DESCRIPTION
## Summary
- add `AutodiscoverAnalysis` class
- support Autodiscover verification in `DomainHealthCheck`
- expose new check in CLI and PowerShell
- export new cmdlet in module manifest
- document Autodiscover example usage
- add unit tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build -v q` *(fails: The build stopped unexpectedly)*

------
https://chatgpt.com/codex/tasks/task_e_685db5706f98832eaa3f4fb740081f5a