### PR TITLE
Add IMAP/POP3 TLS analysis

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -532,6 +532,8 @@ internal class Program
                     HealthCheckType.ARC => hc.ArcAnalysis,
                     HealthCheckType.DANGLINGCNAME => hc.DanglingCnameAnalysis,
                     HealthCheckType.SMTPBANNER => hc.SmtpBannerAnalysis,
+                    HealthCheckType.IMAPTLS => hc.ImapTlsAnalysis,
+                    HealthCheckType.POP3TLS => hc.Pop3TlsAnalysis,
                     HealthCheckType.PORTAVAILABILITY => hc.PortAvailabilityAnalysis,
                     HealthCheckType.PORTSCAN => hc.PortScanAnalysis,
                     HealthCheckType.IPNEIGHBOR => hc.IPNeighborAnalysis,

--- a/DomainDetective.Example/ExampleAnalyseIMAPTLS.cs
+++ b/DomainDetective.Example/ExampleAnalyseIMAPTLS.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseImapTls() {
+        var analysis = new IMAPTLSAnalysis();
+        await analysis.AnalyzeServer("imap.gmail.com", 993, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("imap.gmail.com:993", out var result)) {
+            Helpers.ShowPropertiesTable("IMAP TLS", result);
+        }
+    }
+}

--- a/DomainDetective.Example/ExampleAnalysePOP3TLS.cs
+++ b/DomainDetective.Example/ExampleAnalysePOP3TLS.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalysePop3Tls() {
+        var analysis = new POP3TLSAnalysis();
+        await analysis.AnalyzeServer("pop.gmail.com", 995, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("pop.gmail.com:995", out var result)) {
+            Helpers.ShowPropertiesTable("POP3 TLS", result);
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletTestImapTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestImapTls.cs
@@ -1,0 +1,46 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Checks TLS configuration for a specific IMAP host.</summary>
+    /// <para>Part of the DomainDetective project.</para>
+    /// <example>
+    ///   <summary>Test IMAP TLS.</summary>
+    ///   <code>Test-ImapTls -HostName mail.example.com -Port 993</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "ImapTls", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestImapTls : AsyncPSCmdlet {
+        /// <param name="HostName">IMAP host to check.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string HostName;
+
+        /// <param name="Port">IMAP port number.</param>
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public int Port = 143;
+
+        /// <param name="ShowChain">Output certificate chain information.</param>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter ShowChain;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Checking IMAP TLS for {0}:{1}", HostName, Port);
+            await _healthCheck.CheckImapTlsHost(HostName, Port);
+            var result = _healthCheck.ImapTlsAnalysis.ServerResults[$"{HostName}:{Port}"];
+            WriteObject(result);
+            if (ShowChain && result.Chain.Count > 0) {
+                WriteObject(result.Chain, true);
+            }
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
+++ b/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
@@ -1,0 +1,46 @@
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Checks TLS configuration for a specific POP3 host.</summary>
+    /// <para>Part of the DomainDetective project.</para>
+    /// <example>
+    ///   <summary>Test POP3 TLS.</summary>
+    ///   <code>Test-Pop3Tls -HostName mail.example.com -Port 995</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "Pop3Tls", DefaultParameterSetName = "ServerName")]
+    public sealed class CmdletTestPop3Tls : AsyncPSCmdlet {
+        /// <param name="HostName">POP3 host to check.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
+        public string HostName;
+
+        /// <param name="Port">POP3 port number.</param>
+        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        public int Port = 110;
+
+        /// <param name="ShowChain">Output certificate chain information.</param>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter ShowChain;
+
+        private InternalLogger _logger;
+        private DomainHealthCheck _healthCheck;
+
+        protected override Task BeginProcessingAsync() {
+            _logger = new InternalLogger(false);
+            var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
+            internalLoggerPowerShell.ResetActivityIdCounter();
+            _healthCheck = new DomainHealthCheck(internalLogger: _logger);
+            return Task.CompletedTask;
+        }
+
+        protected override async Task ProcessRecordAsync() {
+            _logger.WriteVerbose("Checking POP3 TLS for {0}:{1}", HostName, Port);
+            await _healthCheck.CheckPop3TlsHost(HostName, Port);
+            var result = _healthCheck.Pop3TlsAnalysis.ServerResults[$"{HostName}:{Port}"];
+            WriteObject(result);
+            if (ShowChain && result.Chain.Count > 0) {
+                WriteObject(result.Chain, true);
+            }
+        }
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -123,6 +123,16 @@ public static class CheckDescriptions {
                 "Verify SMTP TLS configuration.",
                 null,
                 "Use modern TLS and strong ciphers."),
+            // Verify IMAP TLS
+            [HealthCheckType.IMAPTLS] = new(
+                "Verify IMAP TLS configuration.",
+                null,
+                "Use modern TLS and strong ciphers."),
+            // Verify POP3 TLS
+            [HealthCheckType.POP3TLS] = new(
+                "Verify POP3 TLS configuration.",
+                null,
+                "Use modern TLS and strong ciphers."),
             // Verify SMTP Banner
             [HealthCheckType.SMTPBANNER] = new(
                 "Verify SMTP banner.",

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -51,6 +51,10 @@ public enum HealthCheckType {
     STARTTLS,
     /// <summary>Verify SMTP TLS configuration.</summary>
     SMTPTLS,
+    /// <summary>Verify IMAP TLS configuration.</summary>
+    IMAPTLS,
+    /// <summary>Verify POP3 TLS configuration.</summary>
+    POP3TLS,
     /// <summary>Capture SMTP banner information.</summary>
     SMTPBANNER,
     /// <summary>Enumerate SMTP AUTH mechanisms.</summary>

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -206,6 +206,16 @@ namespace DomainDetective {
                         var smtpTlsHosts = mxRecordsForSmtpTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
                         await SmtpTlsAnalysis.AnalyzeServers(smtpTlsHosts, 25, _logger, cancellationToken);
                         break;
+                    case HealthCheckType.IMAPTLS:
+                        var mxRecordsForImapTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
+                        var imapTlsHosts = mxRecordsForImapTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
+                        await ImapTlsAnalysis.AnalyzeServers(imapTlsHosts, 143, _logger, cancellationToken);
+                        break;
+                    case HealthCheckType.POP3TLS:
+                        var mxRecordsForPop3Tls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
+                        var pop3TlsHosts = mxRecordsForPop3Tls.Select(r => r.Data.Split(' ')[1].Trim('.'));
+                        await Pop3TlsAnalysis.AnalyzeServers(pop3TlsHosts, 110, _logger, cancellationToken);
+                        break;
                     case HealthCheckType.SMTPBANNER:
                         var mxRecordsForBanner = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
                         var bannerHosts = mxRecordsForBanner.Select(r => r.Data.Split(' ')[1].Trim('.'));
@@ -440,6 +450,28 @@ namespace DomainDetective {
         public async Task CheckSmtpTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
             ValidatePort(port);
             await SmtpTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks a host for IMAP TLS capabilities.
+        /// </summary>
+        /// <param name="host">Target host name.</param>
+        /// <param name="port">Port to connect to. Must be between 1 and 65535.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task CheckImapTlsHost(string host, int port = 143, CancellationToken cancellationToken = default) {
+            ValidatePort(port);
+            await ImapTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks a host for POP3 TLS capabilities.
+        /// </summary>
+        /// <param name="host">Target host name.</param>
+        /// <param name="port">Port to connect to. Must be between 1 and 65535.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task CheckPop3TlsHost(string host, int port = 110, CancellationToken cancellationToken = default) {
+            ValidatePort(port);
+            await Pop3TlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -682,6 +714,38 @@ namespace DomainDetective {
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
             await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks all MX hosts for IMAP TLS configuration.
+        /// </summary>
+        /// <param name="domainName">Domain whose MX records are queried.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task VerifyIMAPTLS(string domainName, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                throw new ArgumentNullException(nameof(domainName));
+            }
+            domainName = ToAscii(domainName);
+            UpdateIsPublicSuffix(domainName);
+            var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
+            var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
+            await ImapTlsAnalysis.AnalyzeServers(tlsHosts, 143, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks all MX hosts for POP3 TLS configuration.
+        /// </summary>
+        /// <param name="domainName">Domain whose MX records are queried.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task VerifyPOP3TLS(string domainName, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                throw new ArgumentNullException(nameof(domainName));
+            }
+            domainName = ToAscii(domainName);
+            UpdateIsPublicSuffix(domainName);
+            var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
+            var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
+            await Pop3TlsAnalysis.AnalyzeServers(tlsHosts, 110, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -1126,6 +1190,8 @@ namespace DomainDetective {
             filtered.OpenRelayAnalysis = active.Contains(HealthCheckType.OPENRELAY) ? CloneAnalysis(OpenRelayAnalysis) : null;
             filtered.StartTlsAnalysis = active.Contains(HealthCheckType.STARTTLS) ? CloneAnalysis(StartTlsAnalysis) : null;
             filtered.SmtpTlsAnalysis = active.Contains(HealthCheckType.SMTPTLS) ? CloneAnalysis(SmtpTlsAnalysis) : null;
+            filtered.ImapTlsAnalysis = active.Contains(HealthCheckType.IMAPTLS) ? CloneAnalysis(ImapTlsAnalysis) : null;
+            filtered.Pop3TlsAnalysis = active.Contains(HealthCheckType.POP3TLS) ? CloneAnalysis(Pop3TlsAnalysis) : null;
             filtered.SmtpBannerAnalysis = active.Contains(HealthCheckType.SMTPBANNER) ? CloneAnalysis(SmtpBannerAnalysis) : null;
             filtered.SmtpAuthAnalysis = active.Contains(HealthCheckType.SMTPAUTH) ? CloneAnalysis(SmtpAuthAnalysis) : null;
             filtered.HttpAnalysis = active.Contains(HealthCheckType.HTTP) ? CloneAnalysis(HttpAnalysis) : null;

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -148,6 +148,22 @@ namespace DomainDetective {
         public SMTPTLSAnalysis SmtpTlsAnalysis { get; private set; } = new SMTPTLSAnalysis();
 
         /// <summary>
+        /// Gets the IMAP TLS analysis.
+        /// </summary>
+        /// <value>Results of IMAP TLS capability checks.</value>
+        public IMAPTLSAnalysis ImapTlsAnalysis { get; private set; } = new IMAPTLSAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public IMAPTLSAnalysis IMAPTLSAnalysis => ImapTlsAnalysis;
+
+        /// <summary>
+        /// Gets the POP3 TLS analysis.
+        /// </summary>
+        /// <value>Results of POP3 TLS capability checks.</value>
+        public POP3TLSAnalysis Pop3TlsAnalysis { get; private set; } = new POP3TLSAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public POP3TLSAnalysis POP3TLSAnalysis => Pop3TlsAnalysis;
+
+        /// <summary>
         /// Gets the SMTP banner analysis.
         /// </summary>
         /// <value>Initial greetings from SMTP servers.</value>

--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,8 @@ Current capabilities include:
 - [x] Verify STARTTLS (detect advertisement downgrades)
 - [x] Verify MTA-STS
 - [x] Verify SMTP TLS
+- [x] Verify IMAP TLS
+- [x] Verify POP3 TLS
 - [x] Verify SMTP Banner
 - [x] Verify TLS-RPT
 - [x] Verify BIMI


### PR DESCRIPTION
## Summary
- extend health checks to include IMAP and POP3 TLS
- integrate into DomainHealthCheck and CLI
- provide PowerShell cmdlets and examples for IMAP/POP3
- document new capabilities in README

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686273651694832eb57c8a21e02944c3