### PR TITLE
Add SMTP AUTH capability analysis

### DIFF
--- a/DomainDetective.Tests/TestSmtpAuthAnalysis.cs
+++ b/DomainDetective.Tests/TestSmtpAuthAnalysis.cs
@@ -1,0 +1,65 @@
+namespace DomainDetective.Tests {
+    public class TestSmtpAuthAnalysis {
+        [Fact]
+        public async Task DetectsLoginAndPlain() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost");
+                await writer.WriteLineAsync("250-AUTH LOGIN PLAIN");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new SmtpAuthAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var mechs = analysis.ServerMechanisms[$"localhost:{port}"];
+                Assert.Contains("LOGIN", mechs);
+                Assert.Contains("PLAIN", mechs);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task ParsesAuthEqualsNotation() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost");
+                await writer.WriteLineAsync("250-AUTH=PLAIN LOGIN");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new SmtpAuthAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var mechs = analysis.ServerMechanisms[$"localhost:{port}"];
+                Assert.Contains("LOGIN", mechs);
+                Assert.Contains("PLAIN", mechs);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -104,6 +104,10 @@ public static class CheckDescriptions {
                 "Capture SMTP banner information.",
                 null,
                 "Verify host name and software identifiers."),
+            [HealthCheckType.SMTPAUTH] = new(
+                "Enumerate SMTP AUTH mechanisms.",
+                null,
+                "Enable secure authentication methods and disable weak ones."),
             [HealthCheckType.HTTP] = new(
                 "Perform HTTP checks.",
                 null,

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -53,6 +53,8 @@ public enum HealthCheckType {
     SMTPTLS,
     /// <summary>Capture SMTP banner information.</summary>
     SMTPBANNER,
+    /// <summary>Enumerate SMTP AUTH mechanisms.</summary>
+    SMTPAUTH,
     /// <summary>Perform HTTP checks.</summary>
     HTTP,
     /// <summary>Validate HPKP configuration.</summary>

--- a/DomainDetective/Protocols/SmtpAuthAnalysis.cs
+++ b/DomainDetective/Protocols/SmtpAuthAnalysis.cs
@@ -64,7 +64,7 @@ namespace DomainDetective {
                         var cap = line.Substring(4).Trim();
                         if (cap.StartsWith("AUTH", StringComparison.OrdinalIgnoreCase)) {
                             var authPart = cap.Substring(4).TrimStart('=', ' ');
-                            foreach (var part in authPart.Split(' ', StringSplitOptions.RemoveEmptyEntries)) {
+                            foreach (var part in authPart.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries)) {
                                 mechanisms.Add(part);
                             }
                         }

--- a/DomainDetective/Protocols/SmtpAuthAnalysis.cs
+++ b/DomainDetective/Protocols/SmtpAuthAnalysis.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective {
+    /// <summary>
+    /// Retrieves advertised AUTH mechanisms from SMTP servers.
+    /// </summary>
+    /// <para>Part of the DomainDetective project.</para>
+    public class SmtpAuthAnalysis {
+        /// <summary>Supported authentication methods per server.</summary>
+        public Dictionary<string, string[]> ServerMechanisms { get; } = new();
+        /// <summary>Connection timeout.</summary>
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+        /// <summary>Checks a single server for AUTH capabilities.</summary>
+        public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+            ServerMechanisms.Clear();
+            cancellationToken.ThrowIfCancellationRequested();
+            var mechs = await QueryAuth(host, port, logger, cancellationToken);
+            ServerMechanisms[$"{host}:{port}"] = mechs;
+        }
+
+        /// <summary>Checks multiple servers for AUTH capabilities.</summary>
+        public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+            ServerMechanisms.Clear();
+            foreach (var host in hosts) {
+                cancellationToken.ThrowIfCancellationRequested();
+                var mechs = await QueryAuth(host, port, logger, cancellationToken);
+                ServerMechanisms[$"{host}:{port}"] = mechs;
+            }
+        }
+
+        private async Task<string[]> QueryAuth(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
+            using var client = new TcpClient();
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(Timeout);
+            try {
+#if NET6_0_OR_GREATER
+                await client.ConnectAsync(host, port, timeoutCts.Token);
+#else
+                await client.ConnectAsync(host, port).WaitWithCancellation(timeoutCts.Token);
+#endif
+                using NetworkStream network = client.GetStream();
+                using var reader = new StreamReader(network);
+                using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
+#if NET8_0_OR_GREATER
+                await reader.ReadLineAsync(timeoutCts.Token);
+#else
+                await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+#endif
+                timeoutCts.Token.ThrowIfCancellationRequested();
+                await writer.WriteLineAsync($"EHLO example.com");
+
+                var mechanisms = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                string? line;
+                while ((line = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token)) != null) {
+                    timeoutCts.Token.ThrowIfCancellationRequested();
+                    logger?.WriteVerbose($"EHLO response: {line}");
+                    if (line.StartsWith("250", StringComparison.Ordinal)) {
+                        var cap = line.Substring(4).Trim();
+                        if (cap.StartsWith("AUTH", StringComparison.OrdinalIgnoreCase)) {
+                            var authPart = cap.Substring(4).TrimStart('=', ' ');
+                            foreach (var part in authPart.Split(' ', StringSplitOptions.RemoveEmptyEntries)) {
+                                mechanisms.Add(part);
+                            }
+                        }
+                        if (!line.StartsWith("250-", StringComparison.Ordinal)) {
+                            break;
+                        }
+                    } else if (line.StartsWith("4") || line.StartsWith("5")) {
+                        break;
+                    }
+                }
+
+#if NET8_0_OR_GREATER
+                await writer.WriteLineAsync("QUIT".AsMemory(), timeoutCts.Token);
+                await writer.FlushAsync(timeoutCts.Token);
+#else
+                await writer.WriteLineAsync("QUIT");
+                await writer.FlushAsync();
+#endif
+                try {
+                    await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+                } catch (IOException) {
+                    // ignore
+                }
+
+                return mechanisms.Count == 0 ? Array.Empty<string>() : new List<string>(mechanisms).ToArray();
+            } catch (Exception ex) {
+                logger?.WriteError("SMTP AUTH check failed for {0}:{1} - {2}", host, port, ex.Message);
+                return Array.Empty<string>();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SmtpAuthAnalysis` for parsing AUTH mechanisms
- expose new analysis and verification helper in `DomainHealthCheck`
- track new `SMTPAUTH` check type with descriptions
- test SMTP AUTH parser for LOGIN and PLAIN detection

## Testing
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_685fe88786b0832ea307b9c769e001df