### PR TITLE
Add SPF record chunk length warnings

### DIFF
--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -135,6 +135,7 @@ namespace DomainDetective {
             foreach (var record in spfRecordList) {
                 SpfRecords.AddRange(record.DataStringsEscaped);
             }
+            WarnIfSpfRecordChunksTooLong(logger);
             // However for analysis we only need the Data, as provided by DnsClientX
             if (dnsResults.Count() == 1) {
                 SpfRecord = dnsResults.First().Data;
@@ -291,6 +292,15 @@ namespace DomainDetective {
                 }
             }
             ExceedsTotalCharacterLimit = totalLength > 512;
+        }
+
+        private void WarnIfSpfRecordChunksTooLong(InternalLogger? logger) {
+            for (int i = 0; i < SpfRecords.Count; i++) {
+                if (SpfRecords[i].Length > 255) {
+                    _warnings.Add($"SPF record chunk {i + 1} exceeds 255 characters.");
+                    logger?.WriteWarning($"SPF record chunk {i + 1} exceeds 255 characters.");
+                }
+            }
         }
 
         private void AddPartToList(string part, InternalLogger? logger) {

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -294,6 +294,7 @@ namespace DomainDetective {
             ExceedsTotalCharacterLimit = totalLength > 512;
         }
 
+        /// <summary>Adds warnings for SPF TXT chunks over 255 characters.</summary>
         private void WarnIfSpfRecordChunksTooLong(InternalLogger? logger) {
             for (int i = 0; i < SpfRecords.Count; i++) {
                 if (SpfRecords[i].Length > 255) {


### PR DESCRIPTION
## Summary
- track SPF record chunk lengths and warn when any exceed 255 characters

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: System.Collections.Generic.KeyNotFoundException)*

------
https://chatgpt.com/codex/tasks/task_e_6862db2bfda4832e945a2d3969683c8f