### PR TITLE
Implement DKIM key size enforcement

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -196,15 +196,16 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public async Task WeakKeyFlagSetFor1024BitKey() {
-            const string record = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
+        public async Task FailsValidationFor512BitKey() {
+            const string record = "v=DKIM1; k=rsa; p=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANYkh3Tqv0f70ACXB6PdpgIRnmX06BMA/5HXYhSggzSJ1ROtTNpo0pmATwwthSMleldrWUVcxf+A5sQ/jvWVnBMCAwEAAQ==;";
 
             var healthCheck = new DomainHealthCheck();
             await healthCheck.CheckDKIM(record);
 
             var result = healthCheck.DKIMAnalysis.AnalysisResults["default"];
-            Assert.True(result.WeakKey);
-            Assert.Equal(1024, result.KeyLength);
+            Assert.False(result.ValidPublicKey);
+            Assert.False(result.ValidRsaKeyLength);
+            Assert.Equal(512, result.KeyLength);
         }
 
         [Fact]

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -89,10 +89,18 @@ namespace DomainDetective {
                                 analysis.KeyLength = rsaKey.Modulus.BitLength;
                                 analysis.ValidRsaKeyLength = analysis.KeyLength >= MinimumRsaKeyBits;
                                 analysis.WeakKey = analysis.KeyLength > 0 && analysis.KeyLength < 2048;
-                                analysis.ValidPublicKey = analysis.ValidRsaKeyLength;
-                                if (analysis.WeakKey)
+                                if (!analysis.ValidRsaKeyLength)
                                 {
-                                    logger?.WriteWarning("DKIM key length {0} bits is weak, use at least 2048 bits.", analysis.KeyLength);
+                                    analysis.ValidPublicKey = false;
+                                    logger?.WriteError("DKIM key length {0} bits is below the minimum of {1} bits.", analysis.KeyLength, MinimumRsaKeyBits);
+                                }
+                                else
+                                {
+                                    analysis.ValidPublicKey = true;
+                                    if (analysis.WeakKey)
+                                    {
+                                        logger?.WriteWarning("DKIM key length {0} bits is weak, use at least 2048 bits.", analysis.KeyLength);
+                                    }
                                 }
                                 } catch (Exception) {
                                     analysis.ValidPublicKey = false;


### PR DESCRIPTION
## Summary
- enforce DKIM RSA key minimum length
- log an error when DKIM key is below minimum
- test validation failure with a 512-bit DKIM key

## Testing
- `dotnet test -v minimal` *(fails: Failed: 17, Passed: 442)*

------
https://chatgpt.com/codex/tasks/task_e_686689a0f358832ebe46a2b650173a7f