### PR TITLE
Fix DANE logger race

### DIFF
--- a/DomainDetective.Tests/DisableParallel.cs
+++ b/DomainDetective.Tests/DisableParallel.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
## Summary
- disable test parallelization to avoid the shared logger from leaking messages

## Testing
- `dotnet test --no-build --verbosity minimal --filter "FullyQualifiedName=DomainDetective.Tests.TestDANEnalysis.HttpsQueriesAandAaaaRecordsUsingSystemResolver" DomainDetective.Tests/DomainDetective.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_686c3c3e5650832e88dcfcc7bc51a744