### PR TITLE
fix(cert): only mark self-signed for single cert

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -61,6 +61,7 @@ namespace DomainDetective.Tests {
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeUrl("https://www.google.com", 443, logger);
             Assert.False(analysis.IsSelfSigned);
+            Assert.True(analysis.Chain.Count > 1);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCertificateInfo.cs
+++ b/DomainDetective.Tests/TestCertificateInfo.cs
@@ -29,6 +29,7 @@ namespace DomainDetective.Tests {
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.IsSelfSigned);
+            Assert.Equal(1, analysis.Chain.Count);
         }
     }
 }

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -127,7 +127,7 @@ namespace DomainDetective {
                             Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
                         }
                     }
-                    IsSelfSigned = Certificate.Subject == Certificate.Issuer && Chain.Count == 1;
+                    IsSelfSigned = Chain.Count == 1;
                     IsValid = policyErrors == SslPolicyErrors.None;
                     HostnameMatch = (policyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
                     return IsValid;
@@ -185,7 +185,7 @@ namespace DomainDetective {
                                     foreach (var element in xchain.ChainElements) {
                                         Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
                                     }
-                                    IsSelfSigned = Certificate.Subject == Certificate.Issuer && Chain.Count == 1;
+                                    IsSelfSigned = Chain.Count == 1;
                                 }
                             } catch (Exception ex) {
                                 logger?.WriteError("Error retrieving certificate for {0}: {1}", url, ex.ToString());
@@ -352,7 +352,7 @@ namespace DomainDetective {
             foreach (var element in chain.ChainElements) {
                 Chain.Add(new X509Certificate2(element.Certificate.RawData));
             }
-            IsSelfSigned = certificate.Subject == certificate.Issuer && Chain.Count == 1;
+            IsSelfSigned = Chain.Count == 1;
             PopulateKeyInfo();
             DaysToExpire = (int)(certificate.NotAfter - DateTime.Now).TotalDays;
             DaysValid = (int)(certificate.NotAfter - certificate.NotBefore).TotalDays;


### PR DESCRIPTION
## Summary
- adjust self-signed detection to look only at chain length
- verify chain length in certificate tests

## Testing
- `dotnet test -c Release --verbosity minimal` *(fails: TestCertificateHTTP.UnreachableHostLogsExceptionType, CapturesCipherSuiteWhenEnabled, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68619cb0117c832e9dc8d65c9b278c31