### PR TITLE
Fix CAA flag validation

### DIFF
--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -208,7 +208,7 @@ namespace DomainDetective.Tests {
         public async Task CriticalBitIsDetected() {
             var healthCheck = new DomainHealthCheck();
 
-            await healthCheck.CheckCAA("129 issue \"letsencrypt.org\"");
+            await healthCheck.CheckCAA("128 issue \"letsencrypt.org\"");
 
             Assert.True(healthCheck.CAAAnalysis.AnalysisResults[0].Critical);
         }
@@ -220,9 +220,22 @@ namespace DomainDetective.Tests {
             logger.OnWarningMessage += (_, e) => warnings.Add(e);
             var healthCheck = new DomainHealthCheck(internalLogger: logger);
 
-            await healthCheck.CheckCAA("129 foo \"bar\"");
+            await healthCheck.CheckCAA("128 foo \"bar\"");
 
             Assert.Contains(warnings, w => w.FullMessage.Contains("Unknown CAA property tag"));
+        }
+
+        [Fact]
+        public async Task ReservedFlagBitsTriggerWarning() {
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var healthCheck = new DomainHealthCheck(internalLogger: logger);
+
+            await healthCheck.CheckCAA("129 issue \"letsencrypt.org\"");
+
+            Assert.True(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidFlag);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("reserved flag bits"));
         }
     }
 }

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -128,8 +128,11 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                     analysis.Flag = flag.ToString();
                     if (flag < 0 || flag > 255) {
                         analysis.InvalidFlag = true;
+                    } else if ((flag & 0x7F) != 0 && flag != 128) {
+                        analysis.InvalidFlag = true;
+                        logger?.WriteWarning($"CAA record uses reserved flag bits: {flag}");
                     }
-                    analysis.Critical = (flag & 1) == 1;
+                    analysis.Critical = (flag & 0x80) == 0x80;
 
                     // Validate tag and set the Tag property
                     var validTags = new Dictionary<string, CAATagType>(StringComparer.OrdinalIgnoreCase) {


### PR DESCRIPTION
## Summary
- enforce reserved flag bit rule for CAA
- adjust critical bit logic
- warn when multiple flags present
- test revised critical-bit handling
- test warning for reserved bits

## Testing
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_686689a80f04832ea75fdd8ecc03eb47