### PR TITLE
feat(spf): track redirect visited domains

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -160,6 +160,18 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task RedirectVisitedDomainsTracked() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 redirect=b.example.com";
+            healthCheck.SpfAnalysis.TestSpfRecords["b.example.com"] = "v=spf1 redirect=a.example.com";
+
+            await healthCheck.CheckSPF("v=spf1 redirect=a.example.com");
+
+            Assert.Contains("a.example.com", healthCheck.SpfAnalysis.RedirectVisitedDomains);
+            Assert.Contains("b.example.com", healthCheck.SpfAnalysis.RedirectVisitedDomains);
+        }
+
+        [Fact]
         public async Task DomainEndingWithAllWithoutAllMechanism() {
             var spfRecord = "v=spf1 a:firewall";
             var healthCheck = new DomainHealthCheck();

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -60,6 +60,7 @@ namespace DomainDetective {
         public Dictionary<string, string> TestSpfRecords { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public bool CycleDetected { get; private set; }
         public string CyclePath { get; private set; }
+        public List<string> RedirectVisitedDomains { get; private set; } = new List<string>();
         private HashSet<string> _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
 
@@ -86,6 +87,7 @@ namespace DomainDetective {
             InvalidIpSyntax = false;
             CycleDetected = false;
             CyclePath = null;
+            RedirectVisitedDomains = new List<string>();
             _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             ARecords = new List<string>();
             Ipv4Records = new List<string>();
@@ -212,6 +214,7 @@ namespace DomainDetective {
                 } else if (part.StartsWith("redirect=", StringComparison.OrdinalIgnoreCase)) {
                     var domain = part.Substring("redirect=".Length);
                     if (domain != string.Empty) {
+                        RedirectVisitedDomains.Add(domain);
                         if (!visitedDomains.Add(domain)) {
                             CycleDetected = true;
                             CyclePath ??= string.Join(" -> ", path.Concat(new[] { domain }));


### PR DESCRIPTION
## Summary
- track visited domains when parsing `redirect=` modifiers
- add unit test for tracking redirect cycles

## Testing
- `dotnet build`
- `dotnet test` *(fails: DNS and network-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_68618c274854832eb24321c4af1188e7