### PR TITLE
Add DMARC URI scheme warnings

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -137,13 +137,32 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task BadUrisSetInvalidFlag() {
             var dmarcRecord = "v=DMARC1; p=none; rua=mailto:test@example.com,http://bad.example.com,mailto:invalid; ruf=https://reports.example.com";
-            var healthCheck = new DomainHealthCheck();
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var healthCheck = new DomainHealthCheck(internalLogger: logger);
             await healthCheck.CheckDMARC(dmarcRecord);
             Assert.True(healthCheck.DmarcAnalysis.InvalidReportUri);
             Assert.Single(healthCheck.DmarcAnalysis.MailtoRua);
             Assert.Equal("test@example.com", healthCheck.DmarcAnalysis.MailtoRua[0]);
             Assert.Single(healthCheck.DmarcAnalysis.HttpRuf);
             Assert.Equal("https://reports.example.com", healthCheck.DmarcAnalysis.HttpRuf[0]);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("uses HTTP"));
+        }
+
+        [Fact]
+        public async Task MissingSchemeTriggersWarning() {
+            var dmarcRecord = "v=DMARC1; p=none; rua=reports.example.com";
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var healthCheck = new DomainHealthCheck(internalLogger: logger);
+            await healthCheck.CheckDMARC(dmarcRecord);
+
+            Assert.True(healthCheck.DmarcAnalysis.InvalidReportUri);
+            Assert.Empty(healthCheck.DmarcAnalysis.MailtoRua);
+            Assert.Empty(healthCheck.DmarcAnalysis.HttpRua);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("missing a scheme"));
         }
 
         [Fact]

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -192,11 +192,11 @@ namespace DomainDetective {
                             break;
                         case "rua":
                             Rua = value;
-                            AddUriToList(value, MailtoRua, HttpRua);
+                            AddUriToList(value, MailtoRua, HttpRua, logger);
                             break;
                         case "ruf":
                             Ruf = value;
-                            AddUriToList(value, MailtoRuf, HttpRuf);
+                            AddUriToList(value, MailtoRuf, HttpRuf, logger);
                             break;
                         default:
                             var tagPair = $"{key}={value}";
@@ -241,7 +241,7 @@ namespace DomainDetective {
             Pct ??= 100;
         }
 
-        private void AddUriToList(string uri, List<string> mailtoList, List<string> httpList) {
+        private void AddUriToList(string uri, List<string> mailtoList, List<string> httpList, InternalLogger? logger = null) {
             var uris = uri.Split(',');
             foreach (var raw in uris) {
                 var u = raw.Trim();
@@ -259,7 +259,15 @@ namespace DomainDetective {
                     } else {
                         InvalidReportUri = true;
                     }
+                } else if (u.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) {
+                    logger?.WriteWarning("Report URI {0} uses HTTP instead of HTTPS.", u);
+                    if (Uri.TryCreate(u, UriKind.Absolute, out var parsed) && parsed.Scheme == Uri.UriSchemeHttp) {
+                        httpList.Add(u);
+                    } else {
+                        InvalidReportUri = true;
+                    }
                 } else {
+                    logger?.WriteWarning("Report URI {0} is missing a scheme.", u);
                     InvalidReportUri = true;
                 }
             }


### PR DESCRIPTION
## Summary
- warn if DMARC rua/ruf URIs use HTTP or lack a scheme
- test warnings for HTTP and missing scheme values

## Testing
- `dotnet build`
- `dotnet test` *(fails: The argument ... invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68619e755820832ead5fa65f0b44ae05