### PR TITLE
Validate DS digest lengths

### DIFF
--- a/DomainDetective.Tests/TestDNSSECRecordValidation.cs
+++ b/DomainDetective.Tests/TestDNSSECRecordValidation.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System.Reflection;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -11,6 +12,16 @@ namespace DomainDetective.Tests {
             var analysis = new DnsSecAnalysis();
             bool result = await analysis.ValidateRecord(domain, type);
             Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("2371 ECDSAP256SHA256 1 9bacd9689f3c9eceb62e2e533ca7a87669f7e58b")]
+        [InlineData("2371 ECDSAP256SHA256 2 c988ec423e3880eb8dd8a46fe06ca230ee23f35b578d64e78b29c3e1c83d245a")]
+        [InlineData("2371 ECDSAP256SHA256 4 da0163a25f5219588189215e44b444102848e853ae6a78b96ae5c75a4df7c90bd1fbcd5761bd2aa4a477c5fe0b514312")]
+        public void SampleDsRecordsHaveValidLength(string record) {
+            var method = typeof(DnsSecAnalysis).GetMethod("IsDsDigestLengthValid", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { record })!;
+            Assert.True(result);
         }
     }
 }

--- a/DomainDetective.Tests/TestDsDigestLength.cs
+++ b/DomainDetective.Tests/TestDsDigestLength.cs
@@ -15,5 +15,19 @@ namespace DomainDetective.Tests {
             bool result = (bool)method.Invoke(null, new object[] { "2371 ECDSAP256SHA256 2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
             Assert.True(result);
         }
+
+        [Fact]
+        public void ValidSha1DigestLengthReturnsTrue() {
+            var method = typeof(DnsSecAnalysis).GetMethod("IsDsDigestLengthValid", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { "2371 ECDSAP256SHA256 1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" });
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void ValidSha384DigestLengthReturnsTrue() {
+            var method = typeof(DnsSecAnalysis).GetMethod("IsDsDigestLengthValid", BindingFlags.NonPublic | BindingFlags.Static)!;
+            bool result = (bool)method.Invoke(null, new object[] { "2371 ECDSAP256SHA256 4 " + new string('a', 96) });
+            Assert.True(result);
+        }
     }
 }

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -215,12 +215,11 @@ namespace DomainDetective {
             int expected = digestType switch {
                 1 => 40,
                 2 => 64,
-                3 => 64,
                 4 => 96,
-                _ => 0,
+                _ => -1,
             };
 
-            return expected == 0 || parts[3].Length == expected;
+            return expected < 0 || parts[3].Length == expected;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure DS digest length matches SHA-based digest size
- add test cases for SHA-1, SHA-256 and SHA-384 DS digests
- provide sample records in DNSSEC record validation tests

## Testing
- `dotnet test DomainDetective.sln -c Debug --no-build --filter "FullyQualifiedName~DomainDetective.Tests.TestDsDigestLength"`
- ❌ `dotnet test DomainDetective.sln -c Debug -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68682834948c832ea3e7cd55f6c7f0f7