### PR TITLE
Add configurable DANE ports

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -56,6 +56,7 @@ internal class Program
         var summaryOption = new Option<bool>("--summary", "Show condensed summary");
         var jsonOption = new Option<bool>("--json", "Output raw JSON");
         var subPolicyOption = new Option<bool>("--subdomain-policy", "Include DMARC sp tag in policy evaluation");
+        var danePortsOption = new Option<string?>("--dane-ports", "Comma separated list of DANE ports");
         var smimeOption = new Option<FileInfo?>("--smime", "Parse S/MIME certificate file and exit");
         var certOption = new Option<FileInfo?>("--cert", "Parse general certificate file and exit");
         root.Add(domainsArg);
@@ -64,6 +65,7 @@ internal class Program
         root.Add(summaryOption);
         root.Add(jsonOption);
         root.Add(subPolicyOption);
+        root.Add(danePortsOption);
         root.Add(smimeOption);
         root.Add(certOption);
 
@@ -162,6 +164,7 @@ internal class Program
             var summary = result.GetValue(summaryOption);
             var json = result.GetValue(jsonOption);
             var subPolicy = result.GetValue(subPolicyOption);
+            var danePortsValue = result.GetValue(danePortsOption);
             var smime = result.GetValue(smimeOption);
             var cert = result.GetValue(certOption);
 
@@ -197,7 +200,14 @@ internal class Program
             }
 
             var arr = selected.Count > 0 ? selected.ToArray() : null;
-            await RunChecks(domains, arr, checkHttp, json, summary, subPolicy);
+            int[]? danePorts = null;
+            if (!string.IsNullOrWhiteSpace(danePortsValue)) {
+                danePorts = danePortsValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(p => int.TryParse(p, out var val) ? val : 0)
+                    .Where(p => p > 0)
+                    .ToArray();
+            }
+            await RunChecks(domains, arr, checkHttp, json, summary, subPolicy, danePorts);
         });
 
         var config = new CommandLineConfiguration(root);
@@ -335,19 +345,19 @@ internal class Program
         var checkHttp = AnsiConsole.Confirm("Perform plain HTTP check?");
         var subPolicy = AnsiConsole.Confirm("Evaluate subdomain policy?");
 
-        await RunChecks(domains, checks, checkHttp, outputJson, summaryOnly, subPolicy);
+        await RunChecks(domains, checks, checkHttp, outputJson, summaryOnly, subPolicy, null);
         return 0;
     }
 
     /// <summary>
     /// Runs the selected health checks for the provided domains.
     /// </summary>
-    private static async Task RunChecks(string[] domains, HealthCheckType[]? checks, bool checkHttp, bool outputJson, bool summaryOnly, bool subdomainPolicy)
+    private static async Task RunChecks(string[] domains, HealthCheckType[]? checks, bool checkHttp, bool outputJson, bool summaryOnly, bool subdomainPolicy, int[]? danePorts)
     {
         foreach (var domain in domains)
         {
             var hc = new DomainHealthCheck { Verbose = false, UseSubdomainPolicy = subdomainPolicy };
-            await hc.Verify(domain, checks);
+            await hc.Verify(domain, checks, null, null, danePorts);
             if (checkHttp)
             {
                 await hc.VerifyPlainHttp(domain);

--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -21,6 +21,10 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <param name="Ports">Custom ports to query.</param>
+        [Parameter(Mandatory = false, Position = 2, ParameterSetName = "ServerName")]
+        public int[]? Ports;
+
         /// <param name="FullResponse">Return full analysis object.</param>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
@@ -39,7 +43,8 @@ namespace DomainDetective.PowerShell {
         }
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DANE record for domain: {0}", DomainName);
-            await healthCheck.VerifyDANE(DomainName, [ServiceType.SMTP]);
+            var ports = Ports != null && Ports.Length > 0 ? Ports : new[] { (int)ServiceType.SMTP };
+            await healthCheck.VerifyDANE(DomainName, ports);
             WriteObject(healthCheck.DaneAnalysis);
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -32,6 +32,10 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public ServiceType[]? DaneServiceType;
 
+        /// <param name="DanePorts">Custom ports to check for DANE.</param>
+        [Parameter(Mandatory = false)]
+        public int[]? DanePorts;
+
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
@@ -52,7 +56,7 @@ namespace DomainDetective.PowerShell {
 
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying domain health for domain: {0}", DomainName);
-            await _healthCheck.Verify(DomainName, HealthCheckType, DkimSelectors, DaneServiceType);
+            await _healthCheck.Verify(DomainName, HealthCheckType, DkimSelectors, DaneServiceType, DanePorts);
             var result = _healthCheck.FilterAnalyses(HealthCheckType);
             WriteObject(result);
         }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -43,8 +43,9 @@ namespace DomainDetective {
         /// <param name="healthCheckTypes">Health checks to execute or <c>null</c> for defaults.</param>
         /// <param name="dkimSelectors">DKIM selectors to use when verifying DKIM.</param>
         /// <param name="daneServiceType">DANE service types to inspect. When <c>null</c>, SMTP and HTTPS (port 443) are queried.</param>
+        /// <param name="danePorts">Custom ports to check for DANE. Overrides <paramref name="daneServiceType"/> when provided.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
-        public async Task Verify(string domainName, HealthCheckType[] healthCheckTypes = null, string[] dkimSelectors = null, ServiceType[] daneServiceType = null, CancellationToken cancellationToken = default) {
+        public async Task Verify(string domainName, HealthCheckType[] healthCheckTypes = null, string[] dkimSelectors = null, ServiceType[] daneServiceType = null, int[] danePorts = null, CancellationToken cancellationToken = default) {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
@@ -125,7 +126,11 @@ namespace DomainDetective {
                         await ZoneTransferAnalysis.AnalyzeServers(domainName, servers, _logger, cancellationToken);
                         break;
                     case HealthCheckType.DANE:
-                        await VerifyDANE(domainName, daneServiceType, cancellationToken);
+                        if (danePorts != null && danePorts.Length > 0) {
+                            await VerifyDANE(domainName, danePorts, cancellationToken);
+                        } else {
+                            await VerifyDANE(domainName, daneServiceType, cancellationToken);
+                        }
                         break;
                     case HealthCheckType.DNSSEC:
                         DnsSecAnalysis = new DnsSecAnalysis();


### PR DESCRIPTION
## Summary
- allow `DomainHealthCheck.Verify` to accept a custom port list
- enable custom DANE ports from the CLI
- support port overrides in PowerShell cmdlets

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Cert tests cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_686148b5b170832ea5b12a6c7e718798