### PR TITLE
Handle BIMI HTTP errors

### DIFF
--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -51,6 +51,20 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task UnreachableIndicatorSetsFailureReason() {
+            var port = GetFreePort();
+            var record = $"v=BIMI1; l=http://localhost:{port}/logo.svg";            
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = record, Type = DnsRecordType.TXT }
+            };
+            var analysis = new BimiAnalysis();
+            await analysis.AnalyzeBimiRecords(answers, new InternalLogger());
+
+            Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
+            Assert.False(analysis.SvgFetched);
+        }
+
+        [Fact]
         public async Task InvalidSvgFailsValidation() {
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";


### PR DESCRIPTION
## Summary
- catch `HttpRequestException` when downloading BIMI images
- store the failure reason
- test unreachable BIMI URLs

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: DNS/network dependent tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686190be698c832e8599a8f0d7a1a18d