### PR TITLE
Improve SMTP open relay detection

### DIFF
--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -62,7 +62,41 @@ namespace DomainDetective.Tests {
             try {
                 var analysis = new OpenRelayAnalysis();
                 await analysis.AnalyzeServer("localhost", port, new InternalLogger());
-                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port}"].Status); 
+                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port}"].Status);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task RelayUserNotLocalReturnsFalse() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220-test");
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-hello");
+                await writer.WriteLineAsync("250 hello");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-OK");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("551 user not local");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new OpenRelayAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port}"].Status);
             } finally {
                 listener.Stop();
                 await serverTask;


### PR DESCRIPTION
## Summary
- parse numeric SMTP codes in `OpenRelayAnalysis`
- check for denial codes during open relay checks
- add test coverage for 551 responses

## Testing
- `dotnet build DomainDetective.sln -c Release --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --framework net8.0 --no-build --verbosity minimal` *(fails: DNS queries blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686581264438832e914d0dc30826de3a