### PR TITLE
Add cross-platform S/MIME certificate parsing

### DIFF
--- a/DomainDetective.Tests/TestSmimeCertificate.cs
+++ b/DomainDetective.Tests/TestSmimeCertificate.cs
@@ -3,7 +3,19 @@ namespace DomainDetective.Tests {
         [Fact]
         public void ParseCertificateFromFile() {
             var analysis = new SmimeCertificateAnalysis();
-            analysis.AnalyzeFile("Data/smime.pem");
+            var path = Path.Combine("Data", "smime.pem");
+            analysis.AnalyzeFile(path);
+
+            Assert.NotNull(analysis.Certificate);
+            Assert.False(string.IsNullOrEmpty(analysis.Certificate.Subject));
+            Assert.True(analysis.DaysValid > 0);
+        }
+
+        [Fact]
+        public void ParseCertificateFromDirectoryAndFile() {
+            var analysis = new SmimeCertificateAnalysis();
+            var directory = $"Data{Path.DirectorySeparatorChar}";
+            analysis.AnalyzeFile(directory, "smime.pem");
 
             Assert.NotNull(analysis.Certificate);
             Assert.False(string.IsNullOrEmpty(analysis.Certificate.Subject));

--- a/DomainDetective/Protocols/SmimeCertificateAnalysis.cs
+++ b/DomainDetective/Protocols/SmimeCertificateAnalysis.cs
@@ -34,6 +34,7 @@ public class SmimeCertificateAnalysis {
     /// </summary>
     /// <param name="path">Path to the certificate file in DER or PEM format.</param>
     public void AnalyzeFile(string path) {
+        path = path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
         if (!File.Exists(path)) {
             throw new FileNotFoundException("Certificate file not found", path);
         }
@@ -58,6 +59,25 @@ public class SmimeCertificateAnalysis {
         DaysToExpire = (int)(Certificate.NotAfter - DateTime.Now).TotalDays;
         DaysValid = (int)(Certificate.NotAfter - Certificate.NotBefore).TotalDays;
         IsExpired = Certificate.NotAfter < DateTime.Now;
+    }
+
+    /// <summary>
+    /// Loads a certificate from directory and file name using <see cref="Path.Combine(string, string)"/>.
+    /// </summary>
+    /// <param name="directory">Directory containing the certificate.</param>
+    /// <param name="fileName">Certificate file name.</param>
+    public void AnalyzeFile(string directory, string fileName) {
+        if (directory == null) {
+            throw new ArgumentNullException(nameof(directory));
+        }
+
+        if (fileName == null) {
+            throw new ArgumentNullException(nameof(fileName));
+        }
+
+        directory = directory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var fullPath = Path.Combine(directory, fileName);
+        AnalyzeFile(fullPath);
     }
 
     private static byte[] DecodePem(string pem) {


### PR DESCRIPTION
## Summary
- support directory/file paths in `SmimeCertificateAnalysis`
- ensure S/MIME tests build paths in a cross‑platform way

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: UnreachableHostLogsExceptionType, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6861910de024832e8e824e876c326efd