### PR TITLE
Use shared HttpClient with disposal

### DIFF
--- a/DomainDetective.PowerShell/CmdletNewDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletNewDmarcRecord.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Net.Http;
+using DomainDetective;
 using Spectre.Console;
 
 namespace DomainDetective.PowerShell {
@@ -118,7 +119,7 @@ namespace DomainDetective.PowerShell {
                 return;
             }
             try {
-                using var client = new HttpClient();
+                var client = SharedHttpClient.Instance;
                 var data = new Dictionary<string, string> {
                     ["domain"] = DomainName,
                     ["record"] = record

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -383,7 +383,7 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="url">Optional URL to fetch the list from.</param>
         public async Task RefreshPublicSuffixListAsync(string url = DefaultPublicSuffixListUrl) {
-            using var client = new HttpClient();
+            var client = SharedHttpClient.Instance;
             using var stream = await client.GetStreamAsync(url);
             var updated = PublicSuffixList.Load(stream);
             _publicSuffixList = updated;

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -258,7 +258,7 @@ namespace DomainDetective {
                     var gen = new OcspReqGenerator();
                     gen.AddRequest(id);
                     var req = gen.Generate();
-                    using var client = new HttpClient();
+                    var client = SharedHttpClient.Instance;
                     using var content = new ByteArrayContent(req.GetEncoded());
                     content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/ocsp-request");
                     using var resp = await client.PostAsync(OcspUrls[0], content, cancellationToken);
@@ -275,7 +275,7 @@ namespace DomainDetective {
                 }
 
                 if (CrlUrls.Count > 0) {
-                    using var client = new HttpClient();
+                    var client = SharedHttpClient.Instance;
                     using var resp = await client.GetAsync(CrlUrls[0], cancellationToken);
                     if (resp.IsSuccessStatusCode) {
                         var bytes = await resp.Content.ReadAsByteArrayAsync();
@@ -306,7 +306,7 @@ namespace DomainDetective {
             if (CtLogQueryOverride != null) {
                 json = await CtLogQueryOverride(fingerprint);
             } else {
-                using var client = new HttpClient();
+                var client = SharedHttpClient.Instance;
                 foreach (var template in CtLogApiTemplates) {
                     var url = string.Format(template, fingerprint);
                     using var resp = await client.GetAsync(url, cancellationToken);

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -522,7 +522,7 @@ namespace DomainDetective {
         }
 
         public async Task UpdateDnsblDataAsync(string url = DefaultUpdateUrl, bool overwriteExisting = true) {
-            using var client = new HttpClient();
+            var client = SharedHttpClient.Instance;
             var json = await client.GetStringAsync(url);
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
             var config = JsonSerializer.Deserialize<DnsblConfiguration>(json, options);

--- a/DomainDetective/Protocols/IPNeighborAnalysis.cs
+++ b/DomainDetective/Protocols/IPNeighborAnalysis.cs
@@ -48,7 +48,7 @@ public class IPNeighborAnalysis
 
         try
         {
-            using var client = new HttpClient();
+            var client = SharedHttpClient.Instance;
             var url = $"https://api.hackertarget.com/reverseiplookup/?q={ip}";
             using var resp = await client.GetAsync(url);
             if (!resp.IsSuccessStatusCode)
@@ -78,7 +78,7 @@ public class IPNeighborAnalysis
 
         try
         {
-            using var client = new HttpClient();
+            var client = SharedHttpClient.Instance;
             var prefixResp = await client.GetAsync($"https://stat.ripe.net/data/prefix-overview/data.json?resource={ip}");
             prefixResp.EnsureSuccessStatusCode();
             using var prefixStream = await prefixResp.Content.ReadAsStreamAsync();

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -1018,7 +1018,7 @@ public class WhoisAnalysis {
         if (IanaQueryOverride != null) {
             json = await IanaQueryOverride(domain).ConfigureAwait(false);
         } else {
-            using var client = new HttpClient();
+            var client = SharedHttpClient.Instance;
 #if NETSTANDARD2_0 || NET472
             using var response = await client.GetAsync($"https://rdap.iana.org/domain/{domain}", cancellationToken).ConfigureAwait(false);
             json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/DomainDetective/PublicSuffixList.cs
+++ b/DomainDetective/PublicSuffixList.cs
@@ -53,7 +53,7 @@ namespace DomainDetective {
         }
 
         public static async Task<PublicSuffixList> LoadFromUrlAsync(string url) {
-            using var client = new HttpClient();
+            var client = SharedHttpClient.Instance;
             using var stream = await client.GetStreamAsync(url);
             return Load(stream);
         }

--- a/DomainDetective/SharedHttpClient.cs
+++ b/DomainDetective/SharedHttpClient.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Net.Http;
+
+namespace DomainDetective;
+
+public static class SharedHttpClient
+{
+    public static readonly HttpClient Instance;
+
+    static SharedHttpClient()
+    {
+        Instance = new HttpClient();
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => Instance.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- share an HttpClient instance via `SharedHttpClient`
- dispose HttpClient when the process exits
- update callers to use the shared client

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --logger "console;verbosity=minimal"` *(fails: DomainDetective.Tests.TestDomainBlocklist.UnlistedDomainReturnsNegative, TestDomainBlocklist.ListedDomainsReturnPositive, TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps, TestDANEnalysis.TestDANERecordByDomain, TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestDkimAnalysis.TestDKIMByDomain, TestAll.TestAllHealthChecks, TestSpfAnalysis.TestSpfOver255, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestSOAAnalysis.VerifySoaByDomain, TestCAAAnalysis.TestCAARecordByDomain, TestDkimGuess.GuessSelectorsForDomain, TestDMARCAnalysis.TestDMARCByDomain, TestCertificateHTTP.UnreachableHostLogsExceptionType, TestCertificateHTTP.CapturesCipherSuiteWhenEnabled)*


------
https://chatgpt.com/codex/tasks/task_e_6863846be554832eaddabd774fe5c8ff