### PR TITLE
Rename target parameter for threat intel checks

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -544,13 +544,15 @@ namespace DomainDetective {
         }
 
         /// <summary>Queries reputation services for threat listings.</summary>
-        public async Task VerifyThreatIntel(string target, CancellationToken cancellationToken = default) {
-            if (string.IsNullOrWhiteSpace(target)) {
-                throw new ArgumentNullException(nameof(target));
+        /// <param name="domainName">Domain or IP address to check.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task VerifyThreatIntel(string domainName, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(domainName)) {
+                throw new ArgumentNullException(nameof(domainName));
             }
-            target = ToAscii(target);
-            UpdateIsPublicSuffix(target);
-            await ThreatIntelAnalysis.Analyze(target, GoogleSafeBrowsingApiKey, PhishTankApiKey, VirusTotalApiKey, _logger, cancellationToken);
+            domainName = ToAscii(domainName);
+            UpdateIsPublicSuffix(domainName);
+            await ThreatIntelAnalysis.Analyze(domainName, GoogleSafeBrowsingApiKey, PhishTankApiKey, VirusTotalApiKey, _logger, cancellationToken);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- rename `target` to `domainName` in ThreatIntel methods
- document new `domainName` parameter

## Testing
- `dotnet test` *(fails: Invalid URI)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6862838de17c832e996cbf5ebe664144