### PR TITLE
Add customizable CT log queries

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -99,6 +99,7 @@ The `CertificateAnalysis` result now includes:
 - `IsSelfSigned` when the certificate subject equals the issuer and the chain length is one.
 - With `CaptureTlsDetails` enabled, `TlsProtocol`, `CipherAlgorithm` and `CipherStrength` describe the negotiated cipher-suite.
 - `PresentInCtLogs` when the certificate appears in public CT logs.
+- `CtLogApiTemplates` allows customizing the list of CT log APIs queried.
 
 ### HTTP Security Headers
 `HttpAnalysis.DefaultSecurityHeaders` lists security headers that are inspected when header collection is enabled. The list includes `Content-Security-Policy`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy`, `Origin-Agent-Cluster` and several Cross-Origin policies. You can modify the list to capture additional headers.


### PR DESCRIPTION
## Summary
- allow querying multiple CT log APIs via `CtLogApiTemplates`
- document the new API list option

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: Assert.True() and others)*

------
https://chatgpt.com/codex/tasks/task_e_68625c2d0ab0832e907b106e9ab1f59b