### PR TITLE
Add DNS TTL analysis

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -9,3 +9,9 @@
 
 ### What's Changed
 - Enabled trimming on CLI and example projects with partial mode to align with .NET 8 NativeAOT guidance
+
+## 1.0.2
+
+### What's Changed
+- Added TTL analysis for common DNS record types
+- New `Test-DnsTtl` PowerShell cmdlet

--- a/DomainDetective.Example/ExampleAnalyseDnsTtl.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsTtl.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseDnsTtl() {
+        var healthCheck = new DomainHealthCheck { Verbose = false };
+        await healthCheck.Verify("evotec.pl", new[] { HealthCheckType.TTL });
+        Helpers.ShowPropertiesTable(analysisOf: "DNS TTL", objs: healthCheck.DnsTtlAnalysis);
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -58,6 +58,7 @@ public static partial class Program {
         await ExampleAnalyseSecurityTXT();
         await ExampleAnalyseDnsPropagation();
         await ExampleAnalyseDnsPropagationRegions();
+        await ExampleAnalyseDnsTtl();
         await ExampleDomainSummary();
 
         //await ExampleQueryDNS();

--- a/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
@@ -1,0 +1,39 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Analyzes DNS TTL values for a domain.</summary>
+    /// <example>
+    ///   <summary>Check TTL values.</summary>
+    ///   <code>Test-DnsTtl -DomainName example.com</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "DnsTtl", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestDnsTtl : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to query.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        [ValidateNotNullOrEmpty]
+        public string DomainName;
+
+        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Querying TTL for domain: {0}", DomainName);
+            await healthCheck.Verify(DomainName, new[] { HealthCheckType.TTL });
+            WriteObject(healthCheck.DnsTtlAnalysis);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDnsTtlAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsTtlAnalysis.cs
@@ -1,0 +1,34 @@
+using DnsClientX;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestDnsTtlAnalysis {
+        private static DnsTtlAnalysis Create(int ttl) {
+            return new DnsTtlAnalysis {
+                DnsConfiguration = new DnsConfiguration(),
+                QueryDnsOverride = (_, type) => Task.FromResult(new[] { new DnsAnswer { TTL = ttl, Type = type } })
+            };
+        }
+
+        [Fact]
+        public async Task WarnsOnShortTtl() {
+            var analysis = Create(100);
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.Contains(analysis.Warnings, w => w.Contains("shorter"));
+        }
+
+        [Fact]
+        public async Task WarnsOnLongTtl() {
+            var analysis = Create(1000000);
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.Contains(analysis.Warnings, w => w.Contains("exceeds"));
+        }
+
+        [Fact]
+        public async Task NoWarningsInRange() {
+            var analysis = Create(3600);
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.Empty(analysis.Warnings);
+        }
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -95,7 +95,11 @@ public static class CheckDescriptions {
             [HealthCheckType.MESSAGEHEADER] = new(
                 "Parse message headers.",
                 null,
-                "Inspect headers for anomalies.")
+                "Inspect headers for anomalies."),
+            [HealthCheckType.TTL] = new(
+                "Analyze DNS record TTL values.",
+                null,
+                "Adjust TTLs within recommended ranges.")
         };
 
     /// <summary>Gets the description for the specified check type.</summary>

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -47,5 +47,7 @@ public enum HealthCheckType {
     /// <summary>Query contact TXT record.</summary>
     CONTACT,
     /// <summary>Parse message headers.</summary>
-    MESSAGEHEADER
+    MESSAGEHEADER,
+    /// <summary>Analyze DNS record TTL values.</summary>
+    TTL
 }

--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -1,0 +1,83 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    /// <summary>
+    /// Collects TTL values for common DNS records and exposes warnings
+    /// when values fall outside recommended ranges.
+    /// </summary>
+    public class DnsTtlAnalysis {
+        private readonly List<string> _warnings = new();
+
+        /// <summary>Gets TTL values for A records.</summary>
+        public IReadOnlyList<int> ATtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Gets TTL values for AAAA records.</summary>
+        public IReadOnlyList<int> AaaaTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Gets TTL values for MX records.</summary>
+        public IReadOnlyList<int> MxTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Gets TTL values for NS records.</summary>
+        public IReadOnlyList<int> NsTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Gets the TTL value for the SOA record.</summary>
+        public int SoaTtl { get; private set; }
+        /// <summary>Collection of warning messages produced during analysis.</summary>
+        public IReadOnlyList<string> Warnings => _warnings;
+
+        public DnsConfiguration DnsConfiguration { get; set; }
+        public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+        private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {
+            if (QueryDnsOverride != null) {
+                return await QueryDnsOverride(name, type);
+            }
+
+            return await DnsConfiguration.QueryDNS(name, type);
+        }
+
+        /// <summary>
+        /// Queries DNS records for TTL values and evaluates them.
+        /// </summary>
+        /// <param name="domainName">Domain name to analyze.</param>
+        /// <param name="logger">Optional logger used for diagnostics.</param>
+        public async Task Analyze(string domainName, InternalLogger logger) {
+            _warnings.Clear();
+            ATtls = Array.Empty<int>();
+            AaaaTtls = Array.Empty<int>();
+            MxTtls = Array.Empty<int>();
+            NsTtls = Array.Empty<int>();
+            SoaTtl = 0;
+
+            var aRecords = await QueryDns(domainName, DnsRecordType.A);
+            var aaaaRecords = await QueryDns(domainName, DnsRecordType.AAAA);
+            var mxRecords = await QueryDns(domainName, DnsRecordType.MX);
+            var nsRecords = await QueryDns(domainName, DnsRecordType.NS);
+            var soaRecords = await QueryDns(domainName, DnsRecordType.SOA);
+
+            ATtls = aRecords.Select(r => r.TTL).ToArray();
+            AaaaTtls = aaaaRecords.Select(r => r.TTL).ToArray();
+            MxTtls = mxRecords.Select(r => r.TTL).ToArray();
+            NsTtls = nsRecords.Select(r => r.TTL).ToArray();
+            SoaTtl = soaRecords.Length > 0 ? soaRecords[0].TTL : 0;
+
+            Evaluate("A", ATtls, 300, 86400);
+            Evaluate("AAAA", AaaaTtls, 300, 86400);
+            Evaluate("MX", MxTtls, 3600, 172800);
+            Evaluate("NS", NsTtls, 86400, 604800);
+            if (SoaTtl > 0) {
+                Evaluate("SOA", new[] { SoaTtl }, 3600, 86400);
+            }
+        }
+
+        private void Evaluate(string recordType, IEnumerable<int> ttls, int min, int max) {
+            foreach (var ttl in ttls) {
+                if (ttl < min) {
+                    _warnings.Add($"{recordType} TTL {ttl} is shorter than recommended {min} seconds.");
+                } else if (ttl > max) {
+                    _warnings.Add($"{recordType} TTL {ttl} exceeds recommended {max} seconds.");
+                }
+            }
+        }
+    }
+}

--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -64,7 +64,7 @@ namespace DomainDetective {
             Evaluate("A", ATtls, 300, 86400);
             Evaluate("AAAA", AaaaTtls, 300, 86400);
             Evaluate("MX", MxTtls, 3600, 172800);
-            Evaluate("NS", NsTtls, 86400, 604800);
+            Evaluate("NS", NsTtls, 3600, 604800);
             if (SoaTtl > 0) {
                 Evaluate("SOA", new[] { SoaTtl }, 3600, 86400);
             }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -192,6 +192,12 @@ namespace DomainDetective {
         /// <value>Details parsed from message headers.</value>
         public MessageHeaderAnalysis MessageHeaderAnalysis { get; private set; } = new MessageHeaderAnalysis();
 
+        /// <summary>
+        /// Gets DNS TTL analysis.
+        /// </summary>
+        /// <value>Information about record TTL values.</value>
+        public DnsTtlAnalysis DnsTtlAnalysis { get; private set; } = new DnsTtlAnalysis();
+
 
         /// <summary>
         /// Holds DNS client configuration used throughout analyses.
@@ -237,6 +243,10 @@ namespace DomainDetective {
             };
 
             MTASTSAnalysis = new MTASTSAnalysis() {
+                DnsConfiguration = DnsConfiguration
+            };
+
+            DnsTtlAnalysis = new DnsTtlAnalysis {
                 DnsConfiguration = DnsConfiguration
             };
 
@@ -399,6 +409,9 @@ namespace DomainDetective {
                         break;
                     case HealthCheckType.MESSAGEHEADER:
                         MessageHeaderAnalysis = CheckMessageHeaders(string.Empty, cancellationToken);
+                        break;
+                    case HealthCheckType.TTL:
+                        await DnsTtlAnalysis.Analyze(domainName, _logger);
                         break;
                     default:
                         _logger.WriteError("Unknown health check type: {0}", healthCheckType);
@@ -1015,6 +1028,7 @@ namespace DomainDetective {
             filtered.HPKPAnalysis = active.Contains(HealthCheckType.HPKP) ? CloneAnalysis(HPKPAnalysis) : null;
             filtered.ContactInfoAnalysis = active.Contains(HealthCheckType.CONTACT) ? CloneAnalysis(ContactInfoAnalysis) : null;
             filtered.MessageHeaderAnalysis = active.Contains(HealthCheckType.MESSAGEHEADER) ? CloneAnalysis(MessageHeaderAnalysis) : null;
+            filtered.DnsTtlAnalysis = active.Contains(HealthCheckType.TTL) ? CloneAnalysis(DnsTtlAnalysis) : null;
 
             return filtered;
         }

--- a/README.MD
+++ b/README.MD
@@ -15,6 +15,7 @@ Current capabilities include:
 - [x] Verify SOA Records
 - [x] Verify MX Records
 - [x] Verify DNSSEC
+- [x] Analyze DNS TTL
 - [x] Verify DANE/TLSA
 - [x] Verify STARTTLS
 - [x] Verify MTA-STS
@@ -124,6 +125,12 @@ Import the module and call any of the testing cmdlets:
 ```powershell
 Import-Module ./Module/DomainDetective.psd1 -Force
 Test-SpfRecord -DomainName "example.com"
+```
+
+Analyze TTL values:
+
+```powershell
+Test-DnsTtl -DomainName "example.com"
 ```
 
 ### MTA-STS


### PR DESCRIPTION
## Summary
- add `DnsTtlAnalysis` for checking TTL values
- expose new `TTL` HealthCheckType
- hook TTL checks into domain health and PowerShell cmdlet
- document TTL example and update features
- cover TTL logic with unit tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: network issues)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_685db555cfd8832e8ce025856664dd1a