### PR TITLE
Add SPF flattening to IP addresses

### DIFF
--- a/DomainDetective.Tests/TestSPFAnalysis.cs
+++ b/DomainDetective.Tests/TestSPFAnalysis.cs
@@ -457,7 +457,9 @@ namespace DomainDetective.Tests {
 
             _ = await healthCheck.SpfAnalysis.GetFlattenedIpAddresses();
 
-            Assert.Contains("lookup limit", healthCheck.SpfAnalysis.Warnings.First());
+            Assert.Contains(
+                healthCheck.SpfAnalysis.Warnings,
+                w => w.Contains("lookup limit", StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -134,7 +134,7 @@ namespace DomainDetective {
                         break;
                     case HealthCheckType.SPF:
                         var spf = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.TXT, "SPF1", cancellationToken);
-                        await SpfAnalysis.AnalyzeSpfRecords(spf, _logger);
+                        await SpfAnalysis.AnalyzeSpfRecords(spf, _logger, domainName);
                         break;
                     case HealthCheckType.DKIM:
                         var selectors = dkimSelectors;
@@ -730,7 +730,7 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             var spf = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.TXT, "SPF1", cancellationToken);
-            await SpfAnalysis.AnalyzeSpfRecords(spf, _logger);
+            await SpfAnalysis.AnalyzeSpfRecords(spf, _logger, domainName);
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- extend `SpfAnalysis` with domain tracking and IP flattening method
- warn when flattened lookups exceed RFC limit
- update `DomainHealthCheck` to pass domain name to SPF analysis
- cover new functionality with unit tests

## Testing
- `dotnet build --no-restore -c Release`
- `dotnet test -c Release` *(fails: 19 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6868283faaa4832e81b28f0766116409