### PR TITLE
Handle DNS lookup failures

### DIFF
--- a/DomainDetective.Tests/TestDanglingCnameAnalysis.cs
+++ b/DomainDetective.Tests/TestDanglingCnameAnalysis.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
@@ -52,6 +53,14 @@ namespace DomainDetective.Tests {
             await analysis.Analyze("www.example.com", new InternalLogger());
 
             Assert.True(analysis.UnclaimedService);
+        }
+
+        [Fact]
+        public async Task DnsFailureSetsFailureReason() {
+            var analysis = Create((_, _) => throw new Exception("dns fail"));
+            await analysis.Analyze("www.example.com", new InternalLogger());
+
+            Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
         }
     }
 }


### PR DESCRIPTION
## Summary
- set `FailureReason` on `DanglingCnameAnalysis`
- catch exceptions during DNS lookups and capture failure reason
- test DNS failure handling

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: DNS and network dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_686196aa99a8832e9e9a6c6b810e55b4