### PR TITLE
Expose root DNSSEC key tag

### DIFF
--- a/DomainDetective.Tests/TestDNSSECAnalysis.cs
+++ b/DomainDetective.Tests/TestDNSSECAnalysis.cs
@@ -12,6 +12,7 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DnsSecAnalysis.ChainValid);
             Assert.NotEmpty(healthCheck.DnsSecAnalysis.DsTtls);
             Assert.NotEmpty(healthCheck.DnsSecAnalysis.Rrsigs);
+            Assert.NotEqual(0, healthCheck.DnsSecAnalysis.RootKeyTag);
         }
 
         [Fact]

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -42,6 +42,7 @@ namespace DomainDetective {
                 DsMatch = analysis.DsMatch,
                 ChainValid = analysis.ChainValid,
                 DsTtls = analysis.DsTtls,
+                RootKeyTag = analysis.RootKeyTag,
             };
         }
 
@@ -117,6 +118,9 @@ namespace DomainDetective {
 
         /// <summary>TTL values for each DS lookup in the validation chain.</summary>
         public IReadOnlyList<int> DsTtls { get; set; }
+
+        /// <summary>Key tag for the root trust anchor.</summary>
+        public int RootKeyTag { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- include root trust anchor key tag in DNSSEC analysis
- surface root key tag through `DnsSecInfo`
- validate root key tag in DNSSEC tests

## Testing
- `dotnet test` *(fails: The argument ...)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686234f515b0832ea48ad2cfde7117a5