### PR TITLE
Fix DMARC whitespace handling

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -249,5 +249,23 @@ namespace DomainDetective.Tests {
             Assert.Null(analysis.SubPolicyShort);
             Assert.Equal("Quarantine (inherited)", analysis.SubPolicy);
         }
+
+        [Fact]
+        public async Task TrailingWhitespaceNotCountedTowardsLimit() {
+            var record = "v=DMARC1; p=none " + new string('a', 238) + "  ";
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDMARC(record);
+
+            Assert.False(healthCheck.DmarcAnalysis.ExceedsCharacterLimit);
+        }
+
+        [Fact]
+        public async Task ExceedsCharacterLimitWhenTrimmed() {
+            var record = "v=DMARC1; p=none " + new string('a', 239);
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDMARC(record);
+
+            Assert.True(healthCheck.DmarcAnalysis.ExceedsCharacterLimit);
+        }
     }
 }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -124,7 +124,7 @@ namespace DomainDetective {
             logger.WriteVerbose($"Analyzing DMARC record {DmarcRecord}");
 
             // check the character limit
-            ExceedsCharacterLimit = DmarcRecord.Length > 255;
+            ExceedsCharacterLimit = DmarcRecord.Trim().Length > 255;
 
             // check the DMARC record starts correctly
             StartsCorrectly = DmarcRecord.StartsWith("v=DMARC1");


### PR DESCRIPTION
## Summary
- trim DMARC record before verifying character limit
- verify whitespace handling with new tests

## Testing
- `dotnet test --verbosity minimal` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68618becf864832e8fe9110440f8bf07