### PR TITLE
Add cached public suffix list refresh

### DIFF
--- a/DomainDetective.CLI/Commands/RefreshSuffixListCommand.cs
+++ b/DomainDetective.CLI/Commands/RefreshSuffixListCommand.cs
@@ -1,0 +1,24 @@
+using Spectre.Console.Cli;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace DomainDetective.CLI;
+
+internal sealed class RefreshSuffixListSettings : CommandSettings {
+    [CommandOption("--force")]
+    public bool Force { get; set; }
+
+    [CommandOption("--cache-dir")]
+    public DirectoryInfo? CacheDirectory { get; set; }
+}
+
+internal sealed class RefreshSuffixListCommand : AsyncCommand<RefreshSuffixListSettings> {
+    public override async Task<int> ExecuteAsync(CommandContext context, RefreshSuffixListSettings settings) {
+        var hc = new DomainHealthCheck();
+        if (settings.CacheDirectory != null) {
+            hc.CacheDirectory = settings.CacheDirectory.FullName;
+        }
+        await hc.RefreshPublicSuffixListAsync(force: settings.Force);
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -34,6 +34,8 @@ internal static class Program {
                 .WithDescription("Check DNS propagation across public resolvers");
             config.AddCommand<BuildDmarcCommand>("BuildDmarcRecord")
                 .WithDescription("Interactively build a DMARC record");
+            config.AddCommand<RefreshSuffixListCommand>("RefreshSuffixList")
+                .WithDescription("Download the latest public suffix list");
             config.AddCommand<TestSmimeaCommand>("TestSMIMEA")
                 .WithDescription("Query SMIMEA record for an email address");
         });

--- a/DomainDetective.Tests/TestPublicSuffixRefresh.cs
+++ b/DomainDetective.Tests/TestPublicSuffixRefresh.cs
@@ -1,0 +1,42 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestPublicSuffixRefresh {
+        [Fact]
+        public async Task UsesCacheWhenFresh() {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            var fileContent = File.ReadAllBytes(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "public_suffix_list.dat"));
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream);
+                await reader.ReadLineAsync();
+                while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) { }
+                var header = $"HTTP/1.1 200 OK\r\nContent-Length: {fileContent.Length}\r\n\r\n";
+                await stream.WriteAsync(System.Text.Encoding.ASCII.GetBytes(header));
+                await stream.WriteAsync(fileContent);
+            });
+            try {
+                var hc = new DomainHealthCheck { CacheDirectory = dir };
+                await hc.RefreshPublicSuffixListAsync($"http://localhost:{port}/list.dat", force: true);
+                var cache = Path.Combine(dir, "public_suffix_list.dat");
+                var firstTime = File.GetLastWriteTimeUtc(cache);
+                await hc.RefreshPublicSuffixListAsync($"http://localhost:{port}/list.dat");
+                var secondTime = File.GetLastWriteTimeUtc(cache);
+                Assert.Equal(firstTime, secondTime);
+            } finally {
+                listener.Stop();
+                await serverTask;
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}

--- a/DomainDetective.Tests/TestPublicSuffixRefresh.cs
+++ b/DomainDetective.Tests/TestPublicSuffixRefresh.cs
@@ -21,8 +21,9 @@ namespace DomainDetective.Tests {
                 await reader.ReadLineAsync();
                 while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) { }
                 var header = $"HTTP/1.1 200 OK\r\nContent-Length: {fileContent.Length}\r\n\r\n";
-                await stream.WriteAsync(System.Text.Encoding.ASCII.GetBytes(header));
-                await stream.WriteAsync(fileContent);
+                var headerBytes = System.Text.Encoding.ASCII.GetBytes(header);
+                await stream.WriteAsync(headerBytes, 0, headerBytes.Length);
+                await stream.WriteAsync(fileContent, 0, fileContent.Length);
             });
             try {
                 var hc = new DomainHealthCheck { CacheDirectory = dir };

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -1,5 +1,7 @@
 using DnsClientX;
+using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace DomainDetective {
     public partial class DomainHealthCheck {
@@ -50,5 +52,21 @@ namespace DomainDetective {
         /// <summary>Holds DNS client configuration used throughout analyses.</summary>
         /// <value>The DNS configuration instance.</value>
         public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
+
+        /// <summary>
+        /// Directory used for caching downloaded data.
+        /// </summary>
+        public string CacheDirectory {
+            get {
+                if (_cacheDirectory is null) {
+                    var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                    _cacheDirectory = Path.Combine(home, ".domain-detective");
+                }
+                return _cacheDirectory;
+            }
+            set => _cacheDirectory = value;
+        }
+
+        private string? _cacheDirectory;
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -381,6 +381,7 @@ namespace DomainDetective {
 
         /// <summary>
         /// Downloads the latest public suffix list and refreshes cached data.
+        /// Cached data newer than seven days is reused unless <paramref name="force" /> is true.
         /// </summary>
         /// <param name="url">Optional URL to fetch the list from.</param>
         /// <param name="force">Ignore the cache and download fresh data.</param>

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -399,12 +399,12 @@ namespace DomainDetective {
             using var responseStream = await client.GetStreamAsync(url);
             using var memory = new MemoryStream();
             await responseStream.CopyToAsync(memory);
-            memory.Position = 0;
-            _publicSuffixList = PublicSuffixList.Load(memory);
-            memory.Position = 0;
-            using (var file = File.Create(cacheFile)) {
-                memory.CopyTo(file);
-            }
+            var bytes = memory.ToArray();
+
+            using var loadStream = new MemoryStream(bytes, writable: false);
+            _publicSuffixList = PublicSuffixList.Load(loadStream);
+            File.WriteAllBytes(cacheFile, bytes);
+
             TyposquattingAnalysis.PublicSuffixList = _publicSuffixList;
         }
 


### PR DESCRIPTION
## Summary
- cache public suffix list under configurable directory
- load cached list if younger than 7 days
- add CLI command to refresh suffix list
- add tests using temporary directories

## Testing
- `dotnet build`
- `dotnet test -v minimal` *(fails: 18, passed: 414)*

------
https://chatgpt.com/codex/tasks/task_e_68639ace90bc832e9410011d58328048