### PR TITLE
Fix ARC stream disposal

### DIFF
--- a/DomainDetective.Tests/TestARCAnalysisDispose.cs
+++ b/DomainDetective.Tests/TestARCAnalysisDispose.cs
@@ -1,0 +1,30 @@
+using System.IO;
+
+namespace DomainDetective.Tests {
+    public class TestARCAnalysisDispose {
+        private class CountingMemoryStream : MemoryStream {
+            public static int DisposeCount { get; set; }
+            public CountingMemoryStream(byte[] buffer) : base(buffer) { }
+            protected override void Dispose(bool disposing) {
+                if (disposing) {
+                    DisposeCount++;
+                }
+                base.Dispose(disposing);
+            }
+        }
+
+        [Fact]
+        public void DisposesStreamsWhenParsingFails() {
+            var original = ARCAnalysis.StreamFactory;
+            CountingMemoryStream.DisposeCount = 0;
+            ARCAnalysis.StreamFactory = b => new CountingMemoryStream(b);
+            try {
+                var analysis = new ARCAnalysis();
+                analysis.Analyze("Invalid-Header");
+            } finally {
+                ARCAnalysis.StreamFactory = original;
+            }
+            Assert.Equal(2, CountingMemoryStream.DisposeCount);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestARCAnalysisDispose.cs
+++ b/DomainDetective.Tests/TestARCAnalysisDispose.cs
@@ -15,14 +15,14 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public void DisposesStreamsWhenParsingFails() {
-            var original = ARCAnalysis.StreamFactory;
+            var original = ARCAnalysis.CreateStream;
             CountingMemoryStream.DisposeCount = 0;
-            ARCAnalysis.StreamFactory = b => new CountingMemoryStream(b);
+            ARCAnalysis.CreateStream = b => new CountingMemoryStream(b);
             try {
                 var analysis = new ARCAnalysis();
                 analysis.Analyze("Invalid-Header");
             } finally {
-                ARCAnalysis.StreamFactory = original;
+                ARCAnalysis.CreateStream = original;
             }
             Assert.Equal(2, CountingMemoryStream.DisposeCount);
         }

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -18,6 +18,12 @@
       <!-- DNSBL list is built into the code. Use LoadDNSBL to load external files if required. -->
     <EmbeddedResource Include="..\Data\dnsbl.json" />
   </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DomainDetective.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
   <ItemGroup>
     <None Include="..\Data\public_suffix_list.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/DomainDetective/Protocols/ARCAnalysis.cs
+++ b/DomainDetective/Protocols/ARCAnalysis.cs
@@ -11,7 +11,7 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class ARCAnalysis {
-        internal static Func<byte[], Stream> StreamFactory { get; set; } = b => new MemoryStream(b);
+        internal static Func<byte[], Stream> CreateStream = b => new MemoryStream(b);
         /// <summary>Collected ARC-Seal header values.</summary>
         public List<string> ArcSealHeaders { get; } = new();
         /// <summary>Collected ARC-Authentication-Results header values.</summary>
@@ -43,13 +43,13 @@ namespace DomainDetective {
 
             try {
                 var utf8Bytes = Encoding.UTF8.GetBytes(rawHeaders + "\r\n");
-                using (var utf8Stream = StreamFactory(utf8Bytes)) {
+                using (var utf8Stream = CreateStream(utf8Bytes)) {
                     MimeMessage message;
                     try {
                         message = MimeMessage.Load(utf8Stream);
                     } catch (FormatException) {
                         var asciiBytes = Encoding.ASCII.GetBytes(rawHeaders + "\r\n");
-                        using (var asciiStream = StreamFactory(asciiBytes)) {
+                        using (var asciiStream = CreateStream(asciiBytes)) {
                             message = MimeMessage.Load(asciiStream);
                         }
                     }

--- a/DomainDetective/Protocols/ARCAnalysis.cs
+++ b/DomainDetective/Protocols/ARCAnalysis.cs
@@ -11,6 +11,7 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class ARCAnalysis {
+        internal static Func<byte[], Stream> StreamFactory { get; set; } = b => new MemoryStream(b);
         /// <summary>Collected ARC-Seal header values.</summary>
         public List<string> ArcSealHeaders { get; } = new();
         /// <summary>Collected ARC-Authentication-Results header values.</summary>
@@ -42,22 +43,23 @@ namespace DomainDetective {
 
             try {
                 var utf8Bytes = Encoding.UTF8.GetBytes(rawHeaders + "\r\n");
-                using var utf8Stream = new MemoryStream(utf8Bytes);
-                MimeMessage message;
-                try {
-                    message = MimeMessage.Load(utf8Stream);
-                } catch (FormatException) {
-                    utf8Stream.Dispose();
-                    var asciiBytes = Encoding.ASCII.GetBytes(rawHeaders + "\r\n");
-                    using var asciiStream = new MemoryStream(asciiBytes);
-                    message = MimeMessage.Load(asciiStream);
-                }
+                using (var utf8Stream = StreamFactory(utf8Bytes)) {
+                    MimeMessage message;
+                    try {
+                        message = MimeMessage.Load(utf8Stream);
+                    } catch (FormatException) {
+                        var asciiBytes = Encoding.ASCII.GetBytes(rawHeaders + "\r\n");
+                        using (var asciiStream = StreamFactory(asciiBytes)) {
+                            message = MimeMessage.Load(asciiStream);
+                        }
+                    }
 
-                foreach (var header in message.Headers) {
-                    if (header.Field.Equals("ARC-Seal", StringComparison.OrdinalIgnoreCase)) {
-                        ArcSealHeaders.Add(header.Value);
-                    } else if (header.Field.Equals("ARC-Authentication-Results", StringComparison.OrdinalIgnoreCase)) {
-                        ArcAuthenticationResultsHeaders.Add(header.Value);
+                    foreach (var header in message.Headers) {
+                        if (header.Field.Equals("ARC-Seal", StringComparison.OrdinalIgnoreCase)) {
+                            ArcSealHeaders.Add(header.Value);
+                        } else if (header.Field.Equals("ARC-Authentication-Results", StringComparison.OrdinalIgnoreCase)) {
+                            ArcAuthenticationResultsHeaders.Add(header.Value);
+                        }
                     }
                 }
             } catch (Exception ex) {


### PR DESCRIPTION
## Summary
- wrap ARCAnalysis streams in using blocks
- expose stream factory for testing
- add regression test for stream disposal
- allow test project access to internals

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter FullyQualifiedName~TestARCAnalysisDispose`
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68618bc7b2a4832e8f8a95440d359a04