### PR TITLE
Validate TLSRPT JSON schema

### DIFF
--- a/DomainDetective.Tests/Data/tlsrpt-invalid.json
+++ b/DomainDetective.Tests/Data/tlsrpt-invalid.json
@@ -4,17 +4,14 @@
     "start-datetime": "2024-06-01T00:00:00Z",
     "end-datetime": "2024-06-02T00:00:00Z"
   },
-  "contact-info": "tlsrpt@example.com",
   "report-id": "2024-06-01/2024-06-02",
   "policies": [
     {
       "policy": {
-        "policy-type": "tls",
-        "mx-host": "mx.example.com"
+        "policy-type": "tls"
       },
       "summary": {
-        "total-successful-session-count": 90,
-        "total-failure-session-count": 10
+        "total-successful-session-count": 90
       }
     }
   ]

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -92,6 +92,9 @@
         <None Include="Data/tlsrpt.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/tlsrpt-invalid.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/DomainDetective.Tests/TestTlsRptJsonParser.cs
+++ b/DomainDetective.Tests/TestTlsRptJsonParser.cs
@@ -1,4 +1,5 @@
 using DomainDetective;
+using System;
 using System.Linq;
 using Xunit;
 
@@ -11,6 +12,11 @@ namespace DomainDetective.Tests {
             Assert.Equal("mx.example.com", summaries[0].MxHost);
             Assert.Equal(90, summaries[0].SuccessfulSessions);
             Assert.Equal(10, summaries[0].FailedSessions);
+        }
+
+        [Fact]
+        public void InvalidReportThrows() {
+            Assert.Throws<FormatException>(() => TlsRptJsonParser.ParseReport("Data/tlsrpt-invalid.json").ToList());
         }
     }
 }

--- a/DomainDetective/Protocols/TlsRptJsonParser.cs
+++ b/DomainDetective/Protocols/TlsRptJsonParser.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
@@ -12,32 +13,57 @@ namespace DomainDetective {
         public static IEnumerable<TlsRptSummary> ParseReport(string path) {
             var json = File.ReadAllText(path);
             using var doc = JsonDocument.Parse(json);
+
+            ValidateSchema(doc.RootElement);
+
             var list = new List<TlsRptSummary>();
-            if (!doc.RootElement.TryGetProperty("policies", out var policies) || policies.ValueKind != JsonValueKind.Array) {
-                return list;
-            }
+            var policies = doc.RootElement.GetProperty("policies");
+
             foreach (var policy in policies.EnumerateArray()) {
-                var mxHost = string.Empty;
-                if (policy.TryGetProperty("policy", out var pol) && pol.TryGetProperty("mx-host", out var mx)) {
-                    mxHost = mx.GetString() ?? string.Empty;
-                }
-                int success = 0;
-                int failure = 0;
-                if (policy.TryGetProperty("summary", out var summary)) {
-                    if (summary.TryGetProperty("total-successful-session-count", out var s)) {
-                        success = s.GetInt32();
-                    }
-                    if (summary.TryGetProperty("total-failure-session-count", out var f)) {
-                        failure = f.GetInt32();
-                    }
-                }
+                var pol = policy.GetProperty("policy");
+                var mxHost = pol.GetProperty("mx-host").GetString() ?? string.Empty;
+                var summary = policy.GetProperty("summary");
+                int success = summary.GetProperty("total-successful-session-count").GetInt32();
+                int failure = summary.GetProperty("total-failure-session-count").GetInt32();
+
                 list.Add(new TlsRptSummary {
                     MxHost = mxHost,
                     SuccessfulSessions = success,
                     FailedSessions = failure
                 });
             }
+
             return list;
+        }
+
+        private static void ValidateSchema(JsonElement root) {
+            if (!root.TryGetProperty("organization-name", out _)) {
+                throw new FormatException("Missing organization-name field.");
+            }
+            if (!root.TryGetProperty("date-range", out var range)
+                || !range.TryGetProperty("start-datetime", out _)
+                || !range.TryGetProperty("end-datetime", out _)) {
+                throw new FormatException("Missing date-range fields.");
+            }
+            if (!root.TryGetProperty("report-id", out _)) {
+                throw new FormatException("Missing report-id field.");
+            }
+            if (!root.TryGetProperty("policies", out var policies) || policies.ValueKind != JsonValueKind.Array) {
+                throw new FormatException("Missing policies array.");
+            }
+
+            foreach (var policy in policies.EnumerateArray()) {
+                if (!policy.TryGetProperty("policy", out var pol)
+                    || !pol.TryGetProperty("policy-type", out _)
+                    || !pol.TryGetProperty("mx-host", out _)) {
+                    throw new FormatException("Invalid policy entry.");
+                }
+                if (!policy.TryGetProperty("summary", out var summary)
+                    || !summary.TryGetProperty("total-successful-session-count", out _)
+                    || !summary.TryGetProperty("total-failure-session-count", out _)) {
+                    throw new FormatException("Invalid summary entry.");
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- validate TLS-RPT JSON reports using RFC 8460 rules
- update sample JSON data and add invalid sample
- ensure parser throws `FormatException` on malformed data
- cover new behavior with tests

## Testing
- `dotnet test` *(fails: 18, passed: 477)*

------
https://chatgpt.com/codex/tasks/task_e_686958663020832e9de272f2c32a9940