### PR TITLE
Use string.Create for DNS query names

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -19,19 +19,16 @@ namespace DomainDetective {
 
         private static string CreateServiceQuery(int port, string domain) {
 #if NET6_0_OR_GREATER
-            return string.Create(domain.Length + 12, (port, domain), static (span, state) => {
-                var (p, d) = state;
-                var written = 0;
-                span[written++] = '_';
-                p.TryFormat(span.Slice(written), out var digits);
-                written += digits;
-                span[written++] = '.';
-                span[written++] = '_';
-                span[written++] = 't';
-                span[written++] = 'c';
-                span[written++] = 'p';
-                span[written++] = '.';
-                d.AsSpan().CopyTo(span.Slice(written));
+            var portString = port.ToString(CultureInfo.InvariantCulture);
+            return string.Create(portString.Length + domain.Length + 7, (portString, domain), static (span, state) => {
+                var (digits, host) = state;
+                var pos = 0;
+                span[pos++] = '_';
+                digits.AsSpan().CopyTo(span[pos..]);
+                pos += digits.Length;
+                "._tcp.".AsSpan().CopyTo(span[pos..]);
+                pos += 6;
+                host.AsSpan().CopyTo(span[pos..]);
             });
 #else
             return $"_{port}._tcp.{domain}";


### PR DESCRIPTION
## Summary
- refactor DANE verification helpers
- build the `_port._tcp.domain` strings using `string.Create`

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: SOA record not found)*

------
https://chatgpt.com/codex/tasks/task_e_686292ef1b90832ea3448fd67788542f