### PR TITLE
Add privacy protection detection in WHOIS

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -999,7 +999,8 @@ namespace DomainDetective {
                 ExpiryDate = WhoisAnalysis.ExpiryDate,
                 ExpiresSoon = WhoisAnalysis.ExpiresSoon,
                 IsExpired = WhoisAnalysis.IsExpired,
-                RegistrarLocked = WhoisAnalysis.RegistrarLocked
+                RegistrarLocked = WhoisAnalysis.RegistrarLocked,
+                PrivacyProtected = WhoisAnalysis.PrivacyProtected
             };
         }
 

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -51,5 +51,8 @@ namespace DomainDetective {
 
         /// <summary>True when registrar lock is enabled.</summary>
         public bool RegistrarLocked { get; init; }
+
+        /// <summary>True when WHOIS data is privacy protected.</summary>
+        public bool PrivacyProtected { get; init; }
     }
 }


### PR DESCRIPTION
## Summary
- parse registrar privacy indicators in `WhoisAnalysis`
- report `PrivacyProtected` on parsed WHOIS data
- surface privacy info in `DomainSummary`
- flag privacy protection in domain summary
- test WHOIS privacy detection

## Testing
- `dotnet test -v minimal --filter "DetectsPrivacyProtection|DetectsNoPrivacyWhenAbsent"`
- `dotnet test -v minimal` *(fails: TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps, ...)*

------
https://chatgpt.com/codex/tasks/task_e_686153dceed4832eb3952e637a34934b