### PR TITLE
Dispose timers before restart

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagationMonitor.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitor.cs
@@ -56,4 +56,20 @@ public class TestDnsPropagationMonitor {
             System.IO.File.Delete(file);
         }
     }
+
+    [Fact]
+    public void CanStartAndStopMultipleTimes() {
+        var monitor = new DnsPropagationMonitor {
+            Domain = "example.com",
+            RecordType = DnsClientX.DnsRecordType.A,
+            QueryOverride = (_, _) => Task.FromResult(new List<DnsPropagationResult>())
+        };
+        var timerField = typeof(DnsPropagationMonitor).GetField("_timer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        for (int i = 0; i < 3; i++) {
+            monitor.Start();
+            Assert.NotNull(timerField.GetValue(monitor));
+            monitor.Stop();
+            Assert.Null(timerField.GetValue(monitor));
+        }
+    }
 }

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -46,11 +46,15 @@ namespace DomainDetective.Monitoring {
 
         /// <summary>Starts the monitor.</summary>
         public void Start() {
+            Stop();
             _timer = new Timer(async _ => await RunAsync(), null, TimeSpan.Zero, Interval);
         }
 
         /// <summary>Stops the monitor.</summary>
-        public void Stop() => _timer?.Dispose();
+        public void Stop() {
+            _timer?.Dispose();
+            _timer = null;
+        }
 
         /// <summary>Loads DNS servers from JSON file.</summary>
         /// <param name="filePath">Path to server list. If null or empty the builtin list is loaded.</param>


### PR DESCRIPTION
## Summary
- dispose `_timer` before reusing it in `DnsPropagationMonitor`
- set `_timer = null` when stopping the monitor
- ensure multiple Start/Stop cycles work via unit test

## Testing
- `dotnet test`
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686689c22fdc832e82c781573cd393aa