### PR TITLE
Validate AXFR sequence

### DIFF
--- a/DomainDetective.Tests/TestZoneTransferAnalysis.cs
+++ b/DomainDetective.Tests/TestZoneTransferAnalysis.cs
@@ -1,21 +1,39 @@
 namespace DomainDetective.Tests {
     public class TestZoneTransferAnalysis {
-        private static byte[] BuildResponse(byte rcode, ushort answerCount) {
+        private static byte[] BuildMessage(ushort id, byte rcode, ushort answerType) {
             var header = new byte[12];
+            header[0] = (byte)(id >> 8);
+            header[1] = (byte)(id & 0xFF);
+            header[2] = 0x80;
             header[3] = rcode;
-            header[6] = (byte)(answerCount >> 8);
-            header[7] = (byte)(answerCount & 0xFF);
-            var len = (ushort)header.Length;
-            var resp = new byte[len + 2];
-            resp[0] = (byte)(len >> 8);
-            resp[1] = (byte)(len & 0xFF);
-            System.Buffer.BlockCopy(header, 0, resp, 2, header.Length);
+            header[4] = 0x00;
+            header[5] = 0x01;
+            header[6] = 0x00;
+            header[7] = answerType == ushort.MaxValue ? (byte)0 : (byte)1;
+            var list = new System.Collections.Generic.List<byte>(32);
+            list.AddRange(header);
+            list.Add(0x00);
+            list.Add(0x00); list.Add(0xFC);
+            list.Add(0x00); list.Add(0x01);
+            if (answerType != ushort.MaxValue) {
+                list.Add(0x00);
+                list.Add((byte)(answerType >> 8));
+                list.Add((byte)(answerType & 0xFF));
+                list.Add(0x00); list.Add(0x01);
+                list.AddRange(new byte[4]);
+                list.Add(0x00); list.Add(0x00);
+            }
+            var msg = list.ToArray();
+            var resp = new byte[msg.Length + 2];
+            resp[0] = (byte)(msg.Length >> 8);
+            resp[1] = (byte)(msg.Length & 0xFF);
+            System.Buffer.BlockCopy(msg, 0, resp, 2, msg.Length);
             return resp;
         }
 
-        private static byte[] BuildResponse(bool allow) {
-            return BuildResponse(allow ? (byte)0x00 : (byte)0x05, allow ? (ushort)1 : (ushort)0);
-        }
+        private static byte[] BuildSoa(ushort id) => BuildMessage(id, 0, 6);
+        private static byte[] BuildAnswer(ushort id) => BuildMessage(id, 0, 1);
+        private static byte[] BuildError(ushort id) => BuildMessage(id, 5, ushort.MaxValue);
 
         [Fact]
         public async Task DetectOpenZoneTransfer() {
@@ -29,8 +47,11 @@ namespace DomainDetective.Tests {
                 await stream.ReadAsync(buffer, 0, 2);
                 int len = buffer[0] << 8 | buffer[1];
                 if (len > 0) { await stream.ReadAsync(buffer, 0, len); }
-                var resp = BuildResponse(true);
-                await stream.WriteAsync(resp, 0, resp.Length);
+                ushort id = (ushort)((buffer[0] << 8) | buffer[1]);
+                var start = BuildSoa(id);
+                var end = BuildSoa(id);
+                await stream.WriteAsync(start, 0, start.Length);
+                await stream.WriteAsync(end, 0, end.Length);
             });
 
             try {
@@ -55,7 +76,8 @@ namespace DomainDetective.Tests {
                 await stream.ReadAsync(buffer, 0, 2);
                 int len = buffer[0] << 8 | buffer[1];
                 if (len > 0) { await stream.ReadAsync(buffer, 0, len); }
-                var resp = BuildResponse(false);
+                ushort id = (ushort)((buffer[0] << 8) | buffer[1]);
+                var resp = BuildError(id);
                 await stream.WriteAsync(resp, 0, resp.Length);
             });
 
@@ -81,11 +103,14 @@ namespace DomainDetective.Tests {
                 await stream.ReadAsync(buffer, 0, 2);
                 int len = buffer[0] << 8 | buffer[1];
                 if (len > 0) { await stream.ReadAsync(buffer, 0, len); }
+                ushort id = (ushort)((buffer[0] << 8) | buffer[1]);
+                var start = BuildSoa(id);
+                await stream.WriteAsync(start, 0, start.Length);
                 for (int i = 0; i < 1000; i++) {
-                    var resp = BuildResponse(0x00, 0);
+                    var resp = BuildAnswer(id);
                     await stream.WriteAsync(resp, 0, resp.Length);
                 }
-                var finalResp = BuildResponse(0x00, 1);
+                var finalResp = BuildSoa(id);
                 await stream.WriteAsync(finalResp, 0, finalResp.Length);
             });
 
@@ -93,6 +118,35 @@ namespace DomainDetective.Tests {
                 var analysis = new ZoneTransferAnalysis();
                 await analysis.AnalyzeServers("example.com", new[] { "localhost:" + port }, new InternalLogger());
                 Assert.True(analysis.ServerResults["localhost:" + port]);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task DetectInvalidZoneTransfer() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                var buffer = new byte[512];
+                await stream.ReadAsync(buffer, 0, 2);
+                int len = buffer[0] << 8 | buffer[1];
+                if (len > 0) { await stream.ReadAsync(buffer, 0, len); }
+                ushort id = (ushort)((buffer[0] << 8) | buffer[1]);
+                var start = BuildSoa(id);
+                var mid = BuildAnswer(id);
+                await stream.WriteAsync(start, 0, start.Length);
+                await stream.WriteAsync(mid, 0, mid.Length);
+            });
+
+            try {
+                var analysis = new ZoneTransferAnalysis();
+                await analysis.AnalyzeServers("example.com", new[] { "localhost:" + port }, new InternalLogger());
+                Assert.False(analysis.ServerResults["localhost:" + port]);
             } finally {
                 listener.Stop();
                 await serverTask;


### PR DESCRIPTION
## Summary
- enhance ZoneTransferAnalysis to verify message IDs and SOA start/stop records
- update zone transfer tests
- add invalid zone transfer test

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686240698c64832eba0c59bf4f6292bb