### PR TITLE
Fix ARC-Seal validation

### DIFF
--- a/DomainDetective.Tests/Data/arc-missing-sig.txt
+++ b/DomainDetective.Tests/Data/arc-missing-sig.txt
@@ -1,3 +1,4 @@
 ARC-Seal: i=1; a=rsa-sha256; cv=none; b=abc;
+ARC-Authentication-Results: i=1; spf=pass;
+ARC-Seal: i=2; a=rsa-sha256; cv=pass;
 ARC-Authentication-Results: i=2; spf=pass;
-ARC-Seal: i=3; a=rsa-sha256; cv=pass; b=abc;

--- a/DomainDetective.Tests/Data/arc-valid.txt
+++ b/DomainDetective.Tests/Data/arc-valid.txt
@@ -1,4 +1,4 @@
-ARC-Seal: i=1; a=rsa-sha256; cv=none;
+ARC-Seal: i=1; a=rsa-sha256; cv=none; b=abc;
 ARC-Authentication-Results: i=1; spf=pass;
-ARC-Seal: i=2; a=rsa-sha256; cv=pass;
+ARC-Seal: i=2; a=rsa-sha256; cv=pass; b=abc;
 ARC-Authentication-Results: i=2; spf=pass;

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -65,6 +65,9 @@
         <None Include="Data/arc-invalid.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/arc-missing-sig.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="Data/wildcard.pem">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -19,5 +19,14 @@ namespace DomainDetective.Tests {
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
+
+        [Fact]
+        public void MissingSignatureInvalidatesChain() {
+            var raw = File.ReadAllText("Data/arc-missing-sig.txt");
+            var hc = new DomainHealthCheck();
+            var result = hc.VerifyARC(raw);
+            Assert.True(result.ArcHeadersFound);
+            Assert.False(result.ValidChain);
+        }
     }
 }

--- a/DomainDetective/Protocols/ARCAnalysis.cs
+++ b/DomainDetective/Protocols/ARCAnalysis.cs
@@ -87,6 +87,11 @@ namespace DomainDetective {
                     allInstances.Add(inst.Value);
                     sealInstances.Add(inst.Value);
                 }
+
+                if (!HasSignature(seal)) {
+                    ValidChain = false;
+                    return;
+                }
             }
 
             if (allInstances.Count == 0) {
@@ -107,7 +112,7 @@ namespace DomainDetective {
         }
 
         private static int? ParseInstance(string value) {
-            foreach (var part in value.Split(';')) {
+            foreach (var part in value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
                 var trimmed = part.Trim();
                 if (trimmed.StartsWith("i=", StringComparison.OrdinalIgnoreCase)) {
                     if (int.TryParse(trimmed.Substring(2), out var num)) {
@@ -116,6 +121,16 @@ namespace DomainDetective {
                 }
             }
             return null;
+        }
+
+        private static bool HasSignature(string value) {
+            foreach (var part in value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)) {
+                var trimmed = part.Trim();
+                if (trimmed.StartsWith("b=", StringComparison.OrdinalIgnoreCase)) {
+                    return trimmed.Length > 2;
+                }
+            }
+            return false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- enforce presence of `b=` in ARC-Seal headers when validating chains
- improve instance parsing and add signature check helper
- update ARC test fixtures and add missing-signature test

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: 17, passed: 326)*

------
https://chatgpt.com/codex/tasks/task_e_68619ec23db4832e92f8fba5af75ca68