### PR TITLE
Fix ADSP record joining when data empty

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -237,6 +237,19 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task AdspRecordWithEmptyDataIgnored() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = string.Empty, Type = DnsRecordType.TXT }
+            };
+
+            var analysis = new DkimAnalysis();
+            await analysis.AnalyzeAdspRecord(answers, new InternalLogger());
+
+            Assert.True(analysis.AdspRecordExists);
+            Assert.Null(analysis.AdspRecord);
+        }
+
+        [Fact]
         public async Task ParsesCreationDateAndDetectsOldKey() {
             const string record =
                 "v=DKIM1; k=rsa; n=2000-01-01; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -218,7 +218,16 @@ namespace DomainDetective {
                 return;
             }
 
-            AdspRecord = string.Join(" ", records.Select(r => r.Data));
+            var chunks = records
+                .Select(r => r.Data)
+                .Where(d => !string.IsNullOrEmpty(d))
+                .ToList();
+
+            if (!chunks.Any()) {
+                return;
+            }
+
+            AdspRecord = string.Join(" ", chunks);
             logger?.WriteWarning("ADSP record found but ADSP is obsolete.");
         }
 


### PR DESCRIPTION
## Summary
- check ADSP record chunks before calling `string.Join`
- add unit test for empty ADSP record data

## Testing
- `dotnet test --verbosity minimal` *(fails: SOA record not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866dcfe21b0832ebe2463bf490fdfe8