### PR TITLE
Fix typo in comment

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -208,7 +208,7 @@ namespace DomainDetective {
                         await VerifyWebsiteCertificate(domainName, cancellationToken: cancellationToken);
                         break;
                     case HealthCheckType.SECURITYTXT:
-                        // lets reset the SecurityTXTAnalysis, so it's overwritten completly on next run
+                        // lets reset the SecurityTXTAnalysis, so it's overwritten completely on next run
                         SecurityTXTAnalysis = new SecurityTXTAnalysis();
                         await SecurityTXTAnalysis.AnalyzeSecurityTxtRecord(domainName, _logger);
                         break;


### PR DESCRIPTION
## Summary
- fix spelling in SecurityTXT analysis comment
- regenerate PowerShell help documentation

## Testing
- `dotnet build DomainDetective.PowerShell/DomainDetective.PowerShell.csproj -c Release`
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails)*

------
https://chatgpt.com/codex/tasks/task_e_6862da5e5ce4832eaaac729017acd648