### PR TITLE
Fix DNS tunneling analysis null log handling

### DIFF
--- a/DomainDetective.Tests/TestDnsTunnelingAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsTunnelingAnalysis.cs
@@ -20,5 +20,13 @@ namespace DomainDetective.Tests {
             analysis.Analyze("example.com", logs);
             Assert.Contains(analysis.Alerts, a => a.Reason.Contains("High"));
         }
+
+        [Fact]
+        public void SkipsNullEntries() {
+            var analysis = new DnsTunnelingAnalysis();
+            string?[] logs = { null, "", "  ", "2024-01-01T00:00:00Z sub.example.com" };
+            analysis.Analyze("example.com", logs);
+            Assert.Empty(analysis.Alerts);
+        }
     }
 }

--- a/DomainDetective/Protocols/DnsTunnelingAnalysis.cs
+++ b/DomainDetective/Protocols/DnsTunnelingAnalysis.cs
@@ -22,10 +22,14 @@ public class DnsTunnelingAnalysis
     /// </summary>
     /// <param name="domainName">Domain to inspect.</param>
     /// <param name="logLines">Lines from DNS query logs.</param>
-    public void Analyze(string domainName, IEnumerable<string> logLines)
+    public void Analyze(string domainName, IEnumerable<string?>? logLines)
     {
         Alerts = new List<DnsTunnelingAlert>();
         var queue = new Queue<DateTimeOffset>();
+        if (logLines == null)
+        {
+            return;
+        }
         foreach (var line in logLines)
         {
             if (string.IsNullOrWhiteSpace(line))


### PR DESCRIPTION
## Summary
- handle null input collections in `DnsTunnelingAnalysis`
- test for log collections that include null entries

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68628371c224832e8a6eb98672305b16