### PR TITLE
Fix port scan tests and set CI timeout

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -21,6 +21,7 @@ jobs:
     test-windows:
         name: 'Windows'
         runs-on: windows-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -61,6 +62,7 @@ jobs:
     test-ubuntu:
         name: 'Ubuntu'
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -102,6 +104,7 @@ jobs:
         if: false # Temporarily disabled
         name: 'macOS'
         runs-on: macos-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -21,6 +21,7 @@ jobs:
     refresh-psd1:
         name: 'Refresh PSD1'
         runs-on: windows-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -49,6 +50,7 @@ jobs:
         needs: refresh-psd1
         name: 'Windows PowerShell 5.1'
         runs-on: windows-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -86,6 +88,7 @@ jobs:
         needs: refresh-psd1
         name: 'Windows PowerShell 7'
         runs-on: windows-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -120,6 +123,7 @@ jobs:
         needs: refresh-psd1
         name: 'Ubuntu PowerShell 7'
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
@@ -163,6 +167,7 @@ jobs:
         needs: refresh-psd1
         name: 'macOS PowerShell 7'
         runs-on: macos-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
@@ -18,8 +18,8 @@ namespace DomainDetective.Tests {
 
             try {
                 var analysis = new PortAvailabilityAnalysis();
-                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
-                var result = analysis.ServerResults[$"localhost:{port}"];
+                await analysis.AnalyzeServer("127.0.0.1", port, new InternalLogger());
+                var result = analysis.ServerResults[$"127.0.0.1:{port}"];
                 Assert.True(result.Success);
                 Assert.True(result.Latency > TimeSpan.Zero);
             } finally {
@@ -32,8 +32,8 @@ namespace DomainDetective.Tests {
         public async Task ReportsFailureWhenPortClosed() {
             var port = GetFreePort();
             var analysis = new PortAvailabilityAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
-            await analysis.AnalyzeServer("localhost", port, new InternalLogger());
-            var result = analysis.ServerResults[$"localhost:{port}"];
+            await analysis.AnalyzeServer("127.0.0.1", port, new InternalLogger());
+            var result = analysis.ServerResults[$"127.0.0.1:{port}"];
             Assert.False(result.Success);
         }
 
@@ -46,7 +46,7 @@ namespace DomainDetective.Tests {
 
             var analysis = new PortAvailabilityAnalysis();
             try {
-                await analysis.AnalyzeServer("localhost", port1, new InternalLogger());
+                await analysis.AnalyzeServer("127.0.0.1", port1, new InternalLogger());
                 Assert.Single(analysis.ServerResults);
                 using var c1 = await acceptTask1; // ensure the connection was accepted before stopping
             } finally {
@@ -59,10 +59,10 @@ namespace DomainDetective.Tests {
             var acceptTask2 = listener2.AcceptTcpClientAsync();
 
             try {
-                await analysis.AnalyzeServer("localhost", port2, new InternalLogger());
+                await analysis.AnalyzeServer("127.0.0.1", port2, new InternalLogger());
                 Assert.Single(analysis.ServerResults);
-                Assert.False(analysis.ServerResults.ContainsKey($"localhost:{port1}"));
-                Assert.True(analysis.ServerResults.ContainsKey($"localhost:{port2}"));
+                Assert.False(analysis.ServerResults.ContainsKey($"127.0.0.1:{port1}"));
+                Assert.True(analysis.ServerResults.ContainsKey($"127.0.0.1:{port2}"));
                 using var c2 = await acceptTask2; // wait for listener to accept before stopping
             } finally {
                 listener2.Stop();

--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -23,7 +23,7 @@ namespace DomainDetective.Tests {
 
             try {
                 var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
-                await analysis.Scan("localhost", new[] { tcpPort, udpPort }, new InternalLogger());
+                await analysis.Scan("127.0.0.1", new[] { tcpPort, udpPort }, new InternalLogger());
                 using var _ = await tcpAccept; // ensure connection completes
 
                 Assert.True(analysis.Results[tcpPort].TcpOpen);


### PR DESCRIPTION
## Summary
- make port-related tests use IPv4 loopback
- add 20 minute timeout to .NET and PowerShell workflows

## Testing
- `dotnet build DomainDetective.Tests/DomainDetective.Tests.csproj --configuration Release --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --framework net8.0 --configuration Release --no-restore` *(fails: TestDMARCAnalysis.TestDMARCByDomain)*

------
https://chatgpt.com/codex/tasks/task_e_68615d9fde60832ea7bf782375a668d7