### PR TITLE
feat(logging): control progress output

### DIFF
--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -35,6 +35,9 @@ internal sealed class CheckDomainSettings : CommandSettings {
 
     [CommandOption("--cert")]
     public FileInfo? Cert { get; set; }
+
+    [CommandOption("--no-progress")]
+    public bool NoProgress { get; set; }
 }
 
 internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
@@ -81,7 +84,8 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
             settings.Summary,
             settings.SubdomainPolicy,
             settings.Unicode,
-            danePorts);
+            danePorts,
+            !settings.NoProgress);
 
         return 0;
     }

--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -135,14 +135,14 @@ internal static class CommandUtilities {
         var checkHttp = AnsiConsole.Confirm("Perform plain HTTP check?");
         var subPolicy = AnsiConsole.Confirm("Evaluate subdomain policy?");
 
-        await RunChecks(domains, checks, checkHttp, outputJson, summaryOnly, subPolicy, false, null);
+        await RunChecks(domains, checks, checkHttp, outputJson, summaryOnly, subPolicy, false, null, true);
         return 0;
     }
 
-    internal static async Task RunChecks(string[] domains, HealthCheckType[]? checks, bool checkHttp, bool outputJson, bool summaryOnly, bool subdomainPolicy, bool unicodeOutput, int[]? danePorts) {
+    internal static async Task RunChecks(string[] domains, HealthCheckType[]? checks, bool checkHttp, bool outputJson, bool summaryOnly, bool subdomainPolicy, bool unicodeOutput, int[]? danePorts, bool showProgress) {
         foreach (var domain in domains) {
-            var logger = new InternalLogger();
-            var hc = new DomainHealthCheck(internalLogger: logger) { Verbose = false, UseSubdomainPolicy = subdomainPolicy, UnicodeOutput = unicodeOutput };
+            var logger = new InternalLogger { IsProgress = showProgress };
+            var hc = new DomainHealthCheck(internalLogger: logger) { Verbose = false, UseSubdomainPolicy = subdomainPolicy, UnicodeOutput = unicodeOutput, Progress = showProgress };
             var needsPortScan = checks?.Contains(HealthCheckType.PORTSCAN) ?? false;
             if (needsPortScan) {
                 await AnsiConsole.Progress().StartAsync(async ctx => {

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -66,7 +66,7 @@ namespace DomainDetective {
         /// <param name="port">Port used for HTTPS.</param>
         /// <param name="logger">Logger instance for diagnostics.</param>
         /// <param name="cancellationToken">Optional cancellation token.</param>
-        public async Task Analyze(IEnumerable<string> hosts, int port = 443, InternalLogger? logger = null, CancellationToken cancellationToken = default) {
+        public async Task Analyze(IEnumerable<string> hosts, int port = 443, InternalLogger? logger = null, CancellationToken cancellationToken = default, bool showProgress = true) {
             logger ??= new InternalLogger();
             Results.Clear();
             var list = hosts.ToList();
@@ -74,7 +74,9 @@ namespace DomainDetective {
             foreach (var host in list) {
                 cancellationToken.ThrowIfCancellationRequested();
                 processed++;
-                logger.WriteProgress("CertificateMonitor", host, processed * 100d / list.Count, processed, list.Count);
+                if (showProgress) {
+                    logger.WriteProgress("CertificateMonitor", host, processed * 100d / list.Count, processed, list.Count);
+                }
                 var analysis = new CertificateAnalysis();
                 await analysis.AnalyzeUrl(host, port, logger, cancellationToken);
                 var entry = new Entry {

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -533,12 +533,12 @@ namespace DomainDetective {
         /// <param name="host">Target host name.</param>
         /// <param name="ports">Ports to scan. Defaults to the top 1000 ports.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
-        public async Task ScanPorts(string host, IEnumerable<int>? ports = null, CancellationToken cancellationToken = default) {
+        public async Task ScanPorts(string host, IEnumerable<int>? ports = null, CancellationToken cancellationToken = default, bool showProgress = true) {
             var list = ports?.ToArray() ?? PortScanAnalysis.DefaultPorts;
             foreach (var p in list) {
                 ValidatePort(p);
             }
-            await PortScanAnalysis.Scan(host, list, _logger, cancellationToken);
+            await PortScanAnalysis.Scan(host, list, _logger, cancellationToken, showProgress);
         }
 
         /// <summary>Queries neighbors sharing the same IP as <paramref name="domainName"/>.</summary>

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -42,7 +42,7 @@ public class PortScanAnalysis
     public static IReadOnlyList<int> DefaultPorts => _topPorts;
 
     /// <summary>Performs a scan against the host.</summary>
-    public async Task Scan(string host, IEnumerable<int>? ports, InternalLogger? logger = null, CancellationToken cancellationToken = default)
+    public async Task Scan(string host, IEnumerable<int>? ports, InternalLogger? logger = null, CancellationToken cancellationToken = default, bool showProgress = true)
     {
         Results.Clear();
         var list = ports ?? _topPorts;
@@ -65,7 +65,9 @@ public class PortScanAnalysis
             {
                 semaphore.Release();
                 var done = Interlocked.Increment(ref processed);
-                logger?.WriteProgress("PortScan", port.ToString(), done * 100d / total, done, total);
+                if (showProgress) {
+                    logger?.WriteProgress("PortScan", port.ToString(), done * 100d / total, done, total);
+                }
             }
         });
         await Task.WhenAll(tasks).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- log progress at 10% increments only
- allow disabling progress via CLI flag and API parameters

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Certificate and DNS tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6862dba6cf4c832ebf04f1d9f27835a1