### PR TITLE
Normalize DNS query input casing

### DIFF
--- a/DomainDetective.Tests/TestDnsServerQuery.cs
+++ b/DomainDetective.Tests/TestDnsServerQuery.cs
@@ -41,5 +41,15 @@ namespace DomainDetective.Tests {
             Assert.NotEmpty(servers);
             Assert.All(servers, s => Assert.Equal("Poland", s.Country));
         }
+
+        [Fact]
+        public void BuilderIsCaseInsensitiveForLocation() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var query = DnsServerQuery.Create().FromLocation("kabul");
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Contains("Kabul", s.Location!, StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/DomainDetective.Tests/TestDnsServerQuery.cs
+++ b/DomainDetective.Tests/TestDnsServerQuery.cs
@@ -31,5 +31,15 @@ namespace DomainDetective.Tests {
             Assert.True(servers.Count <= 2);
             Assert.All(servers, s => Assert.Equal("Poland", s.Country));
         }
+
+        [Fact]
+        public void BuilderIsCaseInsensitive() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var query = DnsServerQuery.Create().FromCountry("poland");
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => Assert.Equal("Poland", s.Country));
+        }
     }
 }

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -16,7 +16,7 @@ namespace DomainDetective {
     /// <summary>Filters by country name.</summary>
     public DnsServerQuery FromCountry(string name) {
         if (!string.IsNullOrWhiteSpace(name) &&
-            CountryIdExtensions.TryParse(name.ToUpperInvariant(), out var id)) {
+            CountryIdExtensions.TryParse(name.Trim().ToUpperInvariant(), out var id)) {
             Country = id;
         }
         return this;
@@ -31,7 +31,7 @@ namespace DomainDetective {
     /// <summary>Filters by location name.</summary>
     public DnsServerQuery FromLocation(string name) {
         if (!string.IsNullOrWhiteSpace(name) &&
-            LocationIdExtensions.TryParse(name.ToUpperInvariant(), out var id)) {
+            LocationIdExtensions.TryParse(name.Trim().ToUpperInvariant(), out var id)) {
             Location = id;
         }
         return this;

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -15,7 +15,8 @@ namespace DomainDetective {
 
     /// <summary>Filters by country name.</summary>
     public DnsServerQuery FromCountry(string name) {
-        if (CountryIdExtensions.TryParse(name, out var id)) {
+        if (!string.IsNullOrWhiteSpace(name) &&
+            CountryIdExtensions.TryParse(name.ToUpperInvariant(), out var id)) {
             Country = id;
         }
         return this;
@@ -29,7 +30,8 @@ namespace DomainDetective {
 
     /// <summary>Filters by location name.</summary>
     public DnsServerQuery FromLocation(string name) {
-        if (LocationIdExtensions.TryParse(name, out var id)) {
+        if (!string.IsNullOrWhiteSpace(name) &&
+            LocationIdExtensions.TryParse(name.ToUpperInvariant(), out var id)) {
             Location = id;
         }
         return this;


### PR DESCRIPTION
## Summary
- normalize case of strings passed to `DnsServerQuery`
- ensure `DnsServerQuery` builder is case-insensitive

## Testing
- `dotnet test` *(fails: Assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_686e2dcce870832ea0c941827974614f