### PR TITLE
Add cancellation support in CLI

### DIFF
--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -3,6 +3,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Security.Cryptography.X509Certificates;
 
 namespace DomainDetective.CLI;
@@ -65,7 +66,7 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
         }
 
         if (settings.Domains.Length == 0) {
-            await CommandUtilities.RunWizard();
+            await CommandUtilities.RunWizard(Program.CancellationToken);
             return 0;
         }
 
@@ -97,7 +98,8 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
             settings.SubdomainPolicy,
             settings.Unicode,
             danePorts,
-            !settings.NoProgress);
+            !settings.NoProgress,
+            Program.CancellationToken);
 
         return 0;
     }

--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -1,6 +1,7 @@
 using DnsClientX;
 using Spectre.Console.Cli;
 using System.Text.Json;
+using System.Threading;
 
 namespace DomainDetective.CLI;
 
@@ -27,7 +28,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         analysis.LoadServers(settings.ServersFile.FullName, clearExisting: true);
         var servers = analysis.Servers;
         var domain = CliHelpers.ToAscii(settings.Domain);
-        var results = await analysis.QueryAsync(domain, settings.RecordType, servers);
+        var results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken);
         if (settings.Compare) {
             var groups = DnsPropagationAnalysis.CompareResults(results);
             if (settings.Json) {

--- a/DomainDetective.CLI/Commands/TestSmimeaCommand.cs
+++ b/DomainDetective.CLI/Commands/TestSmimeaCommand.cs
@@ -1,4 +1,5 @@
 using Spectre.Console.Cli;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DomainDetective.CLI {
@@ -17,7 +18,7 @@ namespace DomainDetective.CLI {
                 var domain = email[(at + 1)..];
                 email = $"{local}@{CliHelpers.ToAscii(domain)}";
             }
-            await hc.VerifySMIMEA(email);
+            await hc.VerifySMIMEA(email, Program.CancellationToken);
             CliHelpers.ShowPropertiesTable($"SMIMEA for {settings.Email}", hc.SmimeaAnalysis, false);
             return 0;
         }

--- a/DomainDetective.CLI/Commands/WhoisCommand.cs
+++ b/DomainDetective.CLI/Commands/WhoisCommand.cs
@@ -1,6 +1,7 @@
 using Spectre.Console;
 using Spectre.Console.Cli;
 using System.Text.Json;
+using System.Threading;
 
 namespace DomainDetective.CLI;
 
@@ -19,7 +20,7 @@ internal sealed class WhoisCommand : AsyncCommand<WhoisSettings> {
     public override async Task<int> ExecuteAsync(CommandContext context, WhoisSettings settings) {
         var analysis = new WhoisAnalysis { SnapshotDirectory = settings.SnapshotPath?.FullName };
         var domain = CliHelpers.ToAscii(settings.Domain);
-        await analysis.QueryWhoisServer(domain);
+        await analysis.QueryWhoisServer(domain, Program.CancellationToken);
         IEnumerable<string>? changes = null;
         if (settings.Diff && settings.SnapshotPath != null) {
             changes = analysis.GetWhoisChanges();


### PR DESCRIPTION
## Summary
- listen for `Console.CancelKeyPress` in `Program.Main`
- pass the cancellation token to async helpers and commands

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: KeyNotFoundException etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863849320e8832eaa199f565e84a49b