### PR TITLE
Enforce SMTP banner length

### DIFF
--- a/DomainDetective/Protocols/SMTPBannerAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPBannerAnalysis.cs
@@ -10,6 +10,8 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class SMTPBannerAnalysis {
+        private const int MaxBannerLength = 512;
+        private const int MaxBannerTextLength = MaxBannerLength - 2; // exclude CRLF
         /// <summary>Result of a banner check.</summary>
         /// <para>Part of the DomainDetective project.</para>
         public class BannerResult {
@@ -68,6 +70,10 @@ namespace DomainDetective {
 #else
                 var banner = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
 #endif
+                if (banner != null && banner.Length > MaxBannerTextLength) {
+                    logger?.WriteWarning("Banner from {0}:{1} exceeded {2} bytes and was truncated.", host, port, MaxBannerLength);
+                    banner = banner.Substring(0, MaxBannerTextLength);
+                }
                 timeoutCts.Token.ThrowIfCancellationRequested();
                 try {
 #if NET8_0_OR_GREATER


### PR DESCRIPTION
## Summary
- enforce RFC 5321 512 byte limit for SMTP banners
- add warning when truncation happens
- test long banner truncation

## Testing
- `dotnet test`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686372214cc4832e8a4aa93bd98aeedc