### PR TITLE
Validate host names with Uri.TryCreate

### DIFF
--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -41,6 +41,16 @@ namespace DomainDetective.Tests {
                 await healthCheck.VerifyPlainHttp(domain));
         }
 
+        [Theory]
+        [InlineData("invalid host")]
+        [InlineData("foo/bar")] 
+        [InlineData("http://example.com")] 
+        public async Task VerifyPlainHttpThrowsIfDomainInvalid(string domain) {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await healthCheck.VerifyPlainHttp(domain));
+        }
+
         private static int GetFreePort() {
             var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
             listener.Start();

--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -43,8 +43,9 @@ namespace DomainDetective.Tests {
 
         [Theory]
         [InlineData("invalid host")]
-        [InlineData("foo/bar")] 
-        [InlineData("http://example.com")] 
+        [InlineData("foo/bar")]
+        [InlineData("http://example.com")]
+        [InlineData("localhost:70000")]
         public async Task VerifyPlainHttpThrowsIfDomainInvalid(string domain) {
             var healthCheck = new DomainHealthCheck();
             await Assert.ThrowsAsync<ArgumentException>(async () =>

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -63,7 +63,7 @@ namespace DomainDetective {
                 throw new ArgumentNullException(nameof(domainName));
             }
             IsPublicSuffix = false;
-            domainName = ToAscii(domainName);
+            domainName = ValidateHostName(domainName);
             UpdateIsPublicSuffix(domainName);
             if (healthCheckTypes == null || healthCheckTypes.Length == 0) {
                 healthCheckTypes = new[]                {
@@ -1025,7 +1025,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = ValidateHostName(domainName);
             UpdateIsPublicSuffix(domainName);
             await HttpAnalysis.AnalyzeUrl($"http://{domainName}", false, _logger, cancellationToken: cancellationToken);
         }
@@ -1152,6 +1152,14 @@ namespace DomainDetective {
             if (port <= 0 || port > 65535) {
                 throw new ArgumentOutOfRangeException(nameof(port), "Port must be between 1 and 65535.");
             }
+        }
+
+        private static string ValidateHostName(string domainName) {
+            if (!Uri.TryCreate($"http://{domainName}", UriKind.Absolute, out _)) {
+                throw new ArgumentException("Invalid host name.", nameof(domainName));
+            }
+
+            return ToAscii(domainName);
         }
 
         /// <summary>Creates a copy with only the specified analyses included.</summary>

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1155,11 +1155,16 @@ namespace DomainDetective {
         }
 
         private static string ValidateHostName(string domainName) {
-            if (!Uri.TryCreate($"http://{domainName}", UriKind.Absolute, out _)) {
+            var trimmed = domainName?.Trim();
+            if (string.IsNullOrWhiteSpace(trimmed)) {
+                throw new ArgumentNullException(nameof(domainName));
+            }
+
+            if (Uri.CheckHostName(trimmed) == UriHostNameType.Unknown) {
                 throw new ArgumentException("Invalid host name.", nameof(domainName));
             }
 
-            return ToAscii(domainName);
+            return ToAscii(trimmed);
         }
 
         /// <summary>Creates a copy with only the specified analyses included.</summary>

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -158,6 +158,10 @@ public class MTASTSAnalysis {
         public async Task AnalyzePolicy(string domainName, InternalLogger logger) {
             Reset();
             Logger = logger;
+
+            if (!Uri.TryCreate($"http://{domainName}", UriKind.Absolute, out _)) {
+                throw new ArgumentException("Invalid host name.", nameof(domainName));
+            }
             Domain = domainName;
 
             var dns = await QueryDns($"_mta-sts.{domainName}", DnsRecordType.TXT);

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -43,6 +43,10 @@ namespace DomainDetective {
         public async Task AnalyzeSecurityTxtRecord(string domainName, InternalLogger logger, string pgpPublicKey = null) {
             Logger = logger;
 
+            if (!Uri.TryCreate($"http://{domainName}", UriKind.Absolute, out _)) {
+                throw new ArgumentException("Invalid host name.", nameof(domainName));
+            }
+
             Domain = domainName;
 
             string url = $"https://{domainName}/.well-known/security.txt";


### PR DESCRIPTION
## Summary
- ensure host names are validated using `Uri.TryCreate`
- guard against invalid hosts in security.txt and MTA-STS checks
- validate host names for plain HTTP verification
- test invalid host names

## Testing
- `dotnet test -v minimal` *(fails: The build stopped unexpectedly because of an unexpected logger failure)*

------
https://chatgpt.com/codex/tasks/task_e_686283516bb8832e8b82083b586eb36f