### PR TITLE
Fix ARC chain validation

### DIFF
--- a/DomainDetective.Tests/Data/arc-out-of-order.txt
+++ b/DomainDetective.Tests/Data/arc-out-of-order.txt
@@ -1,0 +1,4 @@
+ARC-Seal: i=2; a=rsa-sha256; cv=pass; b=abc;
+ARC-Authentication-Results: i=2; spf=pass;
+ARC-Seal: i=1; a=rsa-sha256; cv=none; b=abc;
+ARC-Authentication-Results: i=1; spf=pass;

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -71,6 +71,9 @@
         <None Include="Data/arc-empty-sig.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/arc-out-of-order.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="Data/wildcard.pem">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -37,5 +37,14 @@ namespace DomainDetective.Tests {
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
+
+        [Fact]
+        public void OutOfOrderChainIsInvalid() {
+            var raw = File.ReadAllText("Data/arc-out-of-order.txt");
+            var hc = new DomainHealthCheck();
+            var result = hc.VerifyARC(raw);
+            Assert.True(result.ArcHeadersFound);
+            Assert.False(result.ValidChain);
+        }
     }
 }

--- a/DomainDetective/Protocols/ARCAnalysis.cs
+++ b/DomainDetective/Protocols/ARCAnalysis.cs
@@ -69,9 +69,8 @@ namespace DomainDetective {
 
             ArcHeadersFound = ArcSealHeaders.Count > 0 || ArcAuthenticationResultsHeaders.Count > 0;
 
-            var allInstances = new SortedSet<int>();
-            var aarInstances = new HashSet<int>();
-            var sealInstances = new HashSet<int>();
+            var aarSequence = new List<int>();
+            var sealSequence = new List<int>();
 
             foreach (var aar in ArcAuthenticationResultsHeaders) {
                 var inst = ParseInstance(aar);
@@ -80,8 +79,7 @@ namespace DomainDetective {
                     return;
                 }
 
-                allInstances.Add(inst.Value);
-                aarInstances.Add(inst.Value);
+                aarSequence.Add(inst.Value);
             }
 
             foreach (var seal in ArcSealHeaders) {
@@ -96,22 +94,20 @@ namespace DomainDetective {
                     return;
                 }
 
-                allInstances.Add(inst.Value);
-                sealInstances.Add(inst.Value);
+                sealSequence.Add(inst.Value);
             }
 
-            if (allInstances.Count == 0) {
+            if (aarSequence.Count == 0 || sealSequence.Count == 0 || aarSequence.Count != sealSequence.Count) {
                 ValidChain = false;
                 return;
             }
 
-            int expected = 1;
-            foreach (var i in allInstances) {
-                if (i != expected || !aarInstances.Contains(i) || !sealInstances.Contains(i)) {
+            for (int index = 0; index < aarSequence.Count; index++) {
+                var expected = index + 1;
+                if (aarSequence[index] != expected || sealSequence[index] != expected) {
                     ValidChain = false;
                     return;
                 }
-                expected++;
             }
 
             ValidChain = true;


### PR DESCRIPTION
## Summary
- validate ARC header sequence
- test order verification for ARC headers

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --verbosity normal` *(fails: VSTest task returned false)*

------
https://chatgpt.com/codex/tasks/task_e_686371f5ae2c832eb8f3c9592bcb8aa0