### PR TITLE
Use Path.Combine for data paths

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -165,7 +165,7 @@ internal class Program
         var propServers = new Option<FileInfo>("--servers-file")
         {
             Description = "Servers JSON file",
-            DefaultValueFactory = _ => new FileInfo("Data/DNS/PublicDNS.json")
+            DefaultValueFactory = _ => new FileInfo(Path.Combine("Data", "DNS", "PublicDNS.json"))
         };
         var propJson = new Option<bool>("--json", "Output raw JSON");
         var propCompare = new Option<bool>("--compare-results", "Return aggregated comparison of results");

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -7,7 +8,7 @@ namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            analysis.LoadServers(Path.Combine("Data", "DNS", "PublicDNS.json"));
             var servers = analysis.FilterServers(country: "United States", take: 3);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -7,7 +8,7 @@ namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationRegionsClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            analysis.LoadServers(Path.Combine("Data", "DNS", "PublicDNS.json"));
 
             var servers = analysis.FilterServers(take: 8);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -4,7 +4,7 @@ namespace DomainDetective.Tests {
     public class TestARCAnalysis {
         [Fact]
         public void ValidArcChain() {
-            var raw = File.ReadAllText("Data/arc-valid.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "arc-valid.txt"));
             var hc = new DomainHealthCheck();
             var result = hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
@@ -13,7 +13,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public void InvalidArcChain() {
-            var raw = File.ReadAllText("Data/arc-invalid.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "arc-invalid.txt"));
             var hc = new DomainHealthCheck();
             var result = hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
@@ -22,7 +22,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public void MissingSignatureInvalidatesChain() {
-            var raw = File.ReadAllText("Data/arc-missing-sig.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "arc-missing-sig.txt"));
             var hc = new DomainHealthCheck();
             var result = hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
@@ -31,7 +31,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public void EmptySignatureInvalidatesChain() {
-            var raw = File.ReadAllText("Data/arc-empty-sig.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "arc-empty-sig.txt"));
             var hc = new DomainHealthCheck();
             var result = hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);

--- a/DomainDetective.Tests/TestCertificateInfo.cs
+++ b/DomainDetective.Tests/TestCertificateInfo.cs
@@ -4,7 +4,7 @@ namespace DomainDetective.Tests {
     public class TestCertificateInfo {
         [Fact]
         public async Task WeakCertificateFlagsSet() {
-            var cert = new X509Certificate2("Data/weak.pem");
+            var cert = new X509Certificate2(Path.Combine("Data", "weak.pem"));
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.WeakKey);
@@ -15,7 +15,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task StrongCertificateNotFlagged() {
-            var cert = new X509Certificate2("Data/wildcard.pem");
+            var cert = new X509Certificate2(Path.Combine("Data", "wildcard.pem"));
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.False(analysis.WeakKey);
@@ -25,7 +25,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task SelfSignedFlagSet() {
-            var cert = new X509Certificate2("Data/wildcard.pem");
+            var cert = new X509Certificate2(Path.Combine("Data", "wildcard.pem"));
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.IsSelfSigned);

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Tests {
     public class TestDnsPropagation {
         [Fact]
         public void LoadServersAddsEntries() {
-            var file = "Data/DNS/PublicDNS.json";
+            var file = Path.Combine("Data", "DNS", "PublicDNS.json");
             var analysis = new DnsPropagationAnalysis();
             analysis.LoadServers(file, clearExisting: true);
             Assert.NotEmpty(analysis.Servers);

--- a/DomainDetective.Tests/TestFilterServersConcurrency.cs
+++ b/DomainDetective.Tests/TestFilterServersConcurrency.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.Tests {
     public class TestFilterServersConcurrency {
         [Fact]
         public async Task FilterServersHandlesConcurrency() {
-            var file = "Data/DNS/PublicDNS.json";
+            var file = Path.Combine("Data", "DNS", "PublicDNS.json");
             var analysis = new DnsPropagationAnalysis();
             analysis.LoadServers(file, clearExisting: true);
 

--- a/DomainDetective.Tests/TestMessageHeaderAnalysis.cs
+++ b/DomainDetective.Tests/TestMessageHeaderAnalysis.cs
@@ -4,7 +4,7 @@ namespace DomainDetective.Tests {
     public class TestMessageHeaderAnalysis {
         [Fact]
         public void ParseMessageHeaders() {
-            var raw = File.ReadAllText("Data/sample-headers.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "sample-headers.txt"));
             var analysis = new MessageHeaderAnalysis();
             analysis.Parse(raw, new InternalLogger());
 

--- a/DomainDetective.Tests/TestMessageHeaderDuplicates.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDuplicates.cs
@@ -4,7 +4,7 @@ namespace DomainDetective.Tests {
     public class TestMessageHeaderDuplicates {
         [Fact]
         public void ParseHeadersWithDuplicates() {
-            var raw = File.ReadAllText("Data/sample-headers-duplicate.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "sample-headers-duplicate.txt"));
             var analysis = new MessageHeaderAnalysis();
             analysis.Parse(raw, new InternalLogger());
 

--- a/DomainDetective.Tests/TestMessageHeaderMalformed.cs
+++ b/DomainDetective.Tests/TestMessageHeaderMalformed.cs
@@ -4,7 +4,7 @@ namespace DomainDetective.Tests {
     public class TestMessageHeaderMalformed {
         [Fact]
         public void ParseHeadersWithMalformedLines() {
-            var raw = File.ReadAllText("Data/sample-headers-malformed.txt");
+            var raw = File.ReadAllText(Path.Combine("Data", "sample-headers-malformed.txt"));
             var analysis = new MessageHeaderAnalysis();
             analysis.Parse(raw, new InternalLogger());
 

--- a/DomainDetective.Tests/TestTlsRptJsonParser.cs
+++ b/DomainDetective.Tests/TestTlsRptJsonParser.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.Tests {
     public class TestTlsRptJsonParser {
         [Fact]
         public void ParseSampleReport() {
-            var summaries = TlsRptJsonParser.ParseReport("Data/tlsrpt.json").ToList();
+            var summaries = TlsRptJsonParser.ParseReport(Path.Combine("Data", "tlsrpt.json")).ToList();
             Assert.Single(summaries);
             Assert.Equal("mx.example.com", summaries[0].MxHost);
             Assert.Equal(90, summaries[0].SuccessfulSessions);

--- a/DomainDetective.Tests/TestWildcardCertificate.cs
+++ b/DomainDetective.Tests/TestWildcardCertificate.cs
@@ -5,7 +5,7 @@ namespace DomainDetective.Tests {
     public class TestWildcardCertificate {
         [Fact]
         public async Task DetectsWildcardAndSubdomains() {
-            var cert = new X509Certificate2("Data/wildcard.pem");
+            var cert = new X509Certificate2(Path.Combine("Data", "wildcard.pem"));
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.IsWildcardCertificate);
@@ -17,7 +17,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task WarnsOnUnrelatedHosts() {
-            var cert = new X509Certificate2("Data/multi.pem");
+            var cert = new X509Certificate2(Path.Combine("Data", "multi.pem"));
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
             await analysis.AnalyzeCertificate(cert);
             Assert.True(analysis.SecuresUnrelatedHosts);

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -5,7 +5,7 @@ Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 $Results = Test-DnsPropagation -DomainName 'google.com' -RecordType A -CompareResults
 $Results | Format-Table
 
-$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $PSScriptRoot/../Data/DNS/PublicDNS.json
+$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile (Join-Path $PSScriptRoot '..' 'Data' 'DNS' 'PublicDNS.json')
 $PublicServers | Format-Table
 
 $TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -23,7 +23,7 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```
 - `Test-DnsPropagation` – checks how DNS records propagate across public resolvers.
   ```powershell
-  Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile './Data/DNS/PublicDNS.json' -CompareResults
+  Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile (Join-Path '.' 'Data' 'DNS' 'PublicDNS.json') -CompareResults
   ```
 - `Test-CaaRecord` – validates CAA entries.
   ```powershell


### PR DESCRIPTION
## Summary
- use `Path.Combine` in example apps, CLI and tests
- update PowerShell example and README paths

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: DomainDetective.Tests.dll)*

------
https://chatgpt.com/codex/tasks/task_e_686283e01d34832ebd40e36b12058903