### PR TITLE
Adjust TTL warning thresholds

### DIFF
--- a/DomainDetective.Tests/TestDnsTtlAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsTtlAnalysis.cs
@@ -25,6 +25,20 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task WarnsBelowLowerBound() {
+            var analysis = Create(299);
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.Contains(analysis.Warnings, w => w.Contains("shorter"));
+        }
+
+        [Fact]
+        public async Task WarnsAboveUpperBound() {
+            var analysis = Create(86401);
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.Contains(analysis.Warnings, w => w.Contains("exceeds"));
+        }
+
+        [Fact]
         public async Task NoWarningsInRange() {
             var analysis = Create(3600);
             await analysis.Analyze("example.com", new InternalLogger());

--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -64,10 +64,10 @@ namespace DomainDetective {
 
             Evaluate("A", ATtls, 300, 86400);
             Evaluate("AAAA", AaaaTtls, 300, 86400);
-            Evaluate("MX", MxTtls, 3600, 172800);
-            Evaluate("NS", NsTtls, 3600, 604800);
+            Evaluate("MX", MxTtls, 300, 86400);
+            Evaluate("NS", NsTtls, 300, 86400);
             if (SoaTtl > 0) {
-                Evaluate("SOA", new[] { SoaTtl }, 3600, 86400);
+                Evaluate("SOA", new[] { SoaTtl }, 300, 86400);
             }
         }
 


### PR DESCRIPTION
## Summary
- warn when TTLs are below 300 or above 86400
- test TTL warning boundaries

## Testing
- `dotnet test`
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68622da41634832e92f825bf83f7ba03