### PR TITLE
Add CNAME flattening detection

### DIFF
--- a/DomainDetective.Tests/TestFlatteningServiceAnalysis.cs
+++ b/DomainDetective.Tests/TestFlatteningServiceAnalysis.cs
@@ -1,0 +1,38 @@
+using DnsClientX;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestFlatteningServiceAnalysis
+{
+    private static FlatteningServiceAnalysis Create(string cname)
+    {
+        return new FlatteningServiceAnalysis
+        {
+            QueryDnsOverride = (name, type) =>
+            {
+                if (type == DnsRecordType.CNAME)
+                {
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = cname } });
+                }
+                return Task.FromResult(Array.Empty<DnsAnswer>());
+            }
+        };
+    }
+
+    [Fact]
+    public async Task DetectsFlatteningService()
+    {
+        var analysis = Create("alias.cloudflare.net");
+        await analysis.Analyze("example.com", new InternalLogger());
+        Assert.True(analysis.IsFlatteningService);
+    }
+
+    [Fact]
+    public async Task IgnoresRegularCname()
+    {
+        var analysis = Create("alias.example.net");
+        await analysis.Analyze("example.com", new InternalLogger());
+        Assert.False(analysis.IsFlatteningService);
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -163,7 +163,11 @@ public static class CheckDescriptions {
             [HealthCheckType.EDNSSUPPORT] = new(
                 "Test EDNS support on name servers.",
                 null,
-                "Ensure name servers respond to EDNS queries.")
+                "Ensure name servers respond to EDNS queries."),
+            [HealthCheckType.FLATTENINGSERVICE] = new(
+                "Detect CNAMEs pointing to flattening services.",
+                null,
+                "Review CNAME targets and consider removing provider-specific aliases.")
         };
 
     /// <summary>Gets the description for the specified check type.</summary>

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -82,5 +82,7 @@ public enum HealthCheckType {
     /// <summary>Detect wildcard DNS responses.</summary>
     WILDCARDDNS,
     /// <summary>Test EDNS support on name servers.</summary>
-    EDNSSUPPORT
+    EDNSSUPPORT,
+    /// <summary>Detect CNAMEs pointing to flattening services.</summary>
+    FLATTENINGSERVICE
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -232,6 +232,10 @@ namespace DomainDetective {
                         EdnsSupportAnalysis = new EdnsSupportAnalysis { DnsConfiguration = DnsConfiguration };
                         await EdnsSupportAnalysis.Analyze(domainName, _logger);
                         break;
+                    case HealthCheckType.FLATTENINGSERVICE:
+                        FlatteningServiceAnalysis = new FlatteningServiceAnalysis { DnsConfiguration = DnsConfiguration };
+                        await FlatteningServiceAnalysis.Analyze(domainName, _logger, cancellationToken);
+                        break;
                     case HealthCheckType.THREATINTEL:
                         await VerifyThreatIntel(domainName, cancellationToken);
                         break;
@@ -1061,6 +1065,7 @@ namespace DomainDetective {
             filtered.ThreatIntelAnalysis = active.Contains(HealthCheckType.THREATINTEL) ? CloneAnalysis(ThreatIntelAnalysis) : null;
             filtered.WildcardDnsAnalysis = active.Contains(HealthCheckType.WILDCARDDNS) ? CloneAnalysis(WildcardDnsAnalysis) : null;
             filtered.EdnsSupportAnalysis = active.Contains(HealthCheckType.EDNSSUPPORT) ? CloneAnalysis(EdnsSupportAnalysis) : null;
+            filtered.FlatteningServiceAnalysis = active.Contains(HealthCheckType.FLATTENINGSERVICE) ? CloneAnalysis(FlatteningServiceAnalysis) : null;
 
             return filtered;
         }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -255,6 +255,12 @@ namespace DomainDetective {
         /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
         public EdnsSupportAnalysis EDNSSUPPORTAnalysis => EdnsSupportAnalysis;
 
+        /// <summary>Gets the flattening service analysis.</summary>
+        /// <value>Information about CNAME flattening services.</value>
+        public FlatteningServiceAnalysis FlatteningServiceAnalysis { get; private set; } = new FlatteningServiceAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public FlatteningServiceAnalysis FLATTENINGSERVICEAnalysis => FlatteningServiceAnalysis;
+
         // Settings properties moved to DomainHealthCheck.Settings.cs
 
         /// <summary>
@@ -321,6 +327,7 @@ namespace DomainDetective {
             TyposquattingAnalysis.DnsConfiguration = DnsConfiguration;
             WildcardDnsAnalysis.DnsConfiguration = DnsConfiguration;
             EdnsSupportAnalysis.DnsConfiguration = DnsConfiguration;
+            FlatteningServiceAnalysis.DnsConfiguration = DnsConfiguration;
 
             _logger.WriteVerbose("DomainHealthCheck initialized.");
             _logger.WriteVerbose("DnsEndpoint: {0}", DnsEndpoint);

--- a/DomainDetective/Protocols/FlatteningServiceAnalysis.cs
+++ b/DomainDetective/Protocols/FlatteningServiceAnalysis.cs
@@ -1,0 +1,69 @@
+using DnsClientX;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Detects if CNAME records point to known flattening services like Cloudflare.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class FlatteningServiceAnalysis
+{
+    /// <summary>DNS configuration for lookups.</summary>
+    public DnsConfiguration DnsConfiguration { get; set; } = new();
+    /// <summary>Override DNS query logic.</summary>
+    public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+    /// <summary>Indicates whether a CNAME record exists.</summary>
+    public bool CnameRecordExists { get; private set; }
+    /// <summary>The target of the CNAME record.</summary>
+    public string? Target { get; private set; }
+    /// <summary>True when the CNAME points to a known flattening service.</summary>
+    public bool IsFlatteningService { get; private set; }
+
+    private static readonly string[] _flatteningDomains = new[]
+    {
+        "cloudflare.net"
+    };
+
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
+    {
+        if (QueryDnsOverride != null)
+        {
+            return await QueryDnsOverride(name, type);
+        }
+
+        return await DnsConfiguration.QueryDNS(name, type);
+    }
+
+    /// <summary>
+    /// Queries the domain CNAME and determines if it belongs to a flattening service.
+    /// </summary>
+    public async Task Analyze(string domainName, InternalLogger logger, CancellationToken ct = default)
+    {
+        CnameRecordExists = false;
+        Target = null;
+        IsFlatteningService = false;
+        ct.ThrowIfCancellationRequested();
+
+        var cname = await QueryDns(domainName, DnsRecordType.CNAME);
+        if (cname == null || cname.Length == 0)
+        {
+            logger?.WriteVerbose("No CNAME record found.");
+            return;
+        }
+
+        Target = cname[0].Data.TrimEnd('.');
+        CnameRecordExists = true;
+        logger?.WriteVerbose("CNAME target {0}", Target);
+
+        IsFlatteningService = _flatteningDomains.Any(d => Target.EndsWith(d, StringComparison.OrdinalIgnoreCase));
+        if (IsFlatteningService)
+        {
+            logger?.WriteWarning("CNAME uses a known flattening service");
+        }
+    }
+}

--- a/README.MD
+++ b/README.MD
@@ -28,6 +28,7 @@ Current capabilities include:
 - [x] Verify TLS-RPT
 - [x] Verify BIMI
 - [x] Check for dangling CNAME records
+- [x] Detect CNAME flattening services (e.g., Cloudflare)
 - [x] Verify Autodiscover
 - [x] Verify Website Connectivity
   - [x] Verify HTTP/2


### PR DESCRIPTION
## Summary
- add `FlatteningServiceAnalysis` to identify CNAMEs pointing to services like Cloudflare
- expose via new `HealthCheckType.FLATTENINGSERVICE`
- map new check in `DomainHealthCheck` and descriptions
- update README checklist
- cover functionality with unit tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build`

------
https://chatgpt.com/codex/tasks/task_e_686148a2be1c832eb54faa05b98de299