### PR TITLE
Fix ARC chain validation checks

### DIFF
--- a/DomainDetective.Tests/Data/arc-empty-sig.txt
+++ b/DomainDetective.Tests/Data/arc-empty-sig.txt
@@ -1,0 +1,4 @@
+ARC-Seal: i=1; a=rsa-sha256; cv=none; b=abc;
+ARC-Authentication-Results: i=1; spf=pass;
+ARC-Seal: i=2; a=rsa-sha256; cv=pass; b=;
+ARC-Authentication-Results: i=2; spf=pass;

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -68,6 +68,9 @@
         <None Include="Data/arc-missing-sig.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/arc-empty-sig.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="Data/wildcard.pem">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -28,5 +28,14 @@ namespace DomainDetective.Tests {
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
+
+        [Fact]
+        public void EmptySignatureInvalidatesChain() {
+            var raw = File.ReadAllText("Data/arc-empty-sig.txt");
+            var hc = new DomainHealthCheck();
+            var result = hc.VerifyARC(raw);
+            Assert.True(result.ArcHeadersFound);
+            Assert.False(result.ValidChain);
+        }
     }
 }

--- a/DomainDetective/Protocols/ARCAnalysis.cs
+++ b/DomainDetective/Protocols/ARCAnalysis.cs
@@ -75,23 +75,29 @@ namespace DomainDetective {
 
             foreach (var aar in ArcAuthenticationResultsHeaders) {
                 var inst = ParseInstance(aar);
-                if (inst != null) {
-                    allInstances.Add(inst.Value);
-                    aarInstances.Add(inst.Value);
+                if (inst == null) {
+                    ValidChain = false;
+                    return;
                 }
+
+                allInstances.Add(inst.Value);
+                aarInstances.Add(inst.Value);
             }
 
             foreach (var seal in ArcSealHeaders) {
-                var inst = ParseInstance(seal);
-                if (inst != null) {
-                    allInstances.Add(inst.Value);
-                    sealInstances.Add(inst.Value);
-                }
-
                 if (!HasSignature(seal)) {
                     ValidChain = false;
                     return;
                 }
+
+                var inst = ParseInstance(seal);
+                if (inst == null) {
+                    ValidChain = false;
+                    return;
+                }
+
+                allInstances.Add(inst.Value);
+                sealInstances.Add(inst.Value);
             }
 
             if (allInstances.Count == 0) {


### PR DESCRIPTION
## Summary
- return invalid when ARC headers are missing instances
- validate ARC-Seal `b=` parameters
- test ARC-Seal signature checks

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter FullyQualifiedName~TestARCAnalysis --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6862407e34d4832e8b07f9636aae18a0