### PR TITLE
Add IPv6 support to port scanner

### DIFF
--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -36,6 +36,34 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task DetectsIpv6TcpAndUdpOpenPorts() {
+            var tcpListener = new TcpListener(IPAddress.IPv6Loopback, 0);
+            tcpListener.Start();
+            var tcpPort = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+            var tcpAccept = tcpListener.AcceptTcpClientAsync();
+
+            var udpServer = new UdpClient(new IPEndPoint(IPAddress.IPv6Loopback, 0));
+            var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+            var udpTask = Task.Run(async () => {
+                var r = await udpServer.ReceiveAsync();
+                await udpServer.SendAsync(r.Buffer, r.Buffer.Length, r.RemoteEndPoint);
+            });
+
+            try {
+                var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+                await analysis.Scan("::1", new[] { tcpPort, udpPort }, new InternalLogger());
+                using var _ = await tcpAccept;
+
+                Assert.True(analysis.Results[tcpPort].TcpOpen);
+                Assert.True(analysis.Results[udpPort].UdpOpen);
+            } finally {
+                tcpListener.Stop();
+                udpServer.Close();
+                await udpTask;
+            }
+        }
+
+        [Fact]
         public async Task ConfirmsIpv6Reachability() {
             var listener = new TcpListener(IPAddress.IPv6Loopback, 0);
             listener.Start();


### PR DESCRIPTION
## Summary
- handle AddressFamily.InterNetworkV6 when port scanning
- test IPv6 TCP/UDP scanning

## Testing
- `dotnet test --no-build --filter TestPortScanAnalysis`

------
https://chatgpt.com/codex/tasks/task_e_68618c066034832e80bf59ecad74bb83