### PR TITLE
Fix HSTS preload test lock

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -560,7 +560,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DetectsHstsPreloaded() {
-            var preloadPath = Path.Combine(AppContext.BaseDirectory, "hsts_preload.json");
+            var preloadPath = Path.Combine(Path.GetTempPath(), $"hsts_preload_{Guid.NewGuid():N}.json");
             File.WriteAllText(preloadPath, "[\"localhost\"]");
             HttpAnalysis.LoadHstsPreloadList(preloadPath);
             using (File.Open(preloadPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }


### PR DESCRIPTION
## Summary
- create a temporary file for DetectsHstsPreloaded to avoid conflicts with other tests

## Testing
- `dotnet build DomainDetective.sln -c Release --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0 --no-build --verbosity normal --filter "FullyQualifiedName~DetectsHstsPreloaded"`


------
https://chatgpt.com/codex/tasks/task_e_686b8eee9344832eb86067ce237df532