### PR TITLE
Add ping and traceroute utilities

### DIFF
--- a/DomainDetective.Tests/TestPingTraceroute.cs
+++ b/DomainDetective.Tests/TestPingTraceroute.cs
@@ -1,0 +1,35 @@
+using System.Net.NetworkInformation;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Sdk;
+using DomainDetective.Network;
+
+namespace DomainDetective.Tests {
+    public class TestPingTraceroute {
+        [Fact]
+        public async Task PingLocalhost() {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                !RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+                !RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                throw SkipException.ForSkip("ICMP not supported on this platform");
+            }
+
+            var reply = await PingTraceroute.PingAsync("127.0.0.1");
+            Assert.Equal(IPStatus.Success, reply.Status);
+        }
+
+        [Fact]
+        public async Task TracerouteLocalhost() {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) &&
+                !RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&
+                !RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                throw SkipException.ForSkip("ICMP not supported on this platform");
+            }
+
+            var hops = await PingTraceroute.TracerouteAsync("127.0.0.1", maxHops: 3);
+            Assert.NotEmpty(hops);
+            Assert.Equal(IPStatus.Success, hops[^1].Status);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestPingTraceroute.cs
+++ b/DomainDetective.Tests/TestPingTraceroute.cs
@@ -29,7 +29,7 @@ namespace DomainDetective.Tests {
 
             var hops = await PingTraceroute.TracerouteAsync("127.0.0.1", maxHops: 3);
             Assert.NotEmpty(hops);
-            Assert.Equal(IPStatus.Success, hops[^1].Status);
+            Assert.Equal(IPStatus.Success, hops[hops.Count - 1].Status);
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -2,10 +2,12 @@ using DnsClientX;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.NetworkInformation;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json;
 using System.Reflection;
+using DomainDetective.Network;
 
 namespace DomainDetective {
     public partial class DomainHealthCheck {
@@ -866,6 +868,29 @@ namespace DomainDetective {
             }
             UpdateIsPublicSuffix(domainName);
             await HttpAnalysis.AnalyzeUrl($"http://{domainName}", false, _logger, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Sends an ICMP echo request to a host.
+        /// </summary>
+        /// <param name="host">Target host name or address.</param>
+        /// <param name="timeout">Timeout in milliseconds.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task<PingReply> VerifyPing(string host, int timeout = 4000, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await PingTraceroute.PingAsync(host, timeout, _logger);
+        }
+
+        /// <summary>
+        /// Performs a traceroute to the specified host.
+        /// </summary>
+        /// <param name="host">Target host name or address.</param>
+        /// <param name="maxHops">Maximum number of hops to probe.</param>
+        /// <param name="timeout">Timeout per hop in milliseconds.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task<IReadOnlyList<PingTraceroute.TracerouteHop>> VerifyTraceroute(string host, int maxHops = 30, int timeout = 4000, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await PingTraceroute.TracerouteAsync(host, maxHops, timeout, _logger);
         }
 
         /// <summary>

--- a/DomainDetective/Network/PingTraceroute.cs
+++ b/DomainDetective/Network/PingTraceroute.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Net.NetworkInformation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Network;
+
+/// <summary>
+/// Provides ICMP ping and traceroute capabilities.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public static class PingTraceroute
+{
+    /// <summary>Represents a single traceroute hop.</summary>
+    public class TracerouteHop
+    {
+        /// <summary>Gets or sets the hop number.</summary>
+        public int Hop { get; set; }
+        /// <summary>Gets or sets the responding address.</summary>
+        public string? Address { get; set; }
+        /// <summary>Gets or sets the ICMP status of this hop.</summary>
+        public IPStatus Status { get; set; }
+        /// <summary>Gets or sets the roundtrip time in milliseconds.</summary>
+        public long RoundtripTime { get; set; }
+    }
+
+    /// <summary>Sends a single ICMP echo request.</summary>
+    /// <param name="host">Target host name or address.</param>
+    /// <param name="timeout">Timeout in milliseconds.</param>
+    /// <param name="logger">Optional diagnostic logger.</param>
+    /// <returns>The <see cref="PingReply"/> from the operation.</returns>
+    public static async Task<PingReply> PingAsync(string host, int timeout = 4000, InternalLogger? logger = null)
+    {
+        using var ping = new Ping();
+        logger?.WriteVerbose("Pinging {0}", host);
+        var reply = await ping.SendPingAsync(host, timeout);
+        logger?.WriteVerbose("Ping status for {0}: {1}", host, reply.Status);
+        return reply;
+    }
+
+    /// <summary>Runs a traceroute to the specified host.</summary>
+    /// <param name="host">Target host name or address.</param>
+    /// <param name="maxHops">Maximum number of hops.</param>
+    /// <param name="timeout">Timeout per hop in milliseconds.</param>
+    /// <param name="logger">Optional diagnostic logger.</param>
+    /// <returns>Collection of traceroute hops.</returns>
+    public static async Task<IReadOnlyList<TracerouteHop>> TracerouteAsync(string host, int maxHops = 30, int timeout = 4000, InternalLogger? logger = null)
+    {
+        using var ping = new Ping();
+        var buffer = Array.Empty<byte>();
+        var hops = new List<TracerouteHop>(maxHops);
+
+        for (var ttl = 1; ttl <= maxHops; ttl++)
+        {
+            var options = new PingOptions(ttl, true);
+            var reply = await ping.SendPingAsync(host, timeout, buffer, options);
+            hops.Add(new TracerouteHop
+            {
+                Hop = ttl,
+                Address = reply.Address?.ToString(),
+                Status = reply.Status,
+                RoundtripTime = reply.RoundtripTime
+            });
+            logger?.WriteVerbose("Hop {0} -> {1} {2}", ttl, reply.Address, reply.Status);
+            if (reply.Status == IPStatus.Success)
+            {
+                break;
+            }
+        }
+
+        return hops;
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `PingTraceroute` with ping and traceroute features
- expose new `VerifyPing` and `VerifyTraceroute` helpers from `DomainHealthCheck`
- add tests for basic ping and traceroute functionality

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Failed:    17, Passed:   280, Skipped:     0)*

------
https://chatgpt.com/codex/tasks/task_e_686125e43a84832e9db2e202749e7859