### PR TITLE
Extend DNS comparison output

### DIFF
--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -40,12 +40,12 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         var domain = CliHelpers.ToAscii(settings.Domain);
         var results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken);
         if (settings.Compare) {
-            var groups = DnsPropagationAnalysis.CompareResults(results);
+            var details = DnsPropagationAnalysis.GetComparisonDetails(results);
             if (settings.Json) {
-                Console.WriteLine(JsonSerializer.Serialize(groups, DomainHealthCheck.JsonOptions));
+                Console.WriteLine(JsonSerializer.Serialize(details, DomainHealthCheck.JsonOptions));
             } else {
-                foreach (var kvp in groups) {
-                    Console.WriteLine($"{kvp.Key}: {string.Join(',', kvp.Value.Select(s => s.IPAddress.ToString()))}");
+                foreach (var d in details) {
+                    Console.WriteLine($"{d.Records}: {d.IPAddress} ({d.Country}/{d.Location})");
                 }
             }
         } else {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -15,9 +15,9 @@ namespace DomainDetective.Example {
                 Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{string.Join(',', result.Records)} Time:{result.Duration.TotalMilliseconds}ms");
             }
 
-            var comparison = DnsPropagationAnalysis.CompareResults(results);
-            foreach (var kvp in comparison) {
-                Console.WriteLine($"Record set: {kvp.Key} seen by {kvp.Value.Count} servers");
+            var details = DnsPropagationAnalysis.GetComparisonDetails(results);
+            foreach (var d in details) {
+                Console.WriteLine($"{d.Records}: {d.IPAddress} ({d.Country}/{d.Location})");
             }
         }
     }

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -22,11 +22,10 @@ namespace DomainDetective.Example {
                 }
             }
 
-            var comparison = DnsPropagationAnalysis.CompareResults(results);
+            var details = DnsPropagationAnalysis.GetComparisonDetails(results);
             Console.WriteLine("\nSummary by record set:");
-            foreach (var kvp in comparison) {
-                var countries = string.Join(',', kvp.Value.Select(s => s.Country));
-                Console.WriteLine($"Record set: {kvp.Key} seen by {kvp.Value.Count} servers ({countries})");
+            foreach (var d in details) {
+                Console.WriteLine($"{d.Records}: {d.IPAddress} ({d.Country}/{d.Location})");
             }
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -75,8 +75,8 @@ namespace DomainDetective.PowerShell {
             IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location, Take);
             var results = await _analysis.QueryAsync(DomainName, RecordType, servers);
             if (CompareResults) {
-                var comparison = DnsPropagationAnalysis.CompareResults(results);
-                WriteObject(comparison);
+                var details = DnsPropagationAnalysis.GetComparisonDetails(results);
+                WriteObject(details, true);
             } else {
                 WriteObject(results, true);
             }

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -74,7 +74,7 @@ namespace DomainDetective.Tests {
 
             var groups = DnsPropagationAnalysis.CompareResults(results);
             Assert.Equal(2, groups.Count);
-            Assert.Contains(groups, g => g.Value.Any(s => s.IPAddress.Equals(IPAddress.Parse("9.9.9.9"))));
+            Assert.Contains(groups, g => g.Value.Any(s => s.IPAddress == "9.9.9.9"));
         }
 
         [Fact]

--- a/DomainDetective/DnsComparisonDetail.cs
+++ b/DomainDetective/DnsComparisonDetail.cs
@@ -1,0 +1,19 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Detailed comparison record for DNS propagation results.
+/// </summary>
+/// <para>Represents a single server and record set combination.</para>
+public sealed class DnsComparisonDetail {
+    /// <summary>The normalized record set.</summary>
+    public string Records { get; init; } = string.Empty;
+
+    /// <summary>IP address of the server.</summary>
+    public string IPAddress { get; init; } = string.Empty;
+
+    /// <summary>Country of the server.</summary>
+    public string? Country { get; init; }
+
+    /// <summary>Location of the server.</summary>
+    public string? Location { get; init; }
+}

--- a/DomainDetective/DnsComparisonEntry.cs
+++ b/DomainDetective/DnsComparisonEntry.cs
@@ -1,0 +1,16 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Entry describing a DNS server along with its country and location.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public sealed class DnsComparisonEntry {
+    /// <summary>IP address of the server.</summary>
+    public string IPAddress { get; init; } = string.Empty;
+
+    /// <summary>Country of the server.</summary>
+    public string? Country { get; init; }
+
+    /// <summary>Location of the server.</summary>
+    public string? Location { get; init; }
+}


### PR DESCRIPTION
## Summary
- add `DnsComparisonDetail` class to represent comparison results
- expose flattened details via `GetComparisonDetails`
- show detailed records in CLI and PowerShell output
- update examples to print comparison details

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: multiple tests fail)*


------
https://chatgpt.com/codex/tasks/task_e_68684b9777e8832e94f34f7cea74d80a