### PR TITLE
Add DKIM weak key detection

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -25,6 +25,7 @@ namespace DomainDetective.PowerShell {
                     ValidPublicKey = result.ValidPublicKey,
                     ValidRsaKeyLength = result.ValidRsaKeyLength,
                     KeyLength = result.KeyLength,
+                    WeakKey = result.WeakKey,
                     KeyTypeExists = result.KeyTypeExists,
                     ValidKeyType = result.ValidKeyType,
                     PublicKey = result.PublicKey,
@@ -97,6 +98,9 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Length of the RSA public key in bits.</summary>
         public int KeyLength { get; set; }
+
+        /// <summary>True when the RSA key length is under 2048 bits.</summary>
+        public bool WeakKey { get; set; }
 
         /// <summary>Indicates whether the key type is present.</summary>
         public bool KeyTypeExists { get; set; }

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -174,5 +174,29 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidRsaKeyLength);
             Assert.Equal(4096, healthCheck.DKIMAnalysis.AnalysisResults["default"].KeyLength);
         }
+
+        [Fact]
+        public async Task WeakKeyFlagSetFor1024BitKey() {
+            const string record = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            var result = healthCheck.DKIMAnalysis.AnalysisResults["default"];
+            Assert.True(result.WeakKey);
+            Assert.Equal(1024, result.KeyLength);
+        }
+
+        [Fact]
+        public async Task WeakKeyFlagNotSetFor2048BitKey() {
+            const string record = "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA21OfspkRgPHhdCgu3kWgBX+xLyw7wRqM+Y4KaX82Pul9ikEDfZCJ35siFzV2WMH9Od/yM2TtMnubRqm9QN6paEB0VhNgNURQMmyTVsBO1usTJS9IvkIt3JtTFEinzVJLEaOC/F3d6bJaW9MMKUTBra9RcUf/E6dWAaJX8lrK8SefL9adNTwED8ZgFBnFcoJJn6e1W2WyIZ/8XAk+5Jwc7JMFZsdjFYdBSDPNyEfhNsKahVdRvdCG+OeDHyLSiNuFE27wtXaUI2TySDcfSSzE8k8z/Td9mMb0DQ2qaJ6xxk/5cwzwYSXr3sdGp++mHpGOJm18OwfsJmFCuSEcFGrHAQIDAQAB;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            var result = healthCheck.DKIMAnalysis.AnalysisResults["default"];
+            Assert.False(result.WeakKey);
+            Assert.Equal(2048, result.KeyLength);
+        }
     }
 }

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -80,16 +80,19 @@ namespace DomainDetective {
                                 var rsaKey = (RsaKeyParameters)PublicKeyFactory.CreateKey(bytes);
                                 analysis.KeyLength = rsaKey.Modulus.BitLength;
                                 analysis.ValidRsaKeyLength = analysis.KeyLength >= MinimumRsaKeyBits;
+                                analysis.WeakKey = analysis.KeyLength > 0 && analysis.KeyLength < 2048;
                                 analysis.ValidPublicKey = analysis.ValidRsaKeyLength;
                                 } catch (Exception) {
                                     analysis.ValidPublicKey = false;
                                     analysis.ValidRsaKeyLength = false;
-                                analysis.KeyLength = 0;
+                                    analysis.KeyLength = 0;
+                                    analysis.WeakKey = false;
                                 }
                             } catch (FormatException) {
                                 analysis.ValidPublicKey = false;
                                 analysis.ValidRsaKeyLength = false;
                                 analysis.KeyLength = 0;
+                                analysis.WeakKey = false;
                             }
                             break;
                         case "s":
@@ -164,6 +167,8 @@ namespace DomainDetective {
         public bool ValidRsaKeyLength { get; set; }
         /// <summary>Length of the RSA public key in bits.</summary>
         public int KeyLength { get; set; }
+        /// <summary>True when the RSA key length is under 2048 bits.</summary>
+        public bool WeakKey { get; set; }
         /// <summary>Indicates whether the <c>k</c> tag was present.</summary>
         public bool KeyTypeExists { get; set; }
         /// <summary>Gets or sets a value indicating whether the key type is recognized.</summary>

--- a/README.MD
+++ b/README.MD
@@ -229,7 +229,7 @@ Code coverage results are published to [Codecov](https://codecov.io/gh/EvotecIT/
 
 ## Understanding Results
 
-Each analysis type returns an object exposing properties that map to fields described in the relevant RFCs. For example, SPF checks follow [RFC&nbsp;7208](https://datatracker.ietf.org/doc/html/rfc7208) and DMARC analysis references [RFC&nbsp;7489](https://datatracker.ietf.org/doc/html/rfc7489). DKIM validations follow [RFC&nbsp;6376](https://datatracker.ietf.org/doc/html/rfc6376) and enforce RSA public keys of at least 1024&nbsp;bits. DANE TLSA lookups follow [RFC&nbsp;6698](https://datatracker.ietf.org/doc/html/rfc6698).
+Each analysis type returns an object exposing properties that map to fields described in the relevant RFCs. For example, SPF checks follow [RFC&nbsp;7208](https://datatracker.ietf.org/doc/html/rfc7208) and DMARC analysis references [RFC&nbsp;7489](https://datatracker.ietf.org/doc/html/rfc7489). DKIM validations follow [RFC&nbsp;6376](https://datatracker.ietf.org/doc/html/rfc6376) and enforce RSA public keys of at least 1024&nbsp;bits. DKIM analysis also sets `WeakKey` when the RSA key is shorter than 2048&nbsp;bits. DANE TLSA lookups follow [RFC&nbsp;6698](https://datatracker.ietf.org/doc/html/rfc6698).
 
 Boolean fields indicate whether a particular requirement was met. You can inspect the object returned from `DomainHealthCheck` or the PowerShell cmdlets to review these properties and make decisions in automation.
 


### PR DESCRIPTION
## Summary
- flag DKIM RSA keys shorter than 2048 bits
- expose `WeakKey` in PowerShell output
- document DKIM `WeakKey` flag
- test weak key scenarios

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: Invalid URI)*

------
https://chatgpt.com/codex/tasks/task_e_68619d792614832ea24398578e3c1c80