### PR TITLE
Validate constructor arguments

### DIFF
--- a/DomainDetective.Tests/TestDomainHealthCheckConstructor.cs
+++ b/DomainDetective.Tests/TestDomainHealthCheckConstructor.cs
@@ -1,0 +1,11 @@
+using System;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestDomainHealthCheckConstructor {
+        [Fact]
+        public void ConstructorThrowsWhenEndpointNull() {
+            Assert.Throws<ArgumentNullException>(() => new DomainHealthCheck(default));
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -279,6 +279,10 @@ namespace DomainDetective {
         /// <para>Optional logger for diagnostic output.</para>
         /// </param>
         public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.CloudflareWireFormat, InternalLogger internalLogger = null) {
+            if (EqualityComparer<DnsEndpoint>.Default.Equals(dnsEndpoint, default)) {
+                throw new ArgumentNullException(nameof(dnsEndpoint));
+            }
+
             if (internalLogger != null) {
                 _logger = internalLogger;
             }


### PR DESCRIPTION
## Summary
- throw `ArgumentNullException` when `DomainHealthCheck` is instantiated with a default `DnsEndpoint`
- cover the new behaviour in unit tests

## Testing
- `dotnet test --verbosity minimal` *(fails: 17 tests, passed: 315)*

------
https://chatgpt.com/codex/tasks/task_e_6861968451b8832e951e87055f24cb3f