### PR TITLE
Add RSA key length validation to DKIM

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -23,6 +23,7 @@ namespace DomainDetective.PowerShell {
                     StartsCorrectly = result.StartsCorrectly,
                     PublicKeyExists = result.PublicKeyExists,
                     ValidPublicKey = result.ValidPublicKey,
+                    ValidRsaKeyLength = result.ValidRsaKeyLength,
                     KeyTypeExists = result.KeyTypeExists,
                     ValidKeyType = result.ValidKeyType,
                     PublicKey = result.PublicKey,
@@ -86,6 +87,9 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Validation result for the public key.</summary>
         public bool ValidPublicKey { get; set; }
+
+        /// <summary>Indicates whether the RSA key length meets policy.</summary>
+        public bool ValidRsaKeyLength { get; set; }
 
         /// <summary>Indicates whether the key type is present.</summary>
         public bool KeyTypeExists { get; set; }

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -19,6 +19,7 @@ namespace DomainDetective.Tests {
                 Assert.Equal("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB", healthCheck.DKIMAnalysis.AnalysisResults[selector].PublicKey);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].PublicKeyExists);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].ValidPublicKey);
+                Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].ValidRsaKeyLength);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].StartsCorrectly);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].KeyTypeExists);
             }
@@ -41,6 +42,7 @@ namespace DomainDetective.Tests {
             Assert.Equal("MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB", healthCheck.DKIMAnalysis.AnalysisResults["selector1"].PublicKey);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].PublicKeyExists);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].ValidPublicKey);
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].ValidRsaKeyLength);
 
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].Name == "selector2-evotec-pl._domainkey.evotecpoland.onmicrosoft.com");
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].DkimRecord == "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21OfspkRgPHhdCgu3kWgBX+xLyw7wRqM+Y4KaX82Pul9ikEDfZCJ35siFzV2WMH9Od/yM2TtMnubRqm9QN6paEB0VhNgNURQMmyTVsBO1usTJS9IvkIt3JtTFEinzVJLEaOC/F3d6bJaW9MMKUTBra9RcUf/E6dWAaJX8lrK8SefL9adNTwED8ZgFBnFcoJJn6e1W2WyIZ/8XAk+5Jwc7JMFZsdjFYdBSDPNyEfhNsKahVdRvdCG+OeDHyLSiNuFE27wtXaUI2TySDcfSSzE8k8z/Td9mMb0DQ2qaJ6xxk/5cwzwYSXr3sdGp++mHpGOJm18OwfsJmFCuSEcFGrHAQIDAQAB;");
@@ -51,6 +53,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].PublicKey == "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21OfspkRgPHhdCgu3kWgBX+xLyw7wRqM+Y4KaX82Pul9ikEDfZCJ35siFzV2WMH9Od/yM2TtMnubRqm9QN6paEB0VhNgNURQMmyTVsBO1usTJS9IvkIt3JtTFEinzVJLEaOC/F3d6bJaW9MMKUTBra9RcUf/E6dWAaJX8lrK8SefL9adNTwED8ZgFBnFcoJJn6e1W2WyIZ/8XAk+5Jwc7JMFZsdjFYdBSDPNyEfhNsKahVdRvdCG+OeDHyLSiNuFE27wtXaUI2TySDcfSSzE8k8z/Td9mMb0DQ2qaJ6xxk/5cwzwYSXr3sdGp++mHpGOJm18OwfsJmFCuSEcFGrHAQIDAQAB");
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].PublicKeyExists);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].ValidPublicKey);
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].ValidRsaKeyLength);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].StartsCorrectly);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].KeyTypeExists);
 
@@ -104,6 +107,7 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckDKIM(record);
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidRsaKeyLength);
         }
 
         [Fact]
@@ -114,6 +118,7 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckDKIM(record);
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidRsaKeyLength);
         }
 
         [Fact]

--- a/README.MD
+++ b/README.MD
@@ -175,7 +175,7 @@ Code coverage results are published to [Codecov](https://codecov.io/gh/EvotecIT/
 
 ## Understanding Results
 
-Each analysis type returns an object exposing properties that map to fields described in the relevant RFCs. For example, SPF checks follow [RFC&nbsp;7208](https://datatracker.ietf.org/doc/html/rfc7208) and DMARC analysis references [RFC&nbsp;7489](https://datatracker.ietf.org/doc/html/rfc7489). DKIM validations follow [RFC&nbsp;6376](https://datatracker.ietf.org/doc/html/rfc6376) and DANE TLSA lookups follow [RFC&nbsp;6698](https://datatracker.ietf.org/doc/html/rfc6698).
+Each analysis type returns an object exposing properties that map to fields described in the relevant RFCs. For example, SPF checks follow [RFC&nbsp;7208](https://datatracker.ietf.org/doc/html/rfc7208) and DMARC analysis references [RFC&nbsp;7489](https://datatracker.ietf.org/doc/html/rfc7489). DKIM validations follow [RFC&nbsp;6376](https://datatracker.ietf.org/doc/html/rfc6376) and enforce RSA public keys of at least 1024&nbsp;bits. DANE TLSA lookups follow [RFC&nbsp;6698](https://datatracker.ietf.org/doc/html/rfc6698).
 
 Boolean fields indicate whether a particular requirement was met. You can inspect the object returned from `DomainHealthCheck` or the PowerShell cmdlets to review these properties and make decisions in automation.
 


### PR DESCRIPTION
## Summary
- enforce minimum RSA length when parsing DKIM records
- surface RSA length check in PowerShell output
- update tests for short and valid RSA keys
- document RSA requirement in README

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: KeyNotFoundException & other network tests)*

------
https://chatgpt.com/codex/tasks/task_e_685f1532b33c832eb3aa71945ba7075b