### PR TITLE
Validate DKIM canonicalization

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -32,6 +32,8 @@ namespace DomainDetective.PowerShell {
                     Flags = result.Flags,
                     ValidFlags = result.ValidFlags,
                     UnknownFlagCharacters = result.UnknownFlagCharacters,
+                    Canonicalization = result.Canonicalization,
+                    ValidCanonicalization = result.ValidCanonicalization,
                     KeyType = result.KeyType,
                     HashAlgorithm = result.HashAlgorithm
                 };
@@ -115,6 +117,10 @@ namespace DomainDetective.PowerShell {
         public bool ValidFlags { get; set; }
         /// <summary>Unexpected characters found in the flags.</summary>
         public string UnknownFlagCharacters { get; set; }
+        /// <summary>Canonicalization modes specified.</summary>
+        public string Canonicalization { get; set; }
+        /// <summary>Validation result for the canonicalization value.</summary>
+        public bool ValidCanonicalization { get; set; }
 
         /// <summary>Key type value.</summary>
         public string KeyType { get; set; }

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -150,6 +150,17 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task InvalidCanonicalizationIsFlagged() {
+            const string record = "v=DKIM1; k=rsa; c=foo/bar; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidCanonicalization);
+            Assert.Equal("foo/bar", healthCheck.DKIMAnalysis.AnalysisResults["default"].Canonicalization);
+        }
+
+        [Fact]
         public async Task Large4096BitKeyIsValid() {
             const string key =
                 "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEApuPAMwNrEa/+qpJPsLDr" +

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -105,6 +105,13 @@ namespace DomainDetective {
                             analysis.ValidKeyType = string.Equals(value, "rsa", StringComparison.OrdinalIgnoreCase) ||
                                 string.Equals(value, "ed25519", StringComparison.OrdinalIgnoreCase);
                             break;
+                        case "c":
+                            analysis.Canonicalization = value;
+                            var parts = value.ToLowerInvariant().Split('/');
+                            analysis.ValidCanonicalization =
+                                (parts.Length is 1 or 2) &&
+                                parts.All(p => p == "simple" || p == "relaxed");
+                            break;
                         case "h":
                             analysis.HashAlgorithm = value;
                             break;
@@ -178,6 +185,10 @@ namespace DomainDetective {
         public string UnknownFlagCharacters { get; set; }
         /// <summary>Gets or sets a value indicating whether all flag characters are valid.</summary>
         public bool ValidFlags { get; set; }
+        /// <summary>Canonicalization modes specified in the record.</summary>
+        public string Canonicalization { get; set; }
+        /// <summary>Gets a value indicating whether the canonicalization string is valid.</summary>
+        public bool ValidCanonicalization { get; set; }
         /// <summary>Gets or sets the key type.</summary>
         public string KeyType { get; set; }
         /// <summary>Gets or sets the hash algorithm type.</summary>


### PR DESCRIPTION
## Summary
- parse DKIM `c=` tag and validate canonicalization values
- expose canonicalization info in PowerShell output
- cover invalid canonicalization in DKIM tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: TestCAAAnalysis.TestCAARecordByDomain, TestSpfAnalysis.TestSpfOver255, TestDkimGuess.GuessSelectorsForDomain, TestDomainBlocklist.UnlistedDomainReturnsNegative, TestDomainBlocklist.ListedDomainsReturnPositive, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestCertificateHTTP.UnreachableHostLogsExceptionType, TestCertificateHTTP.CapturesCipherSuiteWhenEnabled, TestDkimAnalysis.TestDKIMByDomain, TestDMARCAnalysis.TestDMARCByDomain, TestAll.TestAllHealthChecks, TestSOAAnalysis.VerifySoaByDomain, TestCertificateMonitor.ProducesSummaryCounts)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68619e7cac78832eac081e6e2d5035b2