### PR TITLE
Fix CLI console read line

### DIFF
--- a/DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj
+++ b/DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective.CLI\DomainDetective.CLI.csproj" />
+  </ItemGroup>
+</Project>

--- a/DomainDetective.CLI.Tests/GlobalUsings.cs
+++ b/DomainDetective.CLI.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/DomainDetective.CLI.Tests/TestCliHelpers.cs
+++ b/DomainDetective.CLI.Tests/TestCliHelpers.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using DomainDetective.CLI;
+
+namespace DomainDetective.CLI.Tests {
+    public class TestCliHelpers {
+        [Fact]
+        public void ReadLineRaw_PreservesCarriageReturn() {
+            var original = Console.In;
+            using var reader = new StringReader("value\r\n");
+            Console.SetIn(reader);
+            try {
+                var line = CliHelpers.ReadLineRaw();
+                Assert.Equal("value\r\n", line);
+            } finally {
+                Console.SetIn(original);
+            }
+        }
+    }
+}

--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -2,6 +2,7 @@ using Spectre.Console;
 using System;
 using System.Collections;
 using System.Linq;
+using System.Text;
 using System.Globalization;
 
 namespace DomainDetective.CLI;
@@ -143,5 +144,34 @@ internal static class CliHelpers
             Expand = true
         };
         AnsiConsole.Write(panel);
+    }
+
+    internal static string? ReadLineRaw()
+    {
+        var builder = new StringBuilder();
+        while (true)
+        {
+            var ch = Console.In.Read();
+            if (ch == -1)
+            {
+                return builder.Length == 0 ? null : builder.ToString();
+            }
+
+            builder.Append((char)ch);
+            if (ch == '\n')
+            {
+                break;
+            }
+            if (ch == '\r')
+            {
+                if (Console.In.Peek() == '\n')
+                {
+                    builder.Append((char)Console.In.Read());
+                }
+                break;
+            }
+        }
+
+        return builder.ToString();
     }
 }

--- a/DomainDetective.CLI/DomainDetective.CLI.csproj
+++ b/DomainDetective.CLI/DomainDetective.CLI.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
   </ItemGroup>
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>DomainDetective.CLI.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
   </ItemGroup>
 </Project>

--- a/DomainDetective.sln
+++ b/DomainDetective.sln
@@ -21,6 +21,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DomainDetective.CLI", "Doma
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.Reports", "DomainDetective.Reports\DomainDetective.Reports.csproj", "{0F0260F4-6179-4DC0-8DF5-B1888DD9837E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.CLI.Tests", "DomainDetective.CLI.Tests\DomainDetective.CLI.Tests.csproj", "{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,6 +105,18 @@ Global
 		{0F0260F4-6179-4DC0-8DF5-B1888DD9837E}.Release|x64.Build.0 = Release|Any CPU
 		{0F0260F4-6179-4DC0-8DF5-B1888DD9837E}.Release|x86.ActiveCfg = Release|Any CPU
 		{0F0260F4-6179-4DC0-8DF5-B1888DD9837E}.Release|x86.Build.0 = Release|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Debug|x64.Build.0 = Debug|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Debug|x86.Build.0 = Debug|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x64.ActiveCfg = Release|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x64.Build.0 = Release|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x86.ActiveCfg = Release|Any CPU
+		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add `ReadLineRaw` helper to preserve carriage returns
- expose CLI internals for test project
- create `DomainDetective.CLI.Tests` with regression test

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj --no-build`
- `dotnet test DomainDetective.sln` *(fails: Network-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_6866dce61cc8832e911d1b762bf1928f