### PR TITLE
Handle unknown critical CAA tags

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -16,3 +16,7 @@
 - Added TTL analysis for common DNS record types
 - New `Test-DnsTtl` PowerShell cmdlet
 
+## 1.0.3
+
+### What's Changed
+- warn when CAA records use unknown critical tags

--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -203,5 +203,17 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidTag);
             Assert.False(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidFlag);
         }
+
+        [Fact]
+        public async Task UnknownCriticalPropertyTagTriggersWarning() {
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var healthCheck = new DomainHealthCheck(internalLogger: logger);
+
+            await healthCheck.CheckCAA("1 foo \"bar\"");
+
+            Assert.Contains(warnings, w => w.FullMessage.Contains("Unknown CAA property tag"));
+        }
     }
 }

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -142,7 +142,9 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                     } else {
                         analysis.Tag = CAATagType.Unknown;
                         analysis.InvalidTag = true;
-                        //continue;
+                        if (flag == 1) {
+                            logger?.WriteWarning("Unknown CAA property tag '{0}' flagged as critical", tag);
+                        }
                     }
 
                     // Validate value


### PR DESCRIPTION
## Summary
- warn when CAA records contain unknown critical tags
- test that warning is raised for critical unknown tags

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build` *(failed: The build stopped unexpectedly because of an unexpected logger failure)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~UnknownCriticalPropertyTagTriggersWarning" -v n`

------
https://chatgpt.com/codex/tasks/task_e_6862409d3b1c832eb81a3665a21b925c