### PR TITLE
Fix DNSBL logger null handling

### DIFF
--- a/DomainDetective.Tests/TestInternalLogger.cs
+++ b/DomainDetective.Tests/TestInternalLogger.cs
@@ -15,5 +15,17 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, eventArgs.ProgressCurrentSteps);
             Assert.Equal(5, eventArgs.ProgressTotalSteps);
         }
+
+        [Fact]
+        public void VerboseEventRaised() {
+            var logger = new InternalLogger();
+            LogEventArgs? eventArgs = null;
+            logger.OnVerboseMessage += (_, e) => eventArgs = e;
+
+            logger.WriteVerbose("hello");
+
+            Assert.NotNull(eventArgs);
+            Assert.Equal("hello", eventArgs!.Message);
+        }
     }
 }

--- a/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
@@ -15,7 +15,7 @@ namespace DomainDetective {
         public async IAsyncEnumerable<DNSBLRecord> AnalyzeDomainBlocklists(string domain, InternalLogger logger) {
             Reset();
             Logger = logger;
-            Logger.WriteVerbose($"Checking {domain} against {DomainDNSBLLists.Count} domain blocklists");
+            Logger?.WriteVerbose($"Checking {domain} against {DomainDNSBLLists.Count} domain blocklists");
             var collected = new List<DNSBLRecord>();
             await foreach (var record in QueryDNSBL(DomainDNSBLLists, domain)) {
                 collected.Add(record);

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -159,7 +159,7 @@ namespace DomainDetective {
         /// <summary>Gets a flattened list of all DNSBL records returned.</summary>
         public List<DNSBLRecord> AllResults { get; private set; } = new List<DNSBLRecord>();
 
-        internal InternalLogger Logger { get; set; }
+        internal InternalLogger Logger { get; set; } = new InternalLogger();
 
         /// <summary>
         /// Clears cached results allowing the instance to be reused.
@@ -176,11 +176,11 @@ namespace DomainDetective {
 
             var mxRecords = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX);
 
-            Logger.WriteVerbose($"Checking {domainName} against {DNSBLLists.Count} blacklists");
+            Logger?.WriteVerbose($"Checking {domainName} against {DNSBLLists.Count} blacklists");
             var resultsDomain = await ToListAsync(QueryDNSBL(DNSBLLists, domainName));
             ConvertToResults(domainName, resultsDomain);
 
-            Logger.WriteVerbose($"Checking {domainName} MX records against {DNSBLLists.Count} blacklists");
+            Logger?.WriteVerbose($"Checking {domainName} MX records against {DNSBLLists.Count} blacklists");
             foreach (var mxRecord in mxRecords) {
                 // Extract the IP address from the MX record data
                 string domainRecord = mxRecord.Data.Split(' ')[1];
@@ -190,7 +190,7 @@ namespace DomainDetective {
                     var ipAddress = response.Data;
                     // Perform the DNSBL check for the IP address
 
-                    Logger.WriteVerbose($"Checking {ipAddress} (MX record resolved) against {DNSBLLists.Count} blacklists");
+                    Logger?.WriteVerbose($"Checking {ipAddress} (MX record resolved) against {DNSBLLists.Count} blacklists");
                     var results = await ToListAsync(QueryDNSBL(DNSBLLists, ipAddress));
 
                     //// Add the MX record data to each DNSBLRecord
@@ -218,7 +218,7 @@ namespace DomainDetective {
         public async IAsyncEnumerable<DNSBLRecord> AnalyzeDNSBLRecords(string ipAddressOrHostname, InternalLogger logger) {
             Reset();
             Logger = logger;
-            Logger.WriteVerbose($"Checking {ipAddressOrHostname} against {DNSBLLists.Count} blacklists");
+            Logger?.WriteVerbose($"Checking {ipAddressOrHostname} against {DNSBLLists.Count} blacklists");
             var collected = new List<DNSBLRecord>();
             await foreach (var record in QueryDNSBL(DNSBLLists, ipAddressOrHostname)) {
                 collected.Add(record);


### PR DESCRIPTION
## Summary
- avoid null logger usage in DNSBLAnalysis
- default the logger property to an instance
- test InternalLogger verbose messages

## Testing
- `dotnet test` *(fails: 17 tests, see logs)*

------
https://chatgpt.com/codex/tasks/task_e_686190a47d80832eaeb91a1b49087799