### PR TITLE
Add dmarcian selectors to DKIM checks

### DIFF
--- a/DomainDetective.Tests/TestDKIMGuess.cs
+++ b/DomainDetective.Tests/TestDKIMGuess.cs
@@ -8,5 +8,11 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults.ContainsKey("selector1"));
             Assert.True(healthCheck.DKIMAnalysis.AnalysisResults.ContainsKey("selector2"));
         }
+        [Fact]
+        public void GuessSelectorsIncludesDmarcianData() {
+            var selectors = DomainDetective.Definitions.DKIMSelectors.GuessSelectors().ToList();
+            Assert.Contains("selector2019", selectors);
+            Assert.True(selectors.Count > 17);
+        }
     }
 }

--- a/DomainDetective/Definitions/DKIMSelectors.cs
+++ b/DomainDetective/Definitions/DKIMSelectors.cs
@@ -26,6 +26,39 @@ namespace DomainDetective.Definitions {
 
         internal static readonly string[] AmazonSes = new[] { "amazonses" };
 
+        private static readonly string[] Dmarcian = new[] {
+            "selector1",
+            "selector2",
+            "selector3",
+            "selector4",
+            "k1",
+            "k2",
+            "mail",
+            "mandrill",
+            "mx",
+            "s1024",
+            "s2048",
+            "s1",
+            "s2",
+            "mx1",
+            "mx2",
+            "mailchannels",
+            "default",
+            "google",
+            "mta",
+            "smtp",
+            "dkim",
+            "spf",
+            "mail1",
+            "mail2",
+            "api",
+            "key1",
+            "key2",
+            "selector2019",
+            "selector2020",
+            "selector2021"
+        };
+
         /// <summary>
         /// Returns a deduplicated list of known DKIM selectors.
         /// </summary>
@@ -40,6 +73,7 @@ namespace DomainDetective.Definitions {
                 .Concat(CPanel)
                 .Concat(Fastmail)
                 .Concat(AmazonSes)
+                .Concat(Dmarcian)
                 .Distinct();
         }
     }


### PR DESCRIPTION
## Summary
- load DKIM selectors from new dmarcian list
- expose them via `GuessSelectors`
- verify the new selectors are loaded

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln` *(fails: KeyNotFoundException in TestDkimAnalysis.TestDKIMByDomain)*

------
https://chatgpt.com/codex/tasks/task_e_6868285c33cc832e87838ea26b72e67d