### PR TITLE
Normalize WHOIS expiry timestamps

### DIFF
--- a/DomainDetective.Tests/TestWhoisSnapshots.cs
+++ b/DomainDetective.Tests/TestWhoisSnapshots.cs
@@ -14,11 +14,11 @@ namespace DomainDetective.Tests {
         public async Task DetectsSnapshotChanges() {
             var first = string.Join("\n", new[] {
                 "Domain Name: snapshot.local",
-                "Registry Expiry Date: 2024-01-01"
+                "Registry Expiry Date: 2024-01-01T00:00:00Z"
             });
             var second = string.Join("\n", new[] {
                 "Domain Name: snapshot.local",
-                "Registry Expiry Date: 2025-01-01"
+                "Registry Expiry Date: 2025-01-01T00:00:00Z"
             });
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(dir);
@@ -83,8 +83,8 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
 
-            Assert.Contains("+ Registry Expiry Date: 2025-01-01", diff);
-            Assert.Contains("- Registry Expiry Date: 2024-01-01", diff);
+            Assert.Contains("+ Registry Expiry Date: 2025-01-01T00:00:00Z", diff);
+            Assert.Contains("- Registry Expiry Date: 2024-01-01T00:00:00Z", diff);
         }
     }
 }

--- a/DomainDetective.Tests/TestWhoisSnapshots.cs
+++ b/DomainDetective.Tests/TestWhoisSnapshots.cs
@@ -14,11 +14,11 @@ namespace DomainDetective.Tests {
         public async Task DetectsSnapshotChanges() {
             var first = string.Join("\n", new[] {
                 "Domain Name: snapshot.local",
-                "Registry Expiry Date: 2024-01-01T00:00:00Z"
+                "Registry Expiry Date: 2024-01-01T01:00:00+01:00"
             });
             var second = string.Join("\n", new[] {
                 "Domain Name: snapshot.local",
-                "Registry Expiry Date: 2025-01-01T00:00:00Z"
+                "Registry Expiry Date: 2025-01-01T02:00:00+02:00"
             });
             var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             Directory.CreateDirectory(dir);

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -81,6 +81,16 @@ public class WhoisAnalysis {
         "privacy protection"
     };
 
+    private void SetExpiryDate(string value) {
+        if (DateTime.TryParse(value, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var expiry)) {
+            ExpiryDate = expiry.ToString("yyyy-MM-dd'T'HH:mm:ss'Z'", CultureInfo.InvariantCulture);
+        } else {
+            ExpiryDate = value.Trim();
+        }
+    }
+
     private void ParseRegistrarLicense(string trimmedLine) {
         foreach (var prefix in _licensePrefixes) {
             if (trimmedLine.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)) {
@@ -494,7 +504,7 @@ public class WhoisAnalysis {
                         if (trimmedLine.StartsWith("Registered on:")) {
                             CreationDate = trimmedLine.Substring("Registered on:".Length).Trim();
                         } else if (trimmedLine.StartsWith("Expiry date:")) {
-                            ExpiryDate = trimmedLine.Substring("Expiry date:".Length).Trim();
+                            SetExpiryDate(trimmedLine.Substring("Expiry date:".Length).Trim());
                         } else if (trimmedLine.StartsWith("Last updated:")) {
                             LastUpdated = trimmedLine.Substring("Last updated:".Length).Trim();
                         }
@@ -595,7 +605,7 @@ public class WhoisAnalysis {
             } else if (trimmedLine.StartsWith("registered:")) {
                 CreationDate = trimmedLine.Substring("registered:".Length).Trim();
             } else if (trimmedLine.StartsWith("expire:")) {
-                ExpiryDate = trimmedLine.Substring("expire:".Length).Trim();
+                SetExpiryDate(trimmedLine.Substring("expire:".Length).Trim());
             } else if (trimmedLine.StartsWith("registrar:")) {
                 Registrar = trimmedLine.Substring("registrar:".Length).Trim();
             } else if (trimmedLine.StartsWith("nserver:")) {
@@ -634,7 +644,7 @@ public class WhoisAnalysis {
                 } else if (trimmedLine.StartsWith("registered:")) {
                     CreationDate = trimmedLine.Substring("registered:".Length).Trim();
                 } else if (trimmedLine.StartsWith("expire:")) {
-                    ExpiryDate = trimmedLine.Substring("expire:".Length).Trim();
+                    SetExpiryDate(trimmedLine.Substring("expire:".Length).Trim());
                 } else if (trimmedLine.StartsWith("registrar:")) {
                     Registrar = trimmedLine.Substring("registrar:".Length).Trim();
                 } else if (trimmedLine.StartsWith("registrant:")) {
@@ -678,7 +688,7 @@ public class WhoisAnalysis {
             } else if (line.StartsWith("   Creation Date:")) {
                 CreationDate = line.Substring("   Creation Date:".Length).Trim();
             } else if (line.StartsWith("   Registry Expiry Date:")) {
-                ExpiryDate = line.Substring("   Registry Expiry Date:".Length).Trim();
+                SetExpiryDate(line.Substring("   Registry Expiry Date:".Length).Trim());
             } else if (line.Contains("Updated Date:")) {
                 LastUpdated = line.Substring("   Updated Date:".Length).Trim();
             } else if (line.StartsWith("   Name Server:")) {
@@ -716,7 +726,7 @@ public class WhoisAnalysis {
             } else if (trimmedLine.StartsWith("Creation Date:")) {
                 CreationDate = trimmedLine.Substring("Creation Date:".Length).Trim();
             } else if (trimmedLine.StartsWith("Registry Expiry Date:")) {
-                ExpiryDate = trimmedLine.Substring("Registry Expiry Date:".Length).Trim();
+                SetExpiryDate(trimmedLine.Substring("Registry Expiry Date:".Length).Trim());
             } else if (trimmedLine.StartsWith("Updated Date:")) {
                 LastUpdated = trimmedLine.Substring("Updated Date:".Length).Trim();
             } else if (trimmedLine.StartsWith("Name Server:")) {
@@ -771,7 +781,7 @@ public class WhoisAnalysis {
             } else if (trimmedLine.StartsWith("Creation Date:")) {
                 CreationDate = trimmedLine.Substring("Creation Date:".Length).Trim();
             } else if (trimmedLine.StartsWith("Registry Expiry Date:")) {
-                ExpiryDate = trimmedLine.Substring("Registry Expiry Date:".Length).Trim();
+                SetExpiryDate(trimmedLine.Substring("Registry Expiry Date:".Length).Trim());
             } else if (trimmedLine.StartsWith("Updated Date:")) {
                 LastUpdated = trimmedLine.Substring("Updated Date:".Length).Trim();
             } else if (trimmedLine.StartsWith("Name Server:")) {
@@ -812,7 +822,7 @@ public class WhoisAnalysis {
             } else if (trimmedLine.StartsWith("created:")) {
                 CreationDate = trimmedLine.Substring("created:".Length).Trim();
             } else if (trimmedLine.StartsWith("renewal date:")) {
-                ExpiryDate = trimmedLine.Substring("renewal date:".Length).Trim();
+                SetExpiryDate(trimmedLine.Substring("renewal date:".Length).Trim());
             } else if (trimmedLine.StartsWith("registrant type:")) {
                 RegistrantType = trimmedLine.Substring("registrant type:".Length).Trim();
             } else if (trimmedLine.StartsWith("last modified:")) {


### PR DESCRIPTION
## Summary
- normalize parsed expiry timestamps to UTC
- update snapshot tests for new timestamp format

## Testing
- `dotnet build -c Release`
- `dotnet test` *(fails: Assert.True/Assert.Null due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6869587ae58c832eab4fcb6025f6b572