### PR TITLE
Add RFC 6698 validation for TLSA records

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -162,6 +162,27 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task InvalidCombinationsAreRejected() {
+            var healthCheck = new DomainHealthCheck {
+                Verbose = false
+            };
+
+            var sha256 = new string('A', 64);
+            var invalid = new[] {
+                $"4 1 1 {sha256}",
+                $"1 2 1 {sha256}",
+                $"1 1 3 {sha256}",
+                "-1 0 0 ABCD"
+            };
+
+            foreach (var record in invalid) {
+                await healthCheck.CheckDANE(record);
+                var analysis = healthCheck.DaneAnalysis.AnalysisResults[0];
+                Assert.False(analysis.ValidDANERecord, record);
+            }
+        }
+
+        [Fact]
         public async Task VerifyDaneThrowsIfPortsNull() {
             var healthCheck = new DomainHealthCheck();
             await Assert.ThrowsAsync<ArgumentException>(async () =>

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -128,12 +128,6 @@ namespace DomainDetective {
                     logger?.WriteWarning($"TLSA matching type '{matchingTypeValue}' is invalid, expected 0, 1 or 2");
                 }
 
-                analysis.ValidUsageSelectorMatching =
-                    ValidateTlsaCombination(usageValue, selectorValue, matchingTypeValue);
-                if (!analysis.ValidUsageSelectorMatching) {
-                    logger?.WriteWarning(
-                        $"TLSA combination usage {usageValue}, selector {selectorValue}, matching type {matchingTypeValue} is invalid");
-                }
 
                 analysis.CertificateUsage = TranslateUsage(usageValue);
                 analysis.SelectorField = TranslateSelector(selectorValue);
@@ -159,7 +153,7 @@ namespace DomainDetective {
                     logger?.WriteWarning($"TLSA selector {selectorValue} and matching type {matchingTypeValue} are not recommended for HTTPS");
                 }
 
-                analysis.ValidDANERecord = analysis.ValidUsage && analysis.ValidSelector && analysis.ValidMatchingType && analysis.CorrectNumberOfFields && analysis.CorrectLengthOfCertificateAssociationData && analysis.ValidCertificateAssociationData && analysis.ValidUsageSelectorMatching;
+                analysis.ValidDANERecord = analysis.ValidUsage && analysis.ValidSelector && analysis.ValidMatchingType && analysis.CorrectNumberOfFields && analysis.CorrectLengthOfCertificateAssociationData && analysis.ValidCertificateAssociationData;
 
                 // Add the analysis to the results
                 AnalysisResults.Add(analysis);
@@ -187,11 +181,6 @@ namespace DomainDetective {
             };
         }
 
-        private bool ValidateTlsaCombination(int usageValue, int selectorValue, int matchingTypeValue) {
-            return ValidateUsage(usageValue)
-                && ValidateSelector(selectorValue)
-                && ValidateMatchingType(matchingTypeValue);
-        }
         private string TranslateUsage(int usage) {
             return usage switch {
                 0 => "PKIX-TA: CA Constraint",
@@ -247,8 +236,6 @@ namespace DomainDetective {
         public bool ValidMatchingType { get; set; }
         /// <summary>Gets or sets whether the certificate association data is valid hexadecimal.</summary>
         public bool ValidCertificateAssociationData { get; set; }
-        /// <summary>Gets or sets whether usage, selector and matching type combination is valid.</summary>
-        public bool ValidUsageSelectorMatching { get; set; }
         /// <summary>Gets or sets a value indicating whether this configuration is recommended for SMTP.</summary>
         public bool IsValidChoiceForSmtp { get; set; }
         /// <summary>Gets or sets a value indicating whether this configuration is recommended for HTTPS.</summary>

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -123,9 +123,16 @@ namespace DomainDetective {
 
                 analysis.CorrectLengthOfCertificateAssociationData = matchingTypeValue == 0 || associationData.Length == expectedLength;
                 analysis.LengthOfCertificateAssociationData = associationData.Length;
-                analysis.ValidMatchingType = matchingTypeValue >= 0 && matchingTypeValue <= 2;
+                analysis.ValidMatchingType = ValidateMatchingType(matchingTypeValue);
                 if (!analysis.ValidMatchingType) {
                     logger?.WriteWarning($"TLSA matching type '{matchingTypeValue}' is invalid, expected 0, 1 or 2");
+                }
+
+                analysis.ValidUsageSelectorMatching =
+                    ValidateTlsaCombination(usageValue, selectorValue, matchingTypeValue);
+                if (!analysis.ValidUsageSelectorMatching) {
+                    logger?.WriteWarning(
+                        $"TLSA combination usage {usageValue}, selector {selectorValue}, matching type {matchingTypeValue} is invalid");
                 }
 
                 analysis.CertificateUsage = TranslateUsage(usageValue);
@@ -152,7 +159,7 @@ namespace DomainDetective {
                     logger?.WriteWarning($"TLSA selector {selectorValue} and matching type {matchingTypeValue} are not recommended for HTTPS");
                 }
 
-                analysis.ValidDANERecord = analysis.ValidUsage && analysis.ValidSelector && analysis.ValidMatchingType && analysis.CorrectNumberOfFields && analysis.CorrectLengthOfCertificateAssociationData && analysis.ValidCertificateAssociationData;
+                analysis.ValidDANERecord = analysis.ValidUsage && analysis.ValidSelector && analysis.ValidMatchingType && analysis.CorrectNumberOfFields && analysis.CorrectLengthOfCertificateAssociationData && analysis.ValidCertificateAssociationData && analysis.ValidUsageSelectorMatching;
 
                 // Add the analysis to the results
                 AnalysisResults.Add(analysis);
@@ -172,6 +179,18 @@ namespace DomainDetective {
                 0 or 1 => true,
                 _ => false,
             };
+        }
+        private bool ValidateMatchingType(int matchingValue) {
+            return matchingValue switch {
+                0 or 1 or 2 => true,
+                _ => false,
+            };
+        }
+
+        private bool ValidateTlsaCombination(int usageValue, int selectorValue, int matchingTypeValue) {
+            return ValidateUsage(usageValue)
+                && ValidateSelector(selectorValue)
+                && ValidateMatchingType(matchingTypeValue);
         }
         private string TranslateUsage(int usage) {
             return usage switch {
@@ -228,6 +247,8 @@ namespace DomainDetective {
         public bool ValidMatchingType { get; set; }
         /// <summary>Gets or sets whether the certificate association data is valid hexadecimal.</summary>
         public bool ValidCertificateAssociationData { get; set; }
+        /// <summary>Gets or sets whether usage, selector and matching type combination is valid.</summary>
+        public bool ValidUsageSelectorMatching { get; set; }
         /// <summary>Gets or sets a value indicating whether this configuration is recommended for SMTP.</summary>
         public bool IsValidChoiceForSmtp { get; set; }
         /// <summary>Gets or sets a value indicating whether this configuration is recommended for HTTPS.</summary>


### PR DESCRIPTION
## Summary
- validate combined usage/selector/matching type values
- expose validity info via `ValidUsageSelectorMatching`
- test invalid TLSA field combinations

## Testing
- `dotnet test` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_686958757538832e92581ddd2976c2d9