### PR TITLE
Fix open relay sockets

### DIFF
--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -224,5 +224,18 @@ namespace DomainDetective.Tests {
             listener.Stop();
             try { await serverTask; } catch (System.Exception) { }
         }
+
+        [Fact]
+        public async Task ConnectionFailureReturnsConnectionFailed() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+
+            var analysis = new OpenRelayAnalysis();
+            await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+
+            Assert.Equal(OpenRelayStatus.ConnectionFailed, analysis.ServerResults[$"localhost:{port}"]);
+        }
     }
 }

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -20,8 +20,7 @@ namespace DomainDetective {
         public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
             ServerResults.Clear();
             cancellationToken.ThrowIfCancellationRequested();
-            using var client = new TcpClient();
-            var status = await TryRelay(client, host, port, logger, cancellationToken);
+            var status = await TryRelay(host, port, logger, cancellationToken);
             ServerResults[$"{host}:{port}"] = status;
         }
 
@@ -33,8 +32,7 @@ namespace DomainDetective {
             foreach (var host in hosts) {
                 foreach (var port in ports) {
                     cancellationToken.ThrowIfCancellationRequested();
-                    using var client = new TcpClient();
-                    var status = await TryRelay(client, host, port, logger, cancellationToken);
+                    var status = await TryRelay(host, port, logger, cancellationToken);
                     ServerResults[$"{host}:{port}"] = status;
                 }
             }
@@ -43,7 +41,8 @@ namespace DomainDetective {
         /// <summary>
         /// Attempts to send a relay through the specified server.
         /// </summary>
-        private async Task<OpenRelayStatus> TryRelay(TcpClient client, string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
+        private async Task<OpenRelayStatus> TryRelay(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
+            using var client = new TcpClient();
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(Timeout);
             try {


### PR DESCRIPTION
## Summary
- ensure OpenRelayAnalysis properly disposes sockets
- cover connection failure with regression test

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter FullyQualifiedName~TestOpenRelayAnalysis`

------
https://chatgpt.com/codex/tasks/task_e_686190c6380c832e9a2f95b564ab0f70