### PR TITLE
Add cancellation to FlatteningServiceAnalysis

### DIFF
--- a/DomainDetective/Protocols/FlatteningServiceAnalysis.cs
+++ b/DomainDetective/Protocols/FlatteningServiceAnalysis.cs
@@ -29,14 +29,15 @@ public class FlatteningServiceAnalysis
         "cloudflare.net"
     };
 
-    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (QueryDnsOverride != null)
         {
             return await QueryDnsOverride(name, type);
         }
 
-        return await DnsConfiguration.QueryDNS(name, type);
+        return await DnsConfiguration.QueryDNS(name, type, cancellationToken: cancellationToken);
     }
 
     /// <summary>
@@ -49,7 +50,7 @@ public class FlatteningServiceAnalysis
         IsFlatteningService = false;
         ct.ThrowIfCancellationRequested();
 
-        var cname = await QueryDns(domainName, DnsRecordType.CNAME);
+        var cname = await QueryDns(domainName, DnsRecordType.CNAME, ct);
         if (cname == null || cname.Length == 0)
         {
             logger?.WriteVerbose("No CNAME record found.");


### PR DESCRIPTION
## Summary
- accept `CancellationToken` in `FlatteningServiceAnalysis`
- test cancellation behaviour

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~TestFlatteningServiceAnalysis.HonorsCancellation"`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: various network-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_686196cb70f0832eb64a441a533f4814