### PR TITLE
Extend WHOIS to capture abuse contact email

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -136,6 +136,7 @@ namespace DomainDetective.Tests {
                 await whois.QueryWhoisServer("example.sample");
 
                 Assert.Equal("abuse@example.com", whois.RegistrarAbuseEmail);
+                Assert.Equal("abuse@example.com", whois.RegistrarAbuseContactEmail);
                 Assert.Equal("+1.1234567890", whois.RegistrarAbusePhone);
                 Assert.True(whois.ExpiresSoon);
                 Assert.False(whois.IsExpired);

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -49,6 +49,7 @@ public class WhoisAnalysis {
     public string RegistrarWebsite { get; set; }
     public string RegistrarLicense { get; set; }
     public string RegistrarEmail { get; set; }
+    public string RegistrarAbuseContactEmail { get; set; }
     public string RegistrarAbuseEmail { get; set; }
     public string RegistrarAbusePhone { get; set; }
     public string WhoisData { get; set; }
@@ -459,6 +460,7 @@ public class WhoisAnalysis {
         } else {
             ParseWhoisDataDefault();
         }
+        ParseRegistrarAbuseContactEmail();
         UpdateExpiryFlags();
         UpdateRegistrarLock();
         UpdatePrivacyFlag();
@@ -687,6 +689,7 @@ public class WhoisAnalysis {
                 var value = line.Substring("   Registrar Abuse Contact Email:".Length).Trim();
                 RegistrarEmail = value;
                 RegistrarAbuseEmail = value;
+                RegistrarAbuseContactEmail = value;
             } else if (line.StartsWith("   Registrar Abuse Contact Phone:")) {
                 var value = line.Substring("   Registrar Abuse Contact Phone:".Length).Trim();
                 RegistrarTel = value;
@@ -725,6 +728,7 @@ public class WhoisAnalysis {
                 var value = trimmedLine.Substring("Registrar Abuse Contact Email:".Length).Trim();
                 RegistrarEmail = value;
                 RegistrarAbuseEmail = value;
+                RegistrarAbuseContactEmail = value;
             } else if (trimmedLine.StartsWith("Registrar Abuse Contact Phone:")) {
                 var value = trimmedLine.Substring("Registrar Abuse Contact Phone:".Length).Trim();
                 RegistrarTel = value;
@@ -884,6 +888,22 @@ public class WhoisAnalysis {
                 }
             } else if (trimmedLine.StartsWith("Flags:")) {
                 DnsSec = trimmedLine.Substring("Flags:".Length).Trim();
+            }
+        }
+    }
+
+    private void ParseRegistrarAbuseContactEmail() {
+        foreach (var line in WhoisData.Split('\n')) {
+            var trimmedLine = line.Trim();
+            if (trimmedLine.StartsWith("Registrar Abuse Contact Email:", StringComparison.OrdinalIgnoreCase)) {
+                RegistrarAbuseContactEmail = trimmedLine.Substring("Registrar Abuse Contact Email:".Length).Trim();
+                if (string.IsNullOrEmpty(RegistrarAbuseEmail)) {
+                    RegistrarAbuseEmail = RegistrarAbuseContactEmail;
+                }
+                if (string.IsNullOrEmpty(RegistrarEmail)) {
+                    RegistrarEmail = RegistrarAbuseContactEmail;
+                }
+                break;
             }
         }
     }


### PR DESCRIPTION
## Summary
- track `RegistrarAbuseContactEmail` in WHOIS results
- parse abuse email from WHOIS data across TLDs
- expose the new property via tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6862db5fcd20832eb8fac1dc9eb7f185