### PR TITLE
Stream-based JSON loading

### DIFF
--- a/DomainDetective.Tests/TestDNSBLConfig.cs
+++ b/DomainDetective.Tests/TestDNSBLConfig.cs
@@ -13,6 +13,7 @@ namespace DomainDetective.Tests {
 
                 var analysis = new DNSBLAnalysis();
                 analysis.LoadDnsblConfig(file, clearExisting: true);
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
 
                 var entries = analysis.GetDNSBL().ToList();
                 Assert.Equal(2, entries.Count);
@@ -34,6 +35,7 @@ namespace DomainDetective.Tests {
                 var analysis = new DNSBLAnalysis();
                 var before = analysis.GetDNSBL().Count;
                 analysis.LoadDnsblConfig(file);
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
                 var after = analysis.GetDNSBL().Count;
 
                 Assert.Equal(before + 1, after);
@@ -53,6 +55,7 @@ namespace DomainDetective.Tests {
 
                 var analysis = new DNSBLAnalysis();
                 analysis.LoadDnsblConfig(file, clearExisting: true);
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
 
                 var entries = analysis.GetDNSBL()
                     .Where(e => string.Equals(e.Domain, "dup.test", StringComparison.OrdinalIgnoreCase))

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -172,6 +172,8 @@ namespace DomainDetective.Tests {
                 var analysis = new DnsPropagationAnalysis();
                 analysis.LoadServers(file, clearExisting: true);
 
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+
                 var server = Assert.Single(analysis.Servers);
                 Assert.Equal("Test", server.Country);
                 Assert.Equal("example.com", server.HostName);
@@ -191,6 +193,7 @@ namespace DomainDetective.Tests {
                 File.WriteAllText(file, json);
                 var analysis = new DnsPropagationAnalysis();
                 Assert.Throws<FormatException>(() => analysis.LoadServers(file, clearExisting: true));
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
             }
             finally {
                 File.Delete(file);

--- a/DomainDetective.Tests/TestDnsPropagationMonitor.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitor.cs
@@ -46,6 +46,7 @@ public class TestDnsPropagationMonitor {
                 QueryOverride = (servers, _) => { passed.AddRange(servers); return Task.FromResult(new List<DnsPropagationResult>()); }
             };
             monitor.LoadServers(file);
+            using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
             monitor.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("3.3.3.3"), Enabled = true });
             await monitor.RunAsync();
             Assert.Equal(2, passed.Count);

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -513,6 +513,7 @@ namespace DomainDetective.Tests {
             var preloadPath = Path.Combine(AppContext.BaseDirectory, "hsts_preload.json");
             File.WriteAllText(preloadPath, "[\"localhost\"]");
             HttpAnalysis.LoadHstsPreloadList(preloadPath);
+            using (File.Open(preloadPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -530,6 +531,7 @@ namespace DomainDetective.Tests {
             } finally {
                 listener.Stop();
                 await serverTask;
+                File.Delete(preloadPath);
             }
         }
 

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -48,10 +48,11 @@ namespace DomainDetective {
                 _servers.Clear();
             }
 
-            var json = File.ReadAllText(filePath);
+            using var stream = File.OpenRead(filePath);
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
             options.Converters.Add(new IPAddressJsonConverter());
-            var servers = JsonSerializer.Deserialize<List<PublicDnsEntry>>(json, options);
+            var servers = JsonSerializer.DeserializeAsync<List<PublicDnsEntry>>(stream, options)
+                .GetAwaiter().GetResult();
             if (servers == null) {
                 return;
             }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -460,9 +460,10 @@ namespace DomainDetective {
                 throw new FileNotFoundException($"DNSBL config file not found: {filePath}");
             }
 
-            var json = File.ReadAllText(filePath);
+            using var stream = File.OpenRead(filePath);
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var config = JsonSerializer.Deserialize<DnsblConfiguration>(json, options);
+            var config = JsonSerializer.DeserializeAsync<DnsblConfiguration>(stream, options)
+                .GetAwaiter().GetResult();
             if (config != null) {
                 ApplyDnsblConfiguration(config, overwriteExisting, clearExisting);
             }

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -124,12 +124,12 @@ namespace DomainDetective {
                 return;
             }
             try {
-                var json = File.ReadAllText(filePath);
-                using var doc = JsonDocument.Parse(json);
-                var entries = doc.RootElement.EnumerateArray()
-                    .Select(e => e.GetString())
-                    .Where(s => !string.IsNullOrWhiteSpace(s));
-                _hstsPreload = new HashSet<string>(entries!, StringComparer.OrdinalIgnoreCase);
+                using var stream = File.OpenRead(filePath);
+                var entries = JsonSerializer.DeserializeAsync<string[]>(stream)
+                    .GetAwaiter().GetResult()
+                    ?.Where(s => !string.IsNullOrWhiteSpace(s))
+                    ?? Enumerable.Empty<string>();
+                _hstsPreload = new HashSet<string>(entries, StringComparer.OrdinalIgnoreCase);
             } catch {
                 // ignore malformed preload files
             }


### PR DESCRIPTION
## Summary
- use streaming JsonSerializer APIs when loading DNS or DNSBL files
- ensure JSON files are opened with `using` blocks
- check for file handle leaks in tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.sln -v n` *(fails: The argument ... invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6865543b4954832ea6e8b98998923486