### PR TITLE
Fix POP3 STLS check

### DIFF
--- a/DomainDetective.Tests/TestMailTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestMailTlsAnalysis.cs
@@ -70,7 +70,7 @@ public class TestMailTlsAnalysis
         listener.Start();
         var port = ((IPEndPoint)listener.LocalEndpoint).Port;
         using var cts = new CancellationTokenSource();
-        var serverTask = Task.Run(() => RunPop3ServerNoTls(listener, cert, cts.Token), cts.Token);
+        var serverTask = Task.Run(() => RunPop3ServerNoTls(listener, cts.Token), cts.Token);
 
         try
         {
@@ -165,7 +165,7 @@ public class TestMailTlsAnalysis
         }
     }
 
-    private static async Task RunPop3ServerNoTls(TcpListener listener, X509Certificate2 cert, CancellationToken token)
+    private static async Task RunPop3ServerNoTls(TcpListener listener, CancellationToken token)
     {
         try
         {

--- a/DomainDetective.Tests/TestMailTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestMailTlsAnalysis.cs
@@ -62,6 +62,31 @@ public class TestMailTlsAnalysis
         }
     }
 
+    [Fact]
+    public async Task Pop3TlsMissingCapability()
+    {
+        using var cert = CreateSelfSigned();
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var cts = new CancellationTokenSource();
+        var serverTask = Task.Run(() => RunPop3ServerNoTls(listener, cert, cts.Token), cts.Token);
+
+        try
+        {
+            var analysis = new POP3TLSAnalysis();
+            await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+            var result = analysis.ServerResults[$"localhost:{port}"];
+            Assert.False(result.StartTlsAdvertised);
+        }
+        finally
+        {
+            cts.Cancel();
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
     private static async Task RunImapServer(TcpListener listener, X509Certificate2 cert, SslProtocols protocol, CancellationToken token)
     {
         try
@@ -131,6 +156,44 @@ public class TestMailTlsAnalysis
                     await ssl.AuthenticateAsServerAsync(cert, false, protocol, false);
                     using var sslReader = new StreamReader(ssl);
                     await sslReader.ReadLineAsync();
+                }, token);
+            }
+        }
+        catch
+        {
+            // ignore on shutdown
+        }
+    }
+
+    private static async Task RunPop3ServerNoTls(TcpListener listener, X509Certificate2 cert, CancellationToken token)
+    {
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var clientTask = listener.AcceptTcpClientAsync();
+                var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                if (completed != clientTask)
+                {
+                    try { await clientTask; } catch { }
+                    break;
+                }
+
+                var client = await clientTask;
+                _ = Task.Run(async () =>
+                {
+                    using var tcp = client;
+                    using var stream = tcp.GetStream();
+                    using var reader = new StreamReader(stream);
+                    using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                    await writer.WriteLineAsync("+OK POP3 ready");
+                    await reader.ReadLineAsync();
+                    await writer.WriteLineAsync("+OK\r\nUSER\r\n.");
+                    var cmd = await reader.ReadLineAsync();
+                    if (cmd == "QUIT")
+                    {
+                        await writer.WriteLineAsync("+OK");
+                    }
                 }, token);
             }
         }

--- a/DomainDetective/Protocols/MailTlsAnalysis.cs
+++ b/DomainDetective/Protocols/MailTlsAnalysis.cs
@@ -241,19 +241,10 @@ public class MailTlsAnalysis
                     result.StartTlsAdvertised = capabilities.Contains("STLS");
                     if (!result.StartTlsAdvertised)
                     {
-                        await writer.WriteLineAsync("STLS").WaitWithCancellation(timeoutCts.Token);
-                        var resp = await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
-                        if (resp != null && resp.StartsWith("+OK"))
-                        {
-                            result.StartTlsAdvertised = true;
-                        }
-                        else
-                        {
-                            await writer.WriteLineAsync("QUIT").WaitWithCancellation(timeoutCts.Token);
-                            await writer.FlushAsync().WaitWithCancellation(timeoutCts.Token);
-                            await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
-                            return result;
-                        }
+                        await writer.WriteLineAsync("QUIT").WaitWithCancellation(timeoutCts.Token);
+                        await writer.FlushAsync().WaitWithCancellation(timeoutCts.Token);
+                        await reader.ReadLineAsync().WaitWithCancellation(timeoutCts.Token);
+                        return result;
                     }
                     break;
             }


### PR DESCRIPTION
## Summary
- require STLS capability before starting TLS on POP3 servers
- add unit test for POP3 servers without STLS

## Testing
- `dotnet build DomainDetective.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686827fc8d9c832ebbe15a5c4398576a