### PR TITLE
Implement critical bit detection in CAA parser

### DIFF
--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -205,13 +205,22 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task CriticalBitIsDetected() {
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckCAA("129 issue \"letsencrypt.org\"");
+
+            Assert.True(healthCheck.CAAAnalysis.AnalysisResults[0].Critical);
+        }
+
+        [Fact]
         public async Task UnknownCriticalPropertyTagTriggersWarning() {
             var logger = new InternalLogger();
             var warnings = new List<LogEventArgs>();
             logger.OnWarningMessage += (_, e) => warnings.Add(e);
             var healthCheck = new DomainHealthCheck(internalLogger: logger);
 
-            await healthCheck.CheckCAA("1 foo \"bar\"");
+            await healthCheck.CheckCAA("129 foo \"bar\"");
 
             Assert.Contains(warnings, w => w.FullMessage.Contains("Unknown CAA property tag"));
         }

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -129,6 +129,7 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                     if (flag < 0 || flag > 255) {
                         analysis.InvalidFlag = true;
                     }
+                    analysis.Critical = (flag & 1) == 1;
 
                     // Validate tag and set the Tag property
                     var validTags = new Dictionary<string, CAATagType>(StringComparer.OrdinalIgnoreCase) {
@@ -142,7 +143,7 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                     } else {
                         analysis.Tag = CAATagType.Unknown;
                         analysis.InvalidTag = true;
-                        if (flag == 1) {
+                        if (analysis.Critical) {
                             logger?.WriteWarning("Unknown CAA property tag '{0}' flagged as critical", tag);
                         }
                     }
@@ -345,6 +346,8 @@ As an illustration, a CAA record that is set on example.com is also applicable t
         public string CAARecord { get; set; }
         /// <summary>Gets or sets the flag field.</summary>
         public string Flag { get; set; }
+        /// <summary>Gets or sets a value indicating whether the critical bit is set.</summary>
+        public bool Critical { get; set; }
         /// <summary>Gets or sets the parsed tag type.</summary>
         public CAATagType Tag { get; set; }
         /// <summary>Gets or sets the record value.</summary>


### PR DESCRIPTION
## Summary
- support checking the critical bit when reading CAA records
- warn about unknown critical tags when the bit is set
- add tests for critical bit detection

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0 --verbosity minimal` *(fails: Exceeds lookups should be true, as we expect it over the board)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6862db33e350832ea01784a12682d323