### PR TITLE
Add Public Suffix flag to DomainSummary

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1053,6 +1053,7 @@ namespace DomainDetective {
                 DkimValid = dkimValid,
                 HasMxRecord = MXAnalysis.MxRecordExists,
                 DnsSecValid = DnsSecAnalysis?.ChainValid ?? false,
+                IsPublicSuffix = IsPublicSuffix,
                 ExpiryDate = WhoisAnalysis.ExpiryDate,
                 ExpiresSoon = WhoisAnalysis.ExpiresSoon,
                 IsExpired = WhoisAnalysis.IsExpired,

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -40,6 +40,13 @@ namespace DomainDetective {
         /// <summary>True when DNSSEC validation succeeded.</summary>
         public bool DnsSecValid { get; init; }
 
+        /// <summary>
+        /// Indicates whether the analyzed domain is itself a public suffix as
+        /// defined by <see href="https://datatracker.ietf.org/doc/html/rfc8499"/>
+        /// RFC&nbsp;8499.
+        /// </summary>
+        public bool IsPublicSuffix { get; init; }
+
         /// <summary>Expiration date reported by WHOIS.</summary>
         public string ExpiryDate { get; init; }
 

--- a/README.MD
+++ b/README.MD
@@ -245,6 +245,7 @@ await health.Verify("example.com");
 var summary = health.BuildSummary();
 Console.WriteLine($"Expires on: {summary.ExpiryDate}");
 Console.WriteLine($"Registrar lock: {summary.RegistrarLocked}");
+Console.WriteLine($"Is public suffix: {summary.IsPublicSuffix}");
 ```
 
 WHOIS snapshots can be stored by specifying a snapshot directory when running the CLI or PowerShell cmdlet. Comparing the latest data to the previous snapshot highlights registrar changes. Querying once a day is typically sufficient for monitoring purposes and avoids unnecessary load on WHOIS servers.


### PR DESCRIPTION
## Summary
- expose `IsPublicSuffix` flag in `DomainSummary`
- populate new flag from `DomainHealthCheck`
- document the new property in README

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: networking restrictions prevent tests from reaching external resources)*

------
https://chatgpt.com/codex/tasks/task_e_68624054d0d8832e9bf99b75cc5e823e