### PR TITLE
Add DnsServerQuery builder

### DIFF
--- a/DomainDetective.Tests/TestDnsServerQuery.cs
+++ b/DomainDetective.Tests/TestDnsServerQuery.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestDnsServerQuery {
+        [Fact]
+        public void BuilderFiltersByCountry() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var query = DnsServerQuery.Create().FromCountry("Poland");
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Equal("Poland", s.Country));
+        }
+
+        [Fact]
+        public void BuilderTakeLimitsResults() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var query = DnsServerQuery.Create().Take(3);
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.Equal(3, servers.Count);
+        }
+
+        [Fact]
+        public void BuilderSupportsMultipleFilters() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var query = DnsServerQuery.Create().FromCountry("Poland").Take(2);
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.True(servers.Count <= 2);
+            Assert.All(servers, s => Assert.Equal("Poland", s.Country));
+        }
+    }
+}

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -227,6 +227,19 @@ namespace DomainDetective {
             return query.ToList();
         }
 
+        /// <summary>
+        /// Filters servers using a <see cref="DnsServerQuery"/> builder.
+        /// </summary>
+        /// <param name="query">Query builder specifying filters.</param>
+        /// <returns>The filtered server list.</returns>
+        public IEnumerable<PublicDnsEntry> FilterServers(DnsServerQuery? query) {
+            if (query == null) {
+                return FilterServers();
+            }
+
+            return FilterServers(query.Country, query.Location, query.TakeCount);
+        }
+
         private static string GetCanonicalIp(IPAddress ipAddress) {
             return ipAddress.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
                 ? IPAddress.Parse(ipAddress.ToString()).ToString()

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -1,0 +1,50 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Builder for querying DNS servers by country, location and count.
+/// </summary>
+public sealed class DnsServerQuery {
+    /// <summary>Selected country.</summary>
+    public CountryId? Country { get; private set; }
+    /// <summary>Selected location.</summary>
+    public LocationId? Location { get; private set; }
+    /// <summary>Number of servers to take.</summary>
+    public int? TakeCount { get; private set; }
+
+    /// <summary>Creates a new query instance.</summary>
+    public static DnsServerQuery Create() => new();
+
+    /// <summary>Filters by country name.</summary>
+    public DnsServerQuery FromCountry(string name) {
+        if (CountryIdExtensions.TryParse(name, out var id)) {
+            Country = id;
+        }
+        return this;
+    }
+
+    /// <summary>Filters by country enum.</summary>
+    public DnsServerQuery FromCountry(CountryId id) {
+        Country = id;
+        return this;
+    }
+
+    /// <summary>Filters by location name.</summary>
+    public DnsServerQuery FromLocation(string name) {
+        if (LocationIdExtensions.TryParse(name, out var id)) {
+            Location = id;
+        }
+        return this;
+    }
+
+    /// <summary>Filters by location enum.</summary>
+    public DnsServerQuery FromLocation(LocationId id) {
+        Location = id;
+        return this;
+    }
+
+    /// <summary>Limits the number of servers returned.</summary>
+    public DnsServerQuery Take(int count) {
+        TakeCount = count > 0 ? count : null;
+        return this;
+    }
+}

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -1,14 +1,13 @@
-namespace DomainDetective;
-
-/// <summary>
-/// Builder for querying DNS servers by country, location and count.
-/// </summary>
-public sealed class DnsServerQuery {
-    /// <summary>Selected country.</summary>
-    public CountryId? Country { get; private set; }
-    /// <summary>Selected location.</summary>
-    public LocationId? Location { get; private set; }
-    /// <summary>Number of servers to take.</summary>
+namespace DomainDetective {
+    /// <summary>
+    /// Builder for querying DNS servers by country, location and count.
+    /// </summary>
+    public sealed class DnsServerQuery {
+        /// <summary>Selected country.</summary>
+        public CountryId? Country { get; private set; }
+        /// <summary>Selected location.</summary>
+        public LocationId? Location { get; private set; }
+        /// <summary>Number of servers to take.</summary>
     public int? TakeCount { get; private set; }
 
     /// <summary>Creates a new query instance.</summary>
@@ -46,5 +45,6 @@ public sealed class DnsServerQuery {
     public DnsServerQuery Take(int count) {
         TakeCount = count > 0 ? count : null;
         return this;
+    }
     }
 }


### PR DESCRIPTION
## Summary
- add chainable `DnsServerQuery` for building DNS server filters
- integrate builder with `DnsPropagationAnalysis`
- test query combinations using the new builder

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: DNS/network tests)*

------
https://chatgpt.com/codex/tasks/task_e_6866569b67ac832e8c5d391a6f331f40