### PR TITLE
Remove Task.Yield in TLSRPT analysis

### DIFF
--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -24,7 +24,6 @@ namespace DomainDetective {
         public bool PolicyValid => TlsRptRecordExists && StartsCorrectly && RuaDefined;
 
         public async Task AnalyzeTlsRptRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger, CancellationToken cancellationToken = default) {
-            await Task.Yield();
             cancellationToken.ThrowIfCancellationRequested();
 
             TlsRptRecord = null;


### PR DESCRIPTION
## Summary
- remove unnecessary `Task.Yield` from TLSRPTAnalysis
- verify TLSRPT tests still pass

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~TestTLSRPTAnalysis"`

------
https://chatgpt.com/codex/tasks/task_e_6862836564a0832ebed173f5a20408d4