### PR TITLE
Highlight MTASTS policy mode

### DIFF
--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -76,7 +76,18 @@ internal static class CliHelpers
             }
             else
             {
-                table.AddRow(Markup.Escape(property.Name), Markup.Escape(FormatString(value?.ToString(), unicode)));
+                var stringValue = value?.ToString();
+                if (property.Name == "Mode" && stringValue is not null)
+                {
+                    var escaped = Markup.Escape(FormatString(stringValue, unicode));
+                    if (stringValue.Equals("testing", StringComparison.OrdinalIgnoreCase) ||
+                        stringValue.Equals("none", StringComparison.OrdinalIgnoreCase))
+                    {
+                        table.AddRow(Markup.Escape(property.Name), $"[yellow]{escaped}[/]");
+                        continue;
+                    }
+                }
+                table.AddRow(Markup.Escape(property.Name), Markup.Escape(FormatString(stringValue, unicode)));
             }
         }
     }


### PR DESCRIPTION
## Summary
- emphasize `mode` when reading MTA‑STS policies

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6862db0898a0832e8b7de32ebc466e7b