### PR TITLE
Ensure port availability checks respect socket timeouts

### DIFF
--- a/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Net;
 using System.Net.Sockets;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -64,6 +65,17 @@ namespace DomainDetective.Tests {
             } finally {
                 listener2.Stop();
             }
+        }
+
+        [Fact]
+        public async Task EnforcesTimeout() {
+            var analysis = new PortAvailabilityAnalysis { Timeout = TimeSpan.FromMilliseconds(500) };
+            var sw = Stopwatch.StartNew();
+            await analysis.AnalyzeServer("203.0.113.1", 81, new InternalLogger());
+            sw.Stop();
+            var result = analysis.ServerResults["203.0.113.1:81"];
+            Assert.False(result.Success);
+            Assert.True(sw.Elapsed < TimeSpan.FromSeconds(3));
         }
 
         private static int GetFreePort() {

--- a/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
+++ b/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
@@ -52,6 +52,8 @@ public class PortAvailabilityAnalysis
     private async Task<PortResult> CheckPort(string host, int port, InternalLogger logger, CancellationToken token)
     {
         using var client = new TcpClient();
+        client.SendTimeout = (int)Timeout.TotalMilliseconds;
+        client.ReceiveTimeout = (int)Timeout.TotalMilliseconds;
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
         cts.CancelAfter(Timeout);
         var sw = Stopwatch.StartNew();


### PR DESCRIPTION
## Summary
- set `SendTimeout` and `ReceiveTimeout` on `TcpClient`
- test that unreachable hosts are cancelled according to `Timeout`

## Testing
- `dotnet test` *(fails: 17, Passed: 306)*

------
https://chatgpt.com/codex/tasks/task_e_6861914f8adc832ea1e975cf62cfa4d9