### PR TITLE
Optimize analysis map lookup

### DIFF
--- a/DomainDetective/DomainHealthCheck.AnalysisMap.cs
+++ b/DomainDetective/DomainHealthCheck.AnalysisMap.cs
@@ -1,9 +1,23 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
-namespace DomainDetective;
+namespace DomainDetective
+{
+    public partial class DomainHealthCheck {
+        private static readonly IReadOnlyDictionary<HealthCheckType, PropertyInfo?> AnalysisPropertyMap;
 
-public partial class DomainHealthCheck {
+    static DomainHealthCheck()
+    {
+        var map = new Dictionary<HealthCheckType, PropertyInfo?>();
+        foreach (HealthCheckType check in Enum.GetValues(typeof(HealthCheckType)))
+        {
+            var property = typeof(DomainHealthCheck).GetProperty($"{check}Analysis");
+            map[check] = property;
+        }
+
+        AnalysisPropertyMap = map;
+    }
     /// <summary>
     ///     Creates a dictionary mapping each <see cref="HealthCheckType"/> to
     ///     the corresponding analysis result instance.
@@ -13,15 +27,14 @@ public partial class DomainHealthCheck {
     /// </returns>
     public IReadOnlyDictionary<HealthCheckType, object?> GetAnalysisMap()
     {
-        var map = new Dictionary<HealthCheckType, object?>(
-            Enum.GetValues(typeof(HealthCheckType)).Length);
+        var map = new Dictionary<HealthCheckType, object?>(AnalysisPropertyMap.Count);
 
-        foreach (HealthCheckType check in Enum.GetValues(typeof(HealthCheckType)))
+        foreach (var kvp in AnalysisPropertyMap)
         {
-            var property = GetType().GetProperty($"{check}Analysis");
-            map[check] = property?.GetValue(this);
+            map[kvp.Key] = kvp.Value?.GetValue(this);
         }
 
         return map;
     }
+}
 }


### PR DESCRIPTION
## Summary
- cache `HealthCheckType` property info
- enforce block-scoped namespace style for the analysis map helper

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: The given key 'selector1' was not present in the dictionary)*

------
https://chatgpt.com/codex/tasks/task_e_686384b5fb94832ea8a11e858eb4810f