### PR TITLE
Fix random HttpListener port collisions in tests

### DIFF
--- a/DomainDetective.Tests/PortHelper.cs
+++ b/DomainDetective.Tests/PortHelper.cs
@@ -1,0 +1,21 @@
+namespace DomainDetective.Tests;
+
+using System.Net;
+using System.Net.Sockets;
+
+internal static class PortHelper
+{
+    private static readonly object PortLock = new();
+
+    public static int GetFreePort()
+    {
+        lock (PortLock)
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -391,11 +391,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var socket = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            socket.Start();
-            var port = ((IPEndPoint)socket.LocalEndpoint).Port;
-            socket.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
 
         private static async Task RunServer(TcpListener listener, X509Certificate2 cert, Func<string, (string contentType, byte[] data)> response, CancellationToken token) {

--- a/DomainDetective.Tests/TestDuplicateHealthChecks.cs
+++ b/DomainDetective.Tests/TestDuplicateHealthChecks.cs
@@ -45,11 +45,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var socket = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            socket.Start();
-            var port = ((IPEndPoint)socket.LocalEndpoint).Port;
-            socket.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestHPKPAnalysis.cs
+++ b/DomainDetective.Tests/TestHPKPAnalysis.cs
@@ -168,11 +168,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -38,11 +38,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -617,11 +617,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -349,11 +349,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var l = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            l.Start();
-            var p = ((IPEndPoint)l.LocalEndpoint).Port;
-            l.Stop();
-            return p;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -53,11 +53,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
@@ -79,11 +79,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -118,11 +118,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }

--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -193,11 +193,7 @@ namespace DomainDetective.Tests {
         }
 
         private static int GetFreePort() {
-            var listener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
-            return port;
+            return PortHelper.GetFreePort();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `PortHelper` with locked free port helper
- update tests to use the shared helper for HTTP listeners

## Testing
- `dotnet test --filter "FullyQualifiedName=DomainDetective.Tests.TestMTASTSAnalysis.ParseDnsRecord"`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_686b7a962cc8832eb44100642b91399c