### PR TITLE
Fix PEM decode error handling

### DIFF
--- a/DomainDetective.Tests/Data/corrupt.pem
+++ b/DomainDetective.Tests/Data/corrupt.pem
@@ -1,0 +1,3 @@
+-----BEGIN CERTIFICATE-----
+invalidbase64
+-----END CERTIFICATE-----

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -83,6 +83,9 @@
         <None Include="Data/vmc.pem">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/corrupt.pem">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="Data/tlsrpt.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective.Tests/TestSmimeCertificate.cs
+++ b/DomainDetective.Tests/TestSmimeCertificate.cs
@@ -43,5 +43,14 @@ namespace DomainDetective.Tests {
             Assert.Equal(expected, analysis.DaysToExpire);
             Assert.Equal(analysis.Certificate.NotAfter < DateTime.UtcNow, analysis.IsExpired);
         }
+
+        [Fact]
+        public void CorruptedPemThrowsFormatException() {
+            var analysis = new SmimeCertificateAnalysis();
+            var path = Path.Combine("Data", "corrupt.pem");
+
+            var ex = Assert.Throws<FormatException>(() => analysis.AnalyzeFile(path));
+            Assert.Contains("Invalid PEM", ex.Message);
+        }
     }
 }

--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -264,7 +264,11 @@ namespace DomainDetective {
                 }
             }
             pem = pem.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
-            return Convert.FromBase64String(pem);
+            try {
+                return Convert.FromBase64String(pem);
+            } catch (FormatException ex) {
+                throw new FormatException("Invalid PEM data", ex);
+            }
         }
     }
 }

--- a/DomainDetective/Protocols/SmimeCertificateAnalysis.cs
+++ b/DomainDetective/Protocols/SmimeCertificateAnalysis.cs
@@ -105,6 +105,10 @@ public class SmimeCertificateAnalysis {
             }
         }
         pem = pem.Replace("\r", string.Empty).Replace("\n", string.Empty).Trim();
-        return Convert.FromBase64String(pem);
+        try {
+            return Convert.FromBase64String(pem);
+        } catch (FormatException ex) {
+            throw new FormatException("Invalid PEM data", ex);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- handle bad PEM inputs gracefully in SmimeCertificateAnalysis and BimiAnalysis
- add corrupted PEM file to test data
- assert FormatException is thrown when parsing corrupt PEM

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --verbosity minimal`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "FullyQualifiedName~CorruptedPemThrowsFormatException" --verbosity normal`
- `dotnet build DomainDetective.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686283b3e314832e9ad07ef8e0ce962e