### PR TITLE
Implement DKIM signature padding check

### DIFF
--- a/DomainDetective.Tests/Data/dkim-bad-padding.txt
+++ b/DomainDetective.Tests/Data/dkim-bad-padding.txt
@@ -1,0 +1,6 @@
+From: sender@example.com
+To: recipient@example.com
+Subject: Bad DKIM
+Date: Thu, 1 Jan 2025 00:00:00 +0000
+DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=selector1; h=from:to:subject:date; bh=abc123; b=abc
+

--- a/DomainDetective.Tests/Data/dkimvalidator-headers.txt
+++ b/DomainDetective.Tests/Data/dkimvalidator-headers.txt
@@ -8,9 +8,9 @@ Received: from mail.example.com (mail.example.com. [192.0.2.1])
 DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
         d=example.com; s=selector1; t=1615567890;
         h=from:to:subject:date:message-id:mime-version:content-type;
-        bh=abc123; b=def456
+        bh=abc123; b=ZGVmNDU2
 Authentication-Results: dkimvalidator.com;
-        dkim=pass (1024-bit key) header.d=example.com header.i=@example.com header.b=def456;
+        dkim=pass (1024-bit key) header.d=example.com header.i=@example.com header.b=ZGVmNDU2;
         spf=pass smtp.mailfrom=sender@example.com;
         dmarc=pass header.from=example.com
 From: sender@example.com

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -59,6 +59,9 @@
         <None Include="Data/dkimvalidator-headers.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/dkim-bad-padding.txt">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="Data/arc-valid.txt">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective.Tests/TestEdnsSupportHealthCheck.cs
+++ b/DomainDetective.Tests/TestEdnsSupportHealthCheck.cs
@@ -41,7 +41,7 @@ public class TestEdnsSupportHealthCheck
     [InlineData(null)]
     [InlineData("")]
     [InlineData(" ")]
-    public async Task VerifyEdnsSupportThrowsIfDomainNullOrWhitespace(string domain)
+    public async Task VerifyEdnsSupportThrowsIfDomainNullOrWhitespace(string? domain)
     {
         var hc = new DomainHealthCheck();
         await Assert.ThrowsAsync<ArgumentNullException>(async () => await hc.VerifyEdnsSupport(domain));

--- a/DomainDetective.Tests/TestMessageHeaderDkimInvalid.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDkimInvalid.cs
@@ -1,0 +1,16 @@
+using System.IO;
+
+namespace DomainDetective.Tests {
+    public class TestMessageHeaderDkimInvalid {
+        [Fact]
+        public void RejectsInvalidDkimSignature() {
+            var raw = File.ReadAllText("Data/dkim-bad-padding.txt");
+            var analysis = new MessageHeaderAnalysis();
+            analysis.Parse(raw, new InternalLogger());
+
+            Assert.False(analysis.Headers.ContainsKey("DKIM-Signature"));
+            Assert.Single(analysis.InvalidDkimSignatures);
+        }
+    }
+}
+

--- a/DomainDetective.Tests/TestMessageHeaderDkimValidator.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDkimValidator.cs
@@ -10,7 +10,7 @@ namespace DomainDetective.Tests {
 
             Assert.Equal("someuser@dkimvalidator.com", analysis.Headers["Delivered-To"]);
             Assert.Single(analysis.ReceivedChain);
-            Assert.Contains("v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; s=selector1; t=1615567890; h=from:to:subject:date:message-id:mime-version:content-type; bh=abc123; b=def456", analysis.Headers["DKIM-Signature"]);
+            Assert.Contains("v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; s=selector1; t=1615567890; h=from:to:subject:date:message-id:mime-version:content-type; bh=abc123; b=ZGVmNDU2", analysis.Headers["DKIM-Signature"]);
             Assert.Contains("dkim=pass", analysis.Headers["Authentication-Results"]);
         }
     }

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -40,6 +40,8 @@ namespace DomainDetective {
         public string? ArcResult { get; private set; }
         /// <summary>Optional spam related headers.</summary>
         public Dictionary<string, string> SpamHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
+        /// <summary>Ignored DKIM-Signature headers with invalid signature values.</summary>
+        public List<string> InvalidDkimSignatures { get; } = new();
 
         /// <summary>
         /// Parses <paramref name="rawHeaders"/> into strongly typed properties.
@@ -105,6 +107,13 @@ namespace DomainDetective {
 
         private void AddHeaderValue(string field, string value) {
             var normalized = CanonicalizeValue(value);
+            var lower = field.ToLowerInvariant();
+
+            if (lower == "dkim-signature" && !HasValidSignature(normalized)) {
+                InvalidDkimSignatures.Add(normalized);
+                return;
+            }
+
             if (Headers.TryGetValue(field, out var existing)) {
                 if (!DuplicateHeaders.TryGetValue(field, out var list)) {
                     list = new List<string> { existing };
@@ -114,7 +123,6 @@ namespace DomainDetective {
             }
             Headers[field] = normalized;
 
-            var lower = field.ToLowerInvariant();
             switch (lower) {
                 case "received":
                     ReceivedChain.Add(value);
@@ -199,6 +207,26 @@ namespace DomainDetective {
                     ArcResult = trimmed.Substring(4).Trim();
                 }
             }
+        }
+
+        private static bool HasValidSignature(string value) {
+            foreach (var part in value.Split(';')) {
+                var trimmed = part.Trim();
+                if (trimmed.StartsWith("b=", StringComparison.OrdinalIgnoreCase)) {
+                    var sig = trimmed.Substring(2).Trim();
+                    return IsValidBase64(sig);
+                }
+            }
+            return false;
+        }
+
+        private static bool IsValidBase64(string input) {
+            input = input.Trim();
+            if (input.Length == 0 || input.Length % 4 != 0) {
+                return false;
+            }
+            Span<byte> buffer = stackalloc byte[input.Length];
+            return Convert.TryFromBase64String(input, buffer, out _);
         }
 
         private void ComputeTransitTime() {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -225,8 +225,17 @@ namespace DomainDetective {
             if (input.Length == 0 || input.Length % 4 != 0) {
                 return false;
             }
+#if NET6_0_OR_GREATER
             Span<byte> buffer = stackalloc byte[input.Length];
             return Convert.TryFromBase64String(input, buffer, out _);
+#else
+            try {
+                Convert.FromBase64String(input);
+                return true;
+            } catch (FormatException) {
+                return false;
+            }
+#endif
         }
 
         private void ComputeTransitTime() {


### PR DESCRIPTION
## Summary
- ignore DKIM-Signature headers with bad base64 padding
- record any skipped signatures
- add dataset with malformed DKIM-Signature header
- test that malformed signatures are rejected

## Testing
- `dotnet test --filter TestMessageHeaderDkimInvalid`
- `dotnet test` *(fails: Invalid URI due to DNS queries)*

------
https://chatgpt.com/codex/tasks/task_e_686828058cf0832e8e146f93b3af4e68