### PR TITLE
Fix DNS endpoint defaults

### DIFF
--- a/DomainDetective.PowerShell/CmdletGetFlattenedSpfIp.cs
+++ b/DomainDetective.PowerShell/CmdletGetFlattenedSpfIp.cs
@@ -20,7 +20,7 @@ namespace DomainDetective.PowerShell {
 
         /// <param name="DnsEndpoint">DNS server used for queries.</param>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
-        public DnsEndpoint DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
+        public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
         /// <param name="TestSpfRecord">Optional SPF record used for testing to avoid DNS lookups.</param>
         [Parameter(Mandatory = false)]
@@ -42,7 +42,7 @@ namespace DomainDetective.PowerShell {
             internalLoggerPowerShell.ResetActivityIdCounter();
 
             if (EqualityComparer<DnsEndpoint>.Default.Equals(DnsEndpoint, default)) {
-                DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
+                DnsEndpoint = DnsEndpoint.System;
             }
 
             _healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);

--- a/DomainDetective.Tests/TestDnsConfigurationDefaults.cs
+++ b/DomainDetective.Tests/TestDnsConfigurationDefaults.cs
@@ -1,0 +1,13 @@
+using DnsClientX;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnsConfigurationDefaults {
+        [Fact]
+        public void DefaultEndpointIsSystem() {
+            var config = new DnsConfiguration();
+            Assert.Equal(DnsEndpoint.System, config.DnsEndpoint);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDomainHealthCheckConstructor.cs
+++ b/DomainDetective.Tests/TestDomainHealthCheckConstructor.cs
@@ -1,11 +1,13 @@
 using System;
+using DnsClientX;
 using DomainDetective;
 
 namespace DomainDetective.Tests {
     public class TestDomainHealthCheckConstructor {
         [Fact]
-        public void ConstructorThrowsWhenEndpointNull() {
-            Assert.Throws<ArgumentNullException>(() => new DomainHealthCheck(default));
+        public void ConstructorDefaultsToSystemEndpoint() {
+            var healthCheck = new DomainHealthCheck(default);
+            Assert.Equal(DnsEndpoint.System, healthCheck.DnsEndpoint);
         }
     }
 }

--- a/DomainDetective/DnsConfiguration.cs
+++ b/DomainDetective/DnsConfiguration.cs
@@ -29,7 +29,7 @@ namespace DomainDetective {
         /// Initializes a new instance of the <see cref="DnsConfiguration"/> class with default values.
         /// </summary>
         public DnsConfiguration() {
-            DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
+            DnsEndpoint = DnsEndpoint.System;
             DnsSelectionStrategy = DnsSelectionStrategy.First;
         }
 

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -306,9 +306,9 @@ namespace DomainDetective {
         /// <param name="internalLogger">
         /// <para>Optional logger for diagnostic output.</para>
         /// </param>
-        public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.CloudflareWireFormat, InternalLogger internalLogger = null) {
+        public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.System, InternalLogger internalLogger = null) {
             if (EqualityComparer<DnsEndpoint>.Default.Equals(dnsEndpoint, default)) {
-                throw new ArgumentNullException(nameof(dnsEndpoint));
+                dnsEndpoint = DnsEndpoint.System;
             }
 
             if (internalLogger != null) {

--- a/Module/Tests/FCrDns.Tests.ps1
+++ b/Module/Tests/FCrDns.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'Test-FCrDns cmdlet' {
     It 'executes and returns data' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $result = Test-FCrDns -DomainName 'example.com' -DnsEndpoint CloudflareWireFormat
+        $result = Test-FCrDns -DomainName 'example.com'
         $result | Should -Not -BeNullOrEmpty
     }
     It 'throws if DomainName is empty' {

--- a/Module/Tests/FlattenedSpfIp.Tests.ps1
+++ b/Module/Tests/FlattenedSpfIp.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'Get-FlattenedSpfIp cmdlet' {
     It 'executes and returns data' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $result = Get-FlattenedSpfIp -DomainName 'example.com' -DnsEndpoint CloudflareWireFormat -TestSpfRecord 'v=spf1 ip4:192.0.2.10 -all'
+        $result = Get-FlattenedSpfIp -DomainName 'example.com' -TestSpfRecord 'v=spf1 ip4:192.0.2.10 -all'
         $result | Should -Not -BeNullOrEmpty
         $result | Should -Contain '192.0.2.10'
     }

--- a/Module/Tests/NsRecord.Tests.ps1
+++ b/Module/Tests/NsRecord.Tests.ps1
@@ -1,7 +1,7 @@
 Describe 'Test-NsRecord cmdlet' {
     It 'executes and returns data' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $result = Test-NsRecord -DomainName 'example.com' -DnsEndpoint CloudflareWireFormat
+        $result = Test-NsRecord -DomainName 'example.com'
         $result | Should -Not -BeNullOrEmpty
     }
     It 'throws if DomainName is empty' {


### PR DESCRIPTION
## Summary
- set default DNS endpoint to System in core library
- use System endpoint in cmdlets and tests
- update unit tests for new defaults

## Testing
- `dotnet test` *(fails: Invalid URI - hostname could not be parsed)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686ac2f15bb8832eb277083ec1c8bb76