### PR TITLE
Add RFC algorithm validation for DNSSEC

### DIFF
--- a/DomainDetective.Tests/TestDNSSECUnknownAlgorithm.cs
+++ b/DomainDetective.Tests/TestDNSSECUnknownAlgorithm.cs
@@ -1,13 +1,15 @@
 using System.Reflection;
+using DomainDetective.Protocols;
 using Xunit;
 
 namespace DomainDetective.Tests {
     public class TestDnssecUnknownAlgorithm {
         [Fact]
-        public void UnknownAlgorithmNumberIsParsed() {
+        public void UnknownAlgorithmNumberIsInvalid() {
             var method = typeof(DnsSecAnalysis).GetMethod("AlgorithmNumber", BindingFlags.NonPublic | BindingFlags.Static)!;
             int value = (int)method.Invoke(null, new object[] { "99" })!;
-            Assert.Equal(99, value);
+            Assert.Equal(0, value);
+            Assert.False(DNSKeyAnalysis.IsValidAlgorithmNumber(value));
         }
     }
 }

--- a/DomainDetective/Protocols/DNSKeyAnalysis.cs
+++ b/DomainDetective/Protocols/DNSKeyAnalysis.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace DomainDetective.Protocols {
@@ -5,11 +6,18 @@ namespace DomainDetective.Protocols {
     /// Provides helpers for DNSKEY record validation.
     /// </summary>
     internal static class DNSKeyAnalysis {
+        private static readonly HashSet<int> ValidAlgorithms = new() {
+            0, 1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16, 17, 23, 252, 253, 254,
+        };
         /// <summary>
         /// Determines whether a string consists solely of hexadecimal characters.
         /// </summary>
         internal static bool IsHexadecimal(string input) {
             return Regex.IsMatch(input ?? string.Empty, @"\A[0-9a-fA-F]+\z");
+        }
+
+        internal static bool IsValidAlgorithmNumber(int number) {
+            return ValidAlgorithms.Contains(number);
         }
     }
 }

--- a/DomainDetective/Protocols/DNSKeyAnalysis.cs
+++ b/DomainDetective/Protocols/DNSKeyAnalysis.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Protocols {
     /// </summary>
     internal static class DNSKeyAnalysis {
         private static readonly HashSet<int> ValidAlgorithms = new() {
-            0, 1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16, 17, 23, 252, 253, 254,
+            1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16, 17, 23, 252, 253, 254,
         };
         /// <summary>
         /// Determines whether a string consists solely of hexadecimal characters.

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -169,6 +169,9 @@ namespace DomainDetective {
                 var flags = ushort.Parse(keyParts[0]);
                 var protocol = byte.Parse(keyParts[1]);
                 var algorithm = AlgorithmNumber(keyParts[2]);
+                if (!DNSKeyAnalysis.IsValidAlgorithmNumber(algorithm)) {
+                    return false;
+                }
                 var publicKeyBytes = Convert.FromBase64String(keyParts[3]);
 
                 var rdata = new List<byte>();
@@ -184,6 +187,9 @@ namespace DomainDetective {
 
                 var keyTag = int.Parse(dsParts[0]);
                 var dsAlgorithm = AlgorithmNumber(dsParts[1]);
+                if (!DNSKeyAnalysis.IsValidAlgorithmNumber(dsAlgorithm)) {
+                    return false;
+                }
                 var digestType = int.Parse(dsParts[2]);
                 var digest = dsParts[3];
                 if (!DNSKeyAnalysis.IsHexadecimal(digest)) {
@@ -257,7 +263,7 @@ namespace DomainDetective {
             }
 
             if (int.TryParse(name, out int numeric)) {
-                return numeric;
+                return DNSKeyAnalysis.IsValidAlgorithmNumber(numeric) ? numeric : 0;
             }
 
             return name.ToUpperInvariant() switch {


### PR DESCRIPTION
## Summary
- validate DNSSEC algorithm numbers against RFC list
- fail DS/DNSKEY matching on unknown algorithms
- expose algorithm validity check in `DNSKeyAnalysis`
- update test for invalid algorithm numbers

## Testing
- `dotnet test` *(fails: Assert errors)*

------
https://chatgpt.com/codex/tasks/task_e_6862587b1418832ebb40da346cc6e6a8