### PR TITLE
Fix public suffix reset during verify

### DIFF
--- a/DomainDetective.Tests/TestPublicSuffix.cs
+++ b/DomainDetective.Tests/TestPublicSuffix.cs
@@ -22,5 +22,14 @@ namespace DomainDetective.Tests {
             await healthCheck.VerifySPF(domain);
             Assert.False(healthCheck.IsPublicSuffix);
         }
+
+        [Fact]
+        public async Task StateResetsAcrossMultipleDomains() {
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.Verify("com", [HealthCheckType.SPF]);
+            Assert.True(healthCheck.IsPublicSuffix);
+            await healthCheck.Verify("example.com", [HealthCheckType.SPF]);
+            Assert.False(healthCheck.IsPublicSuffix);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -62,6 +62,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
+            IsPublicSuffix = false;
             domainName = ToAscii(domainName);
             UpdateIsPublicSuffix(domainName);
             if (healthCheckTypes == null || healthCheckTypes.Length == 0) {


### PR DESCRIPTION
## Summary
- reset `IsPublicSuffix` at the start of `Verify`
- test that the flag resets when verifying multiple domains

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68627788ca78832e88dcb4642527f682