### PR TITLE
Add progress reporting for port scanning

### DIFF
--- a/DomainDetective.Tests/TestPortScanProgressOutput.cs
+++ b/DomainDetective.Tests/TestPortScanProgressOutput.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestPortScanProgressOutput
+{
+    [Fact]
+    public async Task WritesProgressLines()
+    {
+        var tcpListener = new TcpListener(IPAddress.Loopback, 0);
+        tcpListener.Start();
+        var tcpPort = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+        var tcpAccept = tcpListener.AcceptTcpClientAsync();
+
+        var udpServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+        var udpTask = Task.Run(async () =>
+        {
+            var r = await udpServer.ReceiveAsync();
+            await udpServer.SendAsync(r.Buffer, r.Buffer.Length, r.RemoteEndPoint);
+        });
+
+        var sw = new StringWriter();
+        var original = Console.Out;
+        Console.SetOut(sw);
+        try
+        {
+            var logger = new InternalLogger { IsProgress = true };
+            var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+            await analysis.Scan("127.0.0.1", new[] { tcpPort, udpPort }, logger);
+            using var _ = await tcpAccept;
+        }
+        finally
+        {
+            Console.SetOut(original);
+            tcpListener.Stop();
+            udpServer.Close();
+            await udpTask;
+        }
+
+        var output = sw.ToString();
+        Assert.Contains("[progress]", output);
+    }
+}

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -47,6 +47,8 @@ public class PortScanAnalysis
         Results.Clear();
         var list = ports ?? _topPorts;
         using var semaphore = new SemaphoreSlim(MaxConcurrency);
+        var total = list.Count();
+        var processed = 0;
         var tasks = list.Select(async port =>
         {
             await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
@@ -62,6 +64,8 @@ public class PortScanAnalysis
             finally
             {
                 semaphore.Release();
+                var done = Interlocked.Increment(ref processed);
+                logger?.WriteProgress("PortScan", port.ToString(), done * 100 / total, done, total);
             }
         });
         await Task.WhenAll(tasks).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- add Spectre.Console progress support for port scans
- emit progress from `PortScanAnalysis`
- test console progress output

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6861970e6ff8832eb50c83f9d83ec26c