### PR TITLE
Fix mailto URI parsing

### DIFF
--- a/DomainDetective.Tests/TestTLSRPTAnalysis.cs
+++ b/DomainDetective.Tests/TestTLSRPTAnalysis.cs
@@ -67,6 +67,16 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task PercentEncodedRuaIsDecoded() {
+            var record = "v=TLSRPTv1;rua=mailto:reports%2Btls@example.com";
+            var analysis = new TLSRPTAnalysis();
+            await analysis.AnalyzeTlsRptRecords(new[] { new DnsAnswer { DataRaw = record, Type = DnsRecordType.TXT } }, new InternalLogger());
+
+            Assert.Single(analysis.MailtoRua);
+            Assert.Equal("reports+tls@example.com", analysis.MailtoRua[0]);
+        }
+
+        [Fact]
         public async Task UnknownTagsAreCollected() {
             var record = "v=TLSRPTv1;rua=mailto:a@example.com;foo=bar;test";
             var analysis = new TLSRPTAnalysis();

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -276,12 +276,14 @@ namespace DomainDetective {
                     }
                 }
                 if (u.StartsWith("mailto:", StringComparison.OrdinalIgnoreCase)) {
-                    var address = u.Substring(7);
+                    var addressPart = u.Substring(7);
                     try {
-                        _ = new System.Net.Mail.MailAddress(address);
-                        mailtoList.Add(address);
+                        var decoded = Uri.UnescapeDataString(addressPart);
+                        _ = new System.Net.Mail.MailAddress(decoded);
+                        mailtoList.Add(decoded);
                     } catch {
                         InvalidReportUri = true;
+                        logger?.WriteWarning("Report URI {0} is not a valid email address.", u);
                     }
                     if (isRuf) {
                         RufSizeLimits.Add(sizeLimit);


### PR DESCRIPTION
## Summary
- decode DMARC rua/ruf mailto URIs and validate addresses
- decode TLSRPT mailto URIs
- test percent-encoding and invalid scheme cases for DMARC/TLSRPT

## Testing
- `dotnet test` *(fails: The argument /workspace/... dll is invalid etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6869587fb800832ead8116c179a71c21