### PR TITLE
Detect TC flag and retry over TCP

### DIFF
--- a/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
+++ b/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
@@ -1,4 +1,7 @@
 using DnsClientX;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests;
@@ -35,5 +38,86 @@ public class TestEdnsSupportAnalysis
         var analysis = Create(false);
         await analysis.Analyze("example.com", new InternalLogger());
         Assert.Contains(analysis.ServerSupport.Values, v => !v);
+    }
+
+    [Fact]
+    public async Task RetriesOverTcpWhenTruncated()
+    {
+        var udpServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+        var tcpListener = new TcpListener(IPAddress.Loopback, port);
+        tcpListener.Start();
+
+        var udpTask = Task.Run(async () =>
+        {
+            var r = await udpServer.ReceiveAsync();
+            var q = r.Buffer;
+            var resp = new byte[12];
+            resp[0] = q[0];
+            resp[1] = q[1];
+            resp[2] = (byte)(0x80 | 0x02 | (q[2] & 0x01));
+            resp[3] = 0x00;
+            await udpServer.SendAsync(resp, resp.Length, r.RemoteEndPoint);
+        });
+
+        var tcpTask = Task.Run(async () =>
+        {
+            using var client = await tcpListener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            var buf = new byte[2];
+            await stream.ReadAsync(buf, 0, 2);
+            int len = buf[0] << 8 | buf[1];
+            var q = new byte[len];
+            if (len > 0)
+            {
+                await stream.ReadAsync(q, 0, len);
+            }
+            var resp = new byte[23];
+            resp[0] = q[0];
+            resp[1] = q[1];
+            resp[2] = (byte)(0x80 | (q[2] & 0x01));
+            resp[3] = 0x00;
+            resp[10] = 0x00;
+            resp[11] = 0x01;
+            resp[12] = 0x00;
+            resp[13] = 0x00;
+            resp[14] = 0x29;
+            resp[15] = 0x10;
+            resp[16] = 0x00;
+            resp[17] = 0x00;
+            resp[18] = 0x00;
+            resp[19] = 0x00;
+            resp[20] = 0x00;
+            resp[21] = 0x00;
+            resp[22] = 0x00;
+            var prefix = new byte[] { (byte)(resp.Length >> 8), (byte)(resp.Length & 0xFF) };
+            await stream.WriteAsync(prefix, 0, 2);
+            await stream.WriteAsync(resp, 0, resp.Length);
+        });
+
+        try
+        {
+            var analysis = new EdnsSupportAnalysis
+            {
+                QueryDnsOverride = (name, type) =>
+                {
+                    if (type == DnsRecordType.NS)
+                    {
+                        return Task.FromResult(new[] { new DnsAnswer { DataRaw = "ns.example.com", Type = DnsRecordType.NS } });
+                    }
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = $"127.0.0.1:{port}", Type = DnsRecordType.A } });
+                }
+            };
+
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.True(analysis.ServerSupport.Values.First());
+        }
+        finally
+        {
+            udpServer.Close();
+            tcpListener.Stop();
+            await udpTask;
+            await tcpTask;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- detect when UDP EDNS response is truncated
- fallback to TCP to complete EDNS test
- verify TCP retry using truncated UDP mock

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: 17 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686196d3f164832ea9b2b41307f217b9