### PR TITLE
Fix FCRDNS alias property

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -387,7 +387,7 @@ internal class Program
                     HealthCheckType.DKIM => hc.DKIMAnalysis,
                     HealthCheckType.MX => hc.MXAnalysis,
                     HealthCheckType.REVERSEDNS => hc.ReverseDnsAnalysis,
-                    HealthCheckType.FCRDNS => hc.FCrDnsAnalysis,
+                    HealthCheckType.FCRDNS => hc.FcrDnsAnalysis,
                     HealthCheckType.CAA => hc.CAAAnalysis,
                     HealthCheckType.NS => hc.NSAnalysis,
                     HealthCheckType.DELEGATION => hc.NSAnalysis,

--- a/DomainDetective.PowerShell/CmdletTestFCrDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestFCrDns.cs
@@ -44,6 +44,6 @@ public sealed class CmdletTestFCrDns : AsyncPSCmdlet
     {
         _logger.WriteVerbose("Querying FCrDNS for domain: {0}", DomainName);
         await _healthCheck.Verify(DomainName, new[] { HealthCheckType.FCRDNS });
-        WriteObject(_healthCheck.FCrDnsAnalysis);
+        WriteObject(_healthCheck.FcrDnsAnalysis);
     }
 }

--- a/DomainDetective.Tests/TestFcrDnsAlias.cs
+++ b/DomainDetective.Tests/TestFcrDnsAlias.cs
@@ -1,0 +1,11 @@
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestFcrDnsAlias {
+        [Fact]
+        public void AliasReturnsSameInstance() {
+            var healthCheck = new DomainHealthCheck();
+            Assert.Same(healthCheck.FcrDnsAnalysis, healthCheck.FCRDNSAnalysis);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -107,7 +107,7 @@ namespace DomainDetective {
                             .Select(r => r.Data.Split(' ')[1].Trim('.'))
                             .Where(h => !string.IsNullOrWhiteSpace(h));
                         await ReverseDnsAnalysis.AnalyzeHosts(rdnsHostsFcr, _logger);
-                        await FCrDnsAnalysis.Analyze(ReverseDnsAnalysis.Results, _logger);
+                        await FcrDnsAnalysis.Analyze(ReverseDnsAnalysis.Results, _logger);
                         break;
                     case HealthCheckType.CAA:
                         var caa = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.CAA, cancellationToken: cancellationToken);
@@ -1065,7 +1065,7 @@ namespace DomainDetective {
             filtered.DKIMAnalysis = active.Contains(HealthCheckType.DKIM) ? CloneAnalysis(DKIMAnalysis) : null;
             filtered.MXAnalysis = active.Contains(HealthCheckType.MX) ? CloneAnalysis(MXAnalysis) : null;
             filtered.ReverseDnsAnalysis = active.Contains(HealthCheckType.REVERSEDNS) ? CloneAnalysis(ReverseDnsAnalysis) : null;
-            filtered.FCrDnsAnalysis = active.Contains(HealthCheckType.FCRDNS) ? CloneAnalysis(FCrDnsAnalysis) : null;
+            filtered.FcrDnsAnalysis = active.Contains(HealthCheckType.FCRDNS) ? CloneAnalysis(FcrDnsAnalysis) : null;
             filtered.CAAAnalysis = active.Contains(HealthCheckType.CAA) ? CloneAnalysis(CAAAnalysis) : null;
             filtered.NSAnalysis =
                 active.Contains(HealthCheckType.NS) || active.Contains(HealthCheckType.DELEGATION)

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -54,10 +54,10 @@ namespace DomainDetective {
 
         /// <summary>Gets the forward-confirmed reverse DNS analysis.</summary>
         /// <value>Results verifying PTR hostnames resolve back to their IP.</value>
-        public FCrDnsAnalysis FCrDnsAnalysis { get; private set; } = new FCrDnsAnalysis();
+        public FCrDnsAnalysis FcrDnsAnalysis { get; private set; } = new FCrDnsAnalysis();
 
         /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
-        public FCrDnsAnalysis FCRDNSAnalysis => FCrDnsAnalysis;
+        public FCrDnsAnalysis FCRDNSAnalysis => FcrDnsAnalysis;
 
         /// <summary>
         /// Gets the CAA analysis.
@@ -302,7 +302,7 @@ namespace DomainDetective {
             };
 
             ReverseDnsAnalysis.DnsConfiguration = DnsConfiguration;
-            FCrDnsAnalysis.DnsConfiguration = DnsConfiguration;
+            FcrDnsAnalysis.DnsConfiguration = DnsConfiguration;
 
             NSAnalysis = new NSAnalysis() {
                 DnsConfiguration = DnsConfiguration


### PR DESCRIPTION
## Summary
- rename FCrDnsAnalysis property to FcrDnsAnalysis
- keep FCRDNSAnalysis alias but point to the renamed property
- reference new property in verification, CLI and PowerShell cmdlet
- add unit test validating the alias

## Testing
- `dotnet test` *(fails: 17 failed, 299 passed)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68618bf94e50832ea293e666b9235e80