### PR TITLE
Add DS algorithm checks

### DIFF
--- a/DomainDetective.Tests/TestDsDeprecatedAlgorithm.cs
+++ b/DomainDetective.Tests/TestDsDeprecatedAlgorithm.cs
@@ -1,0 +1,24 @@
+using DomainDetective.Protocols;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDsDeprecatedAlgorithm {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [InlineData(7)]
+        [InlineData(12)]
+        public void DetectsDeprecatedAlgorithms(int value) {
+            Assert.True(DNSKeyAnalysis.IsDeprecatedAlgorithmNumber(value));
+        }
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(13)]
+        public void NonDeprecatedAlgorithmsReturnFalse(int value) {
+            Assert.False(DNSKeyAnalysis.IsDeprecatedAlgorithmNumber(value));
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSKeyAnalysis.cs
+++ b/DomainDetective/Protocols/DNSKeyAnalysis.cs
@@ -9,6 +9,10 @@ namespace DomainDetective.Protocols {
         private static readonly HashSet<int> ValidAlgorithms = new() {
             1, 2, 3, 5, 6, 7, 8, 10, 12, 13, 14, 15, 16, 17, 23, 252, 253, 254,
         };
+
+        private static readonly HashSet<int> DeprecatedAlgorithms = new() {
+            1, 3, 5, 6, 7, 12,
+        };
         /// <summary>
         /// Determines whether a string consists solely of hexadecimal characters.
         /// </summary>
@@ -18,6 +22,10 @@ namespace DomainDetective.Protocols {
 
         internal static bool IsValidAlgorithmNumber(int number) {
             return ValidAlgorithms.Contains(number);
+        }
+
+        internal static bool IsDeprecatedAlgorithmNumber(int number) {
+            return DeprecatedAlgorithms.Contains(number);
         }
     }
 }

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -111,6 +111,15 @@ namespace DomainDetective {
                     if (!IsDsDigestLengthValid(rec)) {
                         logger?.WriteWarning("DS record for {0} has unexpected digest length", current);
                     }
+                    var parts = rec.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                    if (parts.Length >= 2) {
+                        int alg = AlgorithmNumber(parts[1]);
+                        if (!DNSKeyAnalysis.IsValidAlgorithmNumber(alg)) {
+                            logger?.WriteWarning("DS record for {0} contains unknown algorithm {1}", current, parts[1]);
+                        } else if (DNSKeyAnalysis.IsDeprecatedAlgorithmNumber(alg)) {
+                            logger?.WriteWarning("DS record for {0} uses deprecated algorithm {1}", current, parts[1]);
+                        }
+                    }
                 }
 
                 if (!keyAd) {


### PR DESCRIPTION
## Summary
- detect deprecated DNSSEC algorithms and warn
- warn for deprecated DS algorithms when analyzing results
- test DS deprecation detection

## Testing
- `dotnet test` *(fails: DomainDetective.Tests)*

------
https://chatgpt.com/codex/tasks/task_e_686372086ebc832eaba9c0c45c0bb444