### PR TITLE
Add certificate check type

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -179,6 +179,9 @@ namespace DomainDetective {
                         AutodiscoverAnalysis = new AutodiscoverAnalysis();
                         await AutodiscoverAnalysis.Analyze(domainName, DnsConfiguration, _logger, cancellationToken);
                         break;
+                    case HealthCheckType.CERT:
+                        await VerifyWebsiteCertificate(domainName, cancellationToken: cancellationToken);
+                        break;
                     case HealthCheckType.SECURITYTXT:
                         // lets reset the SecurityTXTAnalysis, so it's overwritten completly on next run
                         SecurityTXTAnalysis = new SecurityTXTAnalysis();


### PR DESCRIPTION
## Summary
- add CERT health check in `DomainHealthCheck.Verify`

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: domain lookups blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68627744feb0832ea7cca07ff5efbd81