### PR TITLE
Handle empty health check list

### DIFF
--- a/DomainDetective.Tests/TestEmptyHealthCheckTypes.cs
+++ b/DomainDetective.Tests/TestEmptyHealthCheckTypes.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestEmptyHealthCheckTypes {
+        [Fact]
+        public async Task VerifyWithEmptyHealthCheckTypesReturns() {
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.Verify("example.com", Array.Empty<HealthCheckType>());
+            Assert.False(healthCheck.IsPublicSuffix);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -89,7 +89,7 @@ namespace DomainDetective {
             IsPublicSuffix = false;
             domainName = ValidateHostName(domainName);
             UpdateIsPublicSuffix(domainName);
-            if (healthCheckTypes == null || healthCheckTypes.Length == 0) {
+            if (healthCheckTypes == null) {
                 healthCheckTypes = new[]                {
                     HealthCheckType.DMARC,
                     HealthCheckType.SPF,
@@ -104,6 +104,10 @@ namespace DomainDetective {
             }
 
             healthCheckTypes = healthCheckTypes.Distinct().ToArray();
+
+            if (healthCheckTypes.Length == 0) {
+                return;
+            }
 
             foreach (var healthCheckType in healthCheckTypes) {
                 cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary
- return early if there are no health checks after deduplication
- add test verifying `Verify` handles an empty health check list

## Testing
- `dotnet test --verbosity minimal` *(fails: DomainDetective.Tests.dll, 17 failed, 394 passed)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "FullyQualifiedName~TestEmptyHealthCheckTypes" --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6862da652c30832eb540427b06dae7c4