### PR TITLE
Handle IDN in command-line args

### DIFF
--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -32,6 +32,23 @@ internal static class CliHelpers
         }
     }
 
+    internal static string ToAscii(string? domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            return domain ?? string.Empty;
+        }
+
+        try
+        {
+            return _idn.GetAscii(domain.Trim().Trim('.'));
+        }
+        catch (ArgumentException)
+        {
+            return domain;
+        }
+    }
+
     private static void AddProperties(Table table, object obj, bool listAsString = false, bool unicode = false)
     {
         if (obj == null)

--- a/DomainDetective.CLI/Commands/AnalyzeDnsTunnelingCommand.cs
+++ b/DomainDetective.CLI/Commands/AnalyzeDnsTunnelingCommand.cs
@@ -17,7 +17,8 @@ internal sealed class AnalyzeDnsTunnelingSettings : CommandSettings {
 internal sealed class AnalyzeDnsTunnelingCommand : Command<AnalyzeDnsTunnelingSettings> {
     [RequiresUnreferencedCode("Calls DomainDetective.CLI.CommandUtilities.AnalyzeDnsTunneling(String, String, Boolean)")]
     public override int Execute(CommandContext context, AnalyzeDnsTunnelingSettings settings) {
-        CommandUtilities.AnalyzeDnsTunneling(settings.Domain, settings.File.FullName, settings.Json);
+        var domain = CliHelpers.ToAscii(settings.Domain);
+        CommandUtilities.AnalyzeDnsTunneling(domain, settings.File.FullName, settings.Json);
         return 0;
     }
 }

--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -2,6 +2,7 @@ using DomainDetective;
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.IO;
+using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 
 namespace DomainDetective.CLI;
@@ -67,6 +68,10 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
             await CommandUtilities.RunWizard();
             return 0;
         }
+
+        settings.Domains = settings.Domains
+            .Select(CliHelpers.ToAscii)
+            .ToArray();
 
         var selected = new List<HealthCheckType>();
         foreach (var check in settings.Checks.SelectMany(c => c.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))) {

--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -26,7 +26,8 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         var analysis = new DnsPropagationAnalysis();
         analysis.LoadServers(settings.ServersFile.FullName, clearExisting: true);
         var servers = analysis.Servers;
-        var results = await analysis.QueryAsync(settings.Domain, settings.RecordType, servers);
+        var domain = CliHelpers.ToAscii(settings.Domain);
+        var results = await analysis.QueryAsync(domain, settings.RecordType, servers);
         if (settings.Compare) {
             var groups = DnsPropagationAnalysis.CompareResults(results);
             if (settings.Json) {

--- a/DomainDetective.CLI/Commands/TestSmimeaCommand.cs
+++ b/DomainDetective.CLI/Commands/TestSmimeaCommand.cs
@@ -10,7 +10,14 @@ namespace DomainDetective.CLI {
     internal sealed class TestSmimeaCommand : AsyncCommand<TestSmimeaSettings> {
         public override async Task<int> ExecuteAsync(CommandContext context, TestSmimeaSettings settings) {
             var hc = new DomainHealthCheck();
-            await hc.VerifySMIMEA(settings.Email);
+            var email = settings.Email;
+            var at = email.IndexOf('@');
+            if (at > 0) {
+                var local = email[..at];
+                var domain = email[(at + 1)..];
+                email = $"{local}@{CliHelpers.ToAscii(domain)}";
+            }
+            await hc.VerifySMIMEA(email);
             CliHelpers.ShowPropertiesTable($"SMIMEA for {settings.Email}", hc.SmimeaAnalysis, false);
             return 0;
         }

--- a/DomainDetective.CLI/Commands/WhoisCommand.cs
+++ b/DomainDetective.CLI/Commands/WhoisCommand.cs
@@ -18,7 +18,8 @@ internal sealed class WhoisSettings : CommandSettings {
 internal sealed class WhoisCommand : AsyncCommand<WhoisSettings> {
     public override async Task<int> ExecuteAsync(CommandContext context, WhoisSettings settings) {
         var analysis = new WhoisAnalysis { SnapshotDirectory = settings.SnapshotPath?.FullName };
-        await analysis.QueryWhoisServer(settings.Domain);
+        var domain = CliHelpers.ToAscii(settings.Domain);
+        await analysis.QueryWhoisServer(domain);
         IEnumerable<string>? changes = null;
         if (settings.Diff && settings.SnapshotPath != null) {
             changes = analysis.GetWhoisChanges();
@@ -26,7 +27,7 @@ internal sealed class WhoisCommand : AsyncCommand<WhoisSettings> {
         if (settings.SnapshotPath != null) {
             analysis.SaveSnapshot();
         }
-        CliHelpers.ShowPropertiesTable($"WHOIS for {settings.Domain}", analysis, false);
+        CliHelpers.ShowPropertiesTable($"WHOIS for {domain}", analysis, false);
         if (changes != null && changes.Any()) {
             AnsiConsole.MarkupLine("[yellow]Changes since last snapshot:[/]");
             foreach (var line in changes) {

--- a/DomainDetective.Example/ExampleAnalyseDMARC.cs
+++ b/DomainDetective.Example/ExampleAnalyseDMARC.cs
@@ -14,8 +14,8 @@ public static partial class Program {
     public static async Task ExampleAnalyseByDomainDMARC() {
         var healthCheck = new DomainHealthCheck();
         healthCheck.Verbose = false;
-        await healthCheck.Verify("evotec.pl", [HealthCheckType.DMARC]);
-        //ShowProperties("DMARC for evotec.pl ", healthCheck.DmarcAnalysis);
-        Helpers.ShowPropertiesTable("DMARC for evotec.pl ", healthCheck.DmarcAnalysis);
+        await healthCheck.Verify("xn--bcher-kva.ch", [HealthCheckType.DMARC]);
+        //ShowProperties("DMARC for bücher.ch ", healthCheck.DmarcAnalysis);
+        Helpers.ShowPropertiesTable("DMARC for bücher.ch ", healthCheck.DmarcAnalysis);
     }
 }

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DomainDetective;
@@ -10,6 +11,11 @@ public static partial class Program {
         if (args.Length > 0 && args.Any(a => !a.StartsWith("-"))) {
             var outputJson = args.Contains("--json");
             var domain = args.First(a => !a.StartsWith("-"));
+            var idn = new IdnMapping();
+            try {
+                domain = idn.GetAscii(domain.Trim().Trim('.'));
+            } catch (ArgumentException) {
+            }
             var healthCheck = new DomainHealthCheck();
             await healthCheck.Verify(domain);
             if (outputJson) {

--- a/Module/Examples/Example.GetWhoisInfo.ps1
+++ b/Module/Examples/Example.GetWhoisInfo.ps1
@@ -7,3 +7,7 @@ $Whois | Format-List
 
 $Example = Get-WhoisInfo -DomainName 'example.com'
 $Example | Format-List
+
+$Idn = Get-WhoisInfo -DomainName 'xn--bcher-kva.ch'
+$Idn | Format-List
+

--- a/Module/Examples/Example.TestSpf.ps1
+++ b/Module/Examples/Example.TestSpf.ps1
@@ -12,3 +12,7 @@ $ResultsMicrosoft | Format-List
 $ResultsEvotec = Test-SpfRecord -DomainName 'evotec.pl' -Verbose
 $ResultsEvotec | Format-Table
 $ResultsEvotec | Format-List
+
+$ResultsIdn = Test-SpfRecord -DomainName 'xn--bcher-kva.ch' -Verbose
+$ResultsIdn | Format-Table
+$ResultsIdn | Format-List


### PR DESCRIPTION
## Summary
- convert CLI domain arguments to ASCII with `IdnMapping`
- showcase IDN domains in example app and PowerShell samples

## Testing
- `dotnet test`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686371d0b810832e8c1e5861a5940feb