### PR TITLE
Add server selection by country count

### DIFF
--- a/DomainDetective.Tests/TestSelectServers.cs
+++ b/DomainDetective.Tests/TestSelectServers.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestSelectServers {
+        [Fact]
+        public void SelectServersReturnsRequestedCounts() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var servers = analysis.SelectServers(new Dictionary<string, int> { ["PL"] = 2, ["DE"] = 1 });
+            Assert.Equal(3, servers.Count);
+            Assert.Equal(2, servers.Count(s => s.Country == "Poland"));
+            Assert.Equal(1, servers.Count(s => s.Country == "Germany"));
+        }
+    }
+}

--- a/Module/Tests/DnsPropagation.Tests.ps1
+++ b/Module/Tests/DnsPropagation.Tests.ps1
@@ -1,0 +1,7 @@
+Describe 'Test-DnsPropagation cmdlet' {
+    It 'accepts CountryCount parameter' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        $result = Test-DnsPropagation -DomainName 'example.com' -RecordType A -CountryCount @{PL=0}
+        $result | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- add `SelectServers` to choose servers from multiple countries
- extend `CmdletTestDnsPropagation` with `CountryCount` parameter
- test selection logic in C# and Pester

## Testing
- `dotnet test` *(fails: 17 tests, passes: 493)*
- `pwsh -NoLogo -Command ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686a347b3ec0832ea916c6a529c76078