### PR TITLE
Add subdomain enumeration and monitoring scheduler

### DIFF
--- a/DomainDetective.Tests/TestMonitorScheduler.cs
+++ b/DomainDetective.Tests/TestMonitorScheduler.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DomainDetective.Monitoring;
+
+namespace DomainDetective.Tests;
+
+public class TestMonitorScheduler
+{
+    private class CaptureNotifier : INotificationSender
+    {
+        public readonly System.Collections.Generic.List<string> Messages = new();
+        public Task SendAsync(string message, CancellationToken ct = default)
+        {
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task TriggersNotificationsOnChange()
+    {
+        var notifier = new CaptureNotifier();
+        var scheduler = new MonitorScheduler
+        {
+            Notifier = notifier,
+            SummaryOverride = _ => Task.FromResult(new DomainSummary { HasMxRecord = true, ExpiryDate = "2025" }),
+            CertificateOverride = _ => Task.FromResult(new CertificateMonitor.Entry
+            {
+                Host = "example.com",
+                Expired = true,
+                ExpiryDate = System.DateTime.UtcNow.AddDays(-1),
+                Analysis = new CertificateAnalysis()
+            })
+        };
+        scheduler.Domains.Add("example.com");
+        await scheduler.RunAsync();
+
+        // next run with different summary should trigger notification
+        scheduler.SummaryOverride = _ => Task.FromResult(new DomainSummary { HasMxRecord = false, ExpiryDate = "2025" });
+        await scheduler.RunAsync();
+
+        Assert.Contains(notifier.Messages, m => m.Contains("Certificate expired"));
+        Assert.Contains(notifier.Messages, m => m.Contains("Changes detected"));
+    }
+}

--- a/DomainDetective.Tests/TestSubdomainEnumeration.cs
+++ b/DomainDetective.Tests/TestSubdomainEnumeration.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DomainDetective;
+using DnsClientX;
+
+namespace DomainDetective.Tests;
+
+public class TestSubdomainEnumeration
+{
+    [Fact]
+    public async Task EnumeratesSubdomains()
+    {
+        var enumr = new SubdomainEnumeration
+        {
+            QueryDnsOverride = (name, type) =>
+            {
+                if (name == "www.example.com")
+                {
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1" } });
+                }
+                return Task.FromResult(System.Array.Empty<DnsAnswer>());
+            },
+            PassiveLookupOverride = (domain, ct) => Task.FromResult<IEnumerable<string>>(new[] { "mail.example.com" })
+        };
+
+        await enumr.Enumerate("example.com", new InternalLogger());
+
+        Assert.Contains("www.example.com", enumr.BruteForceResults);
+        Assert.Contains("mail.example.com", enumr.PassiveResults);
+    }
+}

--- a/DomainDetective/Monitoring/MonitorScheduler.cs
+++ b/DomainDetective/Monitoring/MonitorScheduler.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Monitoring;
+
+/// <summary>
+/// Schedules periodic domain analyses and issues notifications on changes.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class MonitorScheduler
+{
+    /// <summary>Domains to monitor.</summary>
+    public List<string> Domains { get; } = new();
+
+    /// <summary>Interval between runs.</summary>
+    public TimeSpan Interval { get; set; } = TimeSpan.FromHours(24);
+
+    /// <summary>Notification sender.</summary>
+    public INotificationSender? Notifier { get; set; }
+    /// <summary>Override summary generation for testing.</summary>
+    public Func<string, Task<DomainSummary>>? SummaryOverride { private get; set; }
+    /// <summary>Override certificate check for testing.</summary>
+    public Func<string, Task<CertificateMonitor.Entry>>? CertificateOverride { private get; set; }
+
+    private readonly Dictionary<string, DomainSummary> _previous = new();
+    private Timer? _timer;
+
+    /// <summary>Starts the scheduler.</summary>
+    public void Start()
+    {
+        _timer = new Timer(async _ => await RunAsync(), null, TimeSpan.Zero, Interval);
+    }
+
+    /// <summary>Stops the scheduler.</summary>
+    public void Stop() => _timer?.Dispose();
+
+    /// <summary>Runs all analyses once.</summary>
+    public async Task RunAsync(CancellationToken ct = default)
+    {
+        foreach (var domain in Domains)
+        {
+            ct.ThrowIfCancellationRequested();
+            var summary = SummaryOverride != null
+                ? await SummaryOverride(domain)
+                : await BuildSummaryAsync(domain, ct);
+
+            if (_previous.TryGetValue(domain, out var prev))
+            {
+                if (!AreSummariesEqual(prev, summary) && Notifier != null)
+                {
+                    await Notifier.SendAsync($"Changes detected for {domain}", ct);
+                }
+            }
+            _previous[domain] = summary;
+
+            var cert = CertificateOverride != null
+                ? await CertificateOverride(domain)
+                : await CheckCertificateAsync(domain, ct);
+
+            if (cert.Expired && Notifier != null)
+            {
+                await Notifier.SendAsync($"Certificate expired for {domain}", ct);
+            }
+            else if (!cert.Expired && (cert.ExpiryDate - DateTime.UtcNow).TotalDays <= 30 && Notifier != null)
+            {
+                await Notifier.SendAsync($"Certificate for {domain} expires on {cert.ExpiryDate:yyyy-MM-dd}", ct);
+            }
+        }
+    }
+
+    private static bool AreSummariesEqual(DomainSummary a, DomainSummary b)
+    {
+        return a.HasSpfRecord == b.HasSpfRecord &&
+            a.HasDmarcRecord == b.HasDmarcRecord &&
+            a.HasMxRecord == b.HasMxRecord &&
+            a.ExpiryDate == b.ExpiryDate;
+    }
+
+    private static async Task<DomainSummary> BuildSummaryAsync(string domain, CancellationToken ct)
+    {
+        var health = new DomainHealthCheck();
+        await health.Verify(domain, cancellationToken: ct);
+        return health.BuildSummary();
+    }
+
+    private static async Task<CertificateMonitor.Entry> CheckCertificateAsync(string domain, CancellationToken ct)
+    {
+        var monitor = new CertificateMonitor();
+        await monitor.Analyze(new[] { $"https://{domain}" }, 443, new InternalLogger(), ct);
+        return monitor.Results.First();
+    }
+}

--- a/DomainDetective/Monitoring/NotificationSender.cs
+++ b/DomainDetective/Monitoring/NotificationSender.cs
@@ -1,0 +1,63 @@
+using System.Net.Http;
+using System.Text;
+using MailKit.Net.Smtp;
+using MimeKit;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Monitoring;
+
+/// <summary>Defines notification sending behavior.</summary>
+public interface INotificationSender
+{
+    /// <summary>Sends a notification message.</summary>
+    Task SendAsync(string message, CancellationToken ct = default);
+}
+
+/// <summary>Sends notifications via HTTP webhook.</summary>
+public class WebhookNotificationSender : INotificationSender
+{
+    private readonly HttpClient _client = new();
+    public string Url { get; }
+
+    public WebhookNotificationSender(string url)
+    {
+        Url = url;
+    }
+
+    public async Task SendAsync(string message, CancellationToken ct = default)
+    {
+        using var content = new StringContent(message, Encoding.UTF8, "text/plain");
+        await _client.PostAsync(Url, content, ct);
+    }
+}
+
+/// <summary>Sends notifications via SMTP.</summary>
+public class EmailNotificationSender : INotificationSender
+{
+    public string SmtpHost { get; set; } = "localhost";
+    public int Port { get; set; } = 25;
+    public bool UseSsl { get; set; }
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+
+    public async Task SendAsync(string message, CancellationToken ct = default)
+    {
+        var email = new MimeMessage();
+        email.From.Add(MailboxAddress.Parse(From));
+        email.To.Add(MailboxAddress.Parse(To));
+        email.Subject = "DomainDetective Notification";
+        email.Body = new TextPart("plain") { Text = message };
+
+        using var client = new SmtpClient();
+        await client.ConnectAsync(SmtpHost, Port, UseSsl, ct);
+        if (!string.IsNullOrEmpty(Username))
+        {
+            await client.AuthenticateAsync(Username, Password ?? string.Empty, ct);
+        }
+        await client.SendAsync(email, ct);
+        await client.DisconnectAsync(true, ct);
+    }
+}

--- a/DomainDetective/Protocols/SubdomainEnumeration.cs
+++ b/DomainDetective/Protocols/SubdomainEnumeration.cs
@@ -1,0 +1,112 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Enumerates subdomains using dictionary brute force and passive sources.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class SubdomainEnumeration
+{
+    /// <summary>DNS configuration for queries.</summary>
+    public DnsConfiguration DnsConfiguration { get; set; } = new();
+
+    /// <summary>Subdomain wordlist used for brute force.</summary>
+    public List<string> Dictionary { get; } = new() { "www", "mail", "ftp", "dev", "test" };
+
+    /// <summary>Override DNS query logic for testing.</summary>
+    public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+    /// <summary>Override passive enumeration logic for testing.</summary>
+    public Func<string, CancellationToken, Task<IEnumerable<string>>>? PassiveLookupOverride { private get; set; }
+
+    /// <summary>URL template for crt.sh lookups.</summary>
+    public string CrtShUrlTemplate { get; set; } = "https://crt.sh/?q=%25.{0}&output=json";
+
+    /// <summary>List of subdomains discovered via brute force.</summary>
+    public List<string> BruteForceResults { get; private set; } = new();
+
+    /// <summary>List of subdomains discovered via passive sources.</summary>
+    public List<string> PassiveResults { get; private set; } = new();
+
+    private static readonly HttpClient _client = new();
+
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
+    {
+        if (QueryDnsOverride != null)
+        {
+            return await QueryDnsOverride(name, type);
+        }
+        return await DnsConfiguration.QueryDNS(name, type);
+    }
+
+    private async Task<IEnumerable<string>> QueryPassive(string domain, CancellationToken ct)
+    {
+        if (PassiveLookupOverride != null)
+        {
+            return await PassiveLookupOverride(domain, ct);
+        }
+
+        var url = string.Format(CrtShUrlTemplate, domain);
+        using var resp = await _client.GetAsync(url, ct);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var list = new List<string>();
+        foreach (var item in doc.RootElement.EnumerateArray())
+        {
+            if (item.TryGetProperty("name_value", out var nv))
+            {
+                var vals = nv.GetString();
+                if (!string.IsNullOrWhiteSpace(vals))
+                {
+                    list.AddRange(vals.Split('\n'));
+                }
+            }
+        }
+        return list.Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Performs enumeration for <paramref name="domain"/>.
+    /// </summary>
+    public async Task Enumerate(string domain, InternalLogger logger, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+        {
+            throw new ArgumentNullException(nameof(domain));
+        }
+
+        BruteForceResults = new List<string>();
+        PassiveResults = new List<string>();
+
+        foreach (var word in Dictionary)
+        {
+            ct.ThrowIfCancellationRequested();
+            var name = $"{word}.{domain}";
+            var a = await QueryDns(name, DnsRecordType.A);
+            var aaaa = await QueryDns(name, DnsRecordType.AAAA);
+            if ((a?.Length > 0) || (aaaa?.Length > 0))
+            {
+                BruteForceResults.Add(name);
+                logger?.WriteVerbose("Found subdomain: {0}", name);
+            }
+        }
+
+        try
+        {
+            var passive = await QueryPassive(domain, ct);
+            PassiveResults = passive.ToList();
+        }
+        catch (Exception ex)
+        {
+            logger?.WriteError("Passive enumeration failed: {0}", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `SubdomainEnumeration` for brute force and passive enumeration
- add monitoring scheduler for periodic analyses
- send notifications via webhook or email
- restore MimeKit-based email notifications
- add integration tests for new features

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: CertificateMonitor and DNS/WHOIS tests require network)*

------
https://chatgpt.com/codex/tasks/task_e_686125f81368832ea3107af1c574905d