### PR TITLE
Add DNS query throttling

### DIFF
--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -25,6 +25,9 @@ internal sealed class DnsPropagationSettings : CommandSettings {
     [CommandOption("--compare-results")]
     public bool Compare { get; set; }
 
+    [CommandOption("--max-parallelism")]
+    public int MaxParallelism { get; set; }
+
     [CommandOption("--no-progress")]
     public bool NoProgress { get; set; }
 }
@@ -46,12 +49,12 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
 
         List<DnsPropagationResult> results = new();
         if (settings.NoProgress) {
-            results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken);
+            results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken, null, settings.MaxParallelism);
         } else {
             await AnsiConsole.Progress().StartAsync(async ctx => {
                 var task = ctx.AddTask($"Query {domain}", maxValue: 100);
                 var progress = new Progress<double>(p => task.Value = p);
-                results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken, progress);
+                results = await analysis.QueryAsync(domain, settings.RecordType, servers, Program.CancellationToken, progress, settings.MaxParallelism);
             });
         }
         if (settings.Compare) {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -16,7 +16,8 @@ namespace DomainDetective.Example {
                 DnsRecordType.A,
                 servers,
                 cancellationToken: default,
-                progress: progress);
+                progress: progress,
+                maxParallelism: 4);
             foreach (var result in results) {
                 Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{string.Join(',', result.Records)} Time:{result.Duration.TotalMilliseconds}ms");
             }

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -17,7 +17,8 @@ namespace DomainDetective.Example {
                 DnsRecordType.A,
                 servers,
                 cancellationToken: default,
-                progress: progress);
+                progress: progress,
+                maxParallelism: 4);
 
             var grouped = results.GroupBy(r => r.Server.Country);
             foreach (var group in grouped) {

--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -56,6 +56,10 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public string? WebhookUrl;
 
+        /// <param name="MaxParallelism">Maximum concurrent DNS queries.</param>
+        [Parameter(Mandatory = false)]
+        public int MaxParallelism = 0;
+
         private readonly DnsPropagationMonitor _monitor = new();
 
         protected override Task BeginProcessingAsync() {
@@ -64,6 +68,7 @@ namespace DomainDetective.PowerShell {
             _monitor.Interval = TimeSpan.FromSeconds(IntervalSeconds);
             _monitor.Country = Country;
             _monitor.Location = Location;
+            _monitor.MaxParallelism = MaxParallelism;
             var moduleBase = this.MyInvocation.MyCommand.Module?.ModuleBase
                 ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
                 ?? string.Empty;

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -26,7 +26,7 @@ namespace DomainDetective.Tests {
         public async Task QueryHandlesDownServer() {
             var analysis = new DnsPropagationAnalysis();
             analysis.AddServer(new PublicDnsEntry { IPAddress = IPAddress.Parse("192.0.2.1"), Country = "Test" });
-            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers);
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers, maxParallelism: 1);
             Assert.Single(results);
             Assert.False(results[0].Success);
         }
@@ -39,13 +39,13 @@ namespace DomainDetective.Tests {
             cts.Cancel();
 
             await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers, cts.Token));
+                await analysis.QueryAsync("example.com", DnsRecordType.A, analysis.Servers, cts.Token, maxParallelism: 1));
         }
 
         [Fact]
         public async Task QueryReturnsEmptyWhenNoServers() {
             var analysis = new DnsPropagationAnalysis();
-            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, Enumerable.Empty<PublicDnsEntry>());
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, Enumerable.Empty<PublicDnsEntry>(), maxParallelism: 1);
             Assert.Empty(results);
         }
 

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -260,14 +260,24 @@ namespace DomainDetective {
             DnsRecordType recordType,
             IEnumerable<PublicDnsEntry> servers,
             CancellationToken cancellationToken = default,
-            IProgress<double>? progress = null) {
+            IProgress<double>? progress = null,
+            int maxParallelism = 0) {
             var serverList = servers?.ToList() ?? new List<PublicDnsEntry>();
             if (serverList.Count == 0) {
                 return new List<DnsPropagationResult>();
             }
+            maxParallelism = maxParallelism <= 0 ? serverList.Count : Math.Min(maxParallelism, serverList.Count);
 
+            using var semaphore = new SemaphoreSlim(maxParallelism);
             var tasks = serverList
-                .Select(server => QueryServerAsync(domain, recordType, server, cancellationToken))
+                .Select(async server => {
+                    await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try {
+                        return await QueryServerAsync(domain, recordType, server, cancellationToken).ConfigureAwait(false);
+                    } finally {
+                        semaphore.Release();
+                    }
+                })
                 .ToList();
             var results = new List<DnsPropagationResult>(serverList.Count);
             var completed = 0;

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -33,6 +33,9 @@ namespace DomainDetective.Monitoring {
         /// <summary>Additional user supplied servers.</summary>
         public List<PublicDnsEntry> CustomServers { get; } = new();
 
+        /// <summary>Maximum concurrent DNS queries.</summary>
+        public int MaxParallelism { get; set; }
+
         private readonly DnsPropagationAnalysis _analysis = new();
         private Timer? _timer;
 
@@ -76,7 +79,7 @@ namespace DomainDetective.Monitoring {
             var serverList = servers.ToList();
             var results = QueryOverride != null
                 ? await QueryOverride(serverList, ct)
-                : await _analysis.QueryAsync(Domain, RecordType, serverList, ct);
+                : await _analysis.QueryAsync(Domain, RecordType, serverList, ct, null, MaxParallelism);
             var groups = DnsPropagationAnalysis.CompareResults(results);
             if (groups.Count > 1) {
                 var message = $"Propagation discrepancy for {Domain} ({RecordType})";


### PR DESCRIPTION
## Summary
- throttle propagation queries with `SemaphoreSlim`
- expose parallelism control to monitors, CLI and PowerShell
- limit concurrency in DNS propagation tests
- update examples for new parameter

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test` *(fails: Invalid URI / network related errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a341fab48832eb78e8074645fed4d