### PR TITLE
Add HSTS preload eligibility checks

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -337,6 +337,54 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task HstsHeaderFromPreloadSiteIsEligible() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.Headers.Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload");
+                ctx.Response.Close();
+            });
+
+            try {
+                var analysis = new HttpAnalysis();
+                await analysis.AnalyzeUrl(prefix, true, new InternalLogger(), collectHeaders: true);
+                Assert.True(analysis.HstsPreloadEligible);
+                Assert.False(analysis.HstsTooShort);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task HstsHeaderFiveMinutesNotEligibleForPreload() {
+            using var listener = new HttpListener();
+            var prefix = $"http://localhost:{GetFreePort()}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.Headers.Add("Strict-Transport-Security", "max-age=300; includeSubDomains");
+                ctx.Response.Close();
+            });
+
+            try {
+                var analysis = new HttpAnalysis();
+                await analysis.AnalyzeUrl(prefix, true, new InternalLogger(), collectHeaders: true);
+                Assert.False(analysis.HstsPreloadEligible);
+                Assert.True(analysis.HstsTooShort);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
         public async Task DetectsUnsafeContentSecurityPolicyDirectives() {
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -31,6 +31,8 @@ namespace DomainDetective {
         public List<string> UnknownHstsDirectives { get; private set; } = new();
         /// <summary>Gets a value indicating whether the host is on the HSTS preload list.</summary>
         public bool HstsPreloaded { get; private set; }
+        /// <summary>Gets a value indicating whether the HSTS header meets preload list requirements.</summary>
+        public bool HstsPreloadEligible { get; private set; }
         /// <summary>Gets a value indicating whether the X-XSS-Protection header was present.</summary>
         public bool XssProtectionPresent { get; private set; }
         /// <summary>Gets a value indicating whether the Expect-CT header was present.</summary>
@@ -176,6 +178,7 @@ namespace DomainDetective {
             HstsIncludesSubDomains = false;
             HstsTooShort = false;
             HstsPreloaded = false;
+            HstsPreloadEligible = false;
             UnknownHstsDirectives = new List<string>();
             PermissionsPolicyPresent = false;
             PermissionsPolicy.Clear();
@@ -385,6 +388,7 @@ namespace DomainDetective {
                 }
             }
             HstsTooShort = HstsMaxAge.HasValue && HstsMaxAge.Value < 10886400;
+            HstsPreloadEligible = HstsIncludesSubDomains && HstsMaxAge.HasValue && HstsMaxAge.Value >= 31536000;
         }
 
         private void ParseContentSecurityPolicy(string headerValue) {


### PR DESCRIPTION
## Summary
- evaluate Strict-Transport-Security header for preload readiness
- track preload eligibility info
- test preload sample headers from hstspreload.org

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686689876280832ead447d93917bf09a