### PR TITLE
Fix query line endings and ignore comment markers

### DIFF
--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -422,6 +422,9 @@ namespace DomainDetective {
                 if (string.IsNullOrWhiteSpace(trimmed))
                     continue;
 
+                if (trimmed.StartsWith(":%", StringComparison.Ordinal))
+                    continue;
+
                 bool enabled = true;
                 if (trimmed.StartsWith("#")) {
                     enabled = false;

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -383,7 +383,7 @@ public class WhoisAnalysis {
             await tcpClient.ConnectAsync(host, port).WaitWithCancellation(timeoutCts.Token);
 
             using NetworkStream networkStream = tcpClient.GetStream();
-            using (var streamWriter = new StreamWriter(networkStream, Encoding.ASCII, 1024, leaveOpen: true)) {
+            using (var streamWriter = new StreamWriter(networkStream, Encoding.ASCII, 1024, leaveOpen: true) { NewLine = "\r\n" }) {
                 await streamWriter.WriteLineAsync(domain).WaitWithCancellation(timeoutCts.Token);
                 await streamWriter.FlushAsync().WaitWithCancellation(timeoutCts.Token);
             }
@@ -953,7 +953,7 @@ public class WhoisAnalysis {
                 await client.ConnectAsync(host, port).WaitWithCancellation(timeoutCts.Token);
 
                 using NetworkStream stream = client.GetStream();
-                using (var writer = new StreamWriter(stream, Encoding.ASCII, 1024, leaveOpen: true)) {
+                using (var writer = new StreamWriter(stream, Encoding.ASCII, 1024, leaveOpen: true) { NewLine = "\r\n" }) {
                     await writer.WriteLineAsync(ipAddress).WaitWithCancellation(timeoutCts.Token);
                     await writer.FlushAsync().WaitWithCancellation(timeoutCts.Token);
                 }


### PR DESCRIPTION
## Summary
- normalize newline characters when issuing WHOIS queries
- skip `:%` entries when loading DNSBL lists

## Testing
- `dotnet test` *(fails: Invalid DNS URIs lead to multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6862404ce910832e9242335dc7fdb924