### PR TITLE
Load builtin DNS servers when file missing

### DIFF
--- a/DomainDetective.Tests/TestCmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.Tests/TestCmdletStartDnsPropagationMonitor.cs
@@ -1,0 +1,54 @@
+using DomainDetective.PowerShell;
+using DomainDetective.Monitoring;
+using DnsClientX;
+using Pwsh = System.Management.Automation.PowerShell;
+using System.IO;
+
+namespace DomainDetective.Tests;
+
+public class TestCmdletStartDnsPropagationMonitor {
+    [Fact]
+    public void RunsWithBuiltinServersWhenNoFile() {
+        using var ps = Pwsh.Create();
+        ps.AddCommand("Import-Module").AddArgument(typeof(CmdletStartDnsPropagationMonitor).Assembly.Location).Invoke();
+        ps.Commands.Clear();
+        ps.AddCommand("Start-DnsPropagationMonitor")
+            .AddParameter("DomainName", "example.com")
+            .AddParameter("RecordType", DnsRecordType.A)
+            .AddParameter("IntervalSeconds", 1);
+        var results = ps.Invoke();
+        Assert.Empty(ps.Streams.Error);
+        Assert.Single(results);
+        var monitor = Assert.IsType<DnsPropagationMonitor>(results[0].BaseObject);
+        monitor.Stop();
+        var analysisField = typeof(DnsPropagationMonitor).GetField("_analysis", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var analysis = (DnsPropagationAnalysis?)analysisField?.GetValue(monitor);
+        Assert.NotNull(analysis);
+        Assert.NotEmpty(analysis!.Servers);
+    }
+
+    [Fact]
+    public void RunsWithServersFileParameterSet() {
+        var file = Path.GetTempFileName();
+        File.WriteAllText(file, "[{\"IPAddress\":\"192.0.2.1\",\"Enabled\":true}]");
+        using var ps = Pwsh.Create();
+        ps.AddCommand("Import-Module").AddArgument(typeof(CmdletStartDnsPropagationMonitor).Assembly.Location).Invoke();
+        ps.Commands.Clear();
+        ps.AddCommand("Start-DnsPropagationMonitor")
+            .AddParameter("DomainName", "example.com")
+            .AddParameter("RecordType", DnsRecordType.A)
+            .AddParameter("ServersFile", file)
+            .AddParameter("IntervalSeconds", 1);
+        var results = ps.Invoke();
+        File.Delete(file);
+        Assert.Empty(ps.Streams.Error);
+        Assert.Single(results);
+        var monitor = Assert.IsType<DnsPropagationMonitor>(results[0].BaseObject);
+        monitor.Stop();
+        var analysisField = typeof(DnsPropagationMonitor).GetField("_analysis", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var analysis = (DnsPropagationAnalysis?)analysisField?.GetValue(monitor);
+        Assert.NotNull(analysis);
+        Assert.Single(analysis!.Servers);
+        Assert.Equal("192.0.2.1", analysis.Servers[0].IPAddress.ToString());
+    }
+}

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -53,8 +53,14 @@ namespace DomainDetective.Monitoring {
         public void Stop() => _timer?.Dispose();
 
         /// <summary>Loads DNS servers from JSON file.</summary>
-        /// <param name="filePath">Path to server list.</param>
-        public void LoadServers(string filePath) => _analysis.LoadServers(filePath, clearExisting: true);
+        /// <param name="filePath">Path to server list. If null or empty the builtin list is loaded.</param>
+        public void LoadServers(string? filePath) {
+            if (string.IsNullOrWhiteSpace(filePath)) {
+                _analysis.LoadBuiltinServers();
+            } else {
+                _analysis.LoadServers(filePath, clearExisting: true);
+            }
+        }
 
         /// <summary>Loads DNS servers from the embedded list.</summary>
         public void LoadBuiltinServers() => _analysis.LoadBuiltinServers();


### PR DESCRIPTION
## Summary
- handle null/empty paths in `DnsPropagationMonitor.LoadServers`
- add tests for `Start-DnsPropagationMonitor` to cover default and custom server lists

## Testing
- `dotnet test -c Release` *(fails: Assert.True() etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68657f8a4f34832eb7221b29c0868982