### PR TITLE
Improve typosquatting detection with PublicSuffixList

### DIFF
--- a/DomainDetective.Tests/TestTyposquattingAnalysis.cs
+++ b/DomainDetective.Tests/TestTyposquattingAnalysis.cs
@@ -28,5 +28,15 @@ namespace DomainDetective.Tests {
             await hc.VerifyTyposquatting("example.com");
             Assert.NotEmpty(hc.TyposquattingAnalysis.Variants);
         }
+
+        [Fact]
+        public async Task UsesPublicSuffixForMultiLabelTld() {
+            var hc = new DomainHealthCheck();
+            hc.TyposquattingAnalysis.QueryDnsOverride = (_, _) => Task.FromResult(System.Array.Empty<DnsAnswer>());
+
+            await hc.TyposquattingAnalysis.Analyze("foo.example.co.uk", new InternalLogger());
+
+            Assert.Contains("foo.examp1e.co.uk", hc.TyposquattingAnalysis.Variants);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -337,6 +337,7 @@ namespace DomainDetective {
             IPNeighborAnalysis.DnsConfiguration = DnsConfiguration;
             DnsTunnelingAnalysis = new DnsTunnelingAnalysis();
             TyposquattingAnalysis.DnsConfiguration = DnsConfiguration;
+            TyposquattingAnalysis.PublicSuffixList = _publicSuffixList;
             WildcardDnsAnalysis.DnsConfiguration = DnsConfiguration;
             EdnsSupportAnalysis.DnsConfiguration = DnsConfiguration;
             FlatteningServiceAnalysis.DnsConfiguration = DnsConfiguration;
@@ -355,6 +356,7 @@ namespace DomainDetective {
             using var stream = await client.GetStreamAsync(url);
             var updated = PublicSuffixList.Load(stream);
             _publicSuffixList = updated;
+            TyposquattingAnalysis.PublicSuffixList = _publicSuffixList;
         }
 
     }


### PR DESCRIPTION
## Summary
- use PublicSuffixList to determine correct domain label in TyposquattingAnalysis
- propagate PublicSuffixList from DomainHealthCheck
- test multi label public suffix handling

## Testing
- `dotnet build DomainDetective.sln --configuration Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0 --verbosity minimal` *(fails: Assert.*)

------
https://chatgpt.com/codex/tasks/task_e_686196afbc68832e8403322c8c38f1c2