### PR TITLE
Detect SPF redirect loops as PermError

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -172,6 +172,17 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task PermErrorOnRedirectLoop() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 redirect=b.example.com";
+            healthCheck.SpfAnalysis.TestSpfRecords["b.example.com"] = "v=spf1 redirect=a.example.com";
+
+            await healthCheck.CheckSPF("v=spf1 redirect=a.example.com");
+
+            Assert.True(healthCheck.SpfAnalysis.PermError);
+        }
+
+        [Fact]
         public async Task DomainEndingWithAllWithoutAllMechanism() {
             var spfRecord = "v=spf1 a:firewall";
             var healthCheck = new DomainHealthCheck();

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -61,6 +61,7 @@ namespace DomainDetective {
         public Dictionary<string, string> TestSpfRecords { get; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         public bool CycleDetected { get; private set; }
         public string CyclePath { get; private set; }
+        public bool PermError { get; private set; }
         public List<string> RedirectVisitedDomains { get; private set; } = new List<string>();
         private HashSet<string> _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
@@ -94,6 +95,7 @@ namespace DomainDetective {
             InvalidIpSyntax = false;
             CycleDetected = false;
             CyclePath = null;
+            PermError = false;
             RedirectVisitedDomains = new List<string>();
             _visitedDomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             ARecords = new List<string>();
@@ -192,7 +194,8 @@ namespace DomainDetective {
                         if (!visitedDomains.Add(domain)) {
                             CycleDetected = true;
                             CyclePath ??= string.Join(" -> ", path.Concat(new[] { domain }));
-                            continue;
+                            PermError = true;
+                            return dnsLookups;
                         }
 
                         DnsLookups.Add(domain);
@@ -226,7 +229,8 @@ namespace DomainDetective {
                         if (!visitedDomains.Add(domain)) {
                             CycleDetected = true;
                             CyclePath ??= string.Join(" -> ", path.Concat(new[] { domain }));
-                            continue;
+                            PermError = true;
+                            return dnsLookups;
                         }
 
                         DnsLookups.Add(domain);


### PR DESCRIPTION
## Summary
- mark PermError when encountering recursive SPF redirects
- stop processing when redirect loop detected
- unit test verifies PermError flag

## Testing
- `dotnet vstest DomainDetective.Tests/bin/Release/net8.0/DomainDetective.Tests.dll --logger:"console;verbosity=normal"` *(fails: 17 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6862db39b9a4832e9f5e8528aa863fcb