### PR TITLE
Implement SPF exp retrieval

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -1,3 +1,5 @@
+using System.Net;
+
 namespace DomainDetective.Tests {
     public class TestSpfAnalysis {
         [Fact]
@@ -430,6 +432,31 @@ namespace DomainDetective.Tests {
 
             Assert.Contains("Flattened SPF record exceeds", healthCheck.SpfAnalysis.Warnings.First());
             Assert.Equal(record, flattened);
+        }
+
+        [Fact]
+        public async Task ExpModifierReturnsExplanation() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["explain.example.com"] = "%{i} is not authorized";
+
+            await healthCheck.CheckSPF("v=spf1 -all exp=explain.example.com");
+
+            var explanation = await healthCheck.SpfAnalysis.GetExplanationText(IPAddress.Parse("192.0.2.1"), "user@example.com", "mail.example.com", "example.com");
+
+            Assert.Equal("192.0.2.1 is not authorized", explanation);
+        }
+
+        [Fact]
+        public async Task ExpModifierRespectsLookupLimit() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["explain.example.com"] = "%{p} %{p} %{p} %{p}";
+
+            await healthCheck.CheckSPF("v=spf1 -all exp=explain.example.com");
+
+            var explanation = await healthCheck.SpfAnalysis.GetExplanationText(IPAddress.Parse("8.8.8.8"), "user@example.com", "mail.example.com", "example.com");
+
+            Assert.Null(explanation);
+            Assert.True(healthCheck.SpfAnalysis.ExpExceedsDnsLookups);
         }
     }
 }


### PR DESCRIPTION
## Summary
- implement Exp modifier text retrieval with macro expansion
- add DNS query override and lookup limit tracking
- add tests for explanation retrieval and lookup limit

## Testing
- `dotnet build`
- `dotnet test` *(fails: System.UriFormatException, Assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_686827ee13b4832e95c2ee287c10c390