### PR TITLE
Add progress tracking for health checks

### DIFF
--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -143,14 +143,18 @@ internal static class CommandUtilities {
         foreach (var domain in domains) {
             var logger = new InternalLogger { IsProgress = showProgress };
             var hc = new DomainHealthCheck(internalLogger: logger) { Verbose = false, UseSubdomainPolicy = subdomainPolicy, UnicodeOutput = unicodeOutput, Progress = showProgress };
-            var needsPortScan = checks?.Contains(HealthCheckType.PORTSCAN) ?? false;
-            if (needsPortScan) {
+
+            if (showProgress) {
                 await AnsiConsole.Progress().StartAsync(async ctx => {
-                    ProgressTask? task = null;
+                    ProgressTask? portTask = null;
+                    ProgressTask? hcTask = null;
                     void Handler(object? _, LogEventArgs e) {
                         if (e.ProgressActivity == "PortScan" && e.ProgressTotalSteps.HasValue && e.ProgressCurrentSteps.HasValue) {
-                            task ??= ctx.AddTask($"Port scan for {domain}", maxValue: e.ProgressTotalSteps.Value);
-                            task.Value = e.ProgressCurrentSteps.Value;
+                            portTask ??= ctx.AddTask($"Port scan for {domain}", maxValue: e.ProgressTotalSteps.Value);
+                            portTask.Value = e.ProgressCurrentSteps.Value;
+                        } else if (e.ProgressActivity == "HealthCheck" && e.ProgressTotalSteps.HasValue && e.ProgressCurrentSteps.HasValue) {
+                            hcTask ??= ctx.AddTask($"Health checks for {domain}", maxValue: e.ProgressTotalSteps.Value);
+                            hcTask.Value = e.ProgressCurrentSteps.Value;
                         }
                     }
 

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -115,8 +115,17 @@ namespace DomainDetective {
 
             healthCheckTypes = healthCheckTypes.Distinct().ToArray();
 
+            var totalChecks = healthCheckTypes.Length;
+            var processedChecks = 0;
+
             foreach (var healthCheckType in healthCheckTypes) {
                 cancellationToken.ThrowIfCancellationRequested();
+                _logger.WriteProgress(
+                    "HealthCheck",
+                    healthCheckType.ToString(),
+                    processedChecks * 100d / totalChecks,
+                    processedChecks,
+                    totalChecks);
                 switch (healthCheckType) {
                     case HealthCheckType.DMARC:
                         var dmarc = await DnsConfiguration.QueryDNS("_dmarc." + domainName, DnsRecordType.TXT, "DMARC1", cancellationToken);
@@ -313,10 +322,19 @@ namespace DomainDetective {
                     case HealthCheckType.THREATINTEL:
                         await VerifyThreatIntel(domainName, cancellationToken);
                         break;
-                    default:
-                        _logger.WriteError("Unknown health check type: {0}", healthCheckType);
-                        throw new NotSupportedException("Health check type not implemented.");
+                default:
+                    _logger.WriteError("Unknown health check type: {0}", healthCheckType);
+                    throw new NotSupportedException("Health check type not implemented.");
                 }
+
+                processedChecks++;
+                _logger.WriteInformation("{0} check completed", healthCheckType);
+                _logger.WriteProgress(
+                    "HealthCheck",
+                    healthCheckType.ToString(),
+                    processedChecks * 100d / totalChecks,
+                    processedChecks,
+                    totalChecks);
             }
         }
 


### PR DESCRIPTION
## Summary
- wrap Verify health checks with progress updates
- display progress bars for health checks in CLI

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: DNS lookups not permitted)*

------
https://chatgpt.com/codex/tasks/task_e_68639ae2608c832e85c34624b28114e2