### PR TITLE
Add IP WHOIS querying

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -400,5 +400,47 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task QueryIpWhoisParsesData() {
+            var response = string.Join("\n", new[] {
+                "NetRange: 198.51.100.0 - 198.51.100.255",
+                "origin: AS64496"
+            });
+
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                await reader.ReadLineAsync();
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true };
+                await writer.WriteAsync(response);
+            });
+
+            try {
+                var whois = new WhoisAnalysis();
+                var field = typeof(WhoisAnalysis).GetField("IpWhoisServers", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var servers = (System.Collections.Generic.List<string>?)field?.GetValue(whois);
+                Assert.NotNull(servers);
+                var lockField = typeof(WhoisAnalysis).GetField("_ipWhoisServersLock", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var lockObj = lockField?.GetValue(whois);
+                Assert.NotNull(lockObj);
+                lock (lockObj!) {
+                    servers!.Clear();
+                    servers.Add($"127.0.0.1:{port}");
+                }
+
+                var (allocation, asn) = await whois.QueryIpWhois("198.51.100.25");
+
+                Assert.Equal("198.51.100.0 - 198.51.100.255", allocation);
+                Assert.Equal("AS64496", asn);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add QueryIpWhois to WhoisAnalysis for ARIN/RIPE/APNIC
- cover IP WHOIS lookup with new unit test

## Testing
- `dotnet test --no-build --filter QueryIpWhoisParsesData`

------
https://chatgpt.com/codex/tasks/task_e_686125d4c61c832e885bbd95ae218ada