### PR TITLE
Add self-signed certificate detection

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -9,7 +9,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task UnreachableHostSetsIsReachableFalse() {
             var logger = new InternalLogger();
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://nonexistent.invalid", 443, logger);
             Assert.False(analysis.IsReachable);
             Assert.Null(analysis.ProtocolVersion);
@@ -21,7 +21,7 @@ namespace DomainDetective.Tests {
             LogEventArgs? eventArgs = null;
             logger.OnErrorMessage += (_, e) => eventArgs = e;
 
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://nonexistent.invalid", 443, logger);
 
             Assert.NotNull(eventArgs);
@@ -32,7 +32,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task ValidHostSetsProtocolVersion() {
             var logger = new InternalLogger();
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
             Assert.True(analysis.ProtocolVersion?.Major >= 1);
             Assert.Equal(analysis.ProtocolVersion >= new Version(2, 0), analysis.Http2Supported);
@@ -44,7 +44,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task ValidCertificateProvidesExpirationInfo() {
             var logger = new InternalLogger();
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
             Assert.True(analysis.DaysValid > 0);
             Assert.Equal(analysis.DaysToExpire < 0, analysis.IsExpired);
@@ -53,7 +53,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task ValidCertificateIsNotSelfSigned() {
             var logger = new InternalLogger();
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
             Assert.False(analysis.IsSelfSigned);
         }
@@ -61,7 +61,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task ExtractsRevocationEndpoints() {
             var logger = new InternalLogger();
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
             Assert.NotNull(analysis.OcspUrls);
             Assert.NotNull(analysis.CrlUrls);

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -51,6 +51,14 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task ValidCertificateIsNotSelfSigned() {
+            var logger = new InternalLogger();
+            var analysis = new CertificateAnalysis();
+            await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
+            Assert.False(analysis.IsSelfSigned);
+        }
+
+        [Fact]
         public async Task ExtractsRevocationEndpoints() {
             var logger = new InternalLogger();
             var analysis = new CertificateAnalysis();

--- a/DomainDetective.Tests/TestCertificateInfo.cs
+++ b/DomainDetective.Tests/TestCertificateInfo.cs
@@ -22,5 +22,13 @@ namespace DomainDetective.Tests {
             Assert.False(analysis.Sha1Signature);
             Assert.Equal(2048, analysis.KeySize);
         }
+
+        [Fact]
+        public async Task SelfSignedFlagSet() {
+            var cert = new X509Certificate2("Data/wildcard.pem");
+            var analysis = new CertificateAnalysis();
+            await analysis.AnalyzeCertificate(cert);
+            Assert.True(analysis.IsSelfSigned);
+        }
     }
 }

--- a/DomainDetective.Tests/TestCertificateInfo.cs
+++ b/DomainDetective.Tests/TestCertificateInfo.cs
@@ -5,7 +5,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task WeakCertificateFlagsSet() {
             var cert = new X509Certificate2("Data/weak.pem");
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.WeakKey);
             Assert.True(analysis.Sha1Signature);
@@ -16,7 +16,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task StrongCertificateNotFlagged() {
             var cert = new X509Certificate2("Data/wildcard.pem");
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.False(analysis.WeakKey);
             Assert.False(analysis.Sha1Signature);
@@ -26,7 +26,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task SelfSignedFlagSet() {
             var cert = new X509Certificate2("Data/wildcard.pem");
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.IsSelfSigned);
         }

--- a/DomainDetective.Tests/TestWildcardCertificate.cs
+++ b/DomainDetective.Tests/TestWildcardCertificate.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task DetectsWildcardAndSubdomains() {
             var cert = new X509Certificate2("Data/wildcard.pem");
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.IsWildcardCertificate);
             Assert.True(analysis.WildcardSubdomains.ContainsKey("*.example.com"));
@@ -18,7 +18,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task WarnsOnUnrelatedHosts() {
             var cert = new X509Certificate2("Data/multi.pem");
-            var analysis = new CertificateAnalysis();
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.SecuresUnrelatedHosts);
         }

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -68,6 +68,8 @@ namespace DomainDetective {
         public bool IsWildcardCertificate { get; private set; }
         /// <summary>Gets a value indicating the certificate secures multiple unrelated hosts.</summary>
         public bool SecuresUnrelatedHosts { get; private set; }
+        /// <summary>Gets a value indicating whether the certificate is self-signed.</summary>
+        public bool IsSelfSigned { get; private set; }
         /// <summary>Gets the public key algorithm.</summary>
         public string KeyAlgorithm { get; private set; }
         /// <summary>Gets the key size in bits.</summary>
@@ -104,6 +106,7 @@ namespace DomainDetective {
             var builder = new UriBuilder(url) { Port = port };
             url = builder.ToString();
             Url = url;
+            IsSelfSigned = false;
             using (var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 }) {
                 handler.ServerCertificateCustomValidationCallback = (HttpRequestMessage requestMessage, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors policyErrors) => {
                     Certificate = new X509Certificate2(certificate.Export(X509ContentType.Cert));
@@ -113,6 +116,7 @@ namespace DomainDetective {
                             Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
                         }
                     }
+                    IsSelfSigned = Certificate.Subject == Certificate.Issuer && Chain.Count == 1;
                     IsValid = policyErrors == SslPolicyErrors.None;
                     return IsValid;
                 };
@@ -166,6 +170,7 @@ namespace DomainDetective {
                                     foreach (var element in xchain.ChainElements) {
                                         Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
                                     }
+                                    IsSelfSigned = Certificate.Subject == Certificate.Issuer && Chain.Count == 1;
                                 }
                             } catch (Exception ex) {
                                 logger?.WriteError("Error retrieving certificate for {0}: {1}", url, ex.ToString());
@@ -325,12 +330,14 @@ namespace DomainDetective {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         public async Task AnalyzeCertificate(X509Certificate2 certificate, CancellationToken cancellationToken = default) {
             Certificate = new X509Certificate2(certificate.RawData);
+            IsSelfSigned = false;
             var chain = new X509Chain();
             IsValid = chain.Build(certificate);
             Chain.Clear();
             foreach (var element in chain.ChainElements) {
                 Chain.Add(new X509Certificate2(element.Certificate.RawData));
             }
+            IsSelfSigned = certificate.Subject == certificate.Issuer && Chain.Count == 1;
             PopulateKeyInfo();
             DaysToExpire = (int)(certificate.NotAfter - DateTime.Now).TotalDays;
             DaysValid = (int)(certificate.NotAfter - certificate.NotBefore).TotalDays;

--- a/README.MD
+++ b/README.MD
@@ -90,6 +90,7 @@ The `CertificateAnalysis` result now includes:
 - `KeyAlgorithm` and `KeySize` for the leaf certificate.
 - `WeakKey` when the key is under 2048 bits.
 - `Sha1Signature` when the certificate uses SHA‑1.
+- `IsSelfSigned` when the certificate subject equals the issuer and the chain length is one.
 - With `CaptureTlsDetails` enabled, `TlsProtocol`, `CipherAlgorithm` and `CipherStrength` describe the negotiated cipher-suite.
 - `PresentInCtLogs` when the certificate appears in public CT logs.
 


### PR DESCRIPTION
## Summary
- detect self-signed leaf certificates in `CertificateHTTP`
- surface new `IsSelfSigned` flag in docs
- test for self-signed detection
- verify online certs are not self-signed

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: Assert.False, unreachable host, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685fccff76dc832ea4460c14173f76e1