### PR TITLE
Fix examples to use builtin DNS server list

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,17 +1,13 @@
 using DnsClientX;
 using System;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
-            analysis.LoadServers(file);
+            analysis.LoadBuiltinServers();
             var servers = analysis.FilterServers(country: "United States", take: 3);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -1,17 +1,13 @@
 using DnsClientX;
 using System;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationRegionsClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
-            analysis.LoadServers(file);
+            analysis.LoadBuiltinServers();
 
             var servers = analysis.FilterServers(take: 8);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -5,8 +5,7 @@ Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 $Results = Test-DnsPropagation -DomainName 'google.com' -RecordType A -CompareResults
 $Results | Format-Table
 
-$File = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'
-$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $File
+$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX
 $PublicServers | Format-Table
 
 $TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults


### PR DESCRIPTION
## Summary
- update DNS propagation examples to use builtin server list
- clean up PowerShell example

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: TestDKIMByDomain, TestDANEnalysis EmptyServiceTypesDefaultsToSmtpHttps, TestDANEnalysis TestDANERecordByDomain, TestDANEnalysis HttpsQueriesAandAaaaRecordsUsingSystemResolver, TestSpfAnalysis TestSpfOver255, TestSpfAnalysis TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis QueryDomainBySPF, TestCAAAnalysis TestCAARecordByDomain, TestDomainBlocklist UnlistedDomainReturnsNegative, TestDomainBlocklist ListedDomainsReturnPositive, TestDkimGuess GuessSelectorsForDomain, TestCertificateHTTP UnreachableHostLogsExceptionType, TestCertificateHTTP CapturesCipherSuiteWhenEnabled, TestAll TestAllHealthChecks, TestCertificateMonitor ProducesSummaryCounts, TestSOAAnalysis VerifySoaByDomain, TestDMARCAnalysis TestDMARCByDomain)*

------
https://chatgpt.com/codex/tasks/task_e_68657b857c18832ea2e0fde717dbd3b1