### PR TITLE
Add banner sequence check

### DIFF
--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -313,6 +313,36 @@ namespace DomainDetective.Tests {
             }
         }
 
+        [Fact]
+        public async Task WarnsWhenBannerSequenceIncorrect() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("250 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost\r\n250-STARTTLS\r\n250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var logger = new InternalLogger();
+                var warnings = new System.Collections.Generic.List<LogEventArgs>();
+                logger.OnWarningMessage += (_, e) => warnings.Add(e);
+                var analysis = new STARTTLSAnalysis();
+                await analysis.AnalyzeServer("localhost", port, logger);
+                Assert.Contains(warnings, w => w.FullMessage.Contains("Unexpected banner sequence"));
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
         private static System.Security.Cryptography.X509Certificates.X509Certificate2 CreateSelfSigned() {
             using var rsa = System.Security.Cryptography.RSA.Create(2048);
             var req = new System.Security.Cryptography.X509Certificates.CertificateRequest(


### PR DESCRIPTION
## Summary
- log warning when SMTP banner or EHLO response is out of order
- test STARTTLS analysis when server banner is misordered

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: SOA record not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6862586eac70832ea2624935f5f9c83a