### PR TITLE
Replace generic exception with NotSupportedException

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1018,7 +1018,7 @@ namespace DomainDetective {
                         records = new[] { new DnsAnswer { DataRaw = domainName } };
                         break;
                     default:
-                        throw new System.Exception("Service type not implemented.");
+                        throw new NotSupportedException("Service type not implemented.");
                 }
 
                 var recordData = records.Select(x => x.Data ?? x.DataRaw).Distinct();


### PR DESCRIPTION
## Summary
- throw `NotSupportedException` for unsupported service types

## Testing
- `dotnet build DomainDetective.sln -c Release -v minimal`
- `dotnet test DomainDetective.sln -c Release -v minimal` *(fails: Invalid URI)*

------
https://chatgpt.com/codex/tasks/task_e_6862da73134c832e8f55489e6a16f78c