### PR TITLE
Add TTL max boundary test

### DIFF
--- a/DomainDetective.Tests/TestDnsTtlAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsTtlAnalysis.cs
@@ -44,5 +44,12 @@ namespace DomainDetective.Tests {
             await analysis.Analyze("example.com", new InternalLogger());
             Assert.Empty(analysis.Warnings);
         }
+
+        [Fact]
+        public async Task MaxTtlPasses() {
+            var analysis = Create(86400);
+            await analysis.Analyze("example.com", new InternalLogger());
+            Assert.Empty(analysis.Warnings);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add unit test to ensure TTL 86400 is accepted without warnings

## Testing
- `dotnet test` *(fails: SOA record not found, unreachable hosts, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6862836b7090832e92cabf5daf827131