### PR TITLE
Add remediation hints to DomainSummary

### DIFF
--- a/DomainDetective.Tests/TestDomainSummary.cs
+++ b/DomainDetective.Tests/TestDomainSummary.cs
@@ -40,7 +40,21 @@ namespace DomainDetective.Tests {
             await healthCheck.CheckDMARC(dmarcRecord);
             await healthCheck.CheckDKIM(dkimRecord);
 
-            var summary = healthCheck.BuildSummary();
+            var dnsSecProp = typeof(DnsSecAnalysis).GetProperty(
+                "ChainValid",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
+            )!;
+            dnsSecProp.SetValue(healthCheck.DnsSecAnalysis, true);
+
+            var summary = healthCheck
+                .FilterAnalyses(new[]
+                {
+                    HealthCheckType.SPF,
+                    HealthCheckType.DMARC,
+                    HealthCheckType.DKIM,
+                    HealthCheckType.DNSSEC
+                })
+                .BuildSummary();
 
             Assert.True(summary.SpfValid);
             Assert.True(summary.DmarcValid);

--- a/DomainDetective.Tests/TestDomainSummary.cs
+++ b/DomainDetective.Tests/TestDomainSummary.cs
@@ -11,6 +11,7 @@ namespace DomainDetective.Tests {
             var summary = filtered.BuildSummary();
 
             Assert.False(summary.DnsSecValid);
+            Assert.Contains("Sign zones and publish DS records.", summary.Hints);
         }
 
         [Fact]
@@ -44,6 +45,17 @@ namespace DomainDetective.Tests {
             Assert.True(summary.SpfValid);
             Assert.True(summary.DmarcValid);
             Assert.True(summary.DkimValid);
+            Assert.Empty(summary.Hints);
+        }
+
+        [Fact]
+        public void SummaryProvidesHintsWhenChecksFail() {
+            var healthCheck = new DomainHealthCheck();
+            var summary = healthCheck.BuildSummary();
+
+            Assert.Contains("Add or correct the SPF TXT record.", summary.Hints);
+            Assert.Contains("Publish a valid DMARC record.", summary.Hints);
+            Assert.Contains("Ensure DKIM selectors have valid keys.", summary.Hints);
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1200,6 +1200,34 @@ namespace DomainDetective {
                 a.DkimRecordExists && a.StartsCorrectly && a.PublicKeyExists &&
                 a.ValidPublicKey && a.KeyTypeExists && a.ValidKeyType && a.ValidFlags);
 
+            var hints = new List<string>();
+
+            static void AddHint(List<string> list, HealthCheckType type) {
+                var hint = CheckDescriptions.Get(type)?.Remediation;
+                if (!string.IsNullOrWhiteSpace(hint)) {
+                    list.Add(hint);
+                }
+            }
+
+            if (!spfValid) {
+                AddHint(hints, HealthCheckType.SPF);
+            }
+            if (!dmarcValid) {
+                AddHint(hints, HealthCheckType.DMARC);
+            }
+            if (!dkimValid) {
+                AddHint(hints, HealthCheckType.DKIM);
+            }
+            if (!MXAnalysis.MxRecordExists) {
+                AddHint(hints, HealthCheckType.MX);
+            }
+            if (!(DnsSecAnalysis?.ChainValid ?? false)) {
+                AddHint(hints, HealthCheckType.DNSSEC);
+            }
+            if (WhoisAnalysis.IsExpired || WhoisAnalysis.ExpiresSoon) {
+                hints.Add("Renew the domain registration.");
+            }
+
             return new DomainSummary {
                 HasSpfRecord = SpfAnalysis.SpfRecordExists,
                 SpfValid = spfValid,
@@ -1215,7 +1243,8 @@ namespace DomainDetective {
                 ExpiresSoon = WhoisAnalysis.ExpiresSoon,
                 IsExpired = WhoisAnalysis.IsExpired,
                 RegistrarLocked = WhoisAnalysis.RegistrarLocked,
-                PrivacyProtected = WhoisAnalysis.PrivacyProtected
+                PrivacyProtected = WhoisAnalysis.PrivacyProtected,
+                Hints = hints.ToArray()
             };
         }
 

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -1218,7 +1218,7 @@ namespace DomainDetective {
             if (!dkimValid) {
                 AddHint(hints, HealthCheckType.DKIM);
             }
-            if (!MXAnalysis.MxRecordExists) {
+            if (MXAnalysis is { MxRecordExists: false }) {
                 AddHint(hints, HealthCheckType.MX);
             }
             if (!(DnsSecAnalysis?.ChainValid ?? false)) {
@@ -1236,7 +1236,7 @@ namespace DomainDetective {
                 DmarcValid = dmarcValid,
                 HasDkimRecord = DKIMAnalysis.AnalysisResults.Values.Any(a => a.DkimRecordExists),
                 DkimValid = dkimValid,
-                HasMxRecord = MXAnalysis.MxRecordExists,
+                HasMxRecord = MXAnalysis?.MxRecordExists ?? false,
                 DnsSecValid = DnsSecAnalysis?.ChainValid ?? false,
                 IsPublicSuffix = IsPublicSuffix,
                 ExpiryDate = WhoisAnalysis.ExpiryDate,

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace DomainDetective {
     /// <summary>
     ///     Represents condensed results of domain health checks.
@@ -61,5 +64,8 @@ namespace DomainDetective {
 
         /// <summary>True when WHOIS data is privacy protected.</summary>
         public bool PrivacyProtected { get; init; }
+
+        /// <summary>Collection of recommended remediation hints.</summary>
+        public IReadOnlyList<string> Hints { get; init; } = Array.Empty<string>();
     }
 }


### PR DESCRIPTION
## Summary
- map failing health checks to recommended fixes
- expose `Hints` in `DomainSummary`
- test for new hints feature

## Testing
- `dotnet build --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --framework net8.0 --verbosity minimal` *(fails: Value differ, internal logger error)*

------
https://chatgpt.com/codex/tasks/task_e_68639b6257f8832eb0e151bd12adb770