### PR TITLE
Add DNS monitor customization

### DIFF
--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -1,0 +1,81 @@
+using DnsClientX;
+using DomainDetective.Monitoring;
+using System;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Starts background monitoring of DNS propagation.</summary>
+    /// <para>Part of the DomainDetective project.</para>
+    /// <example>
+    ///   <summary>Start monitoring an A record.</summary>
+    ///   <code>Start-DnsPropagationMonitor -DomainName example.com -RecordType A -WebhookUrl https://example.com/webhook</code>
+    /// </example>
+    [Cmdlet(
+        VerbsLifecycle.Start,
+        "DnsPropagationMonitor",
+        SupportsShouldProcess = false,
+        DefaultParameterSetName = "File")]
+    public sealed class CmdletStartDnsPropagationMonitor : AsyncPSCmdlet {
+        /// <param name="DomainName">Domain to monitor.</param>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "File")]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Custom")]
+        [ValidateNotNullOrEmpty]
+        public string DomainName;
+
+        /// <param name="RecordType">DNS record type.</param>
+        [Parameter(Mandatory = true, Position = 1, ParameterSetName = "File")]
+        [Parameter(Mandatory = true, Position = 1, ParameterSetName = "Custom")]
+        public DnsRecordType RecordType;
+
+        /// <param name="ServersFile">Path to JSON file with DNS servers.</param>
+        [Parameter(Mandatory = false, ParameterSetName = "File")]
+        public string ServersFile = "Data/DNS/PublicDNS.json";
+
+        /// <param name="DnsServer">One or more custom DNS servers.</param>
+        [Parameter(Mandatory = false, ParameterSetName = "Custom")]
+        public string[] DnsServer = Array.Empty<string>();
+
+        /// <param name="Country">Filter builtin servers by country.</param>
+        [Parameter(Mandatory = false)]
+        public string? Country;
+
+        /// <param name="Location">Filter builtin servers by location.</param>
+        [Parameter(Mandatory = false)]
+        public string? Location;
+
+        /// <param name="IntervalSeconds">Polling interval in seconds.</param>
+        [Parameter(Mandatory = false)]
+        public int IntervalSeconds = 300;
+
+        /// <param name="WebhookUrl">Webhook URL for notifications.</param>
+        [Parameter(Mandatory = false)]
+        public string? WebhookUrl;
+
+        private readonly DnsPropagationMonitor _monitor = new();
+
+        protected override Task BeginProcessingAsync() {
+            _monitor.Domain = DomainName;
+            _monitor.RecordType = RecordType;
+            _monitor.Interval = TimeSpan.FromSeconds(IntervalSeconds);
+            _monitor.Country = Country;
+            _monitor.Location = Location;
+            _monitor.LoadServers(ServersFile);
+            if (ParameterSetName == "Custom") {
+                foreach (var ip in DnsServer) {
+                    if (System.Net.IPAddress.TryParse(ip, out var parsed)) {
+                        _monitor.AddServer(new PublicDnsEntry { IPAddress = parsed, Enabled = true });
+                    } else {
+                        WriteWarning($"Invalid DNS server IP: {ip}");
+                    }
+                }
+            }
+            if (!string.IsNullOrWhiteSpace(WebhookUrl)) {
+                _monitor.Notifier = new WebhookNotificationSender(WebhookUrl);
+            }
+            _monitor.Start();
+            WriteObject(_monitor);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletStopDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStopDnsPropagationMonitor.cs
@@ -1,0 +1,23 @@
+using DomainDetective.Monitoring;
+using System.Management.Automation;
+using System.Threading.Tasks;
+
+namespace DomainDetective.PowerShell {
+    /// <summary>Stops a running DNS propagation monitor.</summary>
+    /// <para>Part of the DomainDetective project.</para>
+    /// <example>
+    ///   <summary>Stop monitoring.</summary>
+    ///   <code>Stop-DnsPropagationMonitor -Monitor $monitor</code>
+    /// </example>
+    [Cmdlet(VerbsLifecycle.Stop, "DnsPropagationMonitor")]
+    public sealed class CmdletStopDnsPropagationMonitor : AsyncPSCmdlet {
+        /// <param name="Monitor">Monitor instance returned by Start-DnsPropagationMonitor.</param>
+        [Parameter(Mandatory = true, Position = 0)]
+        public DnsPropagationMonitor Monitor = null!;
+
+        protected override Task ProcessRecordAsync() {
+            Monitor.Stop();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDnsPropagationMonitor.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitor.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DomainDetective.Monitoring;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsPropagationMonitor {
+    private class CaptureNotifier : INotificationSender {
+        public readonly List<string> Messages = new();
+        public Task SendAsync(string message, CancellationToken ct = default) {
+            Messages.Add(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task SendsNotificationOnDiscrepancy() {
+        var notifier = new CaptureNotifier();
+        var monitor = new DnsPropagationMonitor {
+            Domain = "example.com",
+            RecordType = DnsClientX.DnsRecordType.A,
+            Notifier = notifier,
+            QueryOverride = (_, _) => Task.FromResult(new List<DnsPropagationResult> {
+                new() { Server = new PublicDnsEntry { IPAddress = IPAddress.Parse("1.1.1.1"), Enabled = true }, RecordType = DnsClientX.DnsRecordType.A, Records = new[] {"1.2.3.4"}, Success = true },
+                new() { Server = new PublicDnsEntry { IPAddress = IPAddress.Parse("8.8.8.8"), Enabled = true }, RecordType = DnsClientX.DnsRecordType.A, Records = new[] {"5.6.7.8"}, Success = true }
+            })
+        };
+
+        await monitor.RunAsync();
+        Assert.Contains(notifier.Messages, m => m.Contains("discrepancy"));
+    }
+
+    [Fact]
+    public async Task HonorsCountryFilterAndCustomServers() {
+        var passed = new List<PublicDnsEntry>();
+        var json = "[ { \"Country\": \"US\", \"IPAddress\": \"1.1.1.1\", \"Enabled\": true }, { \"Country\": \"DE\", \"IPAddress\": \"2.2.2.2\", \"Enabled\": true } ]";
+        var file = System.IO.Path.GetTempFileName();
+        try {
+            System.IO.File.WriteAllText(file, json);
+            var monitor = new DnsPropagationMonitor {
+                Domain = "example.com",
+                RecordType = DnsClientX.DnsRecordType.A,
+                Country = "US",
+                QueryOverride = (servers, _) => { passed.AddRange(servers); return Task.FromResult(new List<DnsPropagationResult>()); }
+            };
+            monitor.LoadServers(file);
+            monitor.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("3.3.3.3"), Enabled = true });
+            await monitor.RunAsync();
+            Assert.Equal(2, passed.Count);
+            Assert.Contains(passed, p => p.IPAddress.Equals(IPAddress.Parse("1.1.1.1")));
+            Assert.Contains(passed, p => p.IPAddress.Equals(IPAddress.Parse("3.3.3.3")));
+        } finally {
+            System.IO.File.Delete(file);
+        }
+    }
+}

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -1,0 +1,77 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Monitoring {
+    /// <summary>Monitors DNS propagation discrepancies over time.</summary>
+    /// <para>Part of the DomainDetective project.</para>
+    public class DnsPropagationMonitor {
+        /// <summary>Domain to query.</summary>
+        public string Domain { get; set; } = string.Empty;
+
+        /// <summary>Record type to check.</summary>
+        public DnsRecordType RecordType { get; set; } = DnsRecordType.A;
+
+        /// <summary>Interval between checks.</summary>
+        public TimeSpan Interval { get; set; } = TimeSpan.FromMinutes(30);
+
+        /// <summary>Notification sender.</summary>
+        public INotificationSender? Notifier { get; set; }
+
+        /// <summary>Override query for testing.</summary>
+        public Func<IEnumerable<PublicDnsEntry>, CancellationToken, Task<List<DnsPropagationResult>>>? QueryOverride { private get; set; }
+
+        /// <summary>Country filter for builtin servers.</summary>
+        public string? Country { get; set; }
+
+        /// <summary>Location filter for builtin servers.</summary>
+        public string? Location { get; set; }
+
+        /// <summary>Additional user supplied servers.</summary>
+        public List<PublicDnsEntry> CustomServers { get; } = new();
+
+        private readonly DnsPropagationAnalysis _analysis = new();
+        private Timer? _timer;
+
+        /// <summary>Adds a custom DNS server.</summary>
+        /// <param name="entry">Server entry.</param>
+        public void AddServer(PublicDnsEntry entry) {
+            if (entry != null) {
+                CustomServers.Add(entry);
+            }
+        }
+
+        /// <summary>Starts the monitor.</summary>
+        public void Start() {
+            _timer = new Timer(async _ => await RunAsync(), null, TimeSpan.Zero, Interval);
+        }
+
+        /// <summary>Stops the monitor.</summary>
+        public void Stop() => _timer?.Dispose();
+
+        /// <summary>Loads DNS servers from JSON file.</summary>
+        /// <param name="filePath">Path to server list.</param>
+        public void LoadServers(string filePath) => _analysis.LoadServers(filePath, clearExisting: true);
+
+        /// <summary>Runs a single propagation check.</summary>
+        public async Task RunAsync(CancellationToken ct = default) {
+            IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location);
+            servers = servers.Concat(CustomServers.Where(s => s.Enabled));
+            var serverList = servers.ToList();
+            var results = QueryOverride != null
+                ? await QueryOverride(serverList, ct)
+                : await _analysis.QueryAsync(Domain, RecordType, serverList, ct);
+            var groups = DnsPropagationAnalysis.CompareResults(results);
+            if (groups.Count > 1) {
+                var message = $"Propagation discrepancy for {Domain} ({RecordType})";
+                Console.WriteLine(message);
+                if (Notifier != null) {
+                    await Notifier.SendAsync(message, ct);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support custom DNS servers and country/location filters in `DnsPropagationMonitor`
- update `Start-DnsPropagationMonitor` cmdlet to accept custom servers
- extend tests to verify custom server support

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: several tests require network access)*

------
https://chatgpt.com/codex/tasks/task_e_6864df5a90d0832eb6de83d6b7499e39