### PR TITLE
fix: handle empty dns server list

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -2,6 +2,7 @@ using DnsClientX;
 using DomainDetective;
 using System.Net;
 using System.Threading;
+using System.Linq;
 namespace DomainDetective.Tests {
     public class TestDnsPropagation {
         [Fact]
@@ -40,6 +41,13 @@ namespace DomainDetective.Tests {
 
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
                 await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers, cts.Token));
+        }
+
+        [Fact]
+        public async Task QueryReturnsEmptyWhenNoServers() {
+            var analysis = new DnsPropagationAnalysis();
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, Enumerable.Empty<PublicDnsEntry>());
+            Assert.Empty(results);
         }
 
         [Fact]

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -179,10 +179,14 @@ namespace DomainDetective {
         /// <param name="cancellationToken">Token used to cancel the operation.</param>
         /// <returns>A list of query results.</returns>
         public async Task<List<DnsPropagationResult>> QueryAsync(string domain, DnsRecordType recordType, IEnumerable<PublicDnsEntry> servers, CancellationToken cancellationToken = default) {
-            var results = new List<DnsPropagationResult>();
-            var tasks = servers.Select(server => QueryServerAsync(domain, recordType, server, cancellationToken));
-            results.AddRange(await Task.WhenAll(tasks));
-            return results;
+            var serverList = servers?.ToList() ?? new List<PublicDnsEntry>();
+            if (serverList.Count == 0) {
+                return new List<DnsPropagationResult>();
+            }
+
+            var tasks = serverList.Select(server => QueryServerAsync(domain, recordType, server, cancellationToken));
+            var results = await Task.WhenAll(tasks);
+            return results.ToList();
         }
 
         private static async Task<DnsPropagationResult> QueryServerAsync(string domain, DnsRecordType recordType, PublicDnsEntry server, CancellationToken cancellationToken) {


### PR DESCRIPTION
## Summary
- prevent `QueryAsync` from processing when server list is empty
- cover empty server list with a new unit test

## Testing
- `dotnet test DomainDetective.sln --verbosity minimal` *(fails: 17, passed: 374)*
- `dotnet build DomainDetective.sln -c Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6862777c04a0832eb6a9de9cc39e8974