### PR TITLE
Add TLSA usage warning and test

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -272,6 +272,25 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task InvalidUsageTriggersWarning() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer {
+                    Name = "_25._tcp.example.com",
+                    DataRaw = "4 1 1 ABCD",
+                    Type = DnsRecordType.TLSA
+                }
+            };
+
+            var analysis = new DANEAnalysis();
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            await analysis.AnalyzeDANERecords(answers, logger);
+
+            Assert.Contains(warnings, w => w.FullMessage.Contains("usage '4' is invalid"));
+        }
+
+        [Fact]
         public async Task ServiceTypeDefaultsToHttps() {
             var record = "3 1 1 " + new string('A', 64);
             var analysis = new DANEAnalysis();

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -88,6 +88,12 @@ namespace DomainDetective {
                 analysis.ValidSelector = selectorParsed && ValidateSelector(selectorValue);
                 analysis.ValidCertificateAssociationData = IsHexadecimal(associationData);
 
+                if (!usageParsed) {
+                    logger?.WriteWarning($"TLSA usage field '{usagePart}' is not numeric");
+                } else if (!ValidateUsage(usageValue)) {
+                    logger?.WriteWarning($"TLSA usage '{usageValue}' is invalid, expected 0-3");
+                }
+
                 if (!selectorParsed) {
                     logger?.WriteWarning($"TLSA selector field '{selectorPart}' is not numeric");
                 } else if (!ValidateSelector(selectorValue)) {


### PR DESCRIPTION
## Summary
- warn when TLSA usage field is non-numeric or outside 0-3
- test new warning behaviour in DANE analysis

## Testing
- `dotnet test` *(fails: 17, passed: 354)*

------
https://chatgpt.com/codex/tasks/task_e_686240956abc832eb9457ed51dc8cc07