### PR TITLE
Add DKIM modulus length warning

### DIFF
--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -88,6 +88,10 @@ namespace DomainDetective {
                                 analysis.ValidRsaKeyLength = analysis.KeyLength >= MinimumRsaKeyBits;
                                 analysis.WeakKey = analysis.KeyLength > 0 && analysis.KeyLength < 2048;
                                 analysis.ValidPublicKey = analysis.ValidRsaKeyLength;
+                                if (analysis.WeakKey)
+                                {
+                                    logger?.WriteWarning("DKIM key length {0} bits is weak, use at least 2048 bits.", analysis.KeyLength);
+                                }
                                 } catch (Exception) {
                                     analysis.ValidPublicKey = false;
                                     analysis.ValidRsaKeyLength = false;


### PR DESCRIPTION
## Summary
- warn when DKIM public key is under 2048 bits

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6862db1b7f48832e87104bb332034308