### PR TITLE
Add domain blocklist checks

### DIFF
--- a/DomainDetective.Tests/TestDomainBlocklist.cs
+++ b/DomainDetective.Tests/TestDomainBlocklist.cs
@@ -1,0 +1,32 @@
+namespace DomainDetective.Tests {
+    public class TestDomainBlocklist {
+        [Fact]
+        public async Task ListedDomainsReturnPositive() {
+            var analysis = new DNSBLAnalysis();
+            analysis.ClearDNSBL();
+            analysis.AddDNSBL("multi.uribl.com");
+            analysis.AddDNSBL("dbl.spamhaus.org");
+
+            await analysis.IsDomainListedAsync("dbltest.com", new InternalLogger());
+            var resultSpamhaus = analysis.Results["dbltest.com"];
+            Assert.Contains("dbl.spamhaus.org", resultSpamhaus.ListedBlacklist);
+            Assert.True(resultSpamhaus.IsBlacklisted);
+
+            await analysis.IsDomainListedAsync("test.uribl.com", new InternalLogger());
+            var resultUribl = analysis.Results["test.uribl.com"];
+            Assert.Contains("multi.uribl.com", resultUribl.ListedBlacklist);
+            Assert.True(resultUribl.IsBlacklisted);
+        }
+
+        [Fact]
+        public async Task UnlistedDomainReturnsNegative() {
+            var analysis = new DNSBLAnalysis();
+            analysis.ClearDNSBL();
+            analysis.AddDNSBL("multi.uribl.com");
+            analysis.AddDNSBL("dbl.spamhaus.org");
+
+            var listed = await analysis.IsDomainListedAsync("example.com", new InternalLogger());
+            Assert.False(listed);
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    public partial class DNSBLAnalysis {
+        private static readonly HashSet<string> _domainBlockLists = new(StringComparer.OrdinalIgnoreCase) {
+            "multi.uribl.com",
+            "dbl.spamhaus.org"
+        };
+
+        internal List<string> DomainDNSBLLists => DnsblEntries
+            .Where(e => e.Enabled && _domainBlockLists.Contains(e.Domain))
+            .Select(e => e.Domain)
+            .ToList();
+
+        public async IAsyncEnumerable<DNSBLRecord> AnalyzeDomainBlocklists(string domain, InternalLogger logger) {
+            Reset();
+            Logger = logger;
+            Logger.WriteVerbose($"Checking {domain} against {DomainDNSBLLists.Count} domain blocklists");
+            var collected = new List<DNSBLRecord>();
+            await foreach (var record in QueryDNSBL(DomainDNSBLLists, domain)) {
+                collected.Add(record);
+                yield return record;
+            }
+            ConvertToResults(domain, collected);
+        }
+
+        public async Task<bool> IsDomainListedAsync(string domain, InternalLogger logger) {
+            await ToListAsync(AnalyzeDomainBlocklists(domain, logger));
+            return Results.TryGetValue(domain, out var result) && result.IsBlacklisted;
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -81,7 +81,7 @@ namespace DomainDetective {
     /// Provides routines to query DNS block lists for a host.
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
-    public class DNSBLAnalysis {
+    public partial class DNSBLAnalysis {
         internal DnsConfiguration DnsConfiguration { get; set; }
 
         /// <summary>
@@ -207,6 +207,7 @@ namespace DomainDetective {
             new("xbl.spamhaus.org"),
             new("z.mailspike.net"),
             new("zen.spamhaus.org"),
+            new("multi.uribl.com"),
             new("zombie.dnsbl.sorbs.net", enabled: false, comment: "https://github.com/EvotecIT/PSBlackListChecker/issues/11"),
             new("bl.emailbasura.org", enabled: false, comment: "dead as per https://github.com/EvotecIT/PSBlackListChecker/issues/8"),
             new("dynip.rothen.com", enabled: false, comment: "dead as per https://github.com/EvotecIT/PSBlackListChecker/issues/9"),
@@ -220,6 +221,7 @@ namespace DomainDetective {
         };
 
         public DNSBLAnalysis() {
+        DnsConfiguration = new DnsConfiguration();
         }
 
         internal List<string> DNSBLLists => DnsblEntries


### PR DESCRIPTION
## Summary
- allow DNSBLAnalysis to be partial
- add URIBL to built-in providers
- add domain blocklist query helper
- test listed and unlisted domains

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: The build stopped unexpectedly due to logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_685fcd2870d4832e9ff4cff90965e32c