### PR TITLE
Add concurrent certificate checks

### DIFF
--- a/DomainDetective.Benchmarks/Benchmarks/CertificateBenchmarks.cs
+++ b/DomainDetective.Benchmarks/Benchmarks/CertificateBenchmarks.cs
@@ -1,0 +1,30 @@
+using BenchmarkDotNet.Attributes;
+
+namespace DomainDetective.Benchmarks;
+
+[MemoryDiagnoser]
+public class CertificateBenchmarks
+{
+    private readonly string[] _urls =
+    [
+        "https://www.google.com",
+        "https://www.microsoft.com",
+        "https://www.github.com",
+        "https://www.stackoverflow.com"
+    ];
+
+    [Benchmark(Baseline = true)]
+    public async Task Sequential()
+    {
+        foreach (var url in _urls)
+        {
+            await CertificateAnalysis.CheckWebsiteCertificate(url);
+        }
+    }
+
+    [Benchmark]
+    public async Task Concurrent()
+    {
+        await CertificateAnalysis.CheckWebsiteCertificates(_urls);
+    }
+}

--- a/DomainDetective.Benchmarks/DomainDetective.Benchmarks.csproj
+++ b/DomainDetective.Benchmarks/DomainDetective.Benchmarks.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
+  </ItemGroup>
+</Project>

--- a/DomainDetective.Benchmarks/Program.cs
+++ b/DomainDetective.Benchmarks/Program.cs
@@ -1,0 +1,11 @@
+using BenchmarkDotNet.Running;
+
+namespace DomainDetective.Benchmarks;
+
+public static class Program
+{
+    public static void Main(string[] args)
+    {
+        BenchmarkRunner.Run<CertificateBenchmarks>();
+    }
+}

--- a/DomainDetective.sln
+++ b/DomainDetective.sln
@@ -23,6 +23,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.Reports", "
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.CLI.Tests", "DomainDetective.CLI.Tests\DomainDetective.CLI.Tests.csproj", "{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.Benchmarks", "DomainDetective.Benchmarks\DomainDetective.Benchmarks.csproj", "{0ADD478F-806C-4D9B-9D92-12860644D4B7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,18 @@ Global
 		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x64.Build.0 = Release|Any CPU
 		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x86.ActiveCfg = Release|Any CPU
 		{6CDBF889-7A84-403D-B0D6-21C47F57A8C6}.Release|x86.Build.0 = Release|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Release|x64.Build.0 = Release|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{0ADD478F-806C-4D9B-9D92-12860644D4B7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -370,6 +370,18 @@ namespace DomainDetective {
         }
 
         /// <summary>
+        /// Checks certificates for multiple URLs concurrently.
+        /// </summary>
+        /// <param name="urls">The URLs. If no scheme is provided, "https://" will be prepended.</param>
+        /// <param name="port">The port.</param>
+        /// <param name="cancellationToken">Cancellation token to stop the operation.</param>
+        /// <returns>List of populated <see cref="CertificateAnalysis"/> instances.</returns>
+        public static async Task<IReadOnlyList<CertificateAnalysis>> CheckWebsiteCertificates(IEnumerable<string> urls, int port = 443, CancellationToken cancellationToken = default) {
+            var tasks = urls.Select(u => CheckWebsiteCertificate(u, port, cancellationToken));
+            return await Task.WhenAll(tasks).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Analyzes a provided certificate without performing any network operations.
         /// </summary>
         /// <param name="certificate">Certificate instance to inspect.</param>


### PR DESCRIPTION
## Summary
- add `CheckWebsiteCertificates` to run validations in parallel
- include BenchmarkDotNet project for sequential vs concurrent comparisons

## Testing
- `dotnet build`
- `dotnet test` *(fails: The given key 'selector1' was not present in the dictionary.)*

------
https://chatgpt.com/codex/tasks/task_e_68697151f5f0832e98102582954f0406