### PR TITLE
Rename DNSSecAnalysis class

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -381,7 +381,7 @@ internal class Program
                     HealthCheckType.ZONETRANSFER => hc.ZoneTransferAnalysis,
                     HealthCheckType.DANE => hc.DaneAnalysis,
                     HealthCheckType.DNSBL => hc.DNSBLAnalysis,
-                    HealthCheckType.DNSSEC => hc.DNSSecAnalysis,
+                    HealthCheckType.DNSSEC => hc.DnsSecAnalysis,
                     HealthCheckType.AUTODISCOVER => hc.AutodiscoverAnalysis,
                     HealthCheckType.CONTACT => hc.ContactInfoAnalysis,
                     HealthCheckType.ARC => hc.ArcAnalysis,

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -40,9 +40,9 @@ namespace DomainDetective.PowerShell {
             _logger.WriteVerbose("Querying DNSSEC for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.DNSSEC });
             if (Raw) {
-                WriteObject(healthCheck.DNSSecAnalysis);
+                WriteObject(healthCheck.DnsSecAnalysis);
             } else {
-                DnsSecInfo info = DnsSecConverter.Convert(healthCheck.DNSSecAnalysis);
+                DnsSecInfo info = DnsSecConverter.Convert(healthCheck.DnsSecAnalysis);
                 WriteObject(info);
             }
         }

--- a/DomainDetective.Tests/TestDNSSECAnalysis.cs
+++ b/DomainDetective.Tests/TestDNSSECAnalysis.cs
@@ -5,12 +5,12 @@ namespace DomainDetective.Tests {
             var healthCheck = new DomainHealthCheck { Verbose = false };
             await healthCheck.Verify("cloudflare.com", [HealthCheckType.DNSSEC]);
 
-            Assert.NotEmpty(healthCheck.DNSSecAnalysis.DnsKeys);
-            Assert.True(healthCheck.DNSSecAnalysis.AuthenticData);
-            Assert.True(healthCheck.DNSSecAnalysis.DsAuthenticData);
-            Assert.True(healthCheck.DNSSecAnalysis.DsMatch);
-            Assert.True(healthCheck.DNSSecAnalysis.ChainValid);
-            Assert.NotEmpty(healthCheck.DNSSecAnalysis.DsTtls);
+            Assert.NotEmpty(healthCheck.DnsSecAnalysis.DnsKeys);
+            Assert.True(healthCheck.DnsSecAnalysis.AuthenticData);
+            Assert.True(healthCheck.DnsSecAnalysis.DsAuthenticData);
+            Assert.True(healthCheck.DnsSecAnalysis.DsMatch);
+            Assert.True(healthCheck.DnsSecAnalysis.ChainValid);
+            Assert.NotEmpty(healthCheck.DnsSecAnalysis.DsTtls);
         }
 
         [Fact]
@@ -18,7 +18,7 @@ namespace DomainDetective.Tests {
             var healthCheck = new DomainHealthCheck { Verbose = false };
             await healthCheck.Verify("dnssec-failed.org", [HealthCheckType.DNSSEC]);
 
-            Assert.False(healthCheck.DNSSecAnalysis.ChainValid);
+            Assert.False(healthCheck.DnsSecAnalysis.ChainValid);
         }
     }
 }

--- a/DomainDetective.Tests/TestDNSSECInvalidDs.cs
+++ b/DomainDetective.Tests/TestDNSSECInvalidDs.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.Tests {
         public void InvalidDsDigestReturnsFalse() {
             var dnskey = "257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==";
             var dsRecord = "2371 ECDSAP256SHA256 2 c988ec423e3880eb8dd8a46fe06ca230ee23f35b578d64e78b29c3e1c83d245z";
-            var method = typeof(DNSSecAnalysis).GetMethod("VerifyDsMatch", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var method = typeof(DnsSecAnalysis).GetMethod("VerifyDsMatch", BindingFlags.NonPublic | BindingFlags.Static)!;
             bool result = (bool)method.Invoke(null, new object[] { dnskey, dsRecord, "example.com" });
             Assert.False(result);
         }
@@ -15,7 +15,7 @@ namespace DomainDetective.Tests {
         public void MismatchedDsDigestReturnsFalse() {
             var dnskey = "257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==";
             var dsRecord = "2371 ECDSAP256SHA256 2 c988ec423e3880eb8dd8a46fe06ca230ee23f35b578d64e78b29c3e1c83d246";
-            var method = typeof(DNSSecAnalysis).GetMethod("VerifyDsMatch", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var method = typeof(DnsSecAnalysis).GetMethod("VerifyDsMatch", BindingFlags.NonPublic | BindingFlags.Static)!;
             bool result = (bool)method.Invoke(null, new object[] { dnskey, dsRecord, "example.com" });
             Assert.False(result);
         }

--- a/DomainDetective.Tests/TestDNSSECRecordValidation.cs
+++ b/DomainDetective.Tests/TestDNSSECRecordValidation.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.Tests {
         [InlineData("cloudflare.com", DnsRecordType.A, true)]
         [InlineData("dnssec-failed.org", DnsRecordType.A, false)]
         public async Task ValidateRecordForZone(string domain, DnsRecordType type, bool expected) {
-            var analysis = new DNSSecAnalysis();
+            var analysis = new DnsSecAnalysis();
             bool result = await analysis.ValidateRecord(domain, type);
             Assert.Equal(expected, result);
         }

--- a/DomainDetective.Tests/TestDNSSECUnknownAlgorithm.cs
+++ b/DomainDetective.Tests/TestDNSSECUnknownAlgorithm.cs
@@ -5,7 +5,7 @@ namespace DomainDetective.Tests {
     public class TestDnssecUnknownAlgorithm {
         [Fact]
         public void UnknownAlgorithmNumberIsParsed() {
-            var method = typeof(DNSSecAnalysis).GetMethod("AlgorithmNumber", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var method = typeof(DnsSecAnalysis).GetMethod("AlgorithmNumber", BindingFlags.NonPublic | BindingFlags.Static)!;
             int value = (int)method.Invoke(null, new object[] { "99" })!;
             Assert.Equal(99, value);
         }

--- a/DomainDetective.Tests/TestDomainSummary.cs
+++ b/DomainDetective.Tests/TestDomainSummary.cs
@@ -16,11 +16,11 @@ namespace DomainDetective.Tests {
         [Fact]
         public void SummaryUsesDnsSecResultWhenAvailable() {
             var healthCheck = new DomainHealthCheck();
-            var prop = typeof(DNSSecAnalysis).GetProperty(
+            var prop = typeof(DnsSecAnalysis).GetProperty(
                 "ChainValid",
                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
             )!;
-            prop.SetValue(healthCheck.DNSSecAnalysis, true);
+            prop.SetValue(healthCheck.DnsSecAnalysis, true);
 
             var summary = healthCheck.BuildSummary();
 

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace DomainDetective {
     /// <summary>
-    ///     Helper methods to convert <see cref="DNSSecAnalysis"/> results into
+    ///     Helper methods to convert <see cref="DnsSecAnalysis"/> results into
     ///     strongly typed objects.
     /// </summary>
     public static class DnsSecConverter {
@@ -12,7 +12,7 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="analysis">DNSSEC analysis instance.</param>
         /// <returns>Structured representation of the results.</returns>
-        public static DnsSecInfo Convert(DNSSecAnalysis analysis) {
+        public static DnsSecInfo Convert(DnsSecAnalysis analysis) {
             List<DsRecordInfo> dsRecords = new();
             if (analysis.DsRecords != null) {
                 foreach (string record in analysis.DsRecords) {

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -126,8 +126,8 @@ namespace DomainDetective {
                         await VerifyDANE(domainName, daneServiceType, cancellationToken);
                         break;
                     case HealthCheckType.DNSSEC:
-                        DNSSecAnalysis = new DNSSecAnalysis();
-                        await DNSSecAnalysis.Analyze(domainName, _logger, DnsConfiguration);
+                        DnsSecAnalysis = new DnsSecAnalysis();
+                        await DnsSecAnalysis.Analyze(domainName, _logger, DnsConfiguration);
                         break;
                     case HealthCheckType.DNSBL:
                         await DNSBLAnalysis.AnalyzeDNSBLRecordsMX(domainName, _logger);
@@ -926,7 +926,7 @@ namespace DomainDetective {
                 HasDkimRecord = DKIMAnalysis.AnalysisResults.Values.Any(a => a.DkimRecordExists),
                 DkimValid = dkimValid,
                 HasMxRecord = MXAnalysis.MxRecordExists,
-                DnsSecValid = DNSSecAnalysis?.ChainValid ?? false,
+                DnsSecValid = DnsSecAnalysis?.ChainValid ?? false,
                 ExpiryDate = WhoisAnalysis.ExpiryDate,
                 ExpiresSoon = WhoisAnalysis.ExpiresSoon,
                 IsExpired = WhoisAnalysis.IsExpired,
@@ -987,7 +987,7 @@ namespace DomainDetective {
             filtered.ZoneTransferAnalysis = active.Contains(HealthCheckType.ZONETRANSFER) ? CloneAnalysis(ZoneTransferAnalysis) : null;
             filtered.DaneAnalysis = active.Contains(HealthCheckType.DANE) ? CloneAnalysis(DaneAnalysis) : null;
             filtered.DNSBLAnalysis = active.Contains(HealthCheckType.DNSBL) ? CloneAnalysis(DNSBLAnalysis) : null;
-            filtered.DNSSecAnalysis = active.Contains(HealthCheckType.DNSSEC) ? CloneAnalysis(DNSSecAnalysis) : null;
+            filtered.DnsSecAnalysis = active.Contains(HealthCheckType.DNSSEC) ? CloneAnalysis(DnsSecAnalysis) : null;
             filtered.MTASTSAnalysis = active.Contains(HealthCheckType.MTASTS) ? CloneAnalysis(MTASTSAnalysis) : null;
             filtered.TLSRPTAnalysis = active.Contains(HealthCheckType.TLSRPT) ? CloneAnalysis(TLSRPTAnalysis) : null;
             filtered.BimiAnalysis = active.Contains(HealthCheckType.BIMI) ? CloneAnalysis(BimiAnalysis) : null;

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -87,7 +87,7 @@ namespace DomainDetective {
         /// Gets the DNSSEC analysis.
         /// </summary>
         /// <value>Information about DNSSEC chain validity.</value>
-        public DNSSecAnalysis DNSSecAnalysis { get; private set; } = new DNSSecAnalysis();
+        public DnsSecAnalysis DnsSecAnalysis { get; private set; } = new DnsSecAnalysis();
 
         /// <summary>
         /// Gets the MTA-STS analysis.

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -13,7 +13,7 @@ namespace DomainDetective {
     /// Provides DNSSEC validation utilities for a domain.
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
-    public class DNSSecAnalysis {
+    public class DnsSecAnalysis {
         /// <summary>Gets the DS records returned for the domain.</summary>
         public IReadOnlyList<string> DsRecords { get; private set; } = new List<string>();
 


### PR DESCRIPTION
## Summary
- rename `DNSSecAnalysis` to `DnsSecAnalysis`
- update usages in CLI, PowerShell module, health check logic and tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test --no-build --logger "trx" --results-directory /tmp/test-results`

------
https://chatgpt.com/codex/tasks/task_e_6860f639e63c832eb230cf3b3071771b