### PR TITLE
Add static JsonSerializerOptions

### DIFF
--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -57,7 +57,7 @@ internal static class CommandUtilities {
         var result = hc.CheckMessageHeaders(headerText);
 
         if (json) {
-            var jsonText = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+            var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
             Console.WriteLine(jsonText);
         } else {
             CliHelpers.ShowPropertiesTable("Message Header Analysis", result, false);
@@ -87,7 +87,7 @@ internal static class CommandUtilities {
         var result = hc.VerifyARC(headerText);
 
         if (json) {
-            var jsonText = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+            var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
             Console.WriteLine(jsonText);
         } else {
             CliHelpers.ShowPropertiesTable("ARC Analysis", result, false);
@@ -106,7 +106,7 @@ internal static class CommandUtilities {
         hc.CheckDnsTunneling(domain);
         var result = hc.DnsTunnelingAnalysis;
         if (json) {
-            var jsonText = JsonSerializer.Serialize(result, new JsonSerializerOptions { WriteIndented = true });
+            var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
             Console.WriteLine(jsonText);
         } else {
             CliHelpers.ShowPropertiesTable($"DNS Tunneling for {domain}", result, false);

--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -30,7 +30,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         if (settings.Compare) {
             var groups = DnsPropagationAnalysis.CompareResults(results);
             if (settings.Json) {
-                Console.WriteLine(JsonSerializer.Serialize(groups));
+                Console.WriteLine(JsonSerializer.Serialize(groups, DomainHealthCheck.JsonOptions));
             } else {
                 foreach (var kvp in groups) {
                     Console.WriteLine($"{kvp.Key}: {string.Join(',', kvp.Value.Select(s => s.IPAddress))}");
@@ -38,7 +38,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
             }
         } else {
             if (settings.Json) {
-                Console.WriteLine(JsonSerializer.Serialize(results));
+                Console.WriteLine(JsonSerializer.Serialize(results, DomainHealthCheck.JsonOptions));
             } else {
                 foreach (var r in results) {
                     Console.WriteLine($"{r.Server.IPAddress} {r.Success} {string.Join(',', r.Records)}");

--- a/DomainDetective.Tests/TestJsonSerialization.cs
+++ b/DomainDetective.Tests/TestJsonSerialization.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+
+namespace DomainDetective.Tests {
+    public class TestJsonSerialization {
+        [Fact]
+        public void HealthCheckSerializationConsistent() {
+            var hc = new DomainHealthCheck();
+            var json1 = hc.ToJson();
+            var json2 = JsonSerializer.Serialize(hc, DomainHealthCheck.JsonOptions);
+            Assert.Equal(json1, json2);
+        }
+
+        [Fact]
+        public void SummarySerializationConsistent() {
+            var hc = new DomainHealthCheck();
+            var summary = hc.BuildSummary();
+            var json1 = JsonSerializer.Serialize(summary, DomainHealthCheck.JsonOptions);
+            var json2 = JsonSerializer.Serialize(summary, DomainHealthCheck.JsonOptions);
+            Assert.Equal(json1, json2);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1180,9 +1180,11 @@ namespace DomainDetective {
         /// <see cref="DomainHealthCheck"/>.</para>
         /// </returns>
         public string ToJson(JsonSerializerOptions options = null) {
-            options ??= new JsonSerializerOptions { WriteIndented = true };
+            options ??= JsonOptions;
             if (UnicodeOutput && options.Converters.All(c => c is not IdnStringConverter)) {
-                options.Converters.Add(new IdnStringConverter(true));
+                var local = new JsonSerializerOptions(options);
+                local.Converters.Add(new IdnStringConverter(true));
+                return JsonSerializer.Serialize(this, local);
             }
             return JsonSerializer.Serialize(this, options);
         }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -14,6 +14,11 @@ namespace DomainDetective {
         private PublicSuffixList _publicSuffixList;
         private const string DefaultPublicSuffixListUrl = "https://raw.githubusercontent.com/EvotecIT/DomainDetective/refs/heads/master/Data/public_suffix_list.dat";
 
+        public static readonly JsonSerializerOptions JsonOptions = new()
+        {
+            WriteIndented = true
+        };
+
         /// <summary>
         /// Indicates whether the last verified domain is itself a public suffix.
         /// </summary>

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -64,7 +64,7 @@ public class ThreatIntelAnalysis
                 threatEntries = new[] { new { url = domainName } }
             }
         };
-        var json = JsonSerializer.Serialize(payload);
+        var json = JsonSerializer.Serialize(payload, DomainHealthCheck.JsonOptions);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var resp = await _client.PostAsync(url, content, ct);
         return await ReadAsStringAsync(resp);


### PR DESCRIPTION
## Summary
- reuse a shared JsonSerializerOptions instance
- update CLI and threat intel serialization
- add tests verifying consistent JSON output

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6862da57e1cc832ea02256f98624f7d0