### PR TITLE
Fix DKIM record name handling

### DIFF
--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -55,7 +55,9 @@ namespace DomainDetective {
 
             // create a single string from the list of DnsResult objects
             foreach (var record in dkimRecordList) {
-                analysis.Name = record.Name;
+                if (string.IsNullOrEmpty(analysis.Name) && !string.IsNullOrEmpty(record.Name)) {
+                    analysis.Name = record.Name;
+                }
                 if (record.DataStringsEscaped != null && record.DataStringsEscaped.Length > 0) {
                     analysis.DkimRecord += string.Join(string.Empty, record.DataStringsEscaped);
                 } else {


### PR DESCRIPTION
## Summary
- avoid assigning an empty string to `DkimRecordAnalysis.Name`

## Testing
- `dotnet build --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter "FullyQualifiedName~TestDkimAnalysis.TestDKIMRecord"`

------
https://chatgpt.com/codex/tasks/task_e_686be614f2f0832e88741b0aed7940d2