### PR TITLE
Fix SPF quoted string handling

### DIFF
--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -333,9 +333,21 @@ namespace DomainDetective {
         }
 
         private static string TrimQuotes(string value) {
-            return value.Length > 1 && value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal)
-                ? value.Substring(1, value.Length - 2)
-                : value;
+            if (value.Length > 1) {
+                if (value.StartsWith("\\\"", StringComparison.Ordinal) && value.EndsWith("\\\"", StringComparison.Ordinal)) {
+                    return value.Substring(2, value.Length - 4);
+                }
+                if (value.StartsWith("\\\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal)) {
+                    return value.Substring(2, value.Length - 3);
+                }
+                if (value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\\\"", StringComparison.Ordinal)) {
+                    return value.Substring(1, value.Length - 3);
+                }
+                if (value.StartsWith("\"", StringComparison.Ordinal) && value.EndsWith("\"", StringComparison.Ordinal)) {
+                    return value.Substring(1, value.Length - 2);
+                }
+            }
+            return value;
         }
 
         private void AddPartToList(string part, InternalLogger? logger) {


### PR DESCRIPTION
## Summary
- handle escaped quotes in SPF parsing

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter FullyQualifiedName~TotalLengthBoundary --verbosity minimal` *(fails: Assert.False() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_686becf7e6a4832e8e9647a86d8ff06b