### PR TITLE
Fix DNS propagation RNG

### DIFF
--- a/DomainDetective.Tests/TestFilterServersConcurrency.cs
+++ b/DomainDetective.Tests/TestFilterServersConcurrency.cs
@@ -1,0 +1,19 @@
+using System.Linq;
+using DomainDetective;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestFilterServersConcurrency {
+        [Fact]
+        public async Task FilterServersHandlesConcurrency() {
+            var file = "Data/DNS/PublicDNS.json";
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadServers(file, clearExisting: true);
+
+            var tasks = Enumerable.Range(0, 20)
+                .Select(_ => Task.Run(() => analysis.FilterServers(take: 5).ToList()));
+
+            await Task.WhenAll(tasks);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace static `Random` with thread-local instance
- update `FilterServers` to use the thread-local RNG
- add concurrency unit test for `FilterServers`

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: Invalid URI and network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68618b4f85c0832e82b9a383b403908f