### PR TITLE
Add SocketError details to OpenRelayResult

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseOpenRelay.cs
+++ b/DomainDetective.Example/ExampleAnalyseOpenRelay.cs
@@ -8,7 +8,7 @@ public static partial class Program {
         var analysis = new OpenRelayAnalysis();
         await analysis.AnalyzeServer("smtp.gmail.com", 25, new InternalLogger());
         if (analysis.ServerResults.TryGetValue("smtp.gmail.com:25", out var result)) {
-            Console.WriteLine($"Relay status: {result}");
+            Console.WriteLine($"Relay status: {result.Status}, SocketError: {result.SocketErrorCode}");
         }
     }
 }

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
     /// <summary>Checks if an SMTP server is an open relay.</summary>
-    /// <para>Returns an <see cref="OpenRelayStatus"/> describing the result.</para>
+    /// <para>Returns an <see cref="OpenRelayAnalysis.OpenRelayResult"/> describing the result.</para>
     /// <example>
     ///   <summary>Test a mail server.</summary>
     /// <para>Part of the DomainDetective project.</para>

--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -28,7 +28,7 @@ namespace DomainDetective.Tests {
             try {
                 var analysis = new OpenRelayAnalysis();
                 await analysis.AnalyzeServer("localhost", port, new InternalLogger());
-                Assert.Equal(OpenRelayStatus.AllowsRelay, analysis.ServerResults[$"localhost:{port}"]);
+                Assert.Equal(OpenRelayStatus.AllowsRelay, analysis.ServerResults[$"localhost:{port}"].Status); 
             } finally {
                 listener.Stop();
                 await serverTask;
@@ -62,7 +62,7 @@ namespace DomainDetective.Tests {
             try {
                 var analysis = new OpenRelayAnalysis();
                 await analysis.AnalyzeServer("localhost", port, new InternalLogger());
-                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port}"]);
+                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port}"].Status); 
             } finally {
                 listener.Stop();
                 await serverTask;
@@ -130,7 +130,7 @@ namespace DomainDetective.Tests {
                 await analysis.AnalyzeServer("localhost", port2, new InternalLogger());
                 Assert.Single(analysis.ServerResults);
                 Assert.False(analysis.ServerResults.ContainsKey($"localhost:{port1}"));
-                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port2}"]);
+                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port2}"].Status); 
             } finally {
                 listener2.Stop();
                 await serverTask2;
@@ -188,8 +188,8 @@ namespace DomainDetective.Tests {
                 var analysis = new OpenRelayAnalysis();
                 await analysis.AnalyzeServers(new[] { "localhost" }, new[] { port1, port2 }, new InternalLogger());
                 Assert.Equal(2, analysis.ServerResults.Count);
-                Assert.Equal(OpenRelayStatus.AllowsRelay, analysis.ServerResults[$"localhost:{port1}"]);
-                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port2}"]);
+                Assert.Equal(OpenRelayStatus.AllowsRelay, analysis.ServerResults[$"localhost:{port1}"].Status);
+                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port2}"].Status);
             } finally {
                 listener1.Stop();
                 listener2.Stop();
@@ -235,7 +235,9 @@ namespace DomainDetective.Tests {
             var analysis = new OpenRelayAnalysis();
             await analysis.AnalyzeServer("localhost", port, new InternalLogger());
 
-            Assert.Equal(OpenRelayStatus.ConnectionFailed, analysis.ServerResults[$"localhost:{port}"]);
+            var result = analysis.ServerResults[$"localhost:{port}"];
+            Assert.Equal(OpenRelayStatus.ConnectionFailed, result.Status);
+            Assert.NotNull(result.SocketErrorCode);
         }
 
         [Fact]
@@ -269,7 +271,7 @@ namespace DomainDetective.Tests {
             try {
                 var analysis = new OpenRelayAnalysis();
                 await analysis.AnalyzeServer("localhost", port, new InternalLogger());
-                Assert.Equal(OpenRelayStatus.AllowsRelay, analysis.ServerResults[$"localhost:{port}"]);
+                Assert.Equal(OpenRelayStatus.AllowsRelay, analysis.ServerResults[$"localhost:{port}"].Status); 
             } finally {
                 listener.Stop();
                 await serverTask;


### PR DESCRIPTION
## Summary
- capture SocketException error codes in OpenRelayAnalysis
- surface socket error via `OpenRelayResult`
- update PowerShell cmdlet docs and example output
- adjust unit tests for the new result structure

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: Assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_686283c91840832eaac00e945cecca04