### PR TITLE
Add similarity algorithms

### DIFF
--- a/DomainDetective.Tests/TestTyposquattingAnalysis.cs
+++ b/DomainDetective.Tests/TestTyposquattingAnalysis.cs
@@ -38,5 +38,29 @@ namespace DomainDetective.Tests {
 
             Assert.Contains("foo.examp1e.co.uk", hc.TyposquattingAnalysis.Variants);
         }
+
+        [Fact]
+        public async Task LevenshteinThresholdLimitsVariants() {
+            var analysis = new TyposquattingAnalysis {
+                DnsConfiguration = new DnsConfiguration(),
+                LevenshteinThreshold = 0
+            };
+
+            await analysis.Analyze("example.com", new InternalLogger());
+
+            Assert.Empty(analysis.Variants);
+        }
+
+        [Fact]
+        public async Task DetectsHomoglyphCharacters() {
+            var analysis = new TyposquattingAnalysis {
+                DnsConfiguration = new DnsConfiguration(),
+                DetectHomoglyphs = true
+            };
+
+            await analysis.Analyze("ex\u0430mple.com", new InternalLogger());
+
+            Assert.True(analysis.ContainsHomoglyphs);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -50,5 +50,11 @@ namespace DomainDetective {
         /// <summary>Holds DNS client configuration used throughout analyses.</summary>
         /// <value>The DNS configuration instance.</value>
         public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
+
+        /// <summary>Maximum Levenshtein distance used for typosquatting detection.</summary>
+        public int TyposquattingLevenshteinThreshold { get; set; } = 1;
+
+        /// <summary>Enable detection of homoglyph characters.</summary>
+        public bool EnableHomoglyphDetection { get; set; } = true;
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -587,6 +587,8 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             TyposquattingAnalysis.DnsConfiguration = DnsConfiguration;
+            TyposquattingAnalysis.LevenshteinThreshold = TyposquattingLevenshteinThreshold;
+            TyposquattingAnalysis.DetectHomoglyphs = EnableHomoglyphDetection;
             await TyposquattingAnalysis.Analyze(domainName, _logger, cancellationToken);
         }
 

--- a/DomainDetective/StringAlgorithms.cs
+++ b/DomainDetective/StringAlgorithms.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective {
+    internal static class StringAlgorithms {
+        private static readonly Dictionary<char, char[]> _confusables = new() {
+            ['a'] = new[] { '\u0430', '\uFF41' },
+            ['e'] = new[] { '\u0435', '\uFF45' },
+            ['i'] = new[] { '\u0456', '\uFF49' },
+            ['o'] = new[] { '\u043E', '\uFF4F' },
+            ['c'] = new[] { '\u0441', '\uFF43' },
+            ['p'] = new[] { '\u0440', '\uFF50' },
+            ['x'] = new[] { '\u0445', '\uFF58' },
+            ['y'] = new[] { '\u0443', '\uFF59' },
+            ['b'] = new[] { '\u0432', '\uFF42' }
+        };
+
+        public static int LevenshteinDistance(string source, string target)
+        {
+            if (source == null) throw new ArgumentNullException(nameof(source));
+            if (target == null) throw new ArgumentNullException(nameof(target));
+            var n = source.Length;
+            var m = target.Length;
+            var d = new int[n + 1, m + 1];
+            for (var i = 0; i <= n; i++) d[i, 0] = i;
+            for (var j = 0; j <= m; j++) d[0, j] = j;
+            for (var i = 1; i <= n; i++) {
+                for (var j = 1; j <= m; j++) {
+                    var cost = source[i - 1] == target[j - 1] ? 0 : 1;
+                    d[i, j] = Math.Min(Math.Min(d[i - 1, j] + 1, d[i, j - 1] + 1), d[i - 1, j - 1] + cost);
+                }
+            }
+            return d[n, m];
+        }
+
+        public static bool ContainsHomoglyphs(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+            {
+                return false;
+            }
+
+            foreach (var ch in input)
+            {
+                foreach (var entry in _confusables)
+                {
+                    if (Array.IndexOf(entry.Value, ch) >= 0)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/DomainDetective/StringAlgorithms.cs
+++ b/DomainDetective/StringAlgorithms.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 
-namespace DomainDetective {
-    internal static class StringAlgorithms {
+namespace DomainDetective;
+
+internal static class StringAlgorithms {
         private static readonly Dictionary<char, char[]> _confusables = new() {
             ['a'] = new[] { '\u0430', '\uFF41' },
             ['e'] = new[] { '\u0435', '\uFF45' },
@@ -54,4 +55,3 @@ namespace DomainDetective {
             return false;
         }
     }
-}


### PR DESCRIPTION
## Summary
- add `StringAlgorithms` helper with Levenshtein and homoglyph detection
- support thresholds for typosquatting analysis
- record homoglyph presence and new settings
- expose typosquatting settings
- test homoglyph and Levenshtein features

## Testing
- `dotnet test --no-build`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68639b3ef564832e8e3a12350970cff9