### PR TITLE
Fix UDP port detection logic

### DIFF
--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -18,7 +18,7 @@ namespace DomainDetective.Tests {
             var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
             var udpTask = Task.Run(async () => {
                 var r = await udpServer.ReceiveAsync();
-                await udpServer.SendAsync(r.Buffer, r.Buffer.Length, r.RemoteEndPoint);
+                await udpServer.SendAsync(new byte[] { 1 }, 1, r.RemoteEndPoint);
             });
 
             try {
@@ -46,7 +46,7 @@ namespace DomainDetective.Tests {
             var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
             var udpTask = Task.Run(async () => {
                 var r = await udpServer.ReceiveAsync();
-                await udpServer.SendAsync(r.Buffer, r.Buffer.Length, r.RemoteEndPoint);
+                await udpServer.SendAsync(new byte[] { 1 }, 1, r.RemoteEndPoint);
             });
 
             try {
@@ -76,6 +76,26 @@ namespace DomainDetective.Tests {
                 Assert.True(reachable);
             } finally {
                 listener.Stop();
+            }
+        }
+
+        [Fact]
+        public async Task UdpPortClosedWhenNoResponseData() {
+            var udpServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+            var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+            var udpTask = Task.Run(async () => {
+                var r = await udpServer.ReceiveAsync();
+                await udpServer.SendAsync(Array.Empty<byte>(), 0, r.RemoteEndPoint);
+            });
+
+            try {
+                var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+                await analysis.Scan("127.0.0.1", new[] { udpPort }, new InternalLogger());
+
+                Assert.False(analysis.Results[udpPort].UdpOpen);
+            } finally {
+                udpServer.Close();
+                await udpTask;
             }
         }
     }

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -122,7 +122,7 @@ public class PortScanAnalysis
                 {
                     cts.CancelAfter(Timeout);
                     var result = await udp.ReceiveAsync(cts.Token).ConfigureAwait(false);
-                    udpOpen = result.Buffer.Length >= 0;
+                    udpOpen = result.Buffer.Length > 0;
                 }
 #else
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))


### PR DESCRIPTION
## Summary
- validate UDP response length when scanning ports
- ensure tests send non-empty UDP replies
- test that empty UDP responses result in closed port detection

## Testing
- `dotnet test` *(fails: Failed: 17, Passed: 374)*

------
https://chatgpt.com/codex/tasks/task_e_686277507fa4832ea3b7f530a57244a8