### PR TITLE
Fix TcpClient disposal during port checks

### DIFF
--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -98,6 +98,22 @@ namespace DomainDetective.Tests {
                 await udpTask;
             }
         }
+
+        [Fact]
+        public async Task DetectsTcpClosedPort() {
+            var port = GetFreePort();
+            var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+            await analysis.Scan("127.0.0.1", new[] { port }, new InternalLogger());
+            Assert.False(analysis.Results[port].TcpOpen);
+        }
+
+        private static int GetFreePort() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
     }
 }
 

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -90,9 +90,10 @@ public class PortScanAnalysis
             }
         }
 
-        using (var client = new TcpClient(address.AddressFamily))
-        using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
+        var client = new TcpClient(address.AddressFamily);
+        try
         {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             cts.CancelAfter(Timeout);
             try
             {
@@ -107,6 +108,10 @@ public class PortScanAnalysis
             {
                 logger?.WriteVerbose("TCP {0}:{1} closed - {2}", address, port, ex.Message);
             }
+        }
+        finally
+        {
+            client.Dispose();
         }
         sw.Stop();
 

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -90,9 +90,10 @@ public class PortScanAnalysis
             }
         }
 
-        var client = new TcpClient(address.AddressFamily);
+        TcpClient? client = null;
         try
         {
+            client = new TcpClient(address.AddressFamily);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             cts.CancelAfter(Timeout);
             try
@@ -111,7 +112,7 @@ public class PortScanAnalysis
         }
         finally
         {
-            client.Dispose();
+            client?.Dispose();
         }
         sw.Stop();
 

--- a/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
+++ b/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
@@ -51,9 +51,10 @@ public class PortAvailabilityAnalysis
 
     private async Task<PortResult> CheckPort(string host, int port, InternalLogger logger, CancellationToken token)
     {
-        var client = new TcpClient();
+        TcpClient? client = null;
         try
         {
+            client = new TcpClient();
             client.SendTimeout = (int)Timeout.TotalMilliseconds;
             client.ReceiveTimeout = (int)Timeout.TotalMilliseconds;
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
@@ -78,7 +79,7 @@ public class PortAvailabilityAnalysis
         }
         finally
         {
-            client.Dispose();
+            client?.Dispose();
         }
     }
 }


### PR DESCRIPTION
## Summary
- dispose TcpClient instances in `PortScanAnalysis` and `PortAvailabilityAnalysis` using `try/finally`
- cover closed TCP ports in scanning tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test --no-build` *(fails: Invalid URI hostname, network tests)*
- `dotnet test --no-build --filter TestPortScanAnalysis`
- `dotnet test --no-build --filter TestPortAvailabilityAnalysis`


------
https://chatgpt.com/codex/tasks/task_e_686283ed088c832e8ed2b7f4c3c89a59