### PR TITLE
Fix TLSRPT rua handling

### DIFF
--- a/DomainDetective.Tests/TestTLSRPTAnalysis.cs
+++ b/DomainDetective.Tests/TestTLSRPTAnalysis.cs
@@ -99,5 +99,19 @@ namespace DomainDetective.Tests {
             Assert.Empty(analysis.UnknownTags);
             Assert.True(analysis.PolicyValid);
         }
+
+        [Fact]
+        public async Task MissingRuaLogsWarning() {
+            var record = "v=TLSRPTv1";
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var analysis = new TLSRPTAnalysis();
+
+            await analysis.AnalyzeTlsRptRecords(new[] { new DnsAnswer { DataRaw = record, Type = DnsRecordType.TXT } }, logger);
+
+            Assert.False(analysis.PolicyValid);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("rua"));
+        }
     }
 }

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -82,6 +82,10 @@ namespace DomainDetective {
                     }
                 }
             }
+
+            if (!RuaDefined) {
+                logger?.WriteWarning("TLSRPT record missing rua tag.");
+            }
         }
 
         private void AddUriToList(string uri, List<string> mailtoList, List<string> httpList, List<string> invalidList) {


### PR DESCRIPTION
## Summary
- warn when TLSRPT rua tag is missing
- test missing rua warning

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: UnreachableHostLogsExceptionType, CAA record by domain, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68639bb61228832e86ee64562afc8517