### PR TITLE
Embed Public Suffix List

### DIFF
--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -19,9 +19,7 @@
     <EmbeddedResource Include="..\Data\dnsbl.json" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\Data\public_suffix_list.dat">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <EmbeddedResource Include="..\Data\public_suffix_list.dat" />
     <None Include="..\Data\hsts_preload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
## Summary
- embed `public_suffix_list.dat` as an assembly resource
- load the resource in `DomainHealthCheck`
- provide a helper to refresh the list from the official source

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: 17 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68618bbf49a8832e9be8c1127410ce65