### PR TITLE
Fix DMARC URI warnings

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -147,7 +147,7 @@ namespace DomainDetective.Tests {
             Assert.Equal("test@example.com", healthCheck.DmarcAnalysis.MailtoRua[0]);
             Assert.Single(healthCheck.DmarcAnalysis.HttpRuf);
             Assert.Equal("https://reports.example.com", healthCheck.DmarcAnalysis.HttpRuf[0]);
-            Assert.Contains(warnings, w => w.FullMessage.Contains("uses HTTP"));
+            Assert.Contains(warnings, w => w.FullMessage.Contains("HTTP instead of HTTPS"));
         }
 
         [Fact]

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -253,19 +253,20 @@ namespace DomainDetective {
                     } catch {
                         InvalidReportUri = true;
                     }
-                } else if (u.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) {
-                    if (Uri.TryCreate(u, UriKind.Absolute, out var parsed) && parsed.Scheme == Uri.UriSchemeHttps) {
-                        httpList.Add(u);
-                    } else {
-                        InvalidReportUri = true;
-                    }
-                } else if (u.StartsWith("http://", StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                if (!Uri.TryCreate(u, UriKind.Absolute, out var parsed)) {
+                    logger?.WriteWarning("Report URI {0} is missing a scheme.", u);
+                    InvalidReportUri = true;
+                    continue;
+                }
+
+                if (parsed.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
+                    httpList.Add(u);
+                } else if (parsed.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)) {
                     logger?.WriteWarning("Report URI {0} uses HTTP instead of HTTPS.", u);
-                    if (Uri.TryCreate(u, UriKind.Absolute, out var parsed) && parsed.Scheme == Uri.UriSchemeHttp) {
-                        httpList.Add(u);
-                    } else {
-                        InvalidReportUri = true;
-                    }
+                    httpList.Add(u);
                 } else {
                     logger?.WriteWarning("Report URI {0} is missing a scheme.", u);
                     InvalidReportUri = true;


### PR DESCRIPTION
## Summary
- refactor AddUriToList to always warn when a report URI uses HTTP or is missing a scheme
- adjust DMARC tests to match updated warning message

## Testing
- `dotnet build`
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68622ddc9f74832e953bd261248e9baa