### PR TITLE
Fix SmimeCertificateAnalysis expiration logic

### DIFF
--- a/DomainDetective.Tests/TestSmimeCertificate.cs
+++ b/DomainDetective.Tests/TestSmimeCertificate.cs
@@ -32,5 +32,16 @@ namespace DomainDetective.Tests {
             Assert.False(analysis.HasSecureEmailEku);
             Assert.False(analysis.IsTrustedRoot);
         }
+
+        [Fact]
+        public void CalculatesExpirationUsingUtc() {
+            var analysis = new SmimeCertificateAnalysis();
+            var path = Path.Combine("Data", "smime.pem");
+            analysis.AnalyzeFile(path);
+
+            var expected = (int)(analysis.Certificate.NotAfter - DateTime.UtcNow).TotalDays;
+            Assert.Equal(expected, analysis.DaysToExpire);
+            Assert.Equal(analysis.Certificate.NotAfter < DateTime.UtcNow, analysis.IsExpired);
+        }
     }
 }

--- a/DomainDetective/Protocols/SmimeCertificateAnalysis.cs
+++ b/DomainDetective/Protocols/SmimeCertificateAnalysis.cs
@@ -69,9 +69,9 @@ public class SmimeCertificateAnalysis {
             Chain.Add(new X509Certificate2(element.Certificate.RawData));
         }
 
-        DaysToExpire = (int)(Certificate.NotAfter - DateTime.Now).TotalDays;
+        DaysToExpire = (int)(Certificate.NotAfter - DateTime.UtcNow).TotalDays;
         DaysValid = (int)(Certificate.NotAfter - Certificate.NotBefore).TotalDays;
-        IsExpired = Certificate.NotAfter < DateTime.Now;
+        IsExpired = Certificate.NotAfter < DateTime.UtcNow;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- compute S/MIME certificate expiration using `DateTime.UtcNow`
- test that expiration uses UTC

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Failed: 17, Passed: 374)*

------
https://chatgpt.com/codex/tasks/task_e_6862776f32f0832e814870787c07707a