### PR TITLE
Implement IPv6 reverse lookup for DNSBL

### DIFF
--- a/DomainDetective.Tests/TestDNSBLIPv6.cs
+++ b/DomainDetective.Tests/TestDNSBLIPv6.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Net;
+using System.Reflection;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
@@ -62,6 +63,74 @@ namespace DomainDetective.Tests {
                     .Select(n => n.ToString("x"))
                     .Reverse());
             Assert.Equal(expected, record.IPAddress);
+        }
+
+        [Fact]
+        public void ConvertIpv6BlacklistedResults() {
+            const string address = "2001:db8::dead";
+            var analysis = new DNSBLAnalysis();
+            var method = typeof(DNSBLAnalysis).GetMethod(
+                "ConvertToResults",
+                BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            var nibble = string.Join(
+                ".",
+                IPAddress
+                    .Parse(address)
+                    .GetAddressBytes()
+                    .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
+                    .Select(n => n.ToString("x"))
+                    .Reverse());
+
+            var record = new DNSBLRecord {
+                IPAddress = nibble,
+                OriginalIPAddress = address,
+                FQDN = $"{nibble}.example.test",
+                BlackList = "example.test",
+                IsBlackListed = true,
+                Answer = "127.0.0.2",
+                ReplyMeaning = "Blacklisted",
+            };
+
+            method.Invoke(analysis, new object[] { address, new[] { record } });
+
+            var result = analysis.Results[address];
+            Assert.True(result.IsBlacklisted);
+            Assert.Equal("Blacklisted", result.DNSBLRecords.First().ReplyMeaning);
+        }
+
+        [Fact]
+        public void ConvertIpv6NotListedResults() {
+            const string address = "2001:db8::beef";
+            var analysis = new DNSBLAnalysis();
+            var method = typeof(DNSBLAnalysis).GetMethod(
+                "ConvertToResults",
+                BindingFlags.NonPublic | BindingFlags.Instance)!;
+
+            var nibble = string.Join(
+                ".",
+                IPAddress
+                    .Parse(address)
+                    .GetAddressBytes()
+                    .SelectMany(b => new[] { b >> 4 & 0xF, b & 0xF })
+                    .Select(n => n.ToString("x"))
+                    .Reverse());
+
+            var record = new DNSBLRecord {
+                IPAddress = nibble,
+                OriginalIPAddress = address,
+                FQDN = $"{nibble}.example.test",
+                BlackList = "example.test",
+                IsBlackListed = false,
+                Answer = string.Empty,
+                ReplyMeaning = string.Empty,
+            };
+
+            method.Invoke(analysis, new object[] { address, new[] { record } });
+
+            var result = analysis.Results[address];
+            Assert.False(result.IsBlacklisted);
+            Assert.Empty(result.DNSBLRecords.First().ReplyMeaning);
         }
     }
 }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -277,12 +277,30 @@ namespace DomainDetective {
             return reply.StartsWith("127.") ? (true, "Listed") : (true, string.Empty);
         }
 
+        private static string FormatDnsblName(IPAddress ipAddress) {
+            if (ipAddress.AddressFamily == AddressFamily.InterNetworkV6) {
+                return string.Join(
+                    ".",
+                    ipAddress
+                        .GetAddressBytes()
+                        .SelectMany(b => new[] { (b >> 4) & 0xF, b & 0xF })
+                        .Select(n => n.ToString("x"))
+                        .Reverse());
+            }
+
+            return string.Join(
+                ".",
+                ipAddress
+                    .GetAddressBytes()
+                    .Reverse());
+        }
+
         private async IAsyncEnumerable<DNSBLRecord> QueryDNSBL(IEnumerable<string> dnsblList, string ipAddressOrHostname) {
 
             // Check if the input is an IP address or a hostname
             string name;
             if (IPAddress.TryParse(ipAddressOrHostname, out IPAddress ipAddress)) {
-                name = ipAddress.ToPtrFormat();
+                name = FormatDnsblName(ipAddress);
             } else {
                 // Use the hostname and append the DNSBL list
                 name = ipAddressOrHostname;


### PR DESCRIPTION
## Summary
- reverse IPv6 nibbles before building DNSBL queries
- cover IPv6 blacklist result parsing in tests

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: 17 failed, 453 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6866dd14bbf4832ebb0ef441a40a04b3