### PR TITLE
Add algorithm name mapping for DNSSEC

### DIFF
--- a/DomainDetective.Tests/TestAlgorithmNameMapping.cs
+++ b/DomainDetective.Tests/TestAlgorithmNameMapping.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using DomainDetective.Protocols;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestAlgorithmNameMapping {
+        [Theory]
+        [InlineData(5, "RSASHA1")]
+        [InlineData(8, "RSASHA256")]
+        [InlineData(253, "PRIVATEDNS")]
+        public void MapsAlgorithmNumbersToNames(int value, string expected) {
+            Assert.Equal(expected, DNSKeyAnalysis.AlgorithmName(value));
+        }
+
+        [Fact]
+        public void ParseFunctionsReturnNames() {
+            var converter = typeof(DnsSecConverter);
+            var parseDs = converter.GetMethod("ParseDsRecord", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var ds = (DsRecordInfo)parseDs.Invoke(null, new object[] { "60485 8 2 ABCD" })!;
+            Assert.Equal("RSASHA256", ds.Algorithm);
+
+            var parseKey = converter.GetMethod("ParseDnsKey", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var key = (DnsKeyInfo)parseKey.Invoke(null, new object[] { "257 3 8 AAAA" })!;
+            Assert.Equal("RSASHA256", key.Algorithm);
+
+            var analysisType = typeof(DnsSecAnalysis);
+            var parseSig = analysisType.GetMethod("ParseRrsig", BindingFlags.NonPublic | BindingFlags.Static)!;
+            var sig = (RrsigInfo)parseSig.Invoke(null, new object[] { "DNSKEY 8 2 3600 1755665684 1750395284 2371 example.com. AAAA" })!;
+            Assert.Equal("RSASHA256", sig.Algorithm);
+        }
+    }
+}

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using DomainDetective.Protocols;
 
 namespace DomainDetective {
     /// <summary>
@@ -59,9 +60,16 @@ namespace DomainDetective {
 
             _ = int.TryParse(parts[0], out int keyTag);
             _ = int.TryParse(parts[2], out int digestType);
+            string algorithm = parts[1];
+            if (int.TryParse(parts[1], out int algNum)) {
+                string name = DNSKeyAnalysis.AlgorithmName(algNum);
+                if (!string.IsNullOrEmpty(name)) {
+                    algorithm = name;
+                }
+            }
             return new DsRecordInfo {
                 KeyTag = keyTag,
-                Algorithm = parts[1],
+                Algorithm = algorithm,
                 DigestType = digestType,
                 Digest = parts[3],
             };
@@ -79,10 +87,17 @@ namespace DomainDetective {
 
             _ = int.TryParse(parts[0], out int flags);
             _ = byte.TryParse(parts[1], out byte protocol);
+            string algorithm = parts[2];
+            if (int.TryParse(parts[2], out int algNum)) {
+                string name = DNSKeyAnalysis.AlgorithmName(algNum);
+                if (!string.IsNullOrEmpty(name)) {
+                    algorithm = name;
+                }
+            }
             return new DnsKeyInfo {
                 Flags = flags,
                 Protocol = protocol,
-                Algorithm = parts[2],
+                Algorithm = algorithm,
                 PublicKey = parts[3],
             };
         }

--- a/DomainDetective/Protocols/DNSKeyAnalysis.cs
+++ b/DomainDetective/Protocols/DNSKeyAnalysis.cs
@@ -27,5 +27,32 @@ namespace DomainDetective.Protocols {
         internal static bool IsDeprecatedAlgorithmNumber(int number) {
             return DeprecatedAlgorithms.Contains(number);
         }
+
+        internal static string AlgorithmName(int number) {
+            return number switch {
+                1 => "RSAMD5",
+                2 => "DH",
+                3 => "DSA",
+                4 => "ECC",
+                5 => "RSASHA1",
+                6 => "DSANSEC3SHA1",
+                7 => "RSASHA1NSEC3SHA1",
+                8 => "RSASHA256",
+                9 => "RESERVED",
+                10 => "RSASHA512",
+                11 => "RESERVED",
+                12 => "ECCGOST",
+                13 => "ECDSAP256SHA256",
+                14 => "ECDSAP384SHA384",
+                15 => "ED25519",
+                16 => "ED448",
+                17 => "SM2SM3",
+                23 => "ECC-GOST12",
+                252 => "INDIRECT",
+                253 => "PRIVATEDNS",
+                254 => "PRIVATEOID",
+                _ => string.Empty,
+            };
+        }
     }
 }

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -385,8 +385,16 @@ namespace DomainDetective {
 
             _ = int.TryParse(parts[6], out int keyTag);
 
+            string algorithm = parts[1];
+            if (int.TryParse(parts[1], out int algNum)) {
+                string name = DNSKeyAnalysis.AlgorithmName(algNum);
+                if (!string.IsNullOrEmpty(name)) {
+                    algorithm = name;
+                }
+            }
+
             return new RrsigInfo {
-                Algorithm = parts[1],
+                Algorithm = algorithm,
                 KeyTag = keyTag,
                 Inception = inception,
                 Expiration = expiration,

--- a/README.MD
+++ b/README.MD
@@ -20,6 +20,7 @@ Current capabilities include:
 - [x] Verify DNSSEC
 - [x] Follow the delegation chain and validate DS records
 - [x] Summarize DNSSEC mismatches across the chain
+- [x] Map DNSSEC algorithm numbers to names per RFC 4034
 - [x] Analyze DNS TTL
 - [x] Validate ARC headers
  - [x] Verify DANE/TLSA (queries `_tcp` or `_udp` names, HTTPS on port 443 by default)


### PR DESCRIPTION
## Summary
- map DNS algorithm numbers to their names
- expose algorithm names in parsed results
- test algorithm mapping logic

## Testing
- `dotnet test` *(fails: DomainDetective.Tests.dll)*

------
https://chatgpt.com/codex/tasks/task_e_6866898bf51c832e9a23d8627111ca87