### PR TITLE
Add missing DNSSEC algorithms

### DIFF
--- a/DomainDetective.Tests/TestDNSSECAnalysis.cs
+++ b/DomainDetective.Tests/TestDNSSECAnalysis.cs
@@ -1,3 +1,6 @@
+using DomainDetective;
+using DomainDetective.Protocols;
+
 namespace DomainDetective.Tests {
     public class TestDnssecAnalysis {
         [Fact]
@@ -24,5 +27,32 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.DnsSecAnalysis.ChainValid);
             Assert.NotEmpty(healthCheck.DnsSecAnalysis.MismatchSummary);
         }
-    }
-}
+
+        [Theory]
+        [InlineData(0, "DELETE")]
+        [InlineData(1, "RSAMD5")]
+        [InlineData(2, "DH")]
+        [InlineData(3, "DSA")]
+        [InlineData(4, "ECC")]
+        [InlineData(5, "RSASHA1")]
+        [InlineData(6, "DSANSEC3SHA1")]
+        [InlineData(7, "RSASHA1NSEC3SHA1")]
+        [InlineData(8, "RSASHA256")]
+        [InlineData(9, "RESERVED")]
+        [InlineData(10, "RSASHA512")]
+        [InlineData(11, "RESERVED")]
+        [InlineData(12, "ECCGOST")]
+        [InlineData(13, "ECDSAP256SHA256")]
+        [InlineData(14, "ECDSAP384SHA384")]
+        [InlineData(15, "ED25519")]
+        [InlineData(16, "ED448")]
+        [InlineData(17, "SM2SM3")]
+        [InlineData(23, "ECC-GOST12")]
+        [InlineData(252, "INDIRECT")]
+        [InlineData(253, "PRIVATEDNS")]
+        [InlineData(254, "PRIVATEOID")]
+        [InlineData(255, "RESERVED")]
+        public void AlgorithmNumbersMapToNames(int value, string expected) {
+            Assert.Equal(expected, DNSKeyAnalysis.AlgorithmName(value));
+        }
+    }}

--- a/DomainDetective/Protocols/DNSKeyAnalysis.cs
+++ b/DomainDetective/Protocols/DNSKeyAnalysis.cs
@@ -30,6 +30,7 @@ namespace DomainDetective.Protocols {
 
         internal static string AlgorithmName(int number) {
             return number switch {
+                0 => "DELETE",
                 1 => "RSAMD5",
                 2 => "DH",
                 3 => "DSA",
@@ -51,8 +52,8 @@ namespace DomainDetective.Protocols {
                 252 => "INDIRECT",
                 253 => "PRIVATEDNS",
                 254 => "PRIVATEOID",
+                255 => "RESERVED",
                 _ => string.Empty,
             };
         }
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- add RFC 4034 algorithms to DNSKeyAnalysis
- verify algorithm mappings in DNSSEC unit test

## Testing
- `dotnet test` *(fails: The argument ...)*

------
https://chatgpt.com/codex/tasks/task_e_686e2dc440d8832e81ee99b6e45b53e1