### PR TITLE
Add missing member docs

### DIFF
--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -12,6 +12,10 @@ namespace DomainDetective {
     /// <para>Part of the DomainDetective project.</para>
     public class DnsTtlAnalysis {
         private readonly List<string> _warnings = new();
+
+        /// <summary>
+        /// Indicates whether the zone is signed with DNSSEC.
+        /// </summary>
         public bool DnsSecSigned { get; private set; }
 
         /// <summary>Gets TTL values for A records.</summary>
@@ -27,7 +31,12 @@ namespace DomainDetective {
         /// <summary>Collection of warning messages produced during analysis.</summary>
         public IReadOnlyList<string> Warnings => _warnings;
 
+        /// <summary>Provides DNS query implementation details.</summary>
         public DnsConfiguration DnsConfiguration { get; set; }
+
+        /// <summary>
+        /// Optional override for DNS queries, primarily used for testing.
+        /// </summary>
         public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
 
         private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {

--- a/DomainDetective/DnsblReplyCode.cs
+++ b/DomainDetective/DnsblReplyCode.cs
@@ -3,7 +3,14 @@ namespace DomainDetective {
     /// Provider specific reply code configuration.
     /// </summary>
     public class DnsblReplyCode {
+        /// <summary>
+        /// Indicates whether the returned code means the host is listed.
+        /// </summary>
         public bool IsListed { get; set; }
+
+        /// <summary>
+        /// Human readable explanation of the reply code.
+        /// </summary>
         public string Meaning { get; set; }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -18,6 +18,9 @@ namespace DomainDetective {
         private PublicSuffixList _publicSuffixList;
         private const string DefaultPublicSuffixListUrl = "https://raw.githubusercontent.com/EvotecIT/DomainDetective/refs/heads/master/Data/public_suffix_list.dat";
 
+        /// <summary>
+        /// Serialization settings used when persisting analysis data.
+        /// </summary>
         public static readonly JsonSerializerOptions JsonOptions = new()
         {
             WriteIndented = true,

--- a/DomainDetective/Protocols/AutodiscoverAnalysis.cs
+++ b/DomainDetective/Protocols/AutodiscoverAnalysis.cs
@@ -10,7 +10,10 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class AutodiscoverAnalysis {
+        /// <summary>DNS configuration used for lookups.</summary>
         public DnsConfiguration DnsConfiguration { get; set; }
+
+        /// <summary>Optional DNS query override.</summary>
         public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
         /// <summary>Gets a value indicating whether the _autodiscover._tcp SRV record exists.</summary>
         public bool SrvRecordExists { get; private set; }

--- a/DomainDetective/Protocols/ContactInfoAnalysis.cs
+++ b/DomainDetective/Protocols/ContactInfoAnalysis.cs
@@ -10,8 +10,13 @@ namespace DomainDetective;
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
 public class ContactInfoAnalysis {
+    /// <summary>Raw contact TXT record.</summary>
     public string? ContactRecord { get; private set; }
+
+    /// <summary>True when a contact record was located.</summary>
     public bool RecordExists { get; private set; }
+
+    /// <summary>Parsed key-value fields from the record.</summary>
     public Dictionary<string, string> Fields { get; } = new();
 
     /// <summary>

--- a/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
@@ -4,6 +4,9 @@ using System.Linq;
 using System.Threading.Tasks;
 
 namespace DomainDetective {
+    /// <summary>
+    /// Provides domain-based DNS block list analysis functionality.
+    /// </summary>
     public partial class DNSBLAnalysis {
         private static readonly List<DnsblEntry> _domainBlockLists = new();
 

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -18,15 +18,33 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class MXAnalysis {
+        /// <summary>DNS configuration used for lookups.</summary>
         public DnsConfiguration DnsConfiguration { get; set; }
+
+        /// <summary>Optional DNS query override.</summary>
         public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+        /// <summary>MX records discovered during analysis.</summary>
         public List<string> MxRecords { get; private set; } = new List<string>();
+
+        /// <summary>Indicates whether at least one MX record exists.</summary>
         public bool MxRecordExists { get; private set; } // should be true
+        /// <summary>Indicates that a record incorrectly points to a CNAME.</summary>
         public bool PointsToCname { get; private set; } // should be false
+
+        /// <summary>Indicates that a record incorrectly points to an IP address.</summary>
         public bool PointsToIpAddress { get; private set; } // should be false
+
+        /// <summary>Indicates that a record points to a non-existent domain.</summary>
         public bool PointsToNonExistentDomain { get; private set; } // should be false
+
+        /// <summary>Indicates that a record points to a domain without A/AAAA records.</summary>
         public bool PointsToDomainWithoutAOrAaaaRecord { get; private set; } // should be false
+
+        /// <summary>Indicates whether MX priorities appear in ascending order.</summary>
         public bool PrioritiesInOrder { get; private set; } // RFC 5321 section 5.1
+
+        /// <summary>Indicates whether backup MX servers are present.</summary>
         public bool HasBackupServers { get; private set; }
 
         private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {

--- a/DomainDetective/Protocols/NSAnalysis.cs
+++ b/DomainDetective/Protocols/NSAnalysis.cs
@@ -11,9 +11,16 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class NSAnalysis {
+        /// <summary>Configuration used for DNS queries.</summary>
         public DnsConfiguration DnsConfiguration { get; set; }
+
+        /// <summary>Allows injection of a DNS query implementation for testing.</summary>
         public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+        /// <summary>Optional full DNS query override that returns raw responses.</summary>
         public Func<string, DnsRecordType, Task<IEnumerable<DnsResponse>>>? QueryDnsFullOverride { private get; set; }
+
+        /// <summary>Optional override for recursion testing logic.</summary>
         public Func<string, Task<bool>>? RecursionTestOverride { private get; set; }
         public List<string> NsRecords { get; private set; } = new();
         public bool NsRecordExists { get; private set; }

--- a/DomainDetective/Protocols/ReverseDnsAnalysis.cs
+++ b/DomainDetective/Protocols/ReverseDnsAnalysis.cs
@@ -13,8 +13,13 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class ReverseDnsAnalysis {
+        /// <summary>Provides DNS configuration for lookups.</summary>
         public DnsConfiguration DnsConfiguration { get; set; }
+
+        /// <summary>Optional DNS query override.</summary>
         public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+        /// <summary>Optional override returning raw DNS responses.</summary>
         public Func<string, DnsRecordType, Task<IEnumerable<DnsResponse>>>? QueryDnsFullOverride { private get; set; }
 
         private static readonly Regex _labelRegex = new(

--- a/DomainDetective/Protocols/SMIMEAAnalysis.cs
+++ b/DomainDetective/Protocols/SMIMEAAnalysis.cs
@@ -12,6 +12,7 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class SMIMEAAnalysis {
+        /// <summary>Detailed analysis results for each SMIMEA record.</summary>
         public List<SMIMEARecordAnalysis> AnalysisResults { get; private set; } = new();
         public int NumberOfRecords { get; private set; }
         public bool HasDuplicateRecords { get; private set; }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -20,6 +20,8 @@ namespace DomainDetective {
     /// <para>Part of the DomainDetective project.</para>
     public class SpfAnalysis {
         internal DnsConfiguration DnsConfiguration { get; set; }
+
+        /// <summary>Combined SPF record text.</summary>
         public string SpfRecord { get; private set; }
         public List<string> SpfRecords { get; private set; } = new List<string>();
         public bool SpfRecordExists { get; private set; } // should be true

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -16,12 +16,26 @@ namespace DomainDetective {
         private record CacheEntry(string Content, string Url, bool FallbackUsed, DateTimeOffset Expires);
         private static readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// Clears cached security.txt content used across instances.
+        /// </summary>
         public static void ClearCache() => _cache.Clear();
+        /// <summary>Domain that was analyzed.</summary>
         public string Domain { get; set; }
+
+        /// <summary>True when a security.txt record was found.</summary>
         public bool RecordPresent { get; set; }
+
+        /// <summary>True when the record passed validation.</summary>
         public bool RecordValid { get; set; }
+
+        /// <summary>Indicates the record is signed with PGP.</summary>
         public bool PGPSigned { get; set; }
+
+        /// <summary>Set when fallback retrieval method was used.</summary>
         public bool FallbackUsed { get; set; }
+
+        /// <summary>URL from which the record was downloaded.</summary>
         public string Url { get; set; }
         public HashSet<string> DuplicateTags { get; } = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         // Fields that can appear multiple times as List<string>

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -12,10 +12,19 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class TLSRPTAnalysis {
+        /// <summary>The concatenated TLSRPT record.</summary>
         public string? TlsRptRecord { get; private set; }
+
+        /// <summary>Indicates whether a TLSRPT record exists.</summary>
         public bool TlsRptRecordExists { get; private set; }
+
+        /// <summary>Indicates whether multiple records were found.</summary>
         public bool MultipleRecords { get; private set; }
+
+        /// <summary>Indicates whether the record starts with v=TLSRPTv1.</summary>
         public bool StartsCorrectly { get; private set; }
+
+        /// <summary>True when at least one RUA destination is defined.</summary>
         public bool RuaDefined { get; private set; }
         public List<string> MailtoRua { get; private set; } = new();
         public List<string> HttpRua { get; private set; } = new();

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -34,6 +34,10 @@ public class ThreatIntelAnalysis
 
     internal HttpClient Client => _client;
 
+    /// <summary>
+    /// Initializes a new instance of <see cref="ThreatIntelAnalysis"/>.
+    /// </summary>
+    /// <param name="client">Optional HTTP client used for requests.</param>
     public ThreatIntelAnalysis(HttpClient? client = null)
     {
         _client = client ?? _staticClient;

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -22,6 +22,8 @@ public class WhoisAnalysis {
     private string TLD { get; set; }
     private static readonly IdnMapping _idn = new();
     private string _domainName;
+
+    /// <summary>The domain name being queried.</summary>
     public string DomainName {
         get => _domainName;
         set {
@@ -32,21 +34,52 @@ public class WhoisAnalysis {
             }
         }
     }
+    /// <summary>Top-level domain portion of <see cref="DomainName"/>.</summary>
     public string Tld => TLD;
+
+    /// <summary>WHOIS registrar name.</summary>
     public string Registrar { get; set; }
+
+    /// <summary>Creation date string as returned by the server.</summary>
     public string CreationDate { get; set; }
+
+    /// <summary>Expiry date string as returned by the server.</summary>
     public string ExpiryDate { get; set; }
+
+    /// <summary>Last updated date string.</summary>
     public string LastUpdated { get; set; }
+
+    /// <summary>Entity the domain is registered to.</summary>
     public string RegisteredTo { get; set; }
+
+    /// <summary>Name servers listed in the response.</summary>
     public List<string> NameServers { get; set; } = new List<string>();
+
+    /// <summary>Timeout applied when querying WHOIS servers.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Type of registrant if provided.</summary>
     public string RegistrantType { get; set; }
+
+    /// <summary>Registrant country code.</summary>
     public string Country { get; set; }
+
+    /// <summary>DNSSEC status string.</summary>
     public string DnsSec { get; set; }
+
+    /// <summary>Raw DNS record returned, if any.</summary>
     public string DnsRecord { get; set; }
+
+    /// <summary>Registrar address text.</summary>
     public string RegistrarAddress { get; set; }
+
+    /// <summary>Registrar phone number.</summary>
     public string RegistrarTel { get; set; }
+
+    /// <summary>Registrar website URL.</summary>
     public string RegistrarWebsite { get; set; }
+
+    /// <summary>Registrar licence identifier.</summary>
     public string RegistrarLicense { get; set; }
     public string RegistrarEmail { get; set; }
     public string RegistrarAbuseEmail { get; set; }

--- a/DomainDetective/Protocols/WildcardDnsAnalysis.cs
+++ b/DomainDetective/Protocols/WildcardDnsAnalysis.cs
@@ -27,7 +27,12 @@ public class WildcardDnsAnalysis
     /// <summary>Whether the domain has NS records.</summary>
     public bool NsExists { get; private set; }
 
+    /// <summary>Configuration used for DNS lookups.</summary>
     public DnsConfiguration DnsConfiguration { get; set; } = new();
+
+    /// <summary>
+    /// Optional DNS query delegate for testing purposes.
+    /// </summary>
     public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
 
     private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)

--- a/DomainDetective/PublicSuffixList.cs
+++ b/DomainDetective/PublicSuffixList.cs
@@ -31,6 +31,11 @@ namespace DomainDetective {
             return Load(stream);
         }
 
+        /// <summary>
+        /// Loads the public suffix list from an open <see cref="Stream"/>.
+        /// </summary>
+        /// <param name="stream">Stream containing the list data.</param>
+        /// <returns>An initialized <see cref="PublicSuffixList"/> instance.</returns>
         public static PublicSuffixList Load(Stream stream) {
             var list = new PublicSuffixList();
             using var reader = new StreamReader(stream);
@@ -52,6 +57,11 @@ namespace DomainDetective {
             return list;
         }
 
+        /// <summary>
+        /// Downloads and loads the public suffix list from the given URL.
+        /// </summary>
+        /// <param name="url">HTTP or HTTPS address of the list.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         public static async Task<PublicSuffixList> LoadFromUrlAsync(string url) {
             var client = SharedHttpClient.Instance;
             using var stream = await client.GetStreamAsync(url);


### PR DESCRIPTION
## Summary
- add XML documentation to several public members
- include summaries for partial classes and properties
- enhance doc comments in analysis utilities

## Testing
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686b925fac70832e9a1c8f767f333906