### PR TITLE
Add DKIM creation date parsing

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using DomainDetective;
 
@@ -36,7 +37,9 @@ namespace DomainDetective.PowerShell {
                     Canonicalization = result.Canonicalization,
                     ValidCanonicalization = result.ValidCanonicalization,
                     KeyType = result.KeyType,
-                    HashAlgorithm = result.HashAlgorithm
+                    HashAlgorithm = result.HashAlgorithm,
+                    CreationDate = result.CreationDate,
+                    OldKey = result.OldKey
                 };
             }
         }
@@ -131,6 +134,12 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Hash algorithm used by the key.</summary>
         public string HashAlgorithm { get; set; }
+
+        /// <summary>Date the record appears to have been created.</summary>
+        public DateTime? CreationDate { get; set; }
+
+        /// <summary>True when <see cref="CreationDate"/> is over 12 months old.</summary>
+        public bool OldKey { get; set; }
     }
 
     /// <summary>

--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -1,3 +1,4 @@
+using System;
 using DnsClientX;
 
 namespace DomainDetective.Tests {
@@ -232,6 +233,19 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.AdspRecordExists);
             Assert.Equal("dkim=all", analysis.AdspRecord);
             Assert.Contains(warnings, w => w.FullMessage.Contains("obsolete"));
+        }
+
+        [Fact]
+        public async Task ParsesCreationDateAndDetectsOldKey() {
+            const string record =
+                "v=DKIM1; k=rsa; n=2000-01-01; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
+
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.CheckDKIM(record);
+
+            var result = healthCheck.DKIMAnalysis.AnalysisResults["default"];
+            Assert.Equal(new DateTime(2000, 1, 1), result.CreationDate!.Value.Date);
+            Assert.True(result.OldKey);
         }
     }
 }


### PR DESCRIPTION
## Summary
- parse selector _domainkey creation date
- warn if DKIM key older than 12 months
- expose creation timestamp through PowerShell helper
- test for old key detection

## Testing
- `dotnet test --no-build` *(fails: The argument DomainDetective.Tests.dll is invalid)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6864e02944fc832eb07b3e69e2d46f7b