### PR TITLE
Improve IP converter error reporting

### DIFF
--- a/DomainDetective.Tests/TestIPAddressJsonConverter.cs
+++ b/DomainDetective.Tests/TestIPAddressJsonConverter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Net;
+using System.Text.Json;
+
+namespace DomainDetective.Tests {
+    public class TestIPAddressJsonConverter {
+        private class Dummy {
+            public IPAddress Address { get; set; }
+        }
+
+        [Fact]
+        public void InvalidAddressReportsIndex() {
+            var options = new JsonSerializerOptions { Converters = { new IPAddressJsonConverter() } };
+            var json = "{\"Address\":\"bad ip\"}";
+            var ex = Assert.Throws<FormatException>(() => JsonSerializer.Deserialize<Dummy>(json, options));
+            Assert.Contains("bad ip", ex.Message);
+            Assert.Contains("index 11", ex.Message);
+        }
+    }
+}
+

--- a/DomainDetective/IPAddressJsonConverter.cs
+++ b/DomainDetective/IPAddressJsonConverter.cs
@@ -12,7 +12,8 @@ internal sealed class IPAddressJsonConverter : JsonConverter<IPAddress>
         var value = reader.GetString();
         if (!IPAddress.TryParse(value, out var ip))
         {
-            throw new FormatException($"Invalid IP address '{value}'");
+            var index = reader.TokenStartIndex;
+            throw new FormatException($"Invalid IP address '{value}' at index {index}");
         }
         return ip;
     }


### PR DESCRIPTION
## Summary
- clarify IPAddressJsonConverter errors with byte index
- test JSON parsing of invalid addresses

## Testing
- `dotnet build --no-restore --nologo`
- `dotnet test --filter TestIPAddressJsonConverter --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_68657f85cb18832eb39331eac5565351