### PR TITLE
Add RRSIG support in DNSSEC analysis

### DIFF
--- a/DomainDetective.Tests/TestDNSSECAnalysis.cs
+++ b/DomainDetective.Tests/TestDNSSECAnalysis.cs
@@ -11,6 +11,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DnsSecAnalysis.DsMatch);
             Assert.True(healthCheck.DnsSecAnalysis.ChainValid);
             Assert.NotEmpty(healthCheck.DnsSecAnalysis.DsTtls);
+            Assert.NotEmpty(healthCheck.DnsSecAnalysis.Rrsigs);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestRrsigParsing.cs
+++ b/DomainDetective.Tests/TestRrsigParsing.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestRrsigParsing {
+        [Fact]
+        public void ParseRrsigRecord() {
+            string record = "DNSKEY ECDSAP256SHA256 2 3600 1755665684 1750395284 2371 cloudflare.com. cttiL9pyC8QvCXsG6x3lDaix7y9NRiNY2A+8YovhAbmpRvuEGChMSSYific7AJQwcvqjj3NPtDIjTaKN9y370g==";
+            var method = typeof(DnsSecAnalysis).GetMethod("ParseRrsig", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var info = (RrsigInfo)method.Invoke(null, new object[] { record })!;
+            Assert.Equal(2371, info.KeyTag);
+            Assert.Equal("ECDSAP256SHA256", info.Algorithm);
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1750395284), info.Inception);
+            Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1755665684), info.Expiration);
+        }
+    }
+}

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -27,10 +27,16 @@ namespace DomainDetective {
                 }
             }
 
+            List<RrsigInfo> rrsigs = new();
+            if (analysis.Rrsigs != null) {
+                rrsigs.AddRange(analysis.Rrsigs);
+            }
+
             return new DnsSecInfo {
                 DsRecords = dsRecords,
                 DnsKeys = dnsKeys,
                 Signatures = analysis.Signatures,
+                Rrsigs = rrsigs,
                 AuthenticData = analysis.AuthenticData,
                 DsAuthenticData = analysis.DsAuthenticData,
                 DsMatch = analysis.DsMatch,
@@ -94,6 +100,9 @@ namespace DomainDetective {
         /// <summary>DNSSEC signature records.</summary>
         public IReadOnlyList<string> Signatures { get; set; }
 
+        /// <summary>Structured RRSIG records.</summary>
+        public IReadOnlyList<RrsigInfo> Rrsigs { get; set; }
+
         /// <summary>True when the DNSKEY query had the AD flag set.</summary>
         public bool AuthenticData { get; set; }
 
@@ -144,5 +153,23 @@ namespace DomainDetective {
 
         /// <summary>Base64 encoded public key.</summary>
         public string PublicKey { get; set; }
+    }
+
+    /// <summary>
+    ///     Simplified representation of an RRSIG record.
+    /// </summary>
+    /// <para>Part of the DomainDetective project.</para>
+    public class RrsigInfo {
+        /// <summary>Key tag value.</summary>
+        public int KeyTag { get; set; }
+
+        /// <summary>Algorithm name.</summary>
+        public string Algorithm { get; set; }
+
+        /// <summary>Signature inception time.</summary>
+        public DateTimeOffset Inception { get; set; }
+
+        /// <summary>Signature expiration time.</summary>
+        public DateTimeOffset Expiration { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- extend `DnsSecAnalysis` to parse RRSIG records
- expose RRSIG details through `DnsSecInfo`
- test RRSIG parsing and ensure DNSSEC check includes signatures

## Testing
- `dotnet test DomainDetective.sln` *(fails: SOA record not found, plus many network-based tests)*

------
https://chatgpt.com/codex/tasks/task_e_68619d5417d0832eb8f15d180f35726d