### PR TITLE
Fix TcpListener race on Linux

### DIFF
--- a/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
@@ -11,10 +11,7 @@ namespace DomainDetective.Tests {
             var listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
             var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            var serverTask = Task.Run(async () => {
-                using var client = await listener.AcceptTcpClientAsync();
-                await Task.Delay(10);
-            });
+            var acceptTask = listener.AcceptTcpClientAsync();
 
             try {
                 var analysis = new PortAvailabilityAnalysis();
@@ -22,9 +19,9 @@ namespace DomainDetective.Tests {
                 var result = analysis.ServerResults[$"127.0.0.1:{port}"];
                 Assert.True(result.Success);
                 Assert.True(result.Latency > TimeSpan.Zero);
+                using var c = await acceptTask; // ensure the connection was accepted
             } finally {
                 listener.Stop();
-                await serverTask;
             }
         }
 


### PR DESCRIPTION
## Summary
- fix race in `ReportsSuccessAndLatency` test when run on Linux

## Testing
- `dotnet test --verbosity minimal` *(fails: `DomainDetective.Tests.dll` tests due to network access)*

------
https://chatgpt.com/codex/tasks/task_e_686164edef6c832eb9c46c472edf6966