### PR TITLE
Add TLS analysis for IMAP and POP3

### DIFF
--- a/DomainDetective.Tests/TestMailTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestMailTlsAnalysis.cs
@@ -1,0 +1,150 @@
+using Xunit;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestMailTlsAnalysis
+{
+    [Fact]
+    public async Task ImapTlsWorks()
+    {
+        using var cert = CreateSelfSigned();
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var cts = new CancellationTokenSource();
+        var serverTask = Task.Run(() => RunImapServer(listener, cert, SslProtocols.Tls12, cts.Token), cts.Token);
+
+        try
+        {
+            var analysis = new IMAPTLSAnalysis();
+            await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+            var result = analysis.ServerResults[$"localhost:{port}"];
+            Assert.True(result.StartTlsAdvertised);
+        }
+        finally
+        {
+            cts.Cancel();
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
+    [Fact]
+    public async Task Pop3TlsWorks()
+    {
+        using var cert = CreateSelfSigned();
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var cts = new CancellationTokenSource();
+        var serverTask = Task.Run(() => RunPop3Server(listener, cert, SslProtocols.Tls12, cts.Token), cts.Token);
+
+        try
+        {
+            var analysis = new POP3TLSAnalysis();
+            await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+            var result = analysis.ServerResults[$"localhost:{port}"];
+            Assert.True(result.StartTlsAdvertised);
+        }
+        finally
+        {
+            cts.Cancel();
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
+    private static async Task RunImapServer(TcpListener listener, X509Certificate2 cert, SslProtocols protocol, CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var clientTask = listener.AcceptTcpClientAsync();
+                var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                if (completed != clientTask)
+                {
+                    try { await clientTask; } catch { }
+                    break;
+                }
+
+                var client = await clientTask;
+                _ = Task.Run(async () =>
+                {
+                    using var tcp = client;
+                    using var stream = tcp.GetStream();
+                    using var reader = new StreamReader(stream);
+                    using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                    await writer.WriteLineAsync("* OK IMAP4rev1");
+                    await reader.ReadLineAsync();
+                    await writer.WriteLineAsync("* CAPABILITY IMAP4rev1 STARTTLS\r\nA1 OK");
+                    await reader.ReadLineAsync();
+                    await writer.WriteLineAsync("A2 OK");
+                    using var ssl = new SslStream(stream);
+                    await ssl.AuthenticateAsServerAsync(cert, false, protocol, false);
+                    using var sslReader = new StreamReader(ssl);
+                    await sslReader.ReadLineAsync();
+                }, token);
+            }
+        }
+        catch
+        {
+            // ignore on shutdown
+        }
+    }
+
+    private static async Task RunPop3Server(TcpListener listener, X509Certificate2 cert, SslProtocols protocol, CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var clientTask = listener.AcceptTcpClientAsync();
+                var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                if (completed != clientTask)
+                {
+                    try { await clientTask; } catch { }
+                    break;
+                }
+
+                var client = await clientTask;
+                _ = Task.Run(async () =>
+                {
+                    using var tcp = client;
+                    using var stream = tcp.GetStream();
+                    using var reader = new StreamReader(stream);
+                    using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                    await writer.WriteLineAsync("+OK POP3 ready");
+                    await reader.ReadLineAsync();
+                    await writer.WriteLineAsync("+OK\r\nSTLS\r\n.");
+                    await reader.ReadLineAsync();
+                    await writer.WriteLineAsync("+OK");
+                    using var ssl = new SslStream(stream);
+                    await ssl.AuthenticateAsServerAsync(cert, false, protocol, false);
+                    using var sslReader = new StreamReader(ssl);
+                    await sslReader.ReadLineAsync();
+                }, token);
+            }
+        }
+        catch
+        {
+            // ignore on shutdown
+        }
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string cn = "localhost")
+    {
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest($"CN={cn}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var cert = req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(30));
+        return new X509Certificate2(cert.Export(X509ContentType.Pfx));
+    }
+}

--- a/DomainDetective/Protocols/IMAPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/IMAPTLSAnalysis.cs
@@ -5,16 +5,16 @@ using System.Threading.Tasks;
 namespace DomainDetective;
 
 /// <summary>
-/// Inspects SMTP servers for TLS configuration details.
+/// Inspects IMAP servers for TLS configuration details.
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
-public class SMTPTLSAnalysis : MailTlsAnalysis
+public class IMAPTLSAnalysis : MailTlsAnalysis
 {
-    /// <summary>Analyzes a single SMTP server.</summary>
+    /// <summary>Analyzes a single IMAP server.</summary>
     public Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
-        => base.AnalyzeServer(MailProtocol.Smtp, host, port, logger, cancellationToken);
+        => base.AnalyzeServer(MailProtocol.Imap, host, port, logger, cancellationToken);
 
-    /// <summary>Analyzes multiple SMTP servers.</summary>
+    /// <summary>Analyzes multiple IMAP servers.</summary>
     public Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
-        => base.AnalyzeServers(MailProtocol.Smtp, hosts, port, logger, cancellationToken);
+        => base.AnalyzeServers(MailProtocol.Imap, hosts, port, logger, cancellationToken);
 }

--- a/DomainDetective/Protocols/MailTlsAnalysis.cs
+++ b/DomainDetective/Protocols/MailTlsAnalysis.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Provides TLS analysis for various mail protocols.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class MailTlsAnalysis
+{
+    /// <summary>Supported mail protocols.</summary>
+    public enum MailProtocol
+    {
+        Smtp,
+        Imap,
+        Pop3
+    }
+
+    /// <summary>Result of a TLS check.</summary>
+    public class TlsResult
+    {
+        public bool StartTlsAdvertised { get; set; }
+        public bool CertificateValid { get; set; }
+        public int DaysToExpire { get; set; }
+        public SslProtocols Protocol { get; set; }
+        public bool SupportsTls13 { get; set; }
+        public bool Tls13Used { get; set; }
+        public bool HostnameMatch { get; set; }
+        public CipherAlgorithmType CipherAlgorithm { get; set; }
+        public int CipherStrength { get; set; }
+        public string CipherSuite { get; set; } = string.Empty;
+        public int DhKeyBits { get; set; }
+        public List<X509Certificate2> Chain { get; } = new();
+        public List<X509ChainStatusFlags> ChainErrors { get; } = new();
+    }
+
+    /// <summary>Stores results for each server.</summary>
+    public Dictionary<string, TlsResult> ServerResults { get; } = new();
+    /// <summary>Timeout for connections.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Analyzes a single host.</summary>
+    public async Task AnalyzeServer(MailProtocol protocol, string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        ServerResults.Clear();
+        var result = await CheckTls(protocol, host, port, logger, cancellationToken);
+        ServerResults[$"{host}:{port}"] = result;
+    }
+
+    /// <summary>Analyzes multiple hosts.</summary>
+    public async Task AnalyzeServers(MailProtocol protocol, IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        ServerResults.Clear();
+        foreach (var host in hosts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ServerResults[$"{host}:{port}"] = await CheckTls(protocol, host, port, logger, cancellationToken);
+        }
+    }
+
+    private static string GetQuitCommand(MailProtocol protocol) => protocol switch
+    {
+        MailProtocol.Imap => "A3 LOGOUT",
+        _ => "QUIT"
+    };
+
+    private async Task<TlsResult> CheckTls(MailProtocol protocol, string host, int port, InternalLogger logger, CancellationToken cancellationToken)
+    {
+        var result = new TlsResult();
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(Timeout);
+        try
+        {
+            using var client = new TcpClient();
+#if NET6_0_OR_GREATER
+            await client.ConnectAsync(host, port, timeoutCts.Token);
+#else
+            await client.ConnectAsync(host, port).WaitWithCancellation(timeoutCts.Token);
+#endif
+            using NetworkStream network = client.GetStream();
+            bool directTls = (protocol == MailProtocol.Imap && port == 993) || (protocol == MailProtocol.Pop3 && port == 995);
+            if (directTls)
+            {
+                using var ssl = new SslStream(network, false, (sender, certificate, chain, errors) =>
+                {
+                    result.CertificateValid = errors == SslPolicyErrors.None;
+                    result.HostnameMatch = (errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
+                    result.Chain.Clear();
+                    result.ChainErrors.Clear();
+                    if (certificate is X509Certificate2 cert)
+                    {
+                        result.DaysToExpire = (int)(cert.NotAfter - DateTime.Now).TotalDays;
+                        if (chain != null)
+                        {
+                            foreach (var element in chain.ChainElements)
+                            {
+                                result.Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
+                            }
+                            foreach (var status in chain.ChainStatus)
+                            {
+                                result.ChainErrors.Add(status.Status);
+                            }
+                        }
+                    }
+                    return true;
+                });
+                try
+                {
+#if NET8_0_OR_GREATER
+                    await ssl.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13 | SslProtocols.Tls12, false)
+                        .WaitWithCancellation(timeoutCts.Token);
+#else
+                    await ssl.AuthenticateAsClientAsync(host).WaitWithCancellation(timeoutCts.Token);
+#endif
+                    result.CipherAlgorithm = ssl.CipherAlgorithm;
+                    result.CipherStrength = ssl.CipherStrength;
+#if NET6_0_OR_GREATER
+                    result.CipherSuite = ssl.NegotiatedCipherSuite.ToString();
+#endif
+                    if (ssl.KeyExchangeAlgorithm == ExchangeAlgorithmType.DiffieHellman)
+                    {
+                        result.DhKeyBits = ssl.KeyExchangeStrength;
+                    }
+                    using var secureWriter = new StreamWriter(ssl) { AutoFlush = true, NewLine = "\r\n" };
+                    await secureWriter.WriteLineAsync(GetQuitCommand(protocol)).WaitWithCancellation(timeoutCts.Token);
+                }
+                catch (AuthenticationException ex)
+                {
+                    logger?.WriteVerbose($"TLS authentication failed for {host}:{port} - {ex.Message}");
+                }
+                finally
+                {
+                    result.Protocol = ssl.SslProtocol;
+#if NET8_0_OR_GREATER
+                    result.SupportsTls13 = result.Protocol == SslProtocols.Tls13;
+                    result.Tls13Used = result.SupportsTls13;
+#else
+                    result.SupportsTls13 = (int)result.Protocol == 12288;
+                    result.Tls13Used = result.SupportsTls13;
+#endif
+                    result.StartTlsAdvertised = true;
+                }
+                return result;
+            }
+
+            using var reader = new StreamReader(network);
+            using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
+#if NET8_0_OR_GREATER
+            await reader.ReadLineAsync(timeoutCts.Token);
+#else
+            await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+#endif
+            timeoutCts.Token.ThrowIfCancellationRequested();
+            var capabilities = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            switch (protocol)
+            {
+                case MailProtocol.Smtp:
+                    await writer.WriteLineAsync("EHLO example.com");
+                    string line;
+                    while ((line = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token)) != null)
+                    {
+                        timeoutCts.Token.ThrowIfCancellationRequested();
+                        logger?.WriteVerbose($"EHLO response: {line}");
+                        if (line.StartsWith("250"))
+                        {
+                            string capLine = line.Substring(4).Trim();
+                            foreach (var part in capLine.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                            {
+                                capabilities.Add(part);
+                            }
+                            if (!line.StartsWith("250-"))
+                            {
+                                break;
+                            }
+                        }
+                        else if (line.StartsWith("4") || line.StartsWith("5"))
+                        {
+                            break;
+                        }
+                    }
+                    result.StartTlsAdvertised = capabilities.Contains("STARTTLS");
+                    break;
+                case MailProtocol.Imap:
+                    await writer.WriteLineAsync("A1 CAPABILITY");
+                    while (true)
+                    {
+                        var resp = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+                        timeoutCts.Token.ThrowIfCancellationRequested();
+                        if (resp == null)
+                        {
+                            break;
+                        }
+                        logger?.WriteVerbose($"CAPABILITY response: {resp}");
+                        if (resp.StartsWith("*"))
+                        {
+                            var capLine = resp.Substring(1).Trim();
+                            if (capLine.StartsWith("CAPABILITY", StringComparison.OrdinalIgnoreCase))
+                            {
+                                var caps = capLine.Substring(10).Trim().Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                                foreach (var cap in caps)
+                                {
+                                    capabilities.Add(cap);
+                                }
+                            }
+                        }
+                        else if (resp.StartsWith("A1", StringComparison.OrdinalIgnoreCase))
+                        {
+                            break;
+                        }
+                    }
+                    result.StartTlsAdvertised = capabilities.Contains("STARTTLS");
+                    break;
+                case MailProtocol.Pop3:
+                    await writer.WriteLineAsync("CAPA");
+                    string popLine;
+                    while ((popLine = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token)) != null)
+                    {
+                        timeoutCts.Token.ThrowIfCancellationRequested();
+                        logger?.WriteVerbose($"CAPA response: {popLine}");
+                        if (popLine == ".")
+                        {
+                            break;
+                        }
+                        capabilities.Add(popLine.Trim());
+                    }
+                    result.StartTlsAdvertised = capabilities.Contains("STLS");
+                    if (!result.StartTlsAdvertised)
+                    {
+                        await writer.WriteLineAsync("STLS").WaitWithCancellation(timeoutCts.Token);
+                        var resp = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+                        if (resp != null && resp.StartsWith("+OK"))
+                        {
+                            result.StartTlsAdvertised = true;
+                        }
+                        else
+                        {
+                            await writer.WriteLineAsync("QUIT").WaitWithCancellation(timeoutCts.Token);
+                            await writer.FlushAsync().WaitWithCancellation(timeoutCts.Token);
+                            await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+                            return result;
+                        }
+                    }
+                    break;
+            }
+
+            if (!result.StartTlsAdvertised)
+            {
+                await writer.WriteLineAsync(GetQuitCommand(protocol)).WaitWithCancellation(timeoutCts.Token);
+                await writer.FlushAsync().WaitWithCancellation(timeoutCts.Token);
+                await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+                return result;
+            }
+
+            var startTlsCommand = protocol switch
+            {
+                MailProtocol.Smtp => "STARTTLS",
+                MailProtocol.Imap => "A2 STARTTLS",
+                MailProtocol.Pop3 => "STLS",
+                _ => "STARTTLS"
+            };
+            await writer.WriteLineAsync(startTlsCommand).WaitWithCancellation(timeoutCts.Token);
+            var startTlsResp = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+            bool proceed = protocol switch
+            {
+                MailProtocol.Smtp => startTlsResp != null && startTlsResp.StartsWith("220"),
+                MailProtocol.Imap => startTlsResp != null && startTlsResp.StartsWith("A2", StringComparison.OrdinalIgnoreCase) && startTlsResp.Contains("OK", StringComparison.OrdinalIgnoreCase),
+                MailProtocol.Pop3 => startTlsResp != null && startTlsResp.StartsWith("+OK"),
+                _ => false
+            };
+            if (!proceed)
+            {
+                logger?.WriteVerbose($"{host}:{port} STARTTLS rejected: {startTlsResp}");
+                return result;
+            }
+
+            using var sslStream = new SslStream(network, false, (sender, certificate, chain, errors) =>
+            {
+                result.CertificateValid = errors == SslPolicyErrors.None;
+                result.HostnameMatch = (errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
+                result.Chain.Clear();
+                result.ChainErrors.Clear();
+                if (certificate is X509Certificate2 cert)
+                {
+                    result.DaysToExpire = (int)(cert.NotAfter - DateTime.Now).TotalDays;
+                    if (chain != null)
+                    {
+                        foreach (var element in chain.ChainElements)
+                        {
+                            result.Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
+                        }
+                        foreach (var status in chain.ChainStatus)
+                        {
+                            result.ChainErrors.Add(status.Status);
+                        }
+                    }
+                }
+                return true;
+            });
+
+            try
+            {
+#if NET8_0_OR_GREATER
+                await sslStream.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13 | SslProtocols.Tls12, false)
+                    .WaitWithCancellation(timeoutCts.Token);
+#else
+                await sslStream.AuthenticateAsClientAsync(host).WaitWithCancellation(timeoutCts.Token);
+#endif
+                result.CipherAlgorithm = sslStream.CipherAlgorithm;
+                result.CipherStrength = sslStream.CipherStrength;
+#if NET6_0_OR_GREATER
+                result.CipherSuite = sslStream.NegotiatedCipherSuite.ToString();
+#endif
+                if (sslStream.KeyExchangeAlgorithm == ExchangeAlgorithmType.DiffieHellman)
+                {
+                    result.DhKeyBits = sslStream.KeyExchangeStrength;
+                }
+                using var secureWriter = new StreamWriter(sslStream) { AutoFlush = true, NewLine = "\r\n" };
+                await secureWriter.WriteLineAsync(GetQuitCommand(protocol)).WaitWithCancellation(timeoutCts.Token);
+            }
+            catch (AuthenticationException ex)
+            {
+                logger?.WriteVerbose($"TLS authentication failed for {host}:{port} - {ex.Message}");
+            }
+            finally
+            {
+                result.Protocol = sslStream.SslProtocol;
+#if NET8_0_OR_GREATER
+                result.SupportsTls13 = result.Protocol == SslProtocols.Tls13;
+                result.Tls13Used = result.SupportsTls13;
+#else
+                result.SupportsTls13 = (int)result.Protocol == 12288;
+                result.Tls13Used = result.SupportsTls13;
+#endif
+            }
+        }
+        catch (Exception ex)
+        {
+            logger?.WriteError("TLS check failed for {0}:{1} - {2}", host, port, ex.Message);
+        }
+
+        return result;
+    }
+}

--- a/DomainDetective/Protocols/MailTlsAnalysis.cs
+++ b/DomainDetective/Protocols/MailTlsAnalysis.cs
@@ -271,7 +271,9 @@ public class MailTlsAnalysis
             bool proceed = protocol switch
             {
                 MailProtocol.Smtp => startTlsResp != null && startTlsResp.StartsWith("220"),
-                MailProtocol.Imap => startTlsResp != null && startTlsResp.StartsWith("A2", StringComparison.OrdinalIgnoreCase) && startTlsResp.Contains("OK", StringComparison.OrdinalIgnoreCase),
+                MailProtocol.Imap => startTlsResp != null &&
+                    startTlsResp.StartsWith("A2", StringComparison.OrdinalIgnoreCase) &&
+                    startTlsResp.IndexOf("OK", StringComparison.OrdinalIgnoreCase) >= 0,
                 MailProtocol.Pop3 => startTlsResp != null && startTlsResp.StartsWith("+OK"),
                 _ => false
             };

--- a/DomainDetective/Protocols/POP3TLSAnalysis.cs
+++ b/DomainDetective/Protocols/POP3TLSAnalysis.cs
@@ -5,16 +5,16 @@ using System.Threading.Tasks;
 namespace DomainDetective;
 
 /// <summary>
-/// Inspects SMTP servers for TLS configuration details.
+/// Inspects POP3 servers for TLS configuration details.
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
-public class SMTPTLSAnalysis : MailTlsAnalysis
+public class POP3TLSAnalysis : MailTlsAnalysis
 {
-    /// <summary>Analyzes a single SMTP server.</summary>
+    /// <summary>Analyzes a single POP3 server.</summary>
     public Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
-        => base.AnalyzeServer(MailProtocol.Smtp, host, port, logger, cancellationToken);
+        => base.AnalyzeServer(MailProtocol.Pop3, host, port, logger, cancellationToken);
 
-    /// <summary>Analyzes multiple SMTP servers.</summary>
+    /// <summary>Analyzes multiple POP3 servers.</summary>
     public Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
-        => base.AnalyzeServers(MailProtocol.Smtp, hosts, port, logger, cancellationToken);
+        => base.AnalyzeServers(MailProtocol.Pop3, hosts, port, logger, cancellationToken);
 }


### PR DESCRIPTION
## Summary
- extend TLS analysis to handle IMAP and POP3
- provide simple wrappers for IMAP/POP3
- add tests for IMAP and POP3 TLS support

## Testing
- `dotnet test -v minimal` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68619e2bd294832ea49aa6e07fb9aa92