### PR TITLE
Implement certificate monitor disposal

### DIFF
--- a/DomainDetective.Tests/TestCertificateMonitor.cs
+++ b/DomainDetective.Tests/TestCertificateMonitor.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using System;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
@@ -10,6 +11,15 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, monitor.Results.Count);
             Assert.True(monitor.ValidCount >= 1);
             Assert.True(monitor.FailedCount >= 1);
+        }
+
+        [Fact]
+        public void TimerStopsAfterDispose() {
+            var monitor = new CertificateMonitor();
+            monitor.Start(Array.Empty<string>(), TimeSpan.FromMilliseconds(10));
+            Assert.True(monitor.IsRunning);
+            monitor.Dispose();
+            Assert.False(monitor.IsRunning);
         }
     }
 }

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -4,13 +4,14 @@ using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Timer = System.Threading.Timer;
 
 namespace DomainDetective {
     /// <summary>
     /// Aggregates certificate validity information for multiple hosts.
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
-    public class CertificateMonitor {
+    public class CertificateMonitor : IDisposable {
         /// <summary>Result entry for a single host.</summary>
         public class Entry {
             /// <summary>Host that was checked.</summary>
@@ -27,11 +28,38 @@ namespace DomainDetective {
             public CertificateAnalysis Analysis { get; init; }
         }
 
+        private Timer? _timer;
+        private IReadOnlyList<string> _monitorHosts = Array.Empty<string>();
+        private int _monitorPort;
+        private InternalLogger? _monitorLogger;
+
+        /// <summary>Indicates whether monitoring is active.</summary>
+        public bool IsRunning => _timer != null;
+
         /// <summary>Threshold in days for considering a certificate expiring soon.</summary>
         public int ExpiryWarningDays { get; set; } = 30;
 
         /// <summary>Collection of monitoring results.</summary>
         public List<Entry> Results { get; } = new();
+
+        /// <summary>Begins periodic monitoring of the specified hosts.</summary>
+        /// <param name="hosts">Hosts to monitor.</param>
+        /// <param name="interval">Interval between checks.</param>
+        /// <param name="port">Port used for HTTPS.</param>
+        /// <param name="logger">Optional logger instance.</param>
+        public void Start(IEnumerable<string> hosts, TimeSpan interval, int port = 443, InternalLogger? logger = null) {
+            Stop();
+            _monitorHosts = hosts.ToList();
+            _monitorPort = port;
+            _monitorLogger = logger;
+            _timer = new Timer(async _ => await Analyze(_monitorHosts, _monitorPort, _monitorLogger ?? new InternalLogger()), null, TimeSpan.Zero, interval);
+        }
+
+        /// <summary>Stops periodic monitoring.</summary>
+        public void Stop() {
+            _timer?.Dispose();
+            _timer = null;
+        }
 
         /// <summary>Checks certificates for the provided hosts.</summary>
         /// <param name="hosts">Hostnames or URLs to verify.</param>
@@ -76,5 +104,10 @@ namespace DomainDetective {
         public int IncompleteChainCount => Results.Count(e => !e.ChainComplete && e.Analysis.Certificate != null);
         /// <summary>Number of hosts where the chain status couldn't be determined.</summary>
         public int UnknownChainCount => Results.Count(e => e.Analysis.Certificate == null);
+
+        /// <summary>Disposes timer resources.</summary>
+        public void Dispose() {
+            Stop();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add periodic monitoring timer to `CertificateMonitor`
- clean up timer via `Dispose`
- validate that timers stop in unit tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: Assert.True() in multiple tests)*

------
https://chatgpt.com/codex/tasks/task_e_68618bfdcd54832e8d21b28e400483de