### PR TITLE
Handle CLI errors gracefully

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -3,27 +3,32 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace DomainDetective.CLI;
 
-internal static class Program {
+public static class Program {
     [RequiresDynamicCode("Calls Spectre.Console.Cli.CommandApp.CommandApp(ITypeRegistrar)")]
-    public static Task<int> Main(string[] args) {
-        var app = new CommandApp();
-        app.Configure(config => {
-            config.SetApplicationName("DomainDetective");
-            config.AddCommand<CheckDomainCommand>("check")
-                .WithDescription("Run domain health checks");
-            config.AddCommand<AnalyzeMessageHeaderCommand>("AnalyzeMessageHeader")
-                .WithDescription("Analyze message header");
-            config.AddCommand<AnalyzeArcCommand>("AnalyzeARC")
-                .WithDescription("Analyze ARC headers");
-            config.AddCommand<WhoisCommand>("Whois")
-                .WithDescription("Query WHOIS information");
-            config.AddCommand<AnalyzeDnsTunnelingCommand>("AnalyzeDnsTunneling")
-                .WithDescription("Analyze DNS logs for tunneling patterns");
-            config.AddCommand<DnsPropagationCommand>("DnsPropagation")
-                .WithDescription("Check DNS propagation across public resolvers");
-            config.AddCommand<BuildDmarcCommand>("BuildDmarcRecord")
-                .WithDescription("Interactively build a DMARC record");
-        });
-        return app.RunAsync(args);
+    public static async Task<int> Main(string[] args) {
+        try {
+            var app = new CommandApp();
+            app.Configure(config => {
+                config.SetApplicationName("DomainDetective");
+                config.AddCommand<CheckDomainCommand>("check")
+                    .WithDescription("Run domain health checks");
+                config.AddCommand<AnalyzeMessageHeaderCommand>("AnalyzeMessageHeader")
+                    .WithDescription("Analyze message header");
+                config.AddCommand<AnalyzeArcCommand>("AnalyzeARC")
+                    .WithDescription("Analyze ARC headers");
+                config.AddCommand<WhoisCommand>("Whois")
+                    .WithDescription("Query WHOIS information");
+                config.AddCommand<AnalyzeDnsTunnelingCommand>("AnalyzeDnsTunneling")
+                    .WithDescription("Analyze DNS logs for tunneling patterns");
+                config.AddCommand<DnsPropagationCommand>("DnsPropagation")
+                    .WithDescription("Check DNS propagation across public resolvers");
+                config.AddCommand<BuildDmarcCommand>("BuildDmarcRecord")
+                    .WithDescription("Interactively build a DMARC record");
+            });
+            return await app.RunAsync(args);
+        } catch (Exception ex) {
+            Console.Error.WriteLine(ex);
+            return 1;
+        }
     }
 }

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -34,6 +34,7 @@
     <ItemGroup>
         <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
         <ProjectReference Include="..\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj" />
+        <ProjectReference Include="..\DomainDetective.CLI\DomainDetective.CLI.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DomainDetective.Tests/TestCliExitCodes.cs
+++ b/DomainDetective.Tests/TestCliExitCodes.cs
@@ -1,0 +1,9 @@
+namespace DomainDetective.Tests;
+
+public class TestCliExitCodes {
+    [Fact]
+    public async Task InvalidSmimeFileReturnsErrorCode() {
+        var code = await DomainDetective.CLI.Program.Main(new[] { "check", "--smime", "nonexistent.pem" });
+        Assert.NotEqual(0, code);
+    }
+}


### PR DESCRIPTION
## Summary
- ensure DomainDetective CLI returns an error when analysis throws
- expose CLI `Program` class for tests
- reference CLI project from test suite
- test exit code when an invalid certificate file is given

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: 17 failed, 394 passed)*
- `dotnet test --no-build --filter TestCliExitCodes`

------
https://chatgpt.com/codex/tasks/task_e_6862da3bcc3c832e855e83255d15dd8a