### PR TITLE
Implement FailureReason for ThreatIntelAnalysis

### DIFF
--- a/DomainDetective.Tests/TestThreatIntelAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatIntelAnalysis.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using System.Threading.Tasks;
 using DomainDetective;
 
@@ -47,5 +48,19 @@ public class TestThreatIntelAnalysis
         var a2 = new ThreatIntelAnalysis();
 
         Assert.Same(a1.Client, a2.Client);
+    }
+
+    [Fact]
+    public async Task FeedFailureSetsFailureReason()
+    {
+        var analysis = new ThreatIntelAnalysis
+        {
+            GoogleSafeBrowsingOverride = _ => Task.FromException<string>(new HttpRequestException("offline"))
+        };
+
+        await analysis.Analyze("example.com", "g", null, null, new InternalLogger());
+
+        Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
+        Assert.False(analysis.ListedByGoogle);
     }
 }

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -26,6 +26,8 @@ public class ThreatIntelAnalysis
     public bool ListedByPhishTank { get; private set; }
     /// <summary>True when VirusTotal lists the entry as malicious.</summary>
     public bool ListedByVirusTotal { get; private set; }
+    /// <summary>If feed queries fail, explains why.</summary>
+    public string? FailureReason { get; private set; }
 
     private static readonly HttpClient _staticClient = new();
     private readonly HttpClient _client;
@@ -141,6 +143,7 @@ public class ThreatIntelAnalysis
         ListedByGoogle = false;
         ListedByPhishTank = false;
         ListedByVirusTotal = false;
+        FailureReason = null;
 
         if (!string.IsNullOrWhiteSpace(googleApiKey))
         {
@@ -152,6 +155,7 @@ public class ThreatIntelAnalysis
             catch (Exception ex)
             {
                 logger?.WriteError("Google Safe Browsing query failed: {0}", ex.Message);
+                FailureReason = $"Google Safe Browsing query failed: {ex.Message}";
             }
         }
 
@@ -165,6 +169,7 @@ public class ThreatIntelAnalysis
             catch (Exception ex)
             {
                 logger?.WriteError("PhishTank query failed: {0}", ex.Message);
+                FailureReason = $"PhishTank query failed: {ex.Message}";
             }
         }
 
@@ -178,6 +183,7 @@ public class ThreatIntelAnalysis
             catch (Exception ex)
             {
                 logger?.WriteError("VirusTotal query failed: {0}", ex.Message);
+                FailureReason = $"VirusTotal query failed: {ex.Message}";
             }
         }
     }


### PR DESCRIPTION
## Summary
- capture threat intel feed errors and store them in `FailureReason`
- test error handling when feed queries fail

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: 17 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68619cb40ef4832ea13af9afcf338dda