### PR TITLE
Add DS digest length check

### DIFF
--- a/DomainDetective.Tests/TestDsDigestLength.cs
+++ b/DomainDetective.Tests/TestDsDigestLength.cs
@@ -1,0 +1,19 @@
+using System.Reflection;
+
+namespace DomainDetective.Tests {
+    public class TestDsDigestLength {
+        [Fact]
+        public void InvalidDigestLengthReturnsFalse() {
+            var method = typeof(DnsSecAnalysis).GetMethod("IsDsDigestLengthValid", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { "2371 ECDSAP256SHA256 2 abcd" });
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void ValidDigestLengthReturnsTrue() {
+            var method = typeof(DnsSecAnalysis).GetMethod("IsDsDigestLengthValid", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { "2371 ECDSAP256SHA256 2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+            Assert.True(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- validate DS record digest length for its algorithm
- warn when DS record digest length is unexpected
- test DS digest length parsing

## Testing
- `dotnet build --no-restore --verbosity minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: Assert.Equal mismatch, network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6862db2379a4832e8d25b0039d1eb55b