### PR TITLE
Implement parent NS glue validation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -12,7 +12,7 @@ Current capabilities include:
 - [x] Verify DKIM
 - [x] Verify CAA
 - [x] Verify NS Records
-- [x] Verify Delegation
+- [x] Verify Delegation (parent NS and glue consistency)
 - [x] Verify SOA Records
 - [x] Verify MX Records
 - [x] Verify reverse DNS (PTR)


### PR DESCRIPTION
## Summary
- add ability to query parent zone NS records with glue
- validate glue against child zone when verifying delegation
- expose full DNS query override for testing
- cover glue consistency with new unit tests
- document delegation check details

## Testing
- `dotnet test` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68610fe06b9c832ebf715ada7cef7711