### PR TITLE
Fix SPF Unknown Mechanism detection

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -333,5 +333,15 @@ namespace DomainDetective.Tests {
 
             Assert.Contains("unknown:example.com", healthCheck.SpfAnalysis.UnknownMechanisms);
         }
+
+        [Fact]
+        public async Task VersionTagExcludedFromUnknownMechanisms() {
+            var spfRecord = "v=spf1 -all";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.DoesNotContain("v=spf1", healthCheck.SpfAnalysis.UnknownMechanisms);
+        }
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -357,6 +357,7 @@ namespace DomainDetective {
                    || token.StartsWith("ptr:", StringComparison.OrdinalIgnoreCase)
                    || token.StartsWith("redirect=", StringComparison.OrdinalIgnoreCase)
                    || token.StartsWith("exp=", StringComparison.OrdinalIgnoreCase)
+                   || token.Equals("v=spf1", StringComparison.OrdinalIgnoreCase)
                    || IsAllMechanism(token);
         }
       


### PR DESCRIPTION
## Summary
- exclude `v=spf1` from `UnknownMechanisms`
- cover the case with a new unit test

## Testing
- `dotnet test --filter "FullyQualifiedName~VersionTagExcludedFromUnknownMechanisms" --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685f81683710832ea0b317c8d19a44fa