### PR TITLE
Add FCrDNS validation to reverse DNS analysis

### DIFF
--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -435,7 +435,6 @@ namespace DomainDetective {
                             .Select(r => r.Data.Split(' ')[1].Trim('.'))
                             .Where(h => !string.IsNullOrWhiteSpace(h));
                         await ReverseDnsAnalysis.AnalyzeHosts(rdnsHosts, _logger);
-                        await FCrDnsAnalysis.Analyze(ReverseDnsAnalysis.Results, _logger);
                         break;
                     case HealthCheckType.FCRDNS:
                         var mxRecordsFcr = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);


### PR DESCRIPTION
## Summary
- extend `ReverseDnsAnalysis` to also perform forward DNS lookups
- mark a PTR record as FCrDNS-valid when its hostname maps back to the original IP
- expose FCrDNS status during reverse DNS health checks
- test the new behaviour

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: System.UriFormatException etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6860324c6838832eb46e513d1126bd83