### PR TITLE
Add DKIM 4096-bit test

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -24,6 +24,7 @@ namespace DomainDetective.PowerShell {
                     PublicKeyExists = result.PublicKeyExists,
                     ValidPublicKey = result.ValidPublicKey,
                     ValidRsaKeyLength = result.ValidRsaKeyLength,
+                    KeyLength = result.KeyLength,
                     KeyTypeExists = result.KeyTypeExists,
                     ValidKeyType = result.ValidKeyType,
                     PublicKey = result.PublicKey,
@@ -90,6 +91,9 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Indicates whether the RSA key length meets policy.</summary>
         public bool ValidRsaKeyLength { get; set; }
+
+        /// <summary>Length of the RSA public key in bits.</summary>
+        public int KeyLength { get; set; }
 
         /// <summary>Indicates whether the key type is present.</summary>
         public bool KeyTypeExists { get; set; }

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -20,6 +20,7 @@ namespace DomainDetective.Tests {
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].PublicKeyExists);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].ValidPublicKey);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].ValidRsaKeyLength);
+                Assert.Equal(1024, healthCheck.DKIMAnalysis.AnalysisResults[selector].KeyLength);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].StartsCorrectly);
                 Assert.True(healthCheck.DKIMAnalysis.AnalysisResults[selector].KeyTypeExists);
             }
@@ -43,6 +44,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].PublicKeyExists);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].ValidPublicKey);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector1"].ValidRsaKeyLength);
+            Assert.Equal(1024, healthCheck.DKIMAnalysis.AnalysisResults["selector1"].KeyLength);
 
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].Name == "selector2-evotec-pl._domainkey.evotecpoland.onmicrosoft.com");
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].DkimRecord == "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21OfspkRgPHhdCgu3kWgBX+xLyw7wRqM+Y4KaX82Pul9ikEDfZCJ35siFzV2WMH9Od/yM2TtMnubRqm9QN6paEB0VhNgNURQMmyTVsBO1usTJS9IvkIt3JtTFEinzVJLEaOC/F3d6bJaW9MMKUTBra9RcUf/E6dWAaJX8lrK8SefL9adNTwED8ZgFBnFcoJJn6e1W2WyIZ/8XAk+5Jwc7JMFZsdjFYdBSDPNyEfhNsKahVdRvdCG+OeDHyLSiNuFE27wtXaUI2TySDcfSSzE8k8z/Td9mMb0DQ2qaJ6xxk/5cwzwYSXr3sdGp++mHpGOJm18OwfsJmFCuSEcFGrHAQIDAQAB;");
@@ -54,6 +56,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].PublicKeyExists);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].ValidPublicKey);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].ValidRsaKeyLength);
+            Assert.Equal(2048, healthCheck.DKIMAnalysis.AnalysisResults["selector2"].KeyLength);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].StartsCorrectly);
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["selector2"].KeyTypeExists);
 
@@ -108,6 +111,7 @@ namespace DomainDetective.Tests {
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidRsaKeyLength);
+            Assert.Equal(0, healthCheck.DKIMAnalysis.AnalysisResults["default"].KeyLength);
         }
 
         [Fact]
@@ -119,6 +123,7 @@ namespace DomainDetective.Tests {
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidRsaKeyLength);
+            Assert.Equal(0, healthCheck.DKIMAnalysis.AnalysisResults["default"].KeyLength);
         }
 
         [Fact]
@@ -129,6 +134,7 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckDKIM(record);
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidKeyType);
+            Assert.Equal(0, healthCheck.DKIMAnalysis.AnalysisResults["default"].KeyLength);
         }
 
         [Fact]
@@ -140,6 +146,33 @@ namespace DomainDetective.Tests {
 
             Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidFlags);
             Assert.Contains("z", healthCheck.DKIMAnalysis.AnalysisResults["default"].UnknownFlagCharacters);
+            Assert.Equal(0, healthCheck.DKIMAnalysis.AnalysisResults["default"].KeyLength);
+        }
+
+        [Fact]
+        public async Task Large4096BitKeyIsValid() {
+            const string key =
+                "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApuPAMwNrEa/+qpJPsLDr" +
+                "cr4rFjnsdaGmsKBjsm8aLzIX7WmYpTKAU8xC5FvsrCAoL4YLxBOeEvcje7hwR5yW" +
+                "ncOyb7ZyqVAt5kRZp3MGZrfGll5Hv9+6YisIBM5GrfA0IJRJEZBhVjwNKX00Ae4S" +
+                "AAF+8KKy+li9T2ubeBI2UGkOZy0T3QRUfcGAW7tZP4EX/ja8lhJ/0W+0u1VhMZtz" +
+                "rA1ywN6kxLnnlgQ6z8oXvOw0O1Cy+2jqAUT2kY1lxpiVHbvV7RDw+mmRUKba4AQe" +
+                "gxFdyYAzWNgbc34cH+QxbQ+Gxx9yM5GF975cKHIH972Q7MUeokQWS2hozodFQgcQ" +
+                "/x2ntRbGTmZ5EHkH7k0SxoN2DwiOXkXey4d4OlFUmhi4GdT5Pe5DX82Wes7yf64g" +
+                "n5YFilih2Z8j58w/YHcs1I28d0nESY1ZyYbnmqC5DwJkKYNiVlO2++B//xj+FYMd" +
+                "j7DXJGF03fRQe2aGm70UOVEw+cDd1xuHw7G5NCUvnOj8eoOmaUp1TzMAjdXGUIsl" +
+                "tY0/h/22dhNsktQWIO/s0HhxA/7es44UZh0y2KkD4c4hvOKzoFgXzV6L8U2hTOC9" +
+                "PzGa4yV4U0RxoB3oKoVghD2mCX7ajU7yFtBa1iqpJ8Ez8Y6VS8xJqHo7fCPDvsZ4" +
+                "3lTr1DdO07FUi0QOCf/+BIsCAwEAAQ==";
+
+            string record = $"v=DKIM1; k=rsa; p={key};";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidPublicKey);
+            Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidRsaKeyLength);
+            Assert.Equal(4096, healthCheck.DKIMAnalysis.AnalysisResults["default"].KeyLength);
         }
     }
 }

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -73,16 +73,19 @@ namespace DomainDetective {
                             try {
                                 var bytes = Convert.FromBase64String(value);
                                 try {
-                                    var rsaKey = (RsaKeyParameters)PublicKeyFactory.CreateKey(bytes);
-                                    analysis.ValidRsaKeyLength = rsaKey.Modulus.BitLength >= MinimumRsaKeyBits;
-                                    analysis.ValidPublicKey = analysis.ValidRsaKeyLength;
+                                var rsaKey = (RsaKeyParameters)PublicKeyFactory.CreateKey(bytes);
+                                analysis.KeyLength = rsaKey.Modulus.BitLength;
+                                analysis.ValidRsaKeyLength = analysis.KeyLength >= MinimumRsaKeyBits;
+                                analysis.ValidPublicKey = analysis.ValidRsaKeyLength;
                                 } catch (Exception) {
                                     analysis.ValidPublicKey = false;
                                     analysis.ValidRsaKeyLength = false;
+                                analysis.KeyLength = 0;
                                 }
                             } catch (FormatException) {
                                 analysis.ValidPublicKey = false;
                                 analysis.ValidRsaKeyLength = false;
+                                analysis.KeyLength = 0;
                             }
                             break;
                         case "s":
@@ -151,6 +154,9 @@ namespace DomainDetective {
         public bool ValidPublicKey { get; set; }
         /// <summary>True when the RSA key length meets <see cref="MinimumRsaKeyBits"/>.</summary>
         public bool ValidRsaKeyLength { get; set; }
+        /// <summary>Length of the RSA public key in bits.</summary>
+        public int KeyLength { get; set; }
+        /// <summary>Indicates whether the <c>k</c> tag was present.</summary>
         public bool KeyTypeExists { get; set; }
         /// <summary>Gets or sets a value indicating whether the key type is recognized.</summary>
         public bool ValidKeyType { get; set; }


### PR DESCRIPTION
## Summary
- revert README edits
- document `KeyTypeExists` property
- test DKIM with a 4096-bit key

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Invalid URI: The hostname could not be parsed)*
- `pwsh ./Module/DomainDetective.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_685f8624e0c8832eb28c7881ee039777