### PR TITLE
Fix progress calculations

### DIFF
--- a/DomainDetective.Tests/TestInternalLogger.cs
+++ b/DomainDetective.Tests/TestInternalLogger.cs
@@ -17,6 +17,20 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void ProgressEventHandlesSmallTotals() {
+            var logger = new InternalLogger();
+            LogEventArgs? eventArgs = null;
+            logger.OnProgressMessage += (_, e) => eventArgs = e;
+
+            logger.WriteProgress("activity", "operation", 1 * 100d / 2, 1, 2);
+            Assert.NotNull(eventArgs);
+            Assert.Equal(50, eventArgs!.ProgressPercentage);
+
+            logger.WriteProgress("activity", "operation", 1 * 100d / 3, 1, 3);
+            Assert.Equal(33, eventArgs!.ProgressPercentage);
+        }
+
+        [Fact]
         public void VerboseEventRaised() {
             var logger = new InternalLogger();
             LogEventArgs? eventArgs = null;

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -74,7 +74,7 @@ namespace DomainDetective {
             foreach (var host in list) {
                 cancellationToken.ThrowIfCancellationRequested();
                 processed++;
-                logger.WriteProgress("CertificateMonitor", host, processed * 100 / list.Count, processed, list.Count);
+                logger.WriteProgress("CertificateMonitor", host, processed * 100d / list.Count, processed, list.Count);
                 var analysis = new CertificateAnalysis();
                 await analysis.AnalyzeUrl(host, port, logger, cancellationToken);
                 var entry = new Entry {

--- a/DomainDetective/Logger/InternalLogger.cs
+++ b/DomainDetective/Logger/InternalLogger.cs
@@ -76,14 +76,16 @@ namespace DomainDetective {
             IsVerbose = isVerbose;
         }
 
-        public void WriteProgress(string activity, string currentOperation, int percentCompleted, int? currentSteps = null, int? totalSteps = null) {
+        public void WriteProgress(string activity, string currentOperation, double percentCompleted, int? currentSteps = null, int? totalSteps = null) {
             lock (_lock) {
-                OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, percentCompleted));
+                var roundedPercent = (int)Math.Round(percentCompleted);
+                OnProgressMessage?.Invoke(this, new LogEventArgs(activity, currentOperation, currentSteps, totalSteps, roundedPercent));
                 if (IsProgress) {
+                    var percentText = percentCompleted.ToString("F1");
                     if (currentSteps.HasValue && totalSteps.HasValue) {
-                        Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentCompleted, currentSteps, totalSteps);
+                        Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}% ({3} out of {4})", activity, currentOperation, percentText, currentSteps, totalSteps);
                     } else {
-                        Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}%", activity, currentOperation, percentCompleted);
+                        Console.WriteLine("[progress] activity: {0} / operation: {1} / percent completed: {2}%", activity, currentOperation, percentText);
                     }
                 }
             }

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -65,7 +65,7 @@ public class PortScanAnalysis
             {
                 semaphore.Release();
                 var done = Interlocked.Increment(ref processed);
-                logger?.WriteProgress("PortScan", port.ToString(), done * 100 / total, done, total);
+                logger?.WriteProgress("PortScan", port.ToString(), done * 100d / total, done, total);
             }
         });
         await Task.WhenAll(tasks).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- calculate progress using doubles and show one decimal
- handle small totals correctly
- cover edge cases with unit tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Assert.False()/True etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686283d58dcc832e9b1dbc974ea36f69