### PR TITLE
Add Unicode output option with IdnMapping

### DIFF
--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -2,18 +2,37 @@ using Spectre.Console;
 using System;
 using System.Collections;
 using System.Linq;
+using System.Globalization;
 
 namespace DomainDetective.CLI;
 
 internal static class CliHelpers
 {
+    private static readonly IdnMapping _idn = new();
     /// <summary>
     ///     Adds property rows for <paramref name="obj"/> to <paramref name="table"/>.
     /// </summary>
     /// <param name="table">Target table instance.</param>
     /// <param name="obj">Object to inspect.</param>
     /// <param name="listAsString">Renders list values as comma separated strings when true.</param>
-    private static void AddProperties(Table table, object obj, bool listAsString = false)
+    private static string FormatString(string? value, bool unicode)
+    {
+        if (!unicode || string.IsNullOrEmpty(value))
+        {
+            return value ?? "null";
+        }
+
+        try
+        {
+            return _idn.GetUnicode(value);
+        }
+        catch (ArgumentException)
+        {
+            return value;
+        }
+    }
+
+    private static void AddProperties(Table table, object obj, bool listAsString = false, bool unicode = false)
     {
         if (obj == null)
         {
@@ -28,7 +47,7 @@ internal static class CliHelpers
                 if (listAsString || value is byte[])
                 {
                     var listString = string.Join(", ", listValue.Cast<object>());
-                    table.AddRow(property.Name, listString);
+                    table.AddRow(property.Name, FormatString(listString, unicode));
                 }
                 else
                 {
@@ -37,7 +56,7 @@ internal static class CliHelpers
                     nested.AddColumn("Value");
                     for (var i = 0; i < listValue.Count; i++)
                     {
-                        nested.AddRow(i.ToString(), Markup.Escape(listValue[i]?.ToString() ?? "null"));
+                        nested.AddRow(i.ToString(), Markup.Escape(FormatString(listValue[i]?.ToString(), unicode)));
                     }
                     table.AddRow(new Markup(property.Name), nested);
                 }
@@ -50,14 +69,14 @@ internal static class CliHelpers
                 foreach (DictionaryEntry entry in dictionaryValue)
                 {
                     var key = Markup.Escape(entry.Key.ToString());
-                    var val = Markup.Escape(entry.Value?.ToString() ?? "null");
+                    var val = Markup.Escape(FormatString(entry.Value?.ToString(), unicode));
                     nested.AddRow(key, val);
                 }
                 table.AddRow(new Markup(property.Name), nested);
             }
             else
             {
-                table.AddRow(Markup.Escape(property.Name), Markup.Escape(value?.ToString() ?? "null"));
+                table.AddRow(Markup.Escape(property.Name), Markup.Escape(FormatString(value?.ToString(), unicode)));
             }
         }
     }
@@ -67,7 +86,7 @@ internal static class CliHelpers
     /// </summary>
     /// <param name="title">Panel header text.</param>
     /// <param name="data">Object, list or dictionary to display.</param>
-    public static void ShowPropertiesTable(string title, object data)
+    public static void ShowPropertiesTable(string title, object data, bool unicode = false)
     {
         var table = new Table().Border(TableBorder.Rounded);
         table.AddColumn("Property");
@@ -76,19 +95,19 @@ internal static class CliHelpers
         {
             foreach (DictionaryEntry entry in dictionary)
             {
-                AddProperties(table, entry.Value, true);
+                AddProperties(table, entry.Value, true, unicode);
             }
         }
         else if (data is IList list)
         {
             foreach (var item in list)
             {
-                AddProperties(table, item);
+                AddProperties(table, item, unicode: unicode);
             }
         }
         else
         {
-            AddProperties(table, data);
+            AddProperties(table, data, unicode: unicode);
         }
         var panel = new Panel(table)
         {

--- a/DomainDetective.Example/Helpers.cs
+++ b/DomainDetective.Example/Helpers.cs
@@ -28,7 +28,7 @@ namespace DomainDetective.Example {
         /// <param name="table">Table instance to add rows to.</param>
         /// <param name="obj">Object whose properties will be read.</param>
         /// <param name="listAsString">When true, list values are rendered as comma separated strings.</param>
-        private static void AddPropertiesTable(Table table, object obj, bool listAsString = false) {
+        private static void AddPropertiesTable(Table table, object obj, bool listAsString = false, bool unicode = false) {
             if (obj == null) {
                 return;
             }
@@ -76,7 +76,7 @@ namespace DomainDetective.Example {
         /// <param name="analysisOf">Title shown in the output panel.</param>
         /// <param name="objs">Object, dictionary or list to inspect.</param>
         /// <param name="perProperty">Currently unused.</param>
-        public static void ShowPropertiesTable(string analysisOf, object objs, bool perProperty = false) {
+        public static void ShowPropertiesTable(string analysisOf, object objs, bool perProperty = false, bool unicode = false) {
             var table = new Table();
             table.Border(TableBorder.Rounded);
 
@@ -102,12 +102,12 @@ namespace DomainDetective.Example {
                 table.AddColumn("Value");
 
                 foreach (var obj in list) {
-                    AddPropertiesTable(table, obj);
+                    AddPropertiesTable(table, obj, unicode: unicode);
                 }
             } else {
                 table.AddColumn("Property");
                 table.AddColumn("Value");
-                AddPropertiesTable(table, objs);
+                AddPropertiesTable(table, objs, unicode: unicode);
             }
 
             var panel = new Panel(table)

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -8,6 +8,9 @@ namespace DomainDetective {
         /// </summary>
         public bool UseSubdomainPolicy { get; set; }
 
+        /// <summary>Display domain names in Unicode where possible.</summary>
+        public bool UnicodeOutput { get; set; }
+
         /// <summary>DNS server used when querying records.</summary>
         /// <value>The endpoint for DNS queries.</value>
         public DnsEndpoint DnsEndpoint {

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1073,6 +1073,9 @@ namespace DomainDetective {
         /// </returns>
         public string ToJson(JsonSerializerOptions options = null) {
             options ??= new JsonSerializerOptions { WriteIndented = true };
+            if (UnicodeOutput && options.Converters.All(c => c is not IdnStringConverter)) {
+                options.Converters.Add(new IdnStringConverter(true));
+            }
             return JsonSerializer.Serialize(this, options);
         }
 

--- a/DomainDetective/IdnStringConverter.cs
+++ b/DomainDetective/IdnStringConverter.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective;
+
+internal sealed class IdnStringConverter : JsonConverter<string>
+{
+    private readonly bool _unicode;
+    private static readonly IdnMapping _idn = new();
+
+    public IdnStringConverter(bool unicode)
+    {
+        _unicode = unicode;
+    }
+
+    public override string Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) => reader.GetString()!;
+
+    public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+    {
+        if (_unicode && !string.IsNullOrEmpty(value))
+        {
+            try
+            {
+                value = _idn.GetUnicode(value);
+            }
+            catch (ArgumentException)
+            {
+                // ignore invalid IDN strings
+            }
+        }
+
+        writer.WriteStringValue(value);
+    }
+}

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -20,10 +20,17 @@ namespace DomainDetective;
 /// <para>Part of the DomainDetective project.</para>
 public class WhoisAnalysis {
     private string TLD { get; set; }
+    private static readonly IdnMapping _idn = new();
     private string _domainName;
     public string DomainName {
         get => _domainName;
-        set => _domainName = value;
+        set {
+            try {
+                _domainName = _idn.GetAscii(value.Trim().Trim('.'));
+            } catch (ArgumentException) {
+                _domainName = value;
+            }
+        }
     }
     public string Tld => TLD;
     public string Registrar { get; set; }


### PR DESCRIPTION
## Summary
- add UnicodeOutput setting and IdnStringConverter
- parse IDNs in DMARC parser and aggregate cmdlet
- handle IDNs when reading WHOIS data
- add --unicode CLI option and IDN formatting helpers

## Testing
- `dotnet restore`
- `dotnet build`
- `dotnet test --no-build` *(fails: DomainDetective.Tests.TestCertificateMonitor.ProducesSummaryCounts)*

------
https://chatgpt.com/codex/tasks/task_e_68627360c6ac832e8f1ea78fb981d316