### PR TITLE
Add ADSP detection in DKIM analysis

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -209,5 +209,21 @@ namespace DomainDetective.Tests {
             Assert.False(result.WeakKey);
             Assert.Equal(2048, result.KeyLength);
         }
+
+        [Fact]
+        public async Task DetectsAdspRecord() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "dkim=all", Type = DnsRecordType.TXT }
+            };
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var analysis = new DkimAnalysis();
+            await analysis.AnalyzeAdspRecord(answers, logger);
+
+            Assert.True(analysis.AdspRecordExists);
+            Assert.Equal("dkim=all", analysis.AdspRecord);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("obsolete"));
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -37,6 +37,11 @@ namespace DomainDetective {
                 return;
             }
 
+            var adsp = await DnsConfiguration.QueryDNS($"_adsp._domainkey.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
+            if (adsp.Any()) {
+                await DKIMAnalysis.AnalyzeAdspRecord(adsp, _logger);
+            }
+
             foreach (var selector in selectors) {
                 cancellationToken.ThrowIfCancellationRequested();
                 var dkim = await DnsConfiguration.QueryDNS(name: $"{selector}._domainkey.{domainName}", recordType: DnsRecordType.TXT, filter: "DKIM1", cancellationToken: cancellationToken);
@@ -91,6 +96,11 @@ namespace DomainDetective {
                         var selectors = dkimSelectors;
                         if (selectors == null || selectors.Length == 0) {
                             selectors = Definitions.DKIMSelectors.GuessSelectors().ToArray();
+                        }
+
+                        var adsp = await DnsConfiguration.QueryDNS($"_adsp._domainkey.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
+                        if (adsp.Any()) {
+                            await DKIMAnalysis.AnalyzeAdspRecord(adsp, _logger);
                         }
 
                         foreach (var selector in selectors) {


### PR DESCRIPTION
## Summary
- extend `DkimAnalysis` to query and store ADSP records
- warn when ADSP records are present
- include ADSP checks in domain verification
- test ADSP detection logic

## Testing
- `dotnet test DomainDetective.sln -c Release` *(fails: assert errors due to blocked network)*
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68622db32e18832e9fab1845d1e2e9ac