### PR TITLE
Handle empty MX hosts in certificate checks

### DIFF
--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -145,13 +145,13 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public void ExtractMxHostsSkipsInvalid() {
-            var records = new List<DnsAnswer> {
+            List<DnsAnswer> records = new () {
                 new DnsAnswer { DataRaw = "10 mx1.example.com", Type = DnsRecordType.MX },
                 new DnsAnswer { DataRaw = "20 ", Type = DnsRecordType.MX },
                 new DnsAnswer { DataRaw = "30", Type = DnsRecordType.MX }
             };
 
-            var hosts = CertificateAnalysis.ExtractMxHosts(records).ToList();
+            List<string> hosts = CertificateAnalysis.ExtractMxHosts(records).ToList();
 
             Assert.Single(hosts);
             Assert.Equal("mx1.example.com", hosts[0]);

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -8,6 +8,9 @@ using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Collections.Generic;
+using System.Linq;
+using DnsClientX;
 
 namespace DomainDetective.Tests {
     public class TestCertificateHTTP {
@@ -139,6 +142,20 @@ namespace DomainDetective.Tests {
             }
         }
 #endif
+
+        [Fact]
+        public void ExtractMxHostsSkipsInvalid() {
+            var records = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "10 mx1.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "20 ", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "30", Type = DnsRecordType.MX }
+            };
+
+            var hosts = CertificateAnalysis.ExtractMxHosts(records).ToList();
+
+            Assert.Single(hosts);
+            Assert.Equal("mx1.example.com", hosts[0]);
+        }
 
         private static async Task RunServer(TcpListener listener, X509Certificate2 cert, SslProtocols protocol, CancellationToken token) {
             try {

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -233,40 +233,40 @@ namespace DomainDetective {
                         break;
                     case HealthCheckType.OPENRELAY:
                         var mxRecordsForRelay = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var hosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForRelay);
-                        foreach (var host in hosts) {
+                        IEnumerable<string> hosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForRelay);
+                        foreach (string host in hosts) {
                             cancellationToken.ThrowIfCancellationRequested();
                             await OpenRelayAnalysis.AnalyzeServer(host, 25, _logger, cancellationToken);
                         }
                         break;
                     case HealthCheckType.STARTTLS:
                         var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
+                        IEnumerable<string> tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
                         await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { 25 }, _logger, cancellationToken);
                         break;
                     case HealthCheckType.SMTPTLS:
                         var mxRecordsForSmtpTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var smtpTlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForSmtpTls);
+                        IEnumerable<string> smtpTlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForSmtpTls);
                         await SmtpTlsAnalysis.AnalyzeServers(smtpTlsHosts, 25, _logger, cancellationToken);
                         break;
                     case HealthCheckType.IMAPTLS:
                         var mxRecordsForImapTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var imapTlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForImapTls);
+                        IEnumerable<string> imapTlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForImapTls);
                         await ImapTlsAnalysis.AnalyzeServers(imapTlsHosts, 143, _logger, cancellationToken);
                         break;
                     case HealthCheckType.POP3TLS:
                         var mxRecordsForPop3Tls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var pop3TlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForPop3Tls);
+                        IEnumerable<string> pop3TlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForPop3Tls);
                         await Pop3TlsAnalysis.AnalyzeServers(pop3TlsHosts, 110, _logger, cancellationToken);
                         break;
                     case HealthCheckType.SMTPBANNER:
                         var mxRecordsForBanner = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var bannerHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForBanner);
+                        IEnumerable<string> bannerHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForBanner);
                         await SmtpBannerAnalysis.AnalyzeServers(bannerHosts, 25, _logger, cancellationToken);
                         break;
                     case HealthCheckType.SMTPAUTH:
                         var mxRecordsForAuth = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-                        var authHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForAuth);
+                        IEnumerable<string> authHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForAuth);
                         await SmtpAuthAnalysis.AnalyzeServers(authHosts, 25, _logger, cancellationToken);
                         break;
                     case HealthCheckType.HTTP:
@@ -765,7 +765,7 @@ namespace DomainDetective {
             UpdateIsPublicSuffix(domainName);
             ValidatePort(port);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-            var tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
+            IEnumerable<string> tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
             await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { port }, _logger, cancellationToken);
         }
 
@@ -781,7 +781,7 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-            var tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
+            IEnumerable<string> tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
             await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
         }
 
@@ -797,7 +797,7 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-            var tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
+            IEnumerable<string> tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
             await ImapTlsAnalysis.AnalyzeServers(tlsHosts, 143, _logger, cancellationToken);
         }
 
@@ -813,7 +813,7 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
-            var tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
+            IEnumerable<string> tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
             await Pop3TlsAnalysis.AnalyzeServers(tlsHosts, 110, _logger, cancellationToken);
         }
 
@@ -1070,7 +1070,7 @@ namespace DomainDetective {
                     cancellationToken.ThrowIfCancellationRequested();
                     string domain;
                     if (fromMx) {
-                        var parts = record.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                        string[] parts = record.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                         if (parts.Length < 2 || string.IsNullOrWhiteSpace(parts[1])) {
                             continue;
                         }

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -106,18 +106,18 @@ namespace DomainDetective {
 
         internal static IEnumerable<string> ExtractMxHosts(IEnumerable<DnsAnswer> records)
         {
-            foreach (var record in records)
+            foreach (DnsAnswer record in records)
             {
-                var data = record.Data ?? record.DataRaw;
+                string data = record.Data ?? record.DataRaw;
                 if (string.IsNullOrWhiteSpace(data))
                 {
                     continue;
                 }
 
-                var parts = data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] parts = data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length >= 2)
                 {
-                    var host = parts[1].Trim('.');
+                    string host = parts[1].Trim('.');
                     if (!string.IsNullOrWhiteSpace(host))
                     {
                         yield return host;

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -16,6 +16,7 @@ using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Ocsp;
 using Org.BouncyCastle.X509;
+using DnsClientX;
 
 namespace DomainDetective {
     /// <summary>
@@ -102,6 +103,28 @@ namespace DomainDetective {
 
         /// <summary>CT log API templates. Each entry should contain a {0} placeholder for the SHA-256 fingerprint.</summary>
         public List<string> CtLogApiTemplates { get; } = new() { "https://crt.sh/?sha256={0}&output=json" };
+
+        internal static IEnumerable<string> ExtractMxHosts(IEnumerable<DnsAnswer> records)
+        {
+            foreach (var record in records)
+            {
+                var data = record.Data ?? record.DataRaw;
+                if (string.IsNullOrWhiteSpace(data))
+                {
+                    continue;
+                }
+
+                var parts = data.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length >= 2)
+                {
+                    var host = parts[1].Trim('.');
+                    if (!string.IsNullOrWhiteSpace(host))
+                    {
+                        yield return host;
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Retrieves the certificate from the specified HTTPS endpoint.


### PR DESCRIPTION
## Summary
- skip empty MX hostnames when parsing records
- expose MX host parser in `CertificateAnalysis`
- test invalid MX parsing

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0` *(fails: Invalid URI)*

------
https://chatgpt.com/codex/tasks/task_e_686689e32458832eab5dfaa58d8bfc80