### PR TITLE
Add validation routine for DNS server entries

### DIFF
--- a/DomainDetective.Tests/TestCmdletTestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestCmdletTestDnsPropagation.cs
@@ -24,7 +24,7 @@ public class TestCmdletTestDnsPropagation {
     [Fact]
     public void RunsWithServersFileParameterSet() {
         var file = Path.GetTempFileName();
-        File.WriteAllText(file, "[{\"IPAddress\":\"192.0.2.1\"}]");
+        File.WriteAllText(file, "[{\"IPAddress\":\"192.0.2.1\",\"Country\":\"US\",\"ASN\":\"AS0\"}]");
         using var ps = Pwsh.Create();
         ps.AddCommand("Import-Module").AddArgument(typeof(CmdletTestDnsPropagation).Assembly.Location).Invoke();
         ps.Commands.Clear();

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -15,7 +15,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public void AddAndRemoveServerWorks() {
             var analysis = new DnsPropagationAnalysis();
-            var entry = new PublicDnsEntry { IPAddress = IPAddress.Parse("1.1.1.1"), Country = "Test" };
+            var entry = new PublicDnsEntry { IPAddress = IPAddress.Parse("1.1.1.1"), Country = "Test", ASN = "AS0" };
             analysis.AddServer(entry);
             Assert.Contains(analysis.Servers, s => s.IPAddress.Equals(IPAddress.Parse("1.1.1.1")));
             analysis.RemoveServer("1.1.1.1");
@@ -25,7 +25,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task QueryHandlesDownServer() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("192.0.2.1"), Country = "Test" });
+            analysis.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("192.0.2.1"), Country = "Test", ASN = "AS0" });
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers);
             Assert.Single(results);
             Assert.False(results[0].Success);
@@ -34,7 +34,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task QueryHonorsCancellation() {
             var analysis = new DnsPropagationAnalysis();
-            analysis.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("192.0.2.1"), Country = "Test" });
+            analysis.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("192.0.2.1"), Country = "Test", ASN = "AS0" });
             using var cts = new CancellationTokenSource();
             cts.Cancel();
 

--- a/DomainDetective.Tests/TestDnsPropagationMonitor.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitor.cs
@@ -35,7 +35,7 @@ public class TestDnsPropagationMonitor {
     [Fact]
     public async Task HonorsCountryFilterAndCustomServers() {
         var passed = new List<PublicDnsEntry>();
-        var json = "[ { \"Country\": \"US\", \"IPAddress\": \"1.1.1.1\", \"Enabled\": true }, { \"Country\": \"DE\", \"IPAddress\": \"2.2.2.2\", \"Enabled\": true } ]";
+        var json = "[ { \"Country\": \"US\", \"IPAddress\": \"1.1.1.1\", \"ASN\": \"AS0\", \"Enabled\": true }, { \"Country\": \"DE\", \"IPAddress\": \"2.2.2.2\", \"ASN\": \"AS0\", \"Enabled\": true } ]";
         var file = System.IO.Path.GetTempFileName();
         try {
             System.IO.File.WriteAllText(file, json);
@@ -46,7 +46,7 @@ public class TestDnsPropagationMonitor {
                 QueryOverride = (servers, _) => { passed.AddRange(servers); return Task.FromResult(new List<DnsPropagationResult>()); }
             };
             monitor.LoadServers(file);
-            monitor.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("3.3.3.3"), Enabled = true });
+            monitor.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("3.3.3.3"), Country = "US", ASN = "AS0", Enabled = true });
             await monitor.RunAsync();
             Assert.Equal(2, passed.Count);
             Assert.Contains(passed, p => p.IPAddress.Equals(IPAddress.Parse("1.1.1.1")));

--- a/DomainDetective.Tests/TestDnsPropagationValidation.cs
+++ b/DomainDetective.Tests/TestDnsPropagationValidation.cs
@@ -1,0 +1,45 @@
+using DomainDetective;
+using System.Net;
+
+namespace DomainDetective.Tests {
+    public class TestDnsPropagationValidation {
+        [Fact]
+        public void LoadServersThrowsForMissingCountry() {
+            var json = "[{\"IPAddress\":\"1.2.3.4\",\"ASN\":\"1234\"}]";
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, json);
+                var analysis = new DnsPropagationAnalysis();
+                Assert.Throws<FormatException>(() => analysis.LoadServers(file, clearExisting: true));
+            } finally {
+                File.Delete(file);
+            }
+        }
+
+        [Fact]
+        public void LoadServersThrowsForMissingAsn() {
+            var json = "[{\"Country\":\"US\",\"IPAddress\":\"1.2.3.4\"}]";
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, json);
+                var analysis = new DnsPropagationAnalysis();
+                Assert.Throws<FormatException>(() => analysis.LoadServers(file, clearExisting: true));
+            } finally {
+                File.Delete(file);
+            }
+        }
+
+        [Fact]
+        public void LoadServersThrowsForMissingIp() {
+            var json = "[{\"Country\":\"US\",\"ASN\":\"1234\"}]";
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, json);
+                var analysis = new DnsPropagationAnalysis();
+                Assert.Throws<FormatException>(() => analysis.LoadServers(file, clearExisting: true));
+            } finally {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -57,17 +57,14 @@ namespace DomainDetective {
             }
 
             foreach (var entry in servers) {
-                var canonical = GetCanonicalIp(entry.IPAddress);
-                if (!string.Equals(canonical, entry.IPAddress.ToString(), StringComparison.OrdinalIgnoreCase)) {
-                    throw new FormatException($"Invalid IP address '{entry.IPAddress}'");
-                }
+                ValidateEntry(entry);
 
                 var trimmed = new PublicDnsEntry {
-                    Country = entry.Country?.Trim(),
+                    Country = entry.Country.Trim(),
                     IPAddress = entry.IPAddress,
                     HostName = entry.HostName?.Trim(),
                     Location = entry.Location?.Trim(),
-                    ASN = entry.ASN,
+                    ASN = entry.ASN.Trim(),
                     ASNName = entry.ASNName?.Trim(),
                     Enabled = entry.Enabled
                 };
@@ -102,17 +99,14 @@ namespace DomainDetective {
             }
 
             foreach (var entry in servers) {
-                var canonical = GetCanonicalIp(entry.IPAddress);
-                if (!string.Equals(canonical, entry.IPAddress.ToString(), StringComparison.OrdinalIgnoreCase)) {
-                    throw new FormatException($"Invalid IP address '{entry.IPAddress}'");
-                }
+                ValidateEntry(entry);
 
                 var trimmed = new PublicDnsEntry {
-                    Country = entry.Country?.Trim(),
+                    Country = entry.Country.Trim(),
                     IPAddress = entry.IPAddress,
                     HostName = entry.HostName?.Trim(),
                     Location = entry.Location?.Trim(),
-                    ASN = entry.ASN,
+                    ASN = entry.ASN.Trim(),
                     ASNName = entry.ASNName?.Trim(),
                     Enabled = entry.Enabled
                 };
@@ -228,6 +222,25 @@ namespace DomainDetective {
             return ipAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
                 ? IPAddress.Parse(ipAddress.ToString()).ToString()
                 : ipAddress.ToString();
+        }
+
+        private static void ValidateEntry(PublicDnsEntry entry) {
+            if (entry.IPAddress == null) {
+                throw new FormatException("IPAddress is missing");
+            }
+
+            var canonical = GetCanonicalIp(entry.IPAddress);
+            if (!string.Equals(canonical, entry.IPAddress.ToString(), StringComparison.OrdinalIgnoreCase)) {
+                throw new FormatException($"Invalid IP address '{entry.IPAddress}'");
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.Country?.Trim())) {
+                throw new FormatException("Country is missing");
+            }
+
+            if (string.IsNullOrWhiteSpace(entry.ASN?.Trim())) {
+                throw new FormatException("ASN is missing");
+            }
         }
 
         /// <summary>

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -123,17 +123,24 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="entry">The server entry to add.</param>
         public void AddServer(PublicDnsEntry entry) {
-            if (entry == null || entry.IPAddress == null) {
+            if (entry == null) {
                 return;
             }
 
-            var canonical = GetCanonicalIp(entry.IPAddress);
-            if (!string.Equals(canonical, entry.IPAddress.ToString(), StringComparison.OrdinalIgnoreCase)) {
-                throw new FormatException($"Invalid IP address '{entry.IPAddress}'");
-            }
+            ValidateEntry(entry);
 
-            if (_servers.All(s => !s.IPAddress.Equals(entry.IPAddress))) {
-                _servers.Add(entry);
+            var trimmed = new PublicDnsEntry {
+                Country = entry.Country.Trim(),
+                IPAddress = entry.IPAddress,
+                HostName = entry.HostName?.Trim(),
+                Location = entry.Location?.Trim(),
+                ASN = entry.ASN.Trim(),
+                ASNName = entry.ASNName?.Trim(),
+                Enabled = entry.Enabled
+            };
+
+            if (_servers.All(s => !s.IPAddress.Equals(trimmed.IPAddress))) {
+                _servers.Add(trimmed);
             }
         }
 


### PR DESCRIPTION
## Summary
- validate `Country`, `IPAddress` and `ASN` when loading DNS servers
- throw `FormatException` for invalid or missing fields
- add tests covering malformed server JSON

## Testing
- `dotnet test` *(fails: DomainDetective.Tests.dll)*

------
https://chatgpt.com/codex/tasks/task_e_68657b7dc178832eb6f6877ecae357c8