### PR TITLE
Add SPF macro validation

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -254,6 +254,26 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task ValidMacroProducesNoWarnings() {
+            var spfRecord = "v=spf1 exists:%{i}.spf.%{d} -all";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.Empty(healthCheck.SpfAnalysis.Warnings);
+        }
+
+        [Fact]
+        public async Task InvalidMacroProducesWarning() {
+            var spfRecord = "v=spf1 redirect=%{z}.spf.example.com";
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckSPF(spfRecord);
+
+            Assert.NotEmpty(healthCheck.SpfAnalysis.Warnings);
+        }
+
+        [Fact]
         public async Task NestedIncludesPopulateResolvedCollections() {
             var healthCheck = new DomainHealthCheck();
             healthCheck.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 include:b.example.com a:host.test ip4:10.10.10.10 mx:mx.test -all";


### PR DESCRIPTION
## Summary
- validate SPF macros and collect warnings when invalid
- warn about invalid SPF macro syntax during analysis
- test valid and invalid macro handling

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln` *(fails: Failed: 17, Passed: 327)*

------
https://chatgpt.com/codex/tasks/task_e_68619e6e3bcc832ebfab81fa0aeb77a7