### PR TITLE
Introduce injectable HttpClient

### DIFF
--- a/DomainDetective.Tests/TestThreatIntelAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatIntelAnalysis.cs
@@ -39,4 +39,13 @@ public class TestThreatIntelAnalysis
         Assert.True(health.ThreatIntelAnalysis.ListedByPhishTank);
         Assert.True(health.ThreatIntelAnalysis.ListedByVirusTotal);
     }
+
+    [Fact]
+    public void ReusesHttpClient()
+    {
+        var a1 = new ThreatIntelAnalysis();
+        var a2 = new ThreatIntelAnalysis();
+
+        Assert.Same(a1.Client, a2.Client);
+    }
 }

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -27,7 +27,15 @@ public class ThreatIntelAnalysis
     /// <summary>True when VirusTotal lists the entry as malicious.</summary>
     public bool ListedByVirusTotal { get; private set; }
 
-    private static readonly HttpClient _client = new();
+    private static readonly HttpClient _staticClient = new();
+    private readonly HttpClient _client;
+
+    internal HttpClient Client => _client;
+
+    public ThreatIntelAnalysis(HttpClient? client = null)
+    {
+        _client = client ?? _staticClient;
+    }
 
     private static async Task<string> ReadAsStringAsync(HttpResponseMessage resp)
     {


### PR DESCRIPTION
## Summary
- inject HttpClient in `ThreatIntelAnalysis`
- validate reuse with new unit test

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Assert.False and network-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_686196a64f18832e8c84d45ca1bc6e1b