### PR TITLE
Add domain normalization helper

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -15,8 +15,10 @@ namespace DomainDetective {
     public partial class DomainHealthCheck {
         private static readonly IdnMapping _idn = new();
 
-        private static string ToAscii(string domainName) =>
-            _idn.GetAscii(domainName.Trim().Trim('.')).ToLowerInvariant();
+        private static string NormalizeDomain(string input)
+        {
+            return _idn.GetAscii(input.Trim().Trim('.')).ToLowerInvariant();
+        }
 
         private static string CreateServiceQuery(int port, string domain) {
 #if NET6_0_OR_GREATER
@@ -50,7 +52,7 @@ namespace DomainDetective {
                 host = uri.Host;
             }
 
-            var ascii = ToAscii(host);
+            var ascii = NormalizeDomain(host);
             IsPublicSuffix = _publicSuffixList.IsPublicSuffix(ascii);
         }
         /// Verifies DKIM records for the specified domain.
@@ -63,7 +65,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             if (selectors == null || selectors.Length == 0) {
                 await DKIMAnalysis.QueryWellKnownSelectors(domainName, DnsConfiguration, _logger, cancellationToken);
                 return;
@@ -582,7 +584,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             TyposquattingAnalysis.DnsConfiguration = DnsConfiguration;
             await TyposquattingAnalysis.Analyze(domainName, _logger, cancellationToken);
@@ -595,7 +597,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             await ThreatIntelAnalysis.Analyze(domainName, GoogleSafeBrowsingApiKey, PhishTankApiKey, VirusTotalApiKey, _logger, cancellationToken);
         }
@@ -610,7 +612,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             await EdnsSupportAnalysis.Analyze(domainName, _logger);
         }
@@ -666,7 +668,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             WildcardDnsAnalysis.DnsConfiguration = DnsConfiguration;
             await WildcardDnsAnalysis.Analyze(domainName, _logger, sampleCount);
@@ -709,7 +711,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var spf = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.TXT, "SPF1", cancellationToken);
             await SpfAnalysis.AnalyzeSpfRecords(spf, _logger);
@@ -724,7 +726,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             MTASTSAnalysis = new MTASTSAnalysis {
                 PolicyUrlOverride = MtaStsPolicyUrlOverride,
@@ -743,7 +745,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             ValidatePort(port);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
@@ -760,7 +762,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
@@ -776,7 +778,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
@@ -792,7 +794,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = mxRecordsForTls.Select(r => r.Data.Split(' ')[1].Trim('.'));
@@ -809,7 +811,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             ValidatePort(port);
             var mx = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
@@ -827,7 +829,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             ValidatePort(port);
             var mx = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
@@ -844,7 +846,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             TLSRPTAnalysis = new TLSRPTAnalysis();
             var tlsrpt = await DnsConfiguration.QueryDNS("_smtp._tls." + domainName, DnsRecordType.TXT, cancellationToken: cancellationToken);
@@ -860,7 +862,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             BimiAnalysis = new BimiAnalysis();
             var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
@@ -876,7 +878,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             ContactInfoAnalysis = new ContactInfoAnalysis();
             var contact = await DnsConfiguration.QueryDNS("contact." + domainName, DnsRecordType.TXT, cancellationToken: cancellationToken);
@@ -891,7 +893,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var nsRecords = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.NS, cancellationToken: cancellationToken);
             var servers = nsRecords.Select(r => r.Data.Trim('.'));
@@ -907,7 +909,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var ns = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.NS, cancellationToken: cancellationToken);
             await NSAnalysis.AnalyzeNsRecords(ns, _logger);
@@ -918,7 +920,7 @@ namespace DomainDetective {
         /// Detects dangling CNAME records for the domain.
         /// </summary>
         public async Task VerifyDanglingCname(string domainName, CancellationToken cancellationToken = default) {
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             DanglingCnameAnalysis = new DanglingCnameAnalysis { DnsConfiguration = DnsConfiguration };
             await DanglingCnameAnalysis.Analyze(domainName, _logger, cancellationToken);
         }
@@ -928,7 +930,7 @@ namespace DomainDetective {
         /// <param name="domainName">Domain to verify.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         public async Task VerifyAutodiscover(string domainName, CancellationToken cancellationToken = default) {
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             AutodiscoverAnalysis = new AutodiscoverAnalysis();
             await AutodiscoverAnalysis.Analyze(domainName, DnsConfiguration, _logger, cancellationToken);
         }
@@ -944,7 +946,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             if (ports == null || ports.Length == 0) {
                 throw new ArgumentException("No ports provided.", nameof(ports));
@@ -987,7 +989,7 @@ namespace DomainDetective {
 
             foreach (var service in services.Distinct()) {
                 cancellationToken.ThrowIfCancellationRequested();
-                var host = ToAscii(service.Host).TrimEnd('.');
+                var host = NormalizeDomain(service.Host).TrimEnd('.');
                 var daneName = CreateServiceQuery(service.Port, host);
                 ValidateServiceQueryProtocol(daneName);
                 var dane = await DnsConfiguration.QueryDNS(daneName, DnsRecordType.TLSA, cancellationToken: cancellationToken);
@@ -1014,7 +1016,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
-            domainName = ToAscii(domainName);
+            domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             DaneAnalysis = new DANEAnalysis();
             if (serviceTypes == null || serviceTypes.Length == 0) {
@@ -1174,7 +1176,7 @@ namespace DomainDetective {
         public async Task CheckWHOIS(string domain, CancellationToken cancellationToken = default) {
             var timeout = WhoisAnalysis.Timeout;
             WhoisAnalysis = new WhoisAnalysis { Timeout = timeout };
-            domain = ToAscii(domain);
+            domain = NormalizeDomain(domain);
             UpdateIsPublicSuffix(domain);
             await WhoisAnalysis.QueryWhoisServer(domain, cancellationToken);
             await WhoisAnalysis.QueryIana(domain, cancellationToken);
@@ -1261,10 +1263,10 @@ namespace DomainDetective {
                 if (uri.Port <= 0 || uri.Port > 65535) {
                     throw new ArgumentException("Invalid port.", nameof(domainName));
                 }
-                return $"{ToAscii(uri.IdnHost)}:{uri.Port}";
+                return $"{NormalizeDomain(uri.IdnHost)}:{uri.Port}";
             }
 
-            return ToAscii(uri.IdnHost);
+            return NormalizeDomain(uri.IdnHost);
         }
 
         /// <summary>Creates a copy with only the specified analyses included.</summary>


### PR DESCRIPTION
## Summary
- introduce `NormalizeDomain` helper inside `DomainHealthCheck`
- replace internal calls to old `ToAscii`/`ToLowerInvariant` logic

## Testing
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686384bea414832e8b3840a163ade6be