### PR TITLE
Allow DANE analysis on multiple TLSA records

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -324,5 +324,20 @@ namespace DomainDetective.Tests {
             Assert.True(result.ValidDANERecord);
             Assert.Equal(ServiceType.HTTPS, result.ServiceType);
         }
+
+        [Fact]
+        public async Task MultipleRecordsAreValidated() {
+            var records = new[] {
+                $"3 1 1 {new string('A', 64)}",
+                $"3 1 1 {new string('B', 64)}"
+            };
+
+            var healthCheck = new DomainHealthCheck { Verbose = false };
+            await healthCheck.CheckDANE(records);
+
+            Assert.Equal(2, healthCheck.DaneAnalysis.NumberOfRecords);
+            Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
+            Assert.Equal(2, healthCheck.DaneAnalysis.AnalysisResults.Count);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -458,6 +458,18 @@ namespace DomainDetective {
         }
 
         /// <summary>
+        /// Analyzes multiple DANE records.
+        /// </summary>
+        /// <param name="daneRecords">Collection of TLSA record texts.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task CheckDANE(IEnumerable<string> daneRecords, CancellationToken cancellationToken = default) {
+            var answers = daneRecords.Select(record => new DnsAnswer {
+                DataRaw = record
+            }).ToList();
+            await DaneAnalysis.AnalyzeDANERecords(answers, _logger);
+        }
+
+        /// <summary>
         /// Analyzes a raw SMIMEA record.
         /// </summary>
         /// <param name="smimeaRecord">SMIMEA record text.</param>


### PR DESCRIPTION
## Summary
- add `CheckDANE(IEnumerable<string>)` overload for analyzing many TLSA records
- add unit test verifying multiple TLSA records are processed

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid...)*

------
https://chatgpt.com/codex/tasks/task_e_686828109ab8832eb9376e6e71323cd4