### PR TITLE
Implement caching for security.txt

### DIFF
--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -155,7 +155,7 @@ namespace DomainDetective.Tests {
             listener.Prefixes.Add(prefix);
             listener.Start();
 
-            var expires = DateTime.UtcNow.AddMilliseconds(500).ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var expires = DateTime.UtcNow.AddSeconds(1).ToString("yyyy-MM-ddTHH:mm:ssZ");
             var content = $"Contact: mailto:admin@example.com\nExpires: {expires}";
             int hitCount = 0;
             var serverTask = Task.Run(async () => {
@@ -178,7 +178,7 @@ namespace DomainDetective.Tests {
 
                 Assert.Equal(1, hitCount);
 
-                await Task.Delay(600);
+                await Task.Delay(1100);
                 await healthCheck.Verify(domain, new[] { HealthCheckType.SECURITYTXT });
 
                 Assert.Equal(2, hitCount);


### PR DESCRIPTION
## Summary
- store fetched security.txt policy until the Expires date
- skip HTTP fetch when a valid cached policy is found
- test caching for security.txt policies

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: The argument ...; 17 Failed)*

------
https://chatgpt.com/codex/tasks/task_e_68639b9db268832e8bd3c6553d2eb815