### PR TITLE
Add progress reporting to DNS propagation analysis

### DIFF
--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -1,4 +1,6 @@
 using DnsClientX;
+using DomainDetective;
+using Spectre.Console;
 using Spectre.Console.Cli;
 using System.Reflection;
 using System.Text.Json;
@@ -22,6 +24,9 @@ internal sealed class DnsPropagationSettings : CommandSettings {
 
     [CommandOption("--compare-results")]
     public bool Compare { get; set; }
+
+    [CommandOption("--no-progress")]
+    public bool NoProgress { get; set; }
 }
 
 internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSettings> {
@@ -38,7 +43,17 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         }
         var servers = analysis.Servers;
         var domain = CliHelpers.ToAscii(settings.Domain);
-        var results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken);
+
+        List<DnsPropagationResult> results = new();
+        if (settings.NoProgress) {
+            results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken);
+        } else {
+            await AnsiConsole.Progress().StartAsync(async ctx => {
+                var task = ctx.AddTask($"Query {domain}", maxValue: 100);
+                var progress = new Progress<double>(p => task.Value = p);
+                results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken, progress);
+            });
+        }
         if (settings.Compare) {
             var groups = DnsPropagationAnalysis.CompareResults(results);
             if (settings.Json) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -10,7 +10,13 @@ namespace DomainDetective.Example {
             var analysis = new DnsPropagationAnalysis();
             analysis.LoadBuiltinServers();
             var servers = analysis.FilterServers(country: CountryId.UnitedStates, take: 3);
-            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
+            var progress = new Progress<double>(p => Console.WriteLine($"Progress: {p:F0}%"));
+            var results = await analysis.QueryAsync(
+                "example.com",
+                DnsRecordType.A,
+                servers,
+                cancellationToken: default,
+                progress: progress);
             foreach (var result in results) {
                 Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{string.Join(',', result.Records)} Time:{result.Duration.TotalMilliseconds}ms");
             }

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -1,7 +1,7 @@
 using DnsClientX;
 using System;
+using DomainDetective;
 using System.Linq;
-
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example {
@@ -11,7 +11,13 @@ namespace DomainDetective.Example {
             analysis.LoadBuiltinServers();
 
             var servers = analysis.FilterServers(take: 8);
-            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
+            var progress = new Progress<double>(p => Console.WriteLine($"Progress: {p:F0}%"));
+            var results = await analysis.QueryAsync(
+                "example.com",
+                DnsRecordType.A,
+                servers,
+                cancellationToken: default,
+                progress: progress);
 
             var grouped = results.GroupBy(r => r.Server.Country);
             foreach (var group in grouped) {

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -2,6 +2,7 @@ using DnsClientX;
 using System;
 using DomainDetective;
 using System.Collections.Generic;
+using System.Linq;
 using System.IO;
 using System.Management.Automation;
 using System.Reflection;
@@ -73,7 +74,17 @@ namespace DomainDetective.PowerShell {
 
         protected override async Task ProcessRecordAsync() {
             IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location, Take);
-            var results = await _analysis.QueryAsync(DomainName, RecordType, servers);
+            var serverList = servers.ToList();
+            var progress = new Progress<double>(p => {
+                var record = new ProgressRecord(1, "DnsPropagation", $"{p:F0}% complete") {
+                    PercentComplete = (int)p
+                };
+                if (p >= 100) {
+                    record.RecordType = ProgressRecordType.Completed;
+                }
+                WriteProgress(record);
+            });
+            var results = await _analysis.QueryAsync(DomainName, RecordType, serverList, CancelToken, progress);
             if (CompareResults) {
                 var comparison = DnsPropagationAnalysis.CompareResults(results);
                 WriteObject(comparison);

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -21,12 +21,11 @@ Test-NsRecord -DomainName "example.com" -Verbose
   ```powershell
   Test-DkimRecord -DomainName "example.com" -Selectors "selector1" -Verbose
   ```
-- `Test-DnsPropagation` – checks how DNS records propagate across public resolvers.
+- `Test-DnsPropagation` – checks how DNS records propagate across public resolvers. Progress is reported via `Write-Progress`.
   ```powershell
   $file = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'
   Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile $file -CompareResults
   ```
-  Progress is reported via `Write-Progress`.
 - `Test-CaaRecord` – validates CAA entries.
   ```powershell
   Test-CaaRecord -DomainName "example.com"

--- a/Module/README.MD
+++ b/Module/README.MD
@@ -26,6 +26,7 @@ Test-NsRecord -DomainName "example.com" -Verbose
   $file = Join-Path (Split-Path ([System.Reflection.Assembly]::GetExecutingAssembly().Location)) 'Data/DNS/PublicDNS.json'
   Test-DnsPropagation -DomainName "example.com" -RecordType A -ServersFile $file -CompareResults
   ```
+  Progress is reported via `Write-Progress`.
 - `Test-CaaRecord` – validates CAA entries.
   ```powershell
   Test-CaaRecord -DomainName "example.com"

--- a/README.MD
+++ b/README.MD
@@ -163,6 +163,11 @@ Query an S/MIMEA record:
 ```bash
 ddcli TestSMIMEA user@example.com
 ```
+Check DNS propagation:
+```bash
+ddcli DnsPropagation --domain example.com --record-type A
+```
+Progress is displayed as each resolver responds.
 
 ### Interactive CLI Wizard
 


### PR DESCRIPTION
## Summary
- track progress in `DnsPropagationAnalysis.QueryAsync`
- surface progress in CLI and PowerShell via progress bars
- show progress usage in example and README docs

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68684b88fe68832eb9ca22278cabea67