### PR TITLE
Capture EHLO capabilities

### DIFF
--- a/DomainDetective.Tests/TestSmtpAuthAnalysis.cs
+++ b/DomainDetective.Tests/TestSmtpAuthAnalysis.cs
@@ -95,5 +95,37 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task CapturesServerCapabilities() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost");
+                await writer.WriteLineAsync("250-PIPELINING");
+                await writer.WriteLineAsync("250-AUTH LOGIN");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new SmtpAuthAnalysis { InspectCapabilities = true };
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var caps = analysis.ServerCapabilities[$"localhost:{port}"];
+                Assert.Contains("PIPELINING", caps);
+                Assert.Contains("AUTH", caps);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inspect server capabilities after EHLO
- optionally store capabilities via `InspectCapabilities`
- test capturing SMTP server capabilities

## Testing
- `dotnet build`
- `dotnet test` *(fails: UnreachableHostLogsExceptionType, CapturesCipherSuiteWhenEnabled, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6862db0371cc832eb676b9b359bfa841