### PR TITLE
Add missing file existence checks

### DIFF
--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -1,6 +1,7 @@
 using DomainDetective;
 using Spectre.Console;
 using Spectre.Console.Cli;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 
 namespace DomainDetective.CLI;
@@ -40,6 +41,9 @@ internal sealed class CheckDomainSettings : CommandSettings {
 internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
     public override async Task<int> ExecuteAsync(CommandContext context, CheckDomainSettings settings) {
         if (settings.Smime != null) {
+            if (!settings.Smime.Exists) {
+                throw new FileNotFoundException("S/MIME certificate file not found", settings.Smime.FullName);
+            }
             var smimeAnalysis = new SmimeCertificateAnalysis();
             smimeAnalysis.AnalyzeFile(settings.Smime.FullName);
             CliHelpers.ShowPropertiesTable($"S/MIME certificate {settings.Smime.FullName}", smimeAnalysis, settings.Unicode);
@@ -47,6 +51,9 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
         }
 
         if (settings.Cert != null) {
+            if (!settings.Cert.Exists) {
+                throw new FileNotFoundException("Certificate file not found", settings.Cert.FullName);
+            }
             var certAnalysis = new CertificateAnalysis();
             await certAnalysis.AnalyzeCertificate(new X509Certificate2(settings.Cert.FullName));
             CliHelpers.ShowPropertiesTable($"Certificate {settings.Cert.FullName}", certAnalysis, settings.Unicode);

--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -1,6 +1,7 @@
 using DomainDetective;
 using Spectre.Console;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 
@@ -40,8 +41,7 @@ internal static class CommandUtilities {
         string? headerText = null;
         if (file != null) {
             if (!file.Exists) {
-                AnsiConsole.MarkupLine($"[red]File not found: {file.FullName}[/]");
-                return;
+                throw new FileNotFoundException($"File not found: {file.FullName}", file.FullName);
             }
             headerText = File.ReadAllText(file.FullName);
         } else if (!string.IsNullOrWhiteSpace(header)) {
@@ -70,8 +70,7 @@ internal static class CommandUtilities {
         string? headerText = null;
         if (file != null) {
             if (!file.Exists) {
-                AnsiConsole.MarkupLine($"[red]File not found: {file.FullName}[/]");
-                return;
+                throw new FileNotFoundException($"File not found: {file.FullName}", file.FullName);
             }
             headerText = File.ReadAllText(file.FullName);
         } else if (!string.IsNullOrWhiteSpace(header)) {
@@ -98,8 +97,7 @@ internal static class CommandUtilities {
     [RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
     internal static void AnalyzeDnsTunneling(string domain, string filePath, bool json) {
         if (!File.Exists(filePath)) {
-            AnsiConsole.MarkupLine($"[red]File not found: {filePath}[/]");
-            return;
+            throw new FileNotFoundException($"File not found: {filePath}", filePath);
         }
         var lines = File.ReadAllLines(filePath);
         var hc = new DomainHealthCheck { DnsTunnelingLogs = lines };

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -1,11 +1,13 @@
+using Spectre.Console;
 using Spectre.Console.Cli;
 using System.Diagnostics.CodeAnalysis;
+using System.IO;
 
 namespace DomainDetective.CLI;
 
 internal static class Program {
     [RequiresDynamicCode("Calls Spectre.Console.Cli.CommandApp.CommandApp(ITypeRegistrar)")]
-    public static Task<int> Main(string[] args) {
+    public static async Task<int> Main(string[] args) {
         var app = new CommandApp();
         app.Configure(config => {
             config.SetApplicationName("DomainDetective");
@@ -24,6 +26,11 @@ internal static class Program {
             config.AddCommand<BuildDmarcCommand>("BuildDmarcRecord")
                 .WithDescription("Interactively build a DMARC record");
         });
-        return app.RunAsync(args);
+        try {
+            return await app.RunAsync(args);
+        } catch (FileNotFoundException ex) {
+            AnsiConsole.MarkupLine($"[red]{ex.Message}[/]");
+            return 1;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- validate CLI file parameters exist before use
- surface friendly file-not-found messages

## Testing
- `dotnet test --no-build` *(fails: invalid argument)*

------
https://chatgpt.com/codex/tasks/task_e_6862da35e390832ea1c5c65bee0772cb