### PR TITLE
Add Country/Location enums and update APIs

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using System;
+using DomainDetective;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -12,7 +13,7 @@ namespace DomainDetective.Example {
             var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
             var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
             analysis.LoadServers(file);
-            var servers = analysis.FilterServers(country: "United States", take: 3);
+            var servers = analysis.FilterServers(country: CountryId.UnitedStates, take: 3);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {
                 Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{string.Join(',', result.Records)} Time:{result.Duration.TotalMilliseconds}ms");

--- a/DomainDetective.Generators/CountryLocationGenerator.cs
+++ b/DomainDetective.Generators/CountryLocationGenerator.cs
@@ -1,0 +1,124 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Text;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace DomainDetective.Generators;
+
+[Generator]
+public sealed class CountryLocationGenerator : ISourceGenerator {
+    public void Initialize(GeneratorInitializationContext context) {
+    }
+
+    public void Execute(GeneratorExecutionContext context) {
+        var file = context.AdditionalFiles.FirstOrDefault(f => f.Path.EndsWith("PublicDNS.json"));
+        if (file == null) {
+            return;
+        }
+        var text = file.GetText(context.CancellationToken);
+        if (text == null) {
+            return;
+        }
+        var json = text.ToString();
+        if (json.Length == 0) {
+            return;
+        }
+        using var doc = JsonDocument.Parse(json);
+        var countries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var locations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var element in doc.RootElement.EnumerateArray()) {
+            if (element.TryGetProperty("Country", out var c)) {
+                var val = c.GetString()?.Trim();
+                if (!string.IsNullOrWhiteSpace(val)) {
+                    countries.Add(val);
+                }
+            }
+            if (element.TryGetProperty("Location", out var l)) {
+                var val = l.GetString()?.Trim();
+                if (!string.IsNullOrWhiteSpace(val)) {
+                    locations.Add(val);
+                }
+            }
+        }
+        var countryMap = BuildMap(countries);
+        var locationMap = BuildMap(locations);
+        var sb = new StringBuilder();
+        sb.AppendLine("using System;");
+        sb.AppendLine("using System.Collections.Generic;");
+        sb.AppendLine("#nullable enable");
+        sb.AppendLine("namespace DomainDetective;");
+        sb.AppendLine("public enum CountryId { ");
+        foreach (var id in countryMap.Keys.OrderBy(k => k)) {
+            sb.AppendLine($"    {id},");
+        }
+        sb.AppendLine("}");
+        sb.AppendLine("public enum LocationId { ");
+        foreach (var id in locationMap.Keys.OrderBy(k => k)) {
+            sb.AppendLine($"    {id},");
+        }
+        sb.AppendLine("}");
+        sb.AppendLine("public static partial class CountryIdExtensions {");
+        sb.AppendLine("    private static readonly Dictionary<string, CountryId> _map = new(StringComparer.OrdinalIgnoreCase) {");
+        foreach (var kvp in countryMap) {
+            sb.AppendLine($"        [\"{kvp.Value}\"] = CountryId.{kvp.Key},");
+        }
+        sb.AppendLine("    };\n");
+        sb.AppendLine("    public static string ToName(this CountryId id) => id switch {");
+        foreach (var kvp in countryMap) {
+            sb.AppendLine($"        CountryId.{kvp.Key} => \"{kvp.Value}\",");
+        }
+        sb.AppendLine("        _ => string.Empty");
+        sb.AppendLine("    };\n");
+        sb.AppendLine("    public static bool TryParse(string? name, out CountryId id) {");
+        sb.AppendLine("        if (!string.IsNullOrWhiteSpace(name) && _map.TryGetValue(name.Trim(), out id)) { return true; }\n        id = default; return false; }");
+        sb.AppendLine("}");
+        sb.AppendLine("public static partial class LocationIdExtensions {");
+        sb.AppendLine("    private static readonly Dictionary<string, LocationId> _map = new(StringComparer.OrdinalIgnoreCase) {");
+        foreach (var kvp in locationMap) {
+            sb.AppendLine($"        [\"{kvp.Value}\"] = LocationId.{kvp.Key},");
+        }
+        sb.AppendLine("    };\n");
+        sb.AppendLine("    public static string ToName(this LocationId id) => id switch {");
+        foreach (var kvp in locationMap) {
+            sb.AppendLine($"        LocationId.{kvp.Key} => \"{kvp.Value}\",");
+        }
+        sb.AppendLine("        _ => string.Empty");
+        sb.AppendLine("    };\n");
+        sb.AppendLine("    public static bool TryParse(string? name, out LocationId id) {");
+        sb.AppendLine("        if (!string.IsNullOrWhiteSpace(name) && _map.TryGetValue(name.Trim(), out id)) { return true; }\n        id = default; return false; }");
+        sb.AppendLine("}");
+
+        context.AddSource("CountryLocationEnums.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+    }
+
+    private static Dictionary<string, string> BuildMap(IEnumerable<string> names) {
+        var map = new Dictionary<string, string>();
+        foreach (var name in names) {
+            var id = Sanitize(name);
+            if (!map.ContainsKey(id)) {
+                map[id] = name;
+            }
+        }
+        return map;
+    }
+
+    private static string Sanitize(string value) {
+        var sb = new StringBuilder();
+        var nextUpper = true;
+        foreach (var ch in value) {
+            if (char.IsLetterOrDigit(ch)) {
+                sb.Append(nextUpper ? char.ToUpperInvariant(ch) : ch);
+                nextUpper = false;
+            } else {
+                nextUpper = true;
+            }
+        }
+        if (sb.Length == 0 || char.IsDigit(sb[0])) {
+            sb.Insert(0, '_');
+        }
+        return sb.ToString();
+    }
+}

--- a/DomainDetective.Generators/DomainDetective.Generators.csproj
+++ b/DomainDetective.Generators/DomainDetective.Generators.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />
+    <PackageReference Include="System.Text.Json" Version="8.0.0" PrivateAssets="all" />
+  </ItemGroup>
+</Project>

--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using DomainDetective.Monitoring;
+using DomainDetective;
 using System;
 using System.IO;
 using System.Management.Automation;
@@ -41,11 +42,11 @@ namespace DomainDetective.PowerShell {
 
         /// <param name="Country">Filter builtin servers by country.</param>
         [Parameter(Mandatory = false)]
-        public string? Country;
+        public CountryId? Country;
 
         /// <param name="Location">Filter builtin servers by location.</param>
         [Parameter(Mandatory = false)]
-        public string? Location;
+        public LocationId? Location;
 
         /// <param name="IntervalSeconds">Polling interval in seconds.</param>
         [Parameter(Mandatory = false)]

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -1,5 +1,6 @@
 using DnsClientX;
 using System;
+using DomainDetective;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
@@ -35,11 +36,11 @@ namespace DomainDetective.PowerShell {
 
         /// <param name="Country">Filter servers by country.</param>
         [Parameter(Mandatory = false)]
-        public string Country;
+        public CountryId? Country;
 
         /// <param name="Location">Filter servers by location.</param>
         [Parameter(Mandatory = false)]
-        public string Location;
+        public LocationId? Location;
 
         /// <param name="Take">Limit the number of servers queried.</param>
         [Parameter(Mandatory = false)]

--- a/DomainDetective.Tests/TestDnsPropagationMonitor.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitor.cs
@@ -35,14 +35,14 @@ public class TestDnsPropagationMonitor {
     [Fact]
     public async Task HonorsCountryFilterAndCustomServers() {
         var passed = new List<PublicDnsEntry>();
-        var json = "[ { \"Country\": \"US\", \"IPAddress\": \"1.1.1.1\", \"Enabled\": true }, { \"Country\": \"DE\", \"IPAddress\": \"2.2.2.2\", \"Enabled\": true } ]";
+        var json = "[ { \"Country\": \"United States\", \"IPAddress\": \"1.1.1.1\", \"Enabled\": true }, { \"Country\": \"Germany\", \"IPAddress\": \"2.2.2.2\", \"Enabled\": true } ]";
         var file = System.IO.Path.GetTempFileName();
         try {
             System.IO.File.WriteAllText(file, json);
             var monitor = new DnsPropagationMonitor {
                 Domain = "example.com",
                 RecordType = DnsClientX.DnsRecordType.A,
-                Country = "US",
+                Country = CountryId.UnitedStates,
                 QueryOverride = (servers, _) => { passed.AddRange(servers); return Task.FromResult(new List<DnsPropagationResult>()); }
             };
             monitor.LoadServers(file);

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -211,13 +211,15 @@ namespace DomainDetective {
         /// <param name="location">Location filter.</param>
         /// <param name="take">If specified, randomly selects this many servers.</param>
         /// <returns>The filtered server list.</returns>
-        public IEnumerable<PublicDnsEntry> FilterServers(string country = null, string location = null, int? take = null) {
+        public IEnumerable<PublicDnsEntry> FilterServers(CountryId? country = null, LocationId? location = null, int? take = null) {
             IEnumerable<PublicDnsEntry> query = _servers.Where(s => s.Enabled);
-            if (!string.IsNullOrWhiteSpace(country)) {
-                query = query.Where(s => string.Equals(s.Country, country, StringComparison.OrdinalIgnoreCase));
+            if (country.HasValue) {
+                var name = country.Value.ToName();
+                query = query.Where(s => string.Equals(s.Country, name, StringComparison.OrdinalIgnoreCase));
             }
-            if (!string.IsNullOrWhiteSpace(location)) {
-                query = query.Where(s => s.Location != null && s.Location.IndexOf(location, StringComparison.OrdinalIgnoreCase) >= 0);
+            if (location.HasValue) {
+                var name = location.Value.ToName();
+                query = query.Where(s => s.Location != null && s.Location.IndexOf(name, StringComparison.OrdinalIgnoreCase) >= 0);
             }
             if (take.HasValue) {
                 query = query.OrderBy(_ => _rnd.Value.Next()).Take(take.Value);

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -18,6 +18,7 @@
       <!-- DNSBL list is built into the code. Use LoadDNSBL to load external files if required. -->
     <EmbeddedResource Include="..\Data\dnsbl.json" />
     <EmbeddedResource Include="..\Data\DNS\PublicDNS.json" LogicalName="DomainDetective.DNS.PublicDNS.json" />
+    <AdditionalFiles Include="..\Data\DNS\PublicDNS.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,5 +31,9 @@
     <None Include="..\Data\hsts_preload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective.Generators\DomainDetective.Generators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 </Project>

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -25,10 +25,10 @@ namespace DomainDetective.Monitoring {
         public Func<IEnumerable<PublicDnsEntry>, CancellationToken, Task<List<DnsPropagationResult>>>? QueryOverride { private get; set; }
 
         /// <summary>Country filter for builtin servers.</summary>
-        public string? Country { get; set; }
+        public CountryId? Country { get; set; }
 
         /// <summary>Location filter for builtin servers.</summary>
-        public string? Location { get; set; }
+        public LocationId? Location { get; set; }
 
         /// <summary>Additional user supplied servers.</summary>
         public List<PublicDnsEntry> CustomServers { get; } = new();


### PR DESCRIPTION
## Summary
- generate `CountryId` and `LocationId` enums from PublicDNS.json
- expose enums in `DnsPropagationAnalysis` and `DnsPropagationMonitor`
- update cmdlets and examples to use new enums
- add source generator project

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release` *(fails: Invalid URI and other network issues)*

------
https://chatgpt.com/codex/tasks/task_e_68660ec1dfc0832e9794e1a8fc6f4474