### PR TITLE
Normalize DNSBL domains

### DIFF
--- a/DomainDetective.Tests/TestDNSBLCaseInsensitive.cs
+++ b/DomainDetective.Tests/TestDNSBLCaseInsensitive.cs
@@ -18,5 +18,27 @@ namespace DomainDetective.Tests {
             Assert.Single(entries);
             Assert.Equal(before + 1, analysis.GetDNSBL().Count);
         }
+
+        [Fact]
+        public void AddDnsblStoresLowercaseDomain() {
+            var analysis = new DNSBLAnalysis();
+            analysis.ClearDNSBL();
+
+            analysis.AddDNSBL("MiXeD.Case");
+
+            var entry = Assert.Single(analysis.GetDNSBL());
+            Assert.Equal("mixed.case", entry.Domain);
+        }
+
+        [Fact]
+        public void RemoveDnsblIsCaseInsensitive() {
+            var analysis = new DNSBLAnalysis();
+            analysis.ClearDNSBL();
+
+            analysis.AddDNSBL("remove.test");
+            analysis.RemoveDNSBL("ReMoVe.TeSt");
+
+            Assert.Empty(analysis.GetDNSBL());
+        }
     }
 }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -356,6 +356,7 @@ namespace DomainDetective {
             if (string.IsNullOrWhiteSpace(dnsbl))
                 return;
 
+            dnsbl = dnsbl.ToLowerInvariant();
             var entry = DnsblEntries.FirstOrDefault(e =>
                 StringComparer.OrdinalIgnoreCase.Equals(e.Domain, dnsbl));
             if (entry == null) {
@@ -386,6 +387,10 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="dnsbl">Blacklist host name.</param>
         public void RemoveDNSBL(string dnsbl) {
+            if (string.IsNullOrWhiteSpace(dnsbl))
+                return;
+
+            dnsbl = dnsbl.ToLowerInvariant();
             var entry = DnsblEntries.FirstOrDefault(e =>
                 string.Equals(e.Domain, dnsbl, StringComparison.OrdinalIgnoreCase));
             if (entry != null) {


### PR DESCRIPTION
## Summary
- convert domains to lowercase before adding or removing providers
- test `AddDNSBL` and `RemoveDNSBL` handle casing

## Testing
- `dotnet test` *(fails: Invalid URI due to DNS queries)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd081e50832e950afc9a8d106a29