### PR TITLE
Fix OpenRelay parser multiline SMTP

### DIFF
--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -103,19 +103,28 @@ namespace DomainDetective {
                 return null;
             }
 
-            string? current = line;
-            while (current.StartsWith("250-") || current.StartsWith("220-")) {
+            string code = line.Length >= 3 ? line.Substring(0, 3) : string.Empty;
+            string? lastLine = line;
+
+            while (line.Length >= 4 && line[3] == '-') {
 #if NET8_0_OR_GREATER
-                current = await reader.ReadLineAsync(token);
+                line = await reader.ReadLineAsync(token);
 #else
-                current = await reader.ReadLineAsync().WaitWithCancellation(token);
+                line = await reader.ReadLineAsync().WaitWithCancellation(token);
 #endif
-                if (current == null) {
+                if (line == null) {
+                    break;
+                }
+
+                if (line.StartsWith(code, StringComparison.Ordinal)) {
+                    lastLine = line;
+                } else {
+                    // Start of next response; ignore extra line
                     break;
                 }
             }
 
-            return current;
+            return lastLine;
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle multiline SMTP responses in OpenRelay parser
- test multiline response containing DATA

## Testing
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68622dc0badc832eab18cf91acad242e