### PR TITLE
Extend WHOIS check with IANA lookup

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1013,7 +1013,7 @@ namespace DomainDetective {
         }
 
         /// <summary>
-        /// Queries WHOIS information for a domain.
+        /// Queries WHOIS information and IANA RDAP for a domain.
         /// </summary>
         /// <param name="domain">Domain name to query.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
@@ -1023,6 +1023,7 @@ namespace DomainDetective {
             domain = ToAscii(domain);
             UpdateIsPublicSuffix(domain);
             await WhoisAnalysis.QueryWhoisServer(domain, cancellationToken);
+            await WhoisAnalysis.QueryIana(domain, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- query IANA RDAP after WHOIS lookup

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build` *(fails: DNS lookups blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862735d3fd8832e9d463db65a5caf7a