### PR TITLE
Expose DS key tag calculation

### DIFF
--- a/DomainDetective.Tests/TestDsKeyTag.cs
+++ b/DomainDetective.Tests/TestDsKeyTag.cs
@@ -1,0 +1,13 @@
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDsKeyTag {
+        [Theory]
+        [InlineData("257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU=", 20326)]
+        [InlineData("257 3 13 mdsswUyr3DPW132mOi8V9xESWE8jTo0dxCjjnopKl+GqJxpVXckHAeF+KkxLbxILfDLUT0rAK9iUzy1L53eKGQ==", 2371)]
+        public void KeyTagMatchesExpected(string dnskey, int expected) {
+            int keyTag = DomainDetective.DnsSecAnalysis.ComputeKeyTag(dnskey);
+            Assert.Equal(expected, keyTag);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `DnsSecAnalysis.ComputeKeyTag(string)` to compute DNSKEY key tags
- verify DS key tags using the new method
- test known DNSKEY key tag values

## Testing
- `dotnet build`
- `dotnet test --no-build --filter TestDsKeyTag`
- `dotnet test --no-build` *(fails: DNS/network dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_6869589046b0832ebf00f0c37d0cd403