### PR TITLE
Add port availability analysis

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -30,7 +30,8 @@ internal class Program
         ["danglingcname"] = HealthCheckType.DANGLINGCNAME,
         ["banner"] = HealthCheckType.SMTPBANNER,
         ["rdns"] = HealthCheckType.REVERSEDNS,
-        ["autodiscover"] = HealthCheckType.AUTODISCOVER
+        ["autodiscover"] = HealthCheckType.AUTODISCOVER,
+        ["ports"] = HealthCheckType.PORTAVAILABILITY
     };
 
     /// <summary>
@@ -238,6 +239,7 @@ internal class Program
                     HealthCheckType.CONTACT => hc.ContactInfoAnalysis,
                     HealthCheckType.DANGLINGCNAME => hc.DanglingCnameAnalysis,
                     HealthCheckType.SMTPBANNER => hc.SmtpBannerAnalysis,
+                    HealthCheckType.PORTAVAILABILITY => hc.PortAvailabilityAnalysis,
                     _ => null
                 };
                 if (data != null)

--- a/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
+++ b/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
@@ -1,0 +1,37 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Checks connectivity to common service ports on a host.</summary>
+    /// <example>
+    ///   <summary>Check ports on a server.</summary>
+    ///   <code>Test-PortAvailability -HostName mail.example.com -Ports 25,443</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "PortAvailability", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestPortAvailability : AsyncPSCmdlet {
+        /// <param name="HostName">Host to test.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string HostName;
+
+        /// <param name="Ports">Ports to check.</param>
+        [Parameter(Mandatory = false)]
+        public int[] Ports = new[] { 25, 80, 443, 465, 587 };
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Checking ports on {0}", HostName);
+            await _healthCheck.CheckPortAvailability(HostName, Ports);
+            WriteObject(_healthCheck.PortAvailabilityAnalysis.ServerResults, true);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestPortAvailabilityAnalysis {
+        [Fact]
+        public async Task ReportsSuccessAndLatency() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                await Task.Delay(10);
+            });
+
+            try {
+                var analysis = new PortAvailabilityAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var result = analysis.ServerResults[$"localhost:{port}"];
+                Assert.True(result.Success);
+                Assert.True(result.Latency > TimeSpan.Zero);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task ReportsFailureWhenPortClosed() {
+            var port = GetFreePort();
+            var analysis = new PortAvailabilityAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+            await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+            var result = analysis.ServerResults[$"localhost:{port}"];
+            Assert.False(result.Success);
+        }
+
+        [Fact]
+        public async Task ResultsDoNotAccumulateAcrossCalls() {
+            var listener1 = new TcpListener(IPAddress.Loopback, 0);
+            listener1.Start();
+            var port1 = ((IPEndPoint)listener1.LocalEndpoint).Port;
+            var serverTask1 = Task.Run(async () => { using var c = await listener1.AcceptTcpClientAsync(); });
+
+            var analysis = new PortAvailabilityAnalysis();
+            try {
+                await analysis.AnalyzeServer("localhost", port1, new InternalLogger());
+                Assert.Single(analysis.ServerResults);
+            } finally {
+                listener1.Stop();
+                await serverTask1;
+            }
+
+            var listener2 = new TcpListener(IPAddress.Loopback, 0);
+            listener2.Start();
+            var port2 = ((IPEndPoint)listener2.LocalEndpoint).Port;
+            var serverTask2 = Task.Run(async () => { using var c = await listener2.AcceptTcpClientAsync(); });
+
+            try {
+                await analysis.AnalyzeServer("localhost", port2, new InternalLogger());
+                Assert.Single(analysis.ServerResults);
+                Assert.False(analysis.ServerResults.ContainsKey($"localhost:{port1}"));
+                Assert.True(analysis.ServerResults.ContainsKey($"localhost:{port2}"));
+            } finally {
+                listener2.Stop();
+                await serverTask2;
+            }
+        }
+
+        private static int GetFreePort() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -119,7 +119,11 @@ public static class CheckDescriptions {
             [HealthCheckType.TTL] = new(
                 "Analyze DNS record TTL values.",
                 null,
-                "Adjust TTLs within recommended ranges.")
+                "Adjust TTLs within recommended ranges."),
+            [HealthCheckType.PORTAVAILABILITY] = new(
+                "Test common service ports for availability.",
+                null,
+                "Ensure required services accept connections.")
         };
 
     /// <summary>Gets the description for the specified check type.</summary>

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -59,5 +59,7 @@ public enum HealthCheckType {
     /// <summary>Detect dangling CNAME records.</summary>
     DANGLINGCNAME,
     /// <summary>Analyze DNS record TTL values.</summary>
-    TTL
+    TTL,
+    /// <summary>Test common service ports for availability.</summary>
+    PORTAVAILABILITY
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -228,6 +228,12 @@ namespace DomainDetective {
         public DnsTtlAnalysis DnsTtlAnalysis { get; private set; } = new DnsTtlAnalysis();
 
         /// <summary>
+        /// Gets the port availability analysis.
+        /// </summary>
+        /// <value>TCP port connectivity results.</value>
+        public PortAvailabilityAnalysis PortAvailabilityAnalysis { get; private set; } = new PortAvailabilityAnalysis();
+
+        /// <summary>
         /// Holds DNS client configuration used throughout analyses.
         /// </summary>
         /// <value>The DNS configuration instance.</value>
@@ -283,6 +289,8 @@ namespace DomainDetective {
             DnsTtlAnalysis = new DnsTtlAnalysis {
                 DnsConfiguration = DnsConfiguration
             };
+
+            PortAvailabilityAnalysis = new PortAvailabilityAnalysis();
 
             _logger.WriteVerbose("DomainHealthCheck initialized.");
             _logger.WriteVerbose("DnsEndpoint: {0}", DnsEndpoint);
@@ -469,6 +477,9 @@ namespace DomainDetective {
                     case HealthCheckType.TTL:
                         await DnsTtlAnalysis.Analyze(domainName, _logger);
                         break;
+                    case HealthCheckType.PORTAVAILABILITY:
+                        await CheckPortAvailability(domainName, null, cancellationToken);
+                        break;
                     default:
                         _logger.WriteError("Unknown health check type: {0}", healthCheckType);
                         throw new NotSupportedException("Health check type not implemented.");
@@ -654,6 +665,20 @@ namespace DomainDetective {
         public async Task CheckSmtpBannerHost(string host, int port = 25, CancellationToken cancellationToken = default) {
             ValidatePort(port);
             await SmtpBannerAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Tests connectivity to common service ports on a host.
+        /// </summary>
+        /// <param name="host">Target host name.</param>
+        /// <param name="ports">Ports to check. Defaults to common services.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task CheckPortAvailability(string host, IEnumerable<int>? ports = null, CancellationToken cancellationToken = default) {
+            var list = ports?.ToArray() ?? new[] { 25, 80, 443, 465, 587 };
+            foreach (var p in list) {
+                ValidatePort(p);
+            }
+            await PortAvailabilityAnalysis.AnalyzeServers(new[] { host }, list, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -1153,6 +1178,7 @@ namespace DomainDetective {
             filtered.MessageHeaderAnalysis = active.Contains(HealthCheckType.MESSAGEHEADER) ? CloneAnalysis(MessageHeaderAnalysis) : null;
             filtered.DanglingCnameAnalysis = active.Contains(HealthCheckType.DANGLINGCNAME) ? CloneAnalysis(DanglingCnameAnalysis) : null;
             filtered.DnsTtlAnalysis = active.Contains(HealthCheckType.TTL) ? CloneAnalysis(DnsTtlAnalysis) : null;
+            filtered.PortAvailabilityAnalysis = active.Contains(HealthCheckType.PORTAVAILABILITY) ? CloneAnalysis(PortAvailabilityAnalysis) : null;
 
             return filtered;
         }

--- a/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
+++ b/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+///     Attempts TCP connections to common service ports and records latency.
+/// </summary>
+public class PortAvailabilityAnalysis
+{
+    /// <summary>Represents the result of a single port check.</summary>
+    public class PortResult
+    {
+        /// <summary>Gets a value indicating whether the connection succeeded.</summary>
+        public bool Success { get; init; }
+        /// <summary>Gets the time taken to establish the connection.</summary>
+        public TimeSpan Latency { get; init; }
+    }
+
+    /// <summary>Results for each host and port.</summary>
+    public Dictionary<string, PortResult> ServerResults { get; } = new();
+    /// <summary>Maximum time to wait for a connection.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>Checks a single host and port.</summary>
+    public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        ServerResults.Clear();
+        ServerResults[$"{host}:{port}"] = await CheckPort(host, port, logger, cancellationToken);
+    }
+
+    /// <summary>Checks multiple hosts and ports.</summary>
+    public async Task AnalyzeServers(IEnumerable<string> hosts, IEnumerable<int> ports, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        ServerResults.Clear();
+        foreach (var host in hosts)
+        {
+            foreach (var port in ports)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                ServerResults[$"{host}:{port}"] = await CheckPort(host, port, logger, cancellationToken);
+            }
+        }
+    }
+
+    private async Task<PortResult> CheckPort(string host, int port, InternalLogger logger, CancellationToken token)
+    {
+        using var client = new TcpClient();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+        cts.CancelAfter(Timeout);
+        var sw = Stopwatch.StartNew();
+        try
+        {
+#if NET6_0_OR_GREATER
+            await client.ConnectAsync(host, port, cts.Token);
+#else
+            await client.ConnectAsync(host, port).WaitWithCancellation(cts.Token);
+#endif
+            sw.Stop();
+            return new PortResult { Success = true, Latency = sw.Elapsed };
+        }
+        catch (Exception ex) when (ex is SocketException || ex is OperationCanceledException)
+        {
+            sw.Stop();
+            logger?.WriteVerbose("Port {0}:{1} unreachable - {2}", host, port, ex.Message);
+            return new PortResult { Success = false, Latency = sw.Elapsed };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `PortAvailabilityAnalysis` for TCP latency checks
- integrate port availability check with `DomainHealthCheck`
- expose new analysis via CLI and PowerShell cmdlet
- document the new health check
- add unit tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.sln` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_685e5c803514832e86e64e9786413eca