### PR TITLE
Add DMARC report domain alignment warnings

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -129,7 +129,7 @@ namespace DomainDetective {
                 switch (healthCheckType) {
                     case HealthCheckType.DMARC:
                         var dmarc = await DnsConfiguration.QueryDNS("_dmarc." + domainName, DnsRecordType.TXT, "DMARC1", cancellationToken);
-                        await DmarcAnalysis.AnalyzeDmarcRecords(dmarc, _logger, domainName);
+                        await DmarcAnalysis.AnalyzeDmarcRecords(dmarc, _logger, domainName, _publicSuffixList.GetRegistrableDomain);
                         DmarcAnalysis.EvaluatePolicyStrength(UseSubdomainPolicy);
                         break;
                     case HealthCheckType.SPF:


### PR DESCRIPTION
## Summary
- compare rua/ruf domains to the tested domain via Public Suffix List
- issue warnings when report addresses belong to a different organizational domain
- add regression test for misaligned report addresses

## Testing
- `dotnet test` *(fails: The argument ...)


------
https://chatgpt.com/codex/tasks/task_e_6865810fc2f4832ea5f8e2b7de55c875