### PR TITLE
Add ASN filter support

### DIFF
--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -22,6 +22,12 @@ internal sealed class DnsPropagationSettings : CommandSettings {
     [CommandOption("--json")]
     public bool Json { get; set; }
 
+    [CommandOption("--asn")]
+    public string? Asn { get; set; }
+
+    [CommandOption("--asn-name")]
+    public string? AsnName { get; set; }
+
     [CommandOption("--compare-results")]
     public bool Compare { get; set; }
 
@@ -41,7 +47,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         } else {
             analysis.LoadBuiltinServers();
         }
-        var servers = analysis.Servers;
+        var servers = analysis.FilterServers(asn: settings.Asn, asnName: settings.AsnName);
         var domain = CliHelpers.ToAscii(settings.Domain);
 
         List<DnsPropagationResult> results = new();

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationAsn.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationAsn.cs
@@ -1,0 +1,20 @@
+using DnsClientX;
+using System;
+using DomainDetective;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example {
+    internal class ExampleAnalyseDnsPropagationAsnClass {
+        public static async Task Run() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var asn = analysis.GetAsns().First().Asn;
+            var servers = analysis.FilterServers(asn: asn, take: 2);
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers);
+            foreach (var r in results) {
+                Console.WriteLine($"{r.Server.IPAddress} {r.Success}");
+            }
+        }
+    }
+}

--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -48,6 +48,14 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public LocationId? Location;
 
+        /// <param name="Asn">Filter builtin servers by ASN.</param>
+        [Parameter(Mandatory = false)]
+        public string? Asn;
+
+        /// <param name="AsnName">Filter builtin servers by ASN name.</param>
+        [Parameter(Mandatory = false)]
+        public string? AsnName;
+
         /// <param name="IntervalSeconds">Polling interval in seconds.</param>
         [Parameter(Mandatory = false)]
         public int IntervalSeconds = 300;
@@ -64,6 +72,8 @@ namespace DomainDetective.PowerShell {
             _monitor.Interval = TimeSpan.FromSeconds(IntervalSeconds);
             _monitor.Country = Country;
             _monitor.Location = Location;
+            _monitor.Asn = Asn;
+            _monitor.AsnName = AsnName;
             var moduleBase = this.MyInvocation.MyCommand.Module?.ModuleBase
                 ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
                 ?? string.Empty;

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -43,6 +43,14 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public LocationId? Location;
 
+        /// <param name="Asn">Filter servers by ASN.</param>
+        [Parameter(Mandatory = false)]
+        public string? Asn;
+
+        /// <param name="AsnName">Filter servers by ASN name.</param>
+        [Parameter(Mandatory = false)]
+        public string? AsnName;
+
         /// <param name="Take">Limit the number of servers queried.</param>
         [Parameter(Mandatory = false)]
         public int? Take;
@@ -73,7 +81,7 @@ namespace DomainDetective.PowerShell {
         }
 
         protected override async Task ProcessRecordAsync() {
-            IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location, Take);
+            IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location, Take, Asn, AsnName);
             var serverList = servers.ToList();
             var progress = new Progress<double>(p => {
                 var record = new ProgressRecord(1, "DnsPropagation", $"{p:F0}% complete") {

--- a/DomainDetective.Tests/TestAsnFiltering.cs
+++ b/DomainDetective.Tests/TestAsnFiltering.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestAsnFiltering {
+        [Fact]
+        public void GetAsnsReturnsDistinctValues() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var asns = analysis.GetAsns().ToList();
+            Assert.NotEmpty(asns);
+            Assert.Equal(asns.Count, asns.Distinct().Count());
+        }
+
+        [Fact]
+        public void FilterByAsnReturnsMatchingServers() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var asn = analysis.Servers.First().ASN;
+            var servers = analysis.FilterServers(asn: asn).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Equal(asn, s.ASN));
+        }
+
+        [Fact]
+        public void FilterByAsnNameReturnsMatchingServers() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var name = analysis.Servers.First(s => !string.IsNullOrWhiteSpace(s.ASNName)).ASNName!;
+            var servers = analysis.FilterServers(asnName: name[..3]).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Contains(name[..3], s.ASNName!, System.StringComparison.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDnsServerQuery.cs
+++ b/DomainDetective.Tests/TestDnsServerQuery.cs
@@ -31,5 +31,27 @@ namespace DomainDetective.Tests {
             Assert.True(servers.Count <= 2);
             Assert.All(servers, s => Assert.Equal("Poland", s.Country));
         }
+
+        [Fact]
+        public void BuilderFiltersByAsn() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var asn = analysis.Servers.First().ASN;
+            var query = DnsServerQuery.Create().FromAsn(asn!);
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Equal(asn, s.ASN));
+        }
+
+        [Fact]
+        public void BuilderFiltersByAsnName() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var name = analysis.Servers.First(s => !string.IsNullOrWhiteSpace(s.ASNName)).ASNName!;
+            var query = DnsServerQuery.Create().FromAsnName(name[..3]);
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Contains(name[..3], s.ASNName!, System.StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -1,6 +1,6 @@
 namespace DomainDetective {
     /// <summary>
-    /// Builder for querying DNS servers by country, location and count.
+    /// Builder for querying DNS servers by country, location, ASN and count.
     /// </summary>
     public sealed class DnsServerQuery {
         /// <summary>Selected country.</summary>
@@ -8,7 +8,13 @@ namespace DomainDetective {
         /// <summary>Selected location.</summary>
         public LocationId? Location { get; private set; }
         /// <summary>Number of servers to take.</summary>
-    public int? TakeCount { get; private set; }
+        public int? TakeCount { get; private set; }
+
+        /// <summary>Selected ASN.</summary>
+        public string? ASN { get; private set; }
+
+        /// <summary>Selected ASN name.</summary>
+        public string? ASNName { get; private set; }
 
     /// <summary>Creates a new query instance.</summary>
     public static DnsServerQuery Create() => new();
@@ -41,10 +47,22 @@ namespace DomainDetective {
         return this;
     }
 
-    /// <summary>Limits the number of servers returned.</summary>
-    public DnsServerQuery Take(int count) {
-        TakeCount = count > 0 ? count : null;
-        return this;
-    }
+        /// <summary>Limits the number of servers returned.</summary>
+        public DnsServerQuery Take(int count) {
+            TakeCount = count > 0 ? count : null;
+            return this;
+        }
+
+        /// <summary>Filters by ASN.</summary>
+        public DnsServerQuery FromAsn(string asn) {
+            ASN = string.IsNullOrWhiteSpace(asn) ? null : asn.Trim();
+            return this;
+        }
+
+        /// <summary>Filters by ASN name.</summary>
+        public DnsServerQuery FromAsnName(string name) {
+            ASNName = string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+            return this;
+        }
     }
 }

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -30,6 +30,12 @@ namespace DomainDetective.Monitoring {
         /// <summary>Location filter for builtin servers.</summary>
         public LocationId? Location { get; set; }
 
+        /// <summary>ASN filter for builtin servers.</summary>
+        public string? Asn { get; set; }
+
+        /// <summary>ASN name filter for builtin servers.</summary>
+        public string? AsnName { get; set; }
+
         /// <summary>Additional user supplied servers.</summary>
         public List<PublicDnsEntry> CustomServers { get; } = new();
 
@@ -71,7 +77,7 @@ namespace DomainDetective.Monitoring {
 
         /// <summary>Runs a single propagation check.</summary>
         public async Task RunAsync(CancellationToken ct = default) {
-            IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location);
+            IEnumerable<PublicDnsEntry> servers = _analysis.FilterServers(Country, Location, null, Asn, AsnName);
             servers = servers.Concat(CustomServers.Where(s => s.Enabled));
             var serverList = servers.ToList();
             var results = QueryOverride != null

--- a/Module/Examples/Example.TestDnsPropagation.ps1
+++ b/Module/Examples/Example.TestDnsPropagation.ps1
@@ -10,3 +10,6 @@ $PublicServers | Format-Table
 
 $TxtCheck = Test-DnsPropagation -DomainName 'evotec.pl' -RecordType TXT -CompareResults
 $TxtCheck | Format-Table
+
+# Filter servers by ASN
+$AsnExample = Test-DnsPropagation -DomainName 'example.com' -RecordType A -Asn '396982' -Take 0

--- a/Module/Tests/DnsPropagationAsn.Tests.ps1
+++ b/Module/Tests/DnsPropagationAsn.Tests.ps1
@@ -1,0 +1,10 @@
+Describe 'Test-DnsPropagation ASN filters' {
+    It 'runs with Asn parameter' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        Test-DnsPropagation -DomainName 'example.com' -RecordType A -Take 0 -Asn '396982' | Should -BeNullOrEmpty
+    }
+    It 'runs with AsnName parameter' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        Test-DnsPropagation -DomainName 'example.com' -RecordType A -Take 0 -AsnName 'GOOGLE' | Should -BeNullOrEmpty
+    }
+}


### PR DESCRIPTION
## Summary
- expose ASN filters through CLI and PowerShell
- implement `GetAsns` and ASN filters in DNS propagation
- update PowerShell examples and add new ASN example project
- add unit and Pester tests for ASN filtering

## Testing
- `dotnet build`
- `dotnet test` *(fails: Invalid URI because of network calls)*
- `pwsh -NoProfile -Command ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_686a34928aac832ebd440071df9cba1a