### PR TITLE
Fix DNS propagation file paths

### DIFF
--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -1,7 +1,9 @@
 using DnsClientX;
 using Spectre.Console.Cli;
+using System.Reflection;
 using System.Text.Json;
 using System.Threading;
+using System.IO;
 
 namespace DomainDetective.CLI;
 
@@ -26,7 +28,11 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
     public override async Task<int> ExecuteAsync(CommandContext context, DnsPropagationSettings settings) {
         var analysis = new DnsPropagationAnalysis();
         if (settings.ServersFile != null) {
-            analysis.LoadServers(settings.ServersFile.FullName, clearExisting: true);
+            var inputPath = settings.ServersFile.ToString();
+            var filePath = Path.IsPathRooted(inputPath)
+                ? settings.ServersFile.FullName
+                : Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, inputPath);
+            analysis.LoadServers(filePath, clearExisting: true);
         } else {
             analysis.LoadBuiltinServers();
         }

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,13 +1,17 @@
 using DnsClientX;
 using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
+            var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
+            analysis.LoadServers(file);
             var servers = analysis.FilterServers(country: "United States", take: 3);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -1,13 +1,17 @@
 using DnsClientX;
 using System;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationRegionsClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.LoadServers("Data/DNS/PublicDNS.json");
+            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
+            var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
+            analysis.LoadServers(file);
 
             var servers = analysis.FilterServers(take: 8);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);

--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -1,7 +1,9 @@
 using DnsClientX;
 using DomainDetective.Monitoring;
 using System;
+using System.IO;
 using System.Management.Automation;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
@@ -61,7 +63,10 @@ namespace DomainDetective.PowerShell {
             _monitor.Country = Country;
             _monitor.Location = Location;
             if (!string.IsNullOrWhiteSpace(ServersFile)) {
-                _monitor.LoadServers(ServersFile);
+                var path = Path.IsPathRooted(ServersFile)
+                    ? ServersFile
+                    : Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, ServersFile);
+                _monitor.LoadServers(path);
             } else {
                 _monitor.LoadBuiltinServers();
             }

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -1,7 +1,9 @@
 using DnsClientX;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Management.Automation;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.PowerShell {
@@ -9,7 +11,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Test propagation of an A record.</summary>
-    ///   <code>Test-DnsPropagation -DomainName example.com -RecordType A -ServersFile ./PublicDNS.json</code>
+    ///   <code>$file = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'; Test-DnsPropagation -DomainName example.com -RecordType A -ServersFile $file</code>
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DnsPropagation", DefaultParameterSetName = "ServersFile")]
     public sealed class CmdletTestDnsPropagation : AsyncPSCmdlet {
@@ -51,7 +53,10 @@ namespace DomainDetective.PowerShell {
             internalLoggerPowerShell.ResetActivityIdCounter();
             _analysis = new DnsPropagationAnalysis();
             if (!string.IsNullOrWhiteSpace(ServersFile)) {
-                _analysis.LoadServers(ServersFile, clearExisting: true);
+                var path = Path.IsPathRooted(ServersFile)
+                    ? ServersFile
+                    : Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty, ServersFile);
+                _analysis.LoadServers(path, clearExisting: true);
             } else {
                 _analysis.LoadBuiltinServers();
             }

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -5,7 +5,8 @@ Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 $Results = Test-DnsPropagation -DomainName 'google.com' -RecordType A -CompareResults
 $Results | Format-Table
 
-$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $PSScriptRoot/../Data/DNS/PublicDNS.json
+$File = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'
+$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $File
 $PublicServers | Format-Table
 
 $TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -23,7 +23,8 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```
 - `Test-DnsPropagation` – checks how DNS records propagate across public resolvers.
   ```powershell
-  Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile './Data/DNS/PublicDNS.json' -CompareResults
+  $file = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'
+  Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile $file -CompareResults
   ```
 - `Test-CaaRecord` – validates CAA entries.
   ```powershell


### PR DESCRIPTION
## Summary
- resolve server list paths from executing assembly
- update examples to use the new helper logic
- refresh README references

## Testing
- `dotnet test -v minimal` *(fails: Assert failures)*
- `pwsh -NoLogo -NoProfile -Command ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68654119007c832ebe23276286b632f3