### PR TITLE
Fix wildcard IPv6 detection

### DIFF
--- a/DomainDetective.Tests/TestWildcardDnsAnalysis.cs
+++ b/DomainDetective.Tests/TestWildcardDnsAnalysis.cs
@@ -30,4 +30,25 @@ public class TestWildcardDnsAnalysis
 
         Assert.False(analysis.CatchAll);
     }
+
+    [Fact]
+    public async Task DetectsCatchAllIpv6()
+    {
+        var analysis = new WildcardDnsAnalysis
+        {
+            QueryDnsOverride = (_, type) =>
+            {
+                return type switch
+                {
+                    DnsRecordType.A => Task.FromResult(System.Array.Empty<DnsAnswer>()),
+                    DnsRecordType.AAAA => Task.FromResult(new[] { new DnsAnswer { DataRaw = "2001:0db8::1", Type = DnsRecordType.AAAA } }),
+                    _ => Task.FromResult(System.Array.Empty<DnsAnswer>())
+                };
+            }
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger(), sampleCount: 2);
+
+        Assert.True(analysis.CatchAll);
+    }
 }


### PR DESCRIPTION
## Summary
- normalize IPv6 addresses in `WildcardDnsAnalysis`
- add IPv6 wildcard test

## Testing
- `dotnet build`
- `dotnet test --no-build -f net8.0` *(fails: The argument DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686191496e94832ea4125dad3d628fba