### PR TITLE
Add wildcard DNS and EDNS checks

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -36,7 +36,9 @@ internal class Program
         ["autodiscover"] = HealthCheckType.AUTODISCOVER,
         ["ports"] = HealthCheckType.PORTAVAILABILITY,
         ["ipneighbor"] = HealthCheckType.IPNEIGHBOR,
-        ["dnstunneling"] = HealthCheckType.DNSTUNNELING
+        ["dnstunneling"] = HealthCheckType.DNSTUNNELING,
+        ["wildcarddns"] = HealthCheckType.WILDCARDDNS,
+        ["edns"] = HealthCheckType.EDNSSUPPORT
     };
 
     /// <summary>
@@ -390,6 +392,8 @@ internal class Program
                     HealthCheckType.PORTAVAILABILITY => hc.PortAvailabilityAnalysis,
                     HealthCheckType.IPNEIGHBOR => hc.IPNeighborAnalysis,
                     HealthCheckType.DNSTUNNELING => hc.DnsTunnelingAnalysis,
+                    HealthCheckType.WILDCARDDNS => hc.WildcardDnsAnalysis,
+                    HealthCheckType.EDNSSUPPORT => hc.EdnsSupportAnalysis,
                     _ => null
                 };
                 if (data != null)

--- a/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
+++ b/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
@@ -1,0 +1,43 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell;
+
+/// <summary>Tests EDNS support on authoritative name servers.</summary>
+/// <para>Part of the DomainDetective project.</para>
+/// <example>
+///   <summary>Check EDNS support.</summary>
+///   <code>Test-EdnsSupport -DomainName example.com</code>
+/// </example>
+[Cmdlet(VerbsDiagnostic.Test, "EdnsSupport", DefaultParameterSetName = "ServerName")]
+public sealed class CmdletTestEdnsSupport : AsyncPSCmdlet
+{
+    /// <param name="DomainName">Domain to query.</param>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+    [ValidateNotNullOrEmpty]
+    public string DomainName;
+
+    /// <param name="DnsEndpoint">DNS server used for queries.</param>
+    [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+    public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+    private InternalLogger _logger;
+    private DomainHealthCheck healthCheck;
+
+    protected override Task BeginProcessingAsync()
+    {
+        _logger = new InternalLogger(false);
+        var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
+        internalLoggerPowerShell.ResetActivityIdCounter();
+        healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ProcessRecordAsync()
+    {
+        _logger.WriteVerbose("Querying EDNS support for domain: {0}", DomainName);
+        await healthCheck.Verify(DomainName, new[] { HealthCheckType.EDNSSUPPORT });
+        WriteObject(healthCheck.EdnsSupportAnalysis);
+    }
+}

--- a/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
@@ -1,0 +1,43 @@
+using DnsClientX;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell;
+
+/// <summary>Detects wildcard DNS responses by querying random subdomains.</summary>
+/// <para>Part of the DomainDetective project.</para>
+/// <example>
+///   <summary>Check for wildcard DNS.</summary>
+///   <code>Test-WildcardDns -DomainName example.com</code>
+/// </example>
+[Cmdlet(VerbsDiagnostic.Test, "WildcardDns", DefaultParameterSetName = "ServerName")]
+public sealed class CmdletTestWildcardDns : AsyncPSCmdlet
+{
+    /// <param name="DomainName">Domain to query.</param>
+    [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+    [ValidateNotNullOrEmpty]
+    public string DomainName;
+
+    /// <param name="DnsEndpoint">DNS server used for queries.</param>
+    [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+    public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
+
+    private InternalLogger _logger;
+    private DomainHealthCheck healthCheck;
+
+    protected override Task BeginProcessingAsync()
+    {
+        _logger = new InternalLogger(false);
+        var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
+        internalLoggerPowerShell.ResetActivityIdCounter();
+        healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+        return Task.CompletedTask;
+    }
+
+    protected override async Task ProcessRecordAsync()
+    {
+        _logger.WriteVerbose("Querying wildcard DNS for domain: {0}", DomainName);
+        await healthCheck.Verify(DomainName, new[] { HealthCheckType.WILDCARDDNS });
+        WriteObject(healthCheck.WildcardDnsAnalysis);
+    }
+}

--- a/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
+++ b/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
@@ -1,0 +1,39 @@
+using DnsClientX;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestEdnsSupportAnalysis
+{
+    private static EdnsSupportAnalysis Create(bool support)
+    {
+        return new EdnsSupportAnalysis
+        {
+            QueryDnsOverride = (name, type) =>
+            {
+                if (type == DnsRecordType.NS)
+                {
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = "ns.example.com", Type = DnsRecordType.NS } });
+                }
+                return Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1", Type = DnsRecordType.A } });
+            },
+            QueryServerOverride = _ => Task.FromResult(support)
+        };
+    }
+
+    [Fact]
+    public async Task ReportsSupport()
+    {
+        var analysis = Create(true);
+        await analysis.Analyze("example.com", new InternalLogger());
+        Assert.Contains(analysis.ServerSupport.Values, v => v);
+    }
+
+    [Fact]
+    public async Task ReportsNoSupport()
+    {
+        var analysis = Create(false);
+        await analysis.Analyze("example.com", new InternalLogger());
+        Assert.Contains(analysis.ServerSupport.Values, v => !v);
+    }
+}

--- a/DomainDetective.Tests/TestWildcardDnsAnalysis.cs
+++ b/DomainDetective.Tests/TestWildcardDnsAnalysis.cs
@@ -1,0 +1,33 @@
+using DnsClientX;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestWildcardDnsAnalysis
+{
+    [Fact]
+    public async Task DetectsCatchAll()
+    {
+        var analysis = new WildcardDnsAnalysis
+        {
+            QueryDnsOverride = (_, _) => Task.FromResult(new[] { new DnsAnswer { Type = DnsRecordType.A } })
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger(), sampleCount: 2);
+
+        Assert.True(analysis.CatchAll);
+    }
+
+    [Fact]
+    public async Task NoCatchAllWhenNoRecords()
+    {
+        var analysis = new WildcardDnsAnalysis
+        {
+            QueryDnsOverride = (_, _) => Task.FromResult(System.Array.Empty<DnsAnswer>())
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger(), sampleCount: 2);
+
+        Assert.False(analysis.CatchAll);
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -155,7 +155,15 @@ public static class CheckDescriptions {
             [HealthCheckType.THREATINTEL] = new(
                 "Query reputation services for threats.",
                 null,
-                "Review listed threats and request delisting")
+                "Review listed threats and request delisting"),
+            [HealthCheckType.WILDCARDDNS] = new(
+                "Detect wildcard DNS responses.",
+                null,
+                "Remove or adjust catch-all DNS entries."),
+            [HealthCheckType.EDNSSUPPORT] = new(
+                "Test EDNS support on name servers.",
+                null,
+                "Ensure name servers respond to EDNS queries.")
         };
 
     /// <summary>Gets the description for the specified check type.</summary>

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -78,5 +78,9 @@ public enum HealthCheckType {
     /// <summary>Check for typosquatting domains.</summary>
     TYPOSQUATTING,
     /// <summary>Query reputation services for threats.</summary>
-    THREATINTEL
+    THREATINTEL,
+    /// <summary>Detect wildcard DNS responses.</summary>
+    WILDCARDDNS,
+    /// <summary>Test EDNS support on name servers.</summary>
+    EDNSSUPPORT
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -222,6 +222,14 @@ namespace DomainDetective {
                     case HealthCheckType.TYPOSQUATTING:
                         await VerifyTyposquatting(domainName, cancellationToken);
                         break;
+                    case HealthCheckType.WILDCARDDNS:
+                        WildcardDnsAnalysis = new WildcardDnsAnalysis { DnsConfiguration = DnsConfiguration };
+                        await WildcardDnsAnalysis.Analyze(domainName, _logger);
+                        break;
+                    case HealthCheckType.EDNSSUPPORT:
+                        EdnsSupportAnalysis = new EdnsSupportAnalysis { DnsConfiguration = DnsConfiguration };
+                        await EdnsSupportAnalysis.Analyze(domainName, _logger);
+                        break;
                     case HealthCheckType.THREATINTEL:
                         await VerifyThreatIntel(domainName, cancellationToken);
                         break;
@@ -1012,6 +1020,8 @@ namespace DomainDetective {
             filtered.DnsTunnelingAnalysis = active.Contains(HealthCheckType.DNSTUNNELING) ? CloneAnalysis(DnsTunnelingAnalysis) : null;
             filtered.TyposquattingAnalysis = active.Contains(HealthCheckType.TYPOSQUATTING) ? CloneAnalysis(TyposquattingAnalysis) : null;
             filtered.ThreatIntelAnalysis = active.Contains(HealthCheckType.THREATINTEL) ? CloneAnalysis(ThreatIntelAnalysis) : null;
+            filtered.WildcardDnsAnalysis = active.Contains(HealthCheckType.WILDCARDDNS) ? CloneAnalysis(WildcardDnsAnalysis) : null;
+            filtered.EdnsSupportAnalysis = active.Contains(HealthCheckType.EDNSSUPPORT) ? CloneAnalysis(EdnsSupportAnalysis) : null;
 
             return filtered;
         }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -243,6 +243,18 @@ namespace DomainDetective {
         /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
         public ThreatIntelAnalysis THREATINTELAnalysis => ThreatIntelAnalysis;
 
+        /// <summary>Gets the wildcard DNS analysis.</summary>
+        /// <value>Results of wildcard detection.</value>
+        public WildcardDnsAnalysis WildcardDnsAnalysis { get; private set; } = new WildcardDnsAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public WildcardDnsAnalysis WILDCARDDNSAnalysis => WildcardDnsAnalysis;
+
+        /// <summary>Gets the EDNS support analysis.</summary>
+        /// <value>Information about EDNS capabilities.</value>
+        public EdnsSupportAnalysis EdnsSupportAnalysis { get; private set; } = new EdnsSupportAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public EdnsSupportAnalysis EDNSSUPPORTAnalysis => EdnsSupportAnalysis;
+
         // Settings properties moved to DomainHealthCheck.Settings.cs
 
         /// <summary>
@@ -307,6 +319,8 @@ namespace DomainDetective {
             IPNeighborAnalysis.DnsConfiguration = DnsConfiguration;
             DnsTunnelingAnalysis = new DnsTunnelingAnalysis();
             TyposquattingAnalysis.DnsConfiguration = DnsConfiguration;
+            WildcardDnsAnalysis.DnsConfiguration = DnsConfiguration;
+            EdnsSupportAnalysis.DnsConfiguration = DnsConfiguration;
 
             _logger.WriteVerbose("DomainHealthCheck initialized.");
             _logger.WriteVerbose("DnsEndpoint: {0}", DnsEndpoint);

--- a/DomainDetective/EdnsSupportAnalysis.cs
+++ b/DomainDetective/EdnsSupportAnalysis.cs
@@ -1,0 +1,137 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Determines whether name servers respond to EDNS queries.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class EdnsSupportAnalysis
+{
+    /// <summary>EDNS support results keyed by server.</summary>
+    public Dictionary<string, bool> ServerSupport { get; private set; } = new();
+
+    public DnsConfiguration DnsConfiguration { get; set; } = new();
+    public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+    public Func<string, Task<bool>>? QueryServerOverride { private get; set; }
+
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
+    {
+        if (QueryDnsOverride != null)
+        {
+            return await QueryDnsOverride(name, type);
+        }
+
+        return await DnsConfiguration.QueryDNS(name, type);
+    }
+
+    private static byte[] EncodeDomainName(string domain)
+    {
+        var parts = domain.Split('.');
+        using var ms = new System.IO.MemoryStream();
+        foreach (var p in parts)
+        {
+            ms.WriteByte((byte)p.Length);
+            var bytes = System.Text.Encoding.ASCII.GetBytes(p);
+            ms.Write(bytes, 0, bytes.Length);
+        }
+        ms.WriteByte(0);
+        return ms.ToArray();
+    }
+
+    private static byte[] BuildQuery(string domain, ushort id)
+    {
+        var qname = EncodeDomainName(domain);
+        var query = new byte[12 + qname.Length + 4 + 11];
+        query[0] = (byte)(id >> 8);
+        query[1] = (byte)id;
+        query[2] = 0x01;
+        query[5] = 0x01; // qdcount
+        Buffer.BlockCopy(qname, 0, query, 12, qname.Length);
+        var offset = 12 + qname.Length;
+        query[offset] = 0x00;
+        query[offset + 1] = 0x01;
+        query[offset + 2] = 0x00;
+        query[offset + 3] = 0x01;
+        offset += 4;
+        // OPT record
+        query[10] = 0x00;
+        query[11] = 0x01; // arcount
+        query[offset] = 0x00;
+        query[offset + 1] = 0x00;
+        query[offset + 2] = 0x29;
+        query[offset + 3] = 0x10;
+        query[offset + 4] = 0x00;
+        query[offset + 5] = 0x00;
+        query[offset + 6] = 0x00;
+        query[offset + 7] = 0x00;
+        query[offset + 8] = 0x00;
+        query[offset + 9] = 0x00;
+        query[offset + 10] = 0x00;
+        return query;
+    }
+
+    private static bool HasOptRecord(byte[] data)
+    {
+        for (int i = 0; i < data.Length - 2; i++)
+        {
+            if (data[i] == 0x00 && data[i + 1] == 0x00 && data[i + 2] == 0x29)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static async Task<bool> QueryServerAsync(string ip)
+    {
+        using var udp = new UdpClient();
+        var id = (ushort)new Random().Next(ushort.MaxValue);
+        var query = BuildQuery("example.com", id);
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+#if NET8_0_OR_GREATER
+        await udp.SendAsync(query, ip, 53, cts.Token);
+        var resp = await udp.ReceiveAsync(cts.Token);
+#else
+        await udp.SendAsync(query, query.Length, ip, 53).WaitWithCancellation(cts.Token);
+        var resp = await udp.ReceiveAsync().WaitWithCancellation(cts.Token);
+#endif
+        return HasOptRecord(resp.Buffer);
+    }
+
+    /// <summary>
+    /// Queries authoritative servers to determine EDNS support.
+    /// </summary>
+    /// <param name="domainName">Domain name.</param>
+    /// <param name="logger">Optional logger.</param>
+    public async Task Analyze(string domainName, InternalLogger logger)
+    {
+        ServerSupport.Clear();
+        var ns = await QueryDns(domainName, DnsRecordType.NS);
+        foreach (var record in ns)
+        {
+            var host = record.Data.Trim('.');
+            var a = await QueryDns(host, DnsRecordType.A);
+            foreach (var addr in a)
+            {
+                bool support;
+                if (QueryServerOverride != null)
+                {
+                    support = await QueryServerOverride(addr.Data);
+                }
+                else
+                {
+                    support = await QueryServerAsync(addr.Data);
+                }
+
+                ServerSupport[$"{host} ({addr.Data})"] = support;
+                logger?.WriteVerbose("EDNS support for {0} ({1}): {2}", host, addr.Data, support);
+            }
+        }
+    }
+}

--- a/DomainDetective/WildcardDnsAnalysis.cs
+++ b/DomainDetective/WildcardDnsAnalysis.cs
@@ -1,0 +1,60 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Detects wildcard DNS configurations by querying random subdomains.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class WildcardDnsAnalysis
+{
+    /// <summary>Names that were queried.</summary>
+    public List<string> TestedNames { get; private set; } = new();
+    /// <summary>Names that returned a record.</summary>
+    public List<string> ResolvedNames { get; private set; } = new();
+    /// <summary>Whether all random names resolved.</summary>
+    public bool CatchAll { get; private set; }
+
+    public DnsConfiguration DnsConfiguration { get; set; } = new();
+    public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
+    {
+        if (QueryDnsOverride != null)
+        {
+            return await QueryDnsOverride(name, type);
+        }
+
+        return await DnsConfiguration.QueryDNS(name, type);
+    }
+
+    /// <summary>
+    /// Queries random subdomains and detects wildcard DNS behaviour.
+    /// </summary>
+    /// <param name="domainName">Domain to analyze.</param>
+    /// <param name="logger">Optional logger used for diagnostics.</param>
+    /// <param name="sampleCount">Number of random names to test.</param>
+    public async Task Analyze(string domainName, InternalLogger logger, int sampleCount = 3)
+    {
+        TestedNames.Clear();
+        ResolvedNames.Clear();
+        CatchAll = false;
+
+        for (int i = 0; i < sampleCount; i++)
+        {
+            string sub = $"{Guid.NewGuid():N}.{domainName}";
+            TestedNames.Add(sub);
+            var records = await QueryDns(sub, DnsRecordType.A);
+            if (records.Length > 0)
+            {
+                ResolvedNames.Add(sub);
+            }
+        }
+
+        CatchAll = ResolvedNames.Count == TestedNames.Count;
+        logger?.WriteVerbose("Wildcard DNS for {0}: {1}", domainName, CatchAll);
+    }
+}

--- a/Module/DomainDetective.psd1
+++ b/Module/DomainDetective.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport      = @()
     Author               = 'Przemyslaw Klys'
-    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-Arc', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate', 'Test-DanglingCname', 'Test-FCrDns', 'Test-ThreatIntel')
+    CmdletsToExport      = @('Add-DnsblProvider', 'Clear-DnsblProvider', 'Get-DomainSummary', 'Get-WhoisInfo', 'Import-DnsblConfig', 'Remove-DnsblProvider', 'Test-Arc', 'Test-BimiRecord', 'Test-DomainBlacklist', 'Test-CaaRecord', 'Test-ContactRecord', 'Test-DaneRecord', 'Test-DkimRecord', 'Test-DmarcRecord', 'Test-DNSBLRecord', 'Test-DnsPropagation', 'Test-DnsSec', 'Test-DomainHealth', 'Test-MxRecord', 'Test-NsRecord', 'Test-OpenRelay', 'Test-MessageHeader', 'Test-SecurityTXT', 'Test-SmtpTls', 'Test-SoaRecord', 'Test-SpfRecord', 'Test-StartTls', 'Test-TlsRptRecord', 'Test-WebsiteCertificate', 'Test-DanglingCname', 'Test-FCrDns', 'Test-ThreatIntel', 'Test-DnsTtl', 'Test-DnsTunneling', 'Test-IpNeighbor', 'Test-PortAvailability', 'Test-WildcardDns', 'Test-EdnsSupport')
     CompanyName          = 'Evotec'
     CompatiblePSEditions = @('Desktop', 'Core')
     Copyright            = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/README.MD
+++ b/README.MD
@@ -43,6 +43,8 @@ Current capabilities include:
 - [x] Verify Blacklist (DNSBL)
 - [x] List IP neighbors via reverse/passive DNS
 - [x] Detect DNS tunneling from logs
+- [x] Detect wildcard DNS catch-all
+- [x] Verify EDNS support
 - [x] Check propagation of DNS records across the world/country/company
 - [x] Verify WHOIS
 - [ ] Other things that I haven't thought of yet
@@ -176,6 +178,18 @@ Analyze TTL values:
 
 ```powershell
 Test-DnsTtl -DomainName "example.com"
+```
+
+Check wildcard DNS:
+
+```powershell
+Test-WildcardDns -DomainName "example.com"
+```
+
+Check EDNS support:
+
+```powershell
+Test-EdnsSupport -DomainName "example.com"
 ```
 
 Analyze ARC headers from PowerShell:


### PR DESCRIPTION
## Summary
- add `WildcardDnsAnalysis` to flag catch-all DNS setups
- add `EdnsSupportAnalysis` to test EDNS responses
- integrate new analyses into `DomainHealthCheck`
- expose checks in CLI and PowerShell cmdlets
- document new features
- remove unreleased changelog entry

## Testing
- `dotnet build`
- `dotnet test` *(fails: Failed: 17, Passed: 275)*

------
https://chatgpt.com/codex/tasks/task_e_68610fdc6fc4832ea8be142fa661e5d9