### PR TITLE
Fix reverse DNS normalization

### DIFF
--- a/DomainDetective.Tests/TestFCrDnsAnalysis.cs
+++ b/DomainDetective.Tests/TestFCrDnsAnalysis.cs
@@ -59,4 +59,27 @@ public class TestFCrDnsAnalysis
         var result = Assert.Single(analysis.Results);
         Assert.False(result.ForwardConfirmed);
     }
+
+    [Fact]
+    public async Task TrailingDotInPtrRecordIsHandled()
+    {
+        var map = new Dictionary<(string, DnsRecordType), DnsAnswer[]>
+        {
+            [("mail.example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "1.1.1.3" } },
+            [("mail.example.com", DnsRecordType.AAAA)] = Array.Empty<DnsAnswer>()
+        };
+        var analysis = CreateAnalysis(map);
+        var reverse = new[]
+        {
+            new ReverseDnsAnalysis.ReverseDnsResult
+            {
+                IpAddress = "1.1.1.3",
+                PtrRecord = "mail.example.com.",
+                ExpectedHost = "mail.example.com"
+            }
+        };
+        await analysis.Analyze(reverse);
+        var result = Assert.Single(analysis.Results);
+        Assert.True(result.ForwardConfirmed);
+    }
 }

--- a/DomainDetective/Protocols/FCrDnsAnalysis.cs
+++ b/DomainDetective/Protocols/FCrDnsAnalysis.cs
@@ -53,14 +53,16 @@ public class FCrDnsAnalysis
                 continue;
             }
 
-            var a = await QueryDns(item.PtrRecord, DnsRecordType.A);
-            var aaaa = await QueryDns(item.PtrRecord, DnsRecordType.AAAA);
+            var normalizedPtr = item.PtrRecord.TrimEnd('.');
+
+            var a = await QueryDns(normalizedPtr, DnsRecordType.A);
+            var aaaa = await QueryDns(normalizedPtr, DnsRecordType.AAAA);
             bool match = a.Concat(aaaa).Any(r => r.Data == item.IpAddress);
-            logger?.WriteVerbose($"FCrDNS {item.PtrRecord} -> {string.Join(", ", a.Concat(aaaa).Select(r => r.Data))}");
+            logger?.WriteVerbose($"FCrDNS {normalizedPtr} -> {string.Join(", ", a.Concat(aaaa).Select(r => r.Data))}");
             Results.Add(new FCrDnsResult
             {
                 IpAddress = item.IpAddress,
-                PtrRecord = item.PtrRecord,
+                PtrRecord = normalizedPtr,
                 ForwardConfirmed = match
             });
         }

--- a/DomainDetective/Protocols/ReverseDnsAnalysis.cs
+++ b/DomainDetective/Protocols/ReverseDnsAnalysis.cs
@@ -43,7 +43,10 @@ namespace DomainDetective {
             public string? PtrRecord { get; set; }
             public string ExpectedHost { get; set; }
             /// <summary>True when <see cref="PtrRecord"/> equals <see cref="ExpectedHost"/>.</summary>
-            public bool IsValid => string.Equals(PtrRecord?.TrimEnd('.'), ExpectedHost.TrimEnd('.'), StringComparison.OrdinalIgnoreCase);
+            public bool IsValid => string.Equals(
+                PtrRecord?.TrimEnd('.'),
+                ExpectedHost?.TrimEnd('.'),
+                StringComparison.OrdinalIgnoreCase);
             /// <summary>True when PTR hostname resolves back to <see cref="IpAddress"/>.</summary>
             public bool FcrDnsValid { get; set; }
         }


### PR DESCRIPTION
## Summary
- normalize `ReverseDnsResult.IsValid` comparison
- respect normalized PTR name in `FCrDnsAnalysis`
- test that trailing dots in PTR records are handled

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~TestFCrDnsAnalysis`
- `dotnet test --no-build --filter FullyQualifiedName~TestReverseDnsAnalysis`


------
https://chatgpt.com/codex/tasks/task_e_686277748988832ebd8f6a146f9c0b83