### PR TITLE
Add builtin DNS server parameter set

### DIFF
--- a/DomainDetective.Tests/TestCmdletTestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestCmdletTestDnsPropagation.cs
@@ -1,0 +1,41 @@
+using DomainDetective.PowerShell;
+using DnsClientX;
+using Pwsh = System.Management.Automation.PowerShell;
+using System.IO;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestCmdletTestDnsPropagation {
+    [Fact]
+    public void RunsWithBuiltinServersParameterSet() {
+        using var ps = Pwsh.Create();
+        ps.AddCommand("Import-Module").AddArgument(typeof(CmdletTestDnsPropagation).Assembly.Location).Invoke();
+        ps.Commands.Clear();
+        ps.AddCommand("Test-DnsPropagation")
+            .AddParameter("DomainName", "example.com")
+            .AddParameter("RecordType", DnsRecordType.A)
+            .AddParameter("Take", 0);
+        var results = ps.Invoke();
+        Assert.Empty(ps.Streams.Error);
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public void RunsWithServersFileParameterSet() {
+        var file = Path.GetTempFileName();
+        File.WriteAllText(file, "[{\"IPAddress\":\"192.0.2.1\"}]");
+        using var ps = Pwsh.Create();
+        ps.AddCommand("Import-Module").AddArgument(typeof(CmdletTestDnsPropagation).Assembly.Location).Invoke();
+        ps.Commands.Clear();
+        ps.AddCommand("Test-DnsPropagation")
+            .AddParameter("DomainName", "example.com")
+            .AddParameter("RecordType", DnsRecordType.A)
+            .AddParameter("ServersFile", file)
+            .AddParameter("Take", 0);
+        var results = ps.Invoke();
+        File.Delete(file);
+        Assert.Empty(ps.Streams.Error);
+        Assert.Empty(results);
+    }
+}


### PR DESCRIPTION
## Summary
- add new "Builtin" parameter set to `Test-DnsPropagation`
- load built-in DNS servers when parameter set is used
- create unit tests exercising both parameter sets

## Testing
- `dotnet build --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6865513c69c0832e9620f62f6dc4d985