### PR TITLE
Fix DMARC subdomain policy default

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -235,5 +235,19 @@ namespace DomainDetective.Tests {
             Assert.Equal("Relaxed (defaulted)", analysisDefault.DkimAlignment);
             Assert.Equal("Relaxed (defaulted)", analysisDefault.SpfAlignment);
         }
+
+        [Fact]
+        public async Task SubPolicyDefaultsToDomainPolicy() {
+            var record = new[] {
+                new DnsAnswer { DataRaw = "v=DMARC1; p=quarantine", Type = DnsRecordType.TXT }
+            };
+
+            var analysis = new DmarcAnalysis();
+            await analysis.AnalyzeDmarcRecords(record, new InternalLogger());
+
+            Assert.Equal("quarantine", analysis.PolicyShort);
+            Assert.Null(analysis.SubPolicyShort);
+            Assert.Equal("Quarantine (inherited)", analysis.SubPolicy);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -30,7 +30,7 @@ namespace DomainDetective {
         public bool IsPolicyValid { get; private set; }
 
         public string Policy => TranslatePolicy(PolicyShort);
-        public string SubPolicy => TranslatePolicy(SubPolicyShort);
+        public string SubPolicy => TranslateSubPolicy();
         public string ReportingInterval => TranslateReportingInterval(ReportingIntervalShort);
         public string Percent => TranslatePercentage();
         public string SpfAlignment => TranslateAlignment(SpfAShort);
@@ -287,6 +287,18 @@ namespace DomainDetective {
                 "reject" => "Reject",
                 _ => "Unknown policy",
             };
+        }
+
+        private string TranslateSubPolicy() {
+            if (!string.IsNullOrWhiteSpace(SubPolicyShort)) {
+                return TranslatePolicy(SubPolicyShort);
+            }
+
+            if (!string.IsNullOrWhiteSpace(PolicyShort)) {
+                return $"{TranslatePolicy(PolicyShort)} (inherited)";
+            }
+
+            return "Unknown policy";
         }
 
         private string TranslateFailureReportingOptions(string option) {


### PR DESCRIPTION
## Summary
- inherit domain policy when DMARC `sp` tag is missing
- test default subdomain policy behaviour

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_685f91d12f14832ead2f567d48326429