### PR TITLE
Fix DNSBL unit test for Linux

### DIFF
--- a/DomainDetective.Tests/TestDomainBlocklist.cs
+++ b/DomainDetective.Tests/TestDomainBlocklist.cs
@@ -22,8 +22,20 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task ListedDomainsReturnPositive() {
             var map = new Dictionary<string, DnsAnswer[]>(StringComparer.OrdinalIgnoreCase) {
-                ["dbltest.com.dbl.spamhaus.org"] = new[] { new DnsAnswer { DataRaw = "127.0.0.2", Type = DnsRecordType.A } },
-                ["test.uribl.com.multi.uribl.com"] = new[] { new DnsAnswer { DataRaw = "127.0.0.2", Type = DnsRecordType.A } }
+                ["dbltest.com.dbl.spamhaus.org"] = new[] {
+                    new DnsAnswer {
+                        Name = "dbltest.com.dbl.spamhaus.org",
+                        DataRaw = "127.0.0.2",
+                        Type = DnsRecordType.A
+                    }
+                },
+                ["test.uribl.com.multi.uribl.com"] = new[] {
+                    new DnsAnswer {
+                        Name = "test.uribl.com.multi.uribl.com",
+                        DataRaw = "127.0.0.2",
+                        Type = DnsRecordType.A
+                    }
+                }
             };
             var analysis = CreateAnalysis(map);
             analysis.ClearDNSBL();

--- a/DomainDetective.Tests/TestDomainBlocklist.cs
+++ b/DomainDetective.Tests/TestDomainBlocklist.cs
@@ -4,11 +4,28 @@ using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestDomainBlocklist {
+        private static DNSBLAnalysis CreateAnalysis(Dictionary<string, DnsAnswer[]> map) {
+            return new DNSBLAnalysis {
+                DnsConfiguration = new DnsConfiguration(),
+                QueryDnsFullOverride = (names, _) => {
+                    var list = new List<DnsResponse>();
+                    foreach (var n in names) {
+                        list.Add(new DnsResponse {
+                            Answers = map.TryGetValue(n, out var a) ? a : Array.Empty<DnsAnswer>()
+                        });
+                    }
+                    return Task.FromResult<IEnumerable<DnsResponse>>(list);
+                }
+            };
+        }
+
         [Fact]
         public async Task ListedDomainsReturnPositive() {
-            var analysis = new DNSBLAnalysis {
-                DnsConfiguration = new DnsConfiguration { DnsEndpoint = DnsEndpoint.System }
+            var map = new Dictionary<string, DnsAnswer[]>(StringComparer.OrdinalIgnoreCase) {
+                ["dbltest.com.dbl.spamhaus.org"] = new[] { new DnsAnswer { DataRaw = "127.0.0.2", Type = DnsRecordType.A } },
+                ["test.uribl.com.multi.uribl.com"] = new[] { new DnsAnswer { DataRaw = "127.0.0.2", Type = DnsRecordType.A } }
             };
+            var analysis = CreateAnalysis(map);
             analysis.ClearDNSBL();
             analysis.AddDNSBL("multi.uribl.com");
             analysis.AddDNSBL("dbl.spamhaus.org");
@@ -28,9 +45,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task UnlistedDomainReturnsNegative() {
-            var analysis = new DNSBLAnalysis {
-                DnsConfiguration = new DnsConfiguration { DnsEndpoint = DnsEndpoint.System }
-            };
+            var analysis = CreateAnalysis(new Dictionary<string, DnsAnswer[]>());
             analysis.ClearDNSBL();
             analysis.AddDNSBL("multi.uribl.com");
             analysis.AddDNSBL("dbl.spamhaus.org");

--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task ValidSecurityTxtIsParsed() {
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var prefix = $"http://127.0.0.1:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
             var expires = DateTime.UtcNow.AddDays(30).ToString("yyyy-MM-ddTHH:mm:ssZ");
@@ -159,7 +159,7 @@ namespace DomainDetective.Tests {
             listener.Prefixes.Add(prefix);
             listener.Start();
 
-            var expires = DateTime.UtcNow.AddSeconds(1).ToString("yyyy-MM-ddTHH:mm:ssZ");
+            var expires = DateTime.UtcNow.AddSeconds(2).ToString("yyyy-MM-ddTHH:mm:ssZ");
             var content = $"Contact: mailto:admin@example.com\nExpires: {expires}";
             int hitCount = 0;
             var serverTask = Task.Run(async () => {
@@ -182,7 +182,7 @@ namespace DomainDetective.Tests {
 
                 Assert.Equal(1, hitCount);
 
-                await Task.Delay(1100);
+                await Task.Delay(2100);
                 await healthCheck.Verify(domain, new[] { HealthCheckType.SECURITYTXT });
 
                 Assert.Equal(2, hitCount);


### PR DESCRIPTION
## Summary
- make DNSBL tests deterministic by injecting DNS override
- expose override API for DNSBLAnalysis

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --framework net8.0` *(fails: 15 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_686d519fdcf8832e8972c7bcf8090497