### PR TITLE
Add canonicalization validation to DKIM analysis

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -153,11 +153,19 @@ namespace DomainDetective.Tests {
         public async Task InvalidCanonicalizationIsFlagged() {
             const string record = "v=DKIM1; k=rsa; c=foo/bar; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
 
-            var healthCheck = new DomainHealthCheck();
+            var logger = new InternalLogger();
+            LogEventArgs? error = null;
+            logger.OnErrorMessage += (_, e) => error = e;
+            var healthCheck = new DomainHealthCheck(internalLogger: logger);
             await healthCheck.CheckDKIM(record);
 
-            Assert.False(healthCheck.DKIMAnalysis.AnalysisResults["default"].ValidCanonicalization);
-            Assert.Equal("foo/bar", healthCheck.DKIMAnalysis.AnalysisResults["default"].Canonicalization);
+            var result = healthCheck.DKIMAnalysis.AnalysisResults["default"];
+            Assert.False(result.ValidCanonicalization);
+            Assert.Equal("foo/bar", result.Canonicalization);
+            Assert.Contains("foo", result.UnknownCanonicalizationModes);
+            Assert.Contains("bar", result.UnknownCanonicalizationModes);
+            Assert.NotNull(error);
+            Assert.Contains("Unknown canonicalization mode", error!.FullMessage);
         }
 
         [Fact]

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -117,9 +117,19 @@ namespace DomainDetective {
                         case "c":
                             analysis.Canonicalization = value;
                             var parts = value.ToLowerInvariant().Split('/');
-                            analysis.ValidCanonicalization =
-                                (parts.Length is 1 or 2) &&
-                                parts.All(p => p == "simple" || p == "relaxed");
+                            analysis.ValidCanonicalization = parts.Length is 1 or 2;
+                            foreach (var part in parts)
+                            {
+                                if (part != "simple" && part != "relaxed")
+                                {
+                                    analysis.ValidCanonicalization = false;
+                                    if (!analysis.UnknownCanonicalizationModes.Contains(part))
+                                    {
+                                        analysis.UnknownCanonicalizationModes.Add(part);
+                                        logger?.WriteError("Unknown canonicalization mode: {0}", part);
+                                    }
+                                }
+                            }
                             break;
                         case "h":
                             analysis.HashAlgorithm = value;
@@ -226,6 +236,8 @@ namespace DomainDetective {
         public string UnknownFlagCharacters { get; set; }
         /// <summary>Gets or sets a value indicating whether all flag characters are valid.</summary>
         public bool ValidFlags { get; set; }
+        /// <summary>Unrecognized canonicalization modes.</summary>
+        public List<string> UnknownCanonicalizationModes { get; } = new();
         /// <summary>Canonicalization modes specified in the record.</summary>
         public string Canonicalization { get; set; }
         /// <summary>Gets a value indicating whether the canonicalization string is valid.</summary>


### PR DESCRIPTION
## Summary
- parse `c=` tag and capture any unknown canonicalization values
- record error messages for bad canonicalization strings
- test invalid canonicalization string

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --filter InvalidCanonicalizationIsFlagged`

------
https://chatgpt.com/codex/tasks/task_e_68624084d19c832ea73222ad31e77bc0