### PR TITLE
Fix UDP port scan reliability

### DIFF
--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -129,7 +129,8 @@ public class PortScanAnalysis
             {
                 udp.Client.SendTimeout = (int)Timeout.TotalMilliseconds;
                 udp.Client.ReceiveTimeout = (int)Timeout.TotalMilliseconds;
-                await udp.SendAsync(Array.Empty<byte>(), 0, new IPEndPoint(address, port)).ConfigureAwait(false);
+                udp.Connect(address, port);
+                await udp.SendAsync(Array.Empty<byte>(), 0).ConfigureAwait(false);
 #if NET8_0_OR_GREATER
                 using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
                 {


### PR DESCRIPTION
## Summary
- use `UdpClient.Connect` before sending test probe
- send datagram without specifying remote endpoint

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet vstest DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll --Tests:DomainDetective.Tests.TestPortScanAnalysis.DetectsTcpAndUdpOpenPorts`
- `dotnet vstest DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll --Tests:DomainDetective.Tests.TestPortScanAnalysis.DetectsIpv6TcpAndUdpOpenPorts`
- `dotnet vstest DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll --Tests:DomainDetective.Tests.TestPortScanAnalysis.DetectsTcpClosedPort`


------
https://chatgpt.com/codex/tasks/task_e_686bec994908832eb2ad193bcd5a5465