### PR TITLE
Update DNS propagation samples

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -1,18 +1,14 @@
 using DnsClientX;
 using System;
 using DomainDetective;
-using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
-            analysis.LoadServers(file);
+            analysis.LoadBuiltinServers();
             var servers = analysis.FilterServers(country: CountryId.UnitedStates, take: 3);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
             foreach (var result in results) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -1,17 +1,14 @@
 using DnsClientX;
 using System;
-using System.IO;
 using System.Linq;
-using System.Reflection;
+
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
     internal class ExampleAnalyseDnsPropagationRegionsClass {
         public static async Task Run() {
             var analysis = new DnsPropagationAnalysis();
-            var baseDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) ?? string.Empty;
-            var file = Path.Combine(baseDir, "Data", "DNS", "PublicDNS.json");
-            analysis.LoadServers(file);
+            analysis.LoadBuiltinServers();
 
             var servers = analysis.FilterServers(take: 8);
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -5,8 +5,7 @@ Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 $Results = Test-DnsPropagation -DomainName 'google.com' -RecordType A -CompareResults
 $Results | Format-Table
 
-$File = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'
-$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX -ServersFile $File
+$PublicServers = Test-DnsPropagation -DomainName 'example.com' -RecordType MX
 $PublicServers | Format-Table
 
 $TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults


### PR DESCRIPTION
## Summary
- update example programs to use `LoadBuiltinServers`
- drop explicit server file usage in PowerShell sample

## Testing
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68661b801990832eab04b7ac05ada976