### PR TITLE
Add threat intel service

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
+++ b/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
@@ -1,0 +1,58 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell;
+
+/// <summary>Queries reputation services for a domain or IP address.</summary>
+/// <para>Part of the DomainDetective project.</para>
+/// <example>
+///   <summary>Check reputation listings.</summary>
+///   <code>Test-ThreatIntel -NameOrIpAddress example.com</code>
+/// </example>
+[Cmdlet(VerbsDiagnostic.Test, "ThreatIntel")]
+public sealed class CmdletTestThreatIntel : AsyncPSCmdlet {
+    /// <param name="NameOrIpAddress">Domain or IP address to query.</param>
+    [Parameter(Mandatory = true, Position = 0)]
+    [ValidateNotNullOrEmpty]
+    public string NameOrIpAddress;
+
+    /// <param name="GoogleApiKey">Google Safe Browsing API key.</param>
+    [Parameter(Mandatory = false)]
+    public string? GoogleApiKey;
+
+    /// <param name="PhishTankApiKey">PhishTank API key.</param>
+    [Parameter(Mandatory = false)]
+    public string? PhishTankApiKey;
+
+    /// <param name="VirusTotalApiKey">VirusTotal API key.</param>
+    [Parameter(Mandatory = false)]
+    public string? VirusTotalApiKey;
+
+    private InternalLogger _logger;
+    private DomainHealthCheck _healthCheck;
+
+    protected override Task BeginProcessingAsync() {
+        _logger = new InternalLogger(false);
+        var loggerPs = new InternalLoggerPowerShell(
+            _logger,
+            this.WriteVerbose,
+            this.WriteWarning,
+            this.WriteDebug,
+            this.WriteError,
+            this.WriteProgress,
+            this.WriteInformation);
+        loggerPs.ResetActivityIdCounter();
+        _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ProcessRecordAsync() {
+        _healthCheck.GoogleSafeBrowsingApiKey = GoogleApiKey;
+        _healthCheck.PhishTankApiKey = PhishTankApiKey;
+        _healthCheck.VirusTotalApiKey = VirusTotalApiKey;
+
+        _logger.WriteVerbose("Querying threat intel for {0}", NameOrIpAddress);
+        await _healthCheck.VerifyThreatIntel(NameOrIpAddress);
+        WriteObject(_healthCheck.ThreatIntelAnalysis);
+    }
+}

--- a/DomainDetective.Tests/TestThreatIntelAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatIntelAnalysis.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using DomainDetective;
+
+namespace DomainDetective.Tests;
+
+public class TestThreatIntelAnalysis
+{
+    [Fact]
+    public async Task FlagsListings()
+    {
+        var analysis = new ThreatIntelAnalysis
+        {
+            GoogleSafeBrowsingOverride = _ => Task.FromResult("{\"matches\":[{}] }"),
+            PhishTankOverride = _ => Task.FromResult("{\"results\":{\"valid\":\"true\",\"in_database\":\"true\"}}"),
+            VirusTotalOverride = _ => Task.FromResult("{\"data\":{\"attributes\":{\"last_analysis_stats\":{\"malicious\":1}}}}")
+        };
+
+        await analysis.Analyze("example.com", "g", "p", "v", new InternalLogger());
+
+        Assert.True(analysis.ListedByGoogle);
+        Assert.True(analysis.ListedByPhishTank);
+        Assert.True(analysis.ListedByVirusTotal);
+    }
+
+    [Fact]
+    public async Task IntegratesWithHealthCheck()
+    {
+        var health = new DomainHealthCheck();
+        health.GoogleSafeBrowsingApiKey = "g";
+        health.PhishTankApiKey = "p";
+        health.VirusTotalApiKey = "v";
+        health.ThreatIntelAnalysis.GoogleSafeBrowsingOverride = _ => Task.FromResult("{\"matches\":[{}]}");
+        health.ThreatIntelAnalysis.PhishTankOverride = _ => Task.FromResult("{\"results\":{\"valid\":\"true\",\"in_database\":\"true\"}}");
+        health.ThreatIntelAnalysis.VirusTotalOverride = _ => Task.FromResult("{\"data\":{\"attributes\":{\"last_analysis_stats\":{\"malicious\":1}}}}");
+
+        await health.VerifyThreatIntel("example.com");
+
+        Assert.True(health.ThreatIntelAnalysis.ListedByGoogle);
+        Assert.True(health.ThreatIntelAnalysis.ListedByPhishTank);
+        Assert.True(health.ThreatIntelAnalysis.ListedByVirusTotal);
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -151,7 +151,11 @@ public static class CheckDescriptions {
             [HealthCheckType.TYPOSQUATTING] = new(
                 "Check for typosquatting domains.",
                 null,
-                "Monitor and register common look-alike domains.")
+                "Monitor and register common look-alike domains."),
+            [HealthCheckType.THREATINTEL] = new(
+                "Query reputation services for threats.",
+                null,
+                "Review listed threats and request delisting")
         };
 
     /// <summary>Gets the description for the specified check type.</summary>

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -76,5 +76,7 @@ public enum HealthCheckType {
     /// <summary>Analyze DNS logs for tunneling patterns.</summary>
     DNSTUNNELING,
     /// <summary>Check for typosquatting domains.</summary>
-    TYPOSQUATTING
+    TYPOSQUATTING,
+    /// <summary>Query reputation services for threats.</summary>
+    THREATINTEL
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -132,6 +132,15 @@ namespace DomainDetective {
         /// <value>A URL to use instead of querying DNS.</value>
         public string MtaStsPolicyUrlOverride { get; set; }
 
+        /// <summary>API key for Google Safe Browsing.</summary>
+        public string? GoogleSafeBrowsingApiKey { get; set; }
+
+        /// <summary>API key for PhishTank.</summary>
+        public string? PhishTankApiKey { get; set; }
+
+        /// <summary>API key for VirusTotal.</summary>
+        public string? VirusTotalApiKey { get; set; }
+
         /// <summary>
         /// Gets the TLS certificate analysis.
         /// </summary>
@@ -271,6 +280,12 @@ namespace DomainDetective {
         /// <summary>Gets the typosquatting analysis.</summary>
         /// <value>Potential look-alike domains.</value>
         public TyposquattingAnalysis TyposquattingAnalysis { get; private set; } = new TyposquattingAnalysis();
+
+        /// <summary>Gets the threat intelligence analysis.</summary>
+        /// <value>Results from reputation services.</value>
+        public ThreatIntelAnalysis ThreatIntelAnalysis { get; private set; } = new ThreatIntelAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public ThreatIntelAnalysis THREATINTELAnalysis => ThreatIntelAnalysis;
 
         /// <summary>Log lines used for DNS tunneling analysis.</summary>
         public IEnumerable<string>? DnsTunnelingLogs { get; set; }
@@ -561,6 +576,9 @@ namespace DomainDetective {
                     case HealthCheckType.TYPOSQUATTING:
                         await VerifyTyposquatting(domainName, cancellationToken);
                         break;
+                    case HealthCheckType.THREATINTEL:
+                        await VerifyThreatIntel(domainName, cancellationToken);
+                        break;
                     default:
                         _logger.WriteError("Unknown health check type: {0}", healthCheckType);
                         throw new NotSupportedException("Health check type not implemented.");
@@ -786,6 +804,15 @@ namespace DomainDetective {
             UpdateIsPublicSuffix(domainName);
             TyposquattingAnalysis.DnsConfiguration = DnsConfiguration;
             await TyposquattingAnalysis.Analyze(domainName, _logger, cancellationToken);
+        }
+
+        /// <summary>Queries reputation services for threat listings.</summary>
+        public async Task VerifyThreatIntel(string target, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(target)) {
+                throw new ArgumentNullException(nameof(target));
+            }
+            UpdateIsPublicSuffix(target);
+            await ThreatIntelAnalysis.Analyze(target, GoogleSafeBrowsingApiKey, PhishTankApiKey, VirusTotalApiKey, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -1338,6 +1365,7 @@ namespace DomainDetective {
             filtered.IPNeighborAnalysis = active.Contains(HealthCheckType.IPNEIGHBOR) ? CloneAnalysis(IPNeighborAnalysis) : null;
             filtered.DnsTunnelingAnalysis = active.Contains(HealthCheckType.DNSTUNNELING) ? CloneAnalysis(DnsTunnelingAnalysis) : null;
             filtered.TyposquattingAnalysis = active.Contains(HealthCheckType.TYPOSQUATTING) ? CloneAnalysis(TyposquattingAnalysis) : null;
+            filtered.ThreatIntelAnalysis = active.Contains(HealthCheckType.THREATINTEL) ? CloneAnalysis(ThreatIntelAnalysis) : null;
 
             return filtered;
         }

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Queries threat intelligence services for reputation data.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class ThreatIntelAnalysis
+{
+    /// <summary>Override Safe Browsing query.</summary>
+    public Func<string, Task<string>>? GoogleSafeBrowsingOverride { private get; set; }
+    /// <summary>Override PhishTank query.</summary>
+    public Func<string, Task<string>>? PhishTankOverride { private get; set; }
+    /// <summary>Override VirusTotal query.</summary>
+    public Func<string, Task<string>>? VirusTotalOverride { private get; set; }
+
+    /// <summary>True when Google Safe Browsing lists the entry.</summary>
+    public bool ListedByGoogle { get; private set; }
+    /// <summary>True when PhishTank lists the entry.</summary>
+    public bool ListedByPhishTank { get; private set; }
+    /// <summary>True when VirusTotal lists the entry as malicious.</summary>
+    public bool ListedByVirusTotal { get; private set; }
+
+    private static readonly HttpClient _client = new();
+
+    private static async Task<string> ReadAsStringAsync(HttpResponseMessage resp)
+    {
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadAsStringAsync();
+    }
+
+    private async Task<string> QueryGoogle(string target, string apiKey, CancellationToken ct)
+    {
+        if (GoogleSafeBrowsingOverride != null)
+        {
+            return await GoogleSafeBrowsingOverride(target);
+        }
+
+        var url = $"https://safebrowsing.googleapis.com/v4/threatMatches:find?key={apiKey}";
+        var payload = new
+        {
+            client = new { clientId = "domain-detective", clientVersion = "1.0" },
+            threatInfo = new
+            {
+                threatTypes = new[] { "MALWARE", "SOCIAL_ENGINEERING", "UNWANTED_SOFTWARE", "POTENTIALLY_HARMFUL_APPLICATION" },
+                platformTypes = new[] { "ANY_PLATFORM" },
+                threatEntryTypes = new[] { "URL" },
+                threatEntries = new[] { new { url = target } }
+            }
+        };
+        var json = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var resp = await _client.PostAsync(url, content, ct);
+        return await ReadAsStringAsync(resp);
+    }
+
+    private async Task<string> QueryPhishTank(string target, string apiKey, CancellationToken ct)
+    {
+        if (PhishTankOverride != null)
+        {
+            return await PhishTankOverride(target);
+        }
+
+        var url = $"https://checkurl.phishtank.com/checkurl/?format=json&app_key={apiKey}&url={Uri.EscapeDataString(target)}";
+        using var resp = await _client.GetAsync(url, ct);
+        return await ReadAsStringAsync(resp);
+    }
+
+    private async Task<string> QueryVirusTotal(string target, string apiKey, CancellationToken ct)
+    {
+        if (VirusTotalOverride != null)
+        {
+            return await VirusTotalOverride(target);
+        }
+
+        var isIp = System.Net.IPAddress.TryParse(target, out _);
+        var url = isIp
+            ? $"https://www.virustotal.com/api/v3/ip_addresses/{target}"
+            : $"https://www.virustotal.com/api/v3/domains/{target}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-apikey", apiKey);
+        using var resp = await _client.SendAsync(request, ct);
+        return await ReadAsStringAsync(resp);
+    }
+
+    private static bool ParseGoogle(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("matches", out var m) && m.GetArrayLength() > 0;
+    }
+
+    private static bool ParsePhishTank(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("results", out var res))
+        {
+            return false;
+        }
+        var valid = res.TryGetProperty("valid", out var v) && v.GetString() == "true";
+        var inDb = res.TryGetProperty("in_database", out var db) && db.GetString() == "true";
+        return valid && inDb;
+    }
+
+    private static bool ParseVirusTotal(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("data", out var data))
+        {
+            return false;
+        }
+        if (!data.TryGetProperty("attributes", out var attr))
+        {
+            return false;
+        }
+        if (!attr.TryGetProperty("last_analysis_stats", out var stats))
+        {
+            return false;
+        }
+        return stats.TryGetProperty("malicious", out var mal) && mal.GetInt32() > 0;
+    }
+
+    /// <summary>
+    /// Queries all enabled reputation services.
+    /// </summary>
+    public async Task Analyze(string target, string? googleApiKey, string? phishTankApiKey, string? virusTotalApiKey, InternalLogger logger, CancellationToken ct = default)
+    {
+        ListedByGoogle = false;
+        ListedByPhishTank = false;
+        ListedByVirusTotal = false;
+
+        if (!string.IsNullOrWhiteSpace(googleApiKey))
+        {
+            try
+            {
+                var json = await QueryGoogle(target, googleApiKey, ct);
+                ListedByGoogle = ParseGoogle(json);
+            }
+            catch (Exception ex)
+            {
+                logger?.WriteError("Google Safe Browsing query failed: {0}", ex.Message);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(phishTankApiKey))
+        {
+            try
+            {
+                var json = await QueryPhishTank(target, phishTankApiKey, ct);
+                ListedByPhishTank = ParsePhishTank(json);
+            }
+            catch (Exception ex)
+            {
+                logger?.WriteError("PhishTank query failed: {0}", ex.Message);
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(virusTotalApiKey))
+        {
+            try
+            {
+                var json = await QueryVirusTotal(target, virusTotalApiKey, ct);
+                ListedByVirusTotal = ParseVirusTotal(json);
+            }
+            catch (Exception ex)
+            {
+                logger?.WriteError("VirusTotal query failed: {0}", ex.Message);
+            }
+        }
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-Arc', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate', 'Test-DanglingCname', 'Test-FCrDns')
+    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-Arc', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate', 'Test-DanglingCname', 'Test-FCrDns', 'Test-ThreatIntel')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
## Summary
- add cmdlet to expose ThreatIntelAnalysis
- export new cmdlet via module manifest

## Testing
- `dotnet build` *(succeeded with warnings)*
- `dotnet test` *(fails: 16 failed, 267 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6860326d7b7c832eb5c5a67835d85446