### PR TITLE
Add workflow_dispatch for manual runs

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,6 +1,7 @@
 name: Test .NET
 
 on:
+    workflow_dispatch:
     push:
         branches:
             - master

--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -1,6 +1,7 @@
 name: Test PowerShell
 
 on:
+    workflow_dispatch:
     push:
         branches:
             - master


### PR DESCRIPTION
## Summary
- allow manual triggers for dotnet and PowerShell workflows

## Testing
- `dotnet build DomainDetective.sln --configuration Release --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration Release --no-build --framework net8.0` *(fails: KeyNotFoundException, etc.)*
- `pwsh Module/DomainDetective.Tests.ps1` *(fails: module not recognized, tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686be37e26cc832e9bde3adfc7daa663