### PR TITLE
Set common default DNS user agent

### DIFF
--- a/DomainDetective/DnsConfiguration.cs
+++ b/DomainDetective/DnsConfiguration.cs
@@ -10,6 +10,11 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class DnsConfiguration {
+        internal const string DefaultUserAgent = "Mozilla/5.0";
+        /// <summary>
+        /// Gets or sets the default User-Agent header for DNS queries.
+        /// </summary>
+        public string UserAgent { get; set; } = DefaultUserAgent;
         /// <summary>
         /// Gets or sets the DNS endpoint.
         /// </summary>
@@ -45,6 +50,7 @@ namespace DomainDetective {
                 throw new ArgumentNullException(nameof(name), $"Domain name cannot be null or empty when querying {recordType} records.");
             }
             ClientX client = new(endpoint: DnsEndpoint, DnsSelectionStrategy);
+            client.EndpointConfiguration.UserAgent = UserAgent;
             if (filter != string.Empty) {
                 var data = await client.ResolveFilter(name, recordType, filter);
                 return data.Answers;
@@ -65,6 +71,7 @@ namespace DomainDetective {
             List<DnsAnswer> allAnswers = new();
 
             ClientX client = new(endpoint: DnsEndpoint, DnsSelectionStrategy);
+            client.EndpointConfiguration.UserAgent = UserAgent;
             DnsResponse[] data;
             if (filter != string.Empty) {
                 data = await client.ResolveFilter(names, recordType, filter);
@@ -88,6 +95,7 @@ namespace DomainDetective {
                 throw new ArgumentNullException(nameof(names), $"No domain names provided for querying {recordType} records.");
             }
             ClientX client = new(endpoint: DnsEndpoint, DnsSelectionStrategy);
+            client.EndpointConfiguration.UserAgent = UserAgent;
             DnsResponse[] data = filter != string.Empty
                 ? await client.ResolveFilter(names, recordType, filter)
                 : await client.Resolve(names, recordType);

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -193,6 +193,7 @@ namespace DomainDetective {
             var sw = Stopwatch.StartNew();
             try {
                 var client = new ClientX(server.IPAddress, DnsRequestFormat.DnsOverUDP, 53);
+                client.EndpointConfiguration.UserAgent = DnsConfiguration.DefaultUserAgent;
                 cancellationToken.ThrowIfCancellationRequested();
                 var response = await client.Resolve(domain, recordType);
                 sw.Stop();


### PR DESCRIPTION
## Summary
- add default User-Agent property in `DnsConfiguration`
- reference the default in propagation checks

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68628460b89c832e94a7af38f148114a