### PR TITLE
Fix WHOIS error logging

### DIFF
--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -402,7 +402,11 @@ public class WhoisAnalysis {
             WhoisData = response;
             ParseWhoisData();
         } catch (Exception ex) {
-            _logger.WriteError("Error querying WHOIS server: {0}", ex.Message);
+            _logger.WriteError(
+                "Error querying WHOIS server {0} for domain {1}: {2}",
+                whoisServer,
+                domain,
+                ex.Message);
         }
     }
 


### PR DESCRIPTION
## Summary
- include WHOIS server and domain in WHOIS error logs
- verify that the logger includes server and domain when an error occurs

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test --no-build` *(fails: Assert.True() failures)*

------
https://chatgpt.com/codex/tasks/task_e_686190a8eec8832ea4b7230f52bbc4c8