### PR TITLE
Add DKIM/SPF alignment indicators

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -52,6 +52,8 @@ namespace DomainDetective.PowerShell {
                 Policy = analysis.Policy,
                 SubPolicy = analysis.SubPolicy,
                 Percent = analysis.Percent,
+                DkimAlignment = analysis.DkimAlignment,
+                SpfAlignment = analysis.SpfAlignment,
                 Rua = analysis.Rua,
                 Ruf = analysis.Ruf,
                 MailtoRua = analysis.MailtoRua,
@@ -144,6 +146,12 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Percentage applied to the policy.</summary>
         public string Percent { get; set; }
+
+        /// <summary>DKIM alignment mode.</summary>
+        public string DkimAlignment { get; set; }
+
+        /// <summary>SPF alignment mode.</summary>
+        public string SpfAlignment { get; set; }
 
         /// <summary>Aggregate report destination.</summary>
         public string Rua { get; set; }

--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -213,5 +213,27 @@ namespace DomainDetective.Tests {
                 Assert.Equal(string.Empty, analysis.PolicyRecommendation);
             }
         }
+
+        [Fact]
+        public async Task AlignmentModeTranslation() {
+            var record = new[] {
+                new DnsAnswer { DataRaw = "v=DMARC1; p=reject; adkim=s; aspf=r", Type = DnsRecordType.TXT }
+            };
+
+            var analysis = new DmarcAnalysis();
+            await analysis.AnalyzeDmarcRecords(record, new InternalLogger());
+
+            Assert.Equal("Strict", analysis.DkimAlignment);
+            Assert.Equal("Relaxed", analysis.SpfAlignment);
+
+            var defaultRecord = new[] {
+                new DnsAnswer { DataRaw = "v=DMARC1; p=reject", Type = DnsRecordType.TXT }
+            };
+            var analysisDefault = new DmarcAnalysis();
+            await analysisDefault.AnalyzeDmarcRecords(defaultRecord, new InternalLogger());
+
+            Assert.Equal("Relaxed (defaulted)", analysisDefault.DkimAlignment);
+            Assert.Equal("Relaxed (defaulted)", analysisDefault.SpfAlignment);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -275,7 +275,7 @@ namespace DomainDetective {
             return alignment switch {
                 "s" => "Strict",
                 "r" => "Relaxed",
-                null or "" => "Relaxed (default)", // default to relaxed if no value is provided
+                null or "" => "Relaxed (defaulted)", // default to relaxed if no value is provided
                 _ => "Unknown",
             };
         }


### PR DESCRIPTION
## Summary
- expose alignment info via `Test-DmarcRecord` results
- note when DMARC alignment values are defaulted
- test alignment mode translation

## Testing
- `dotnet restore`
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685f8db02be8832e8c2c66e6bff269a1