### PR TITLE
Add geolocation support for DNS propagation

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationGeo.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationGeo.cs
@@ -1,0 +1,20 @@
+using DnsClientX;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example {
+    internal class ExampleAnalyseDnsPropagationGeoClass {
+        public static async Task Run() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            var servers = analysis.FilterServers(take: 3);
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers, includeGeo: true);
+            foreach (var result in results) {
+                var records = result.Records.Select(r => result.Geo != null && result.Geo.TryGetValue(r, out var info)
+                    ? $"{r} ({info.Country}/{info.City})" : r);
+                Console.WriteLine($"{result.Server.IPAddress} - {string.Join(',', records)}");
+            }
+        }
+    }
+}

--- a/DomainDetective.Tests/TestGeoLookup.cs
+++ b/DomainDetective.Tests/TestGeoLookup.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using DnsClientX;
+namespace DomainDetective.Tests {
+    public class TestGeoLookup {
+        [Fact]
+        public async Task LookupUsesOverride() {
+            var analysis = new DnsPropagationAnalysis {
+                GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", City = "NY" })
+            };
+            var info = await analysis.GetGeoLocationAsync("1.1.1.1", CancellationToken.None);
+            Assert.NotNull(info);
+            Assert.Equal("US", info!.Country);
+            Assert.Equal("NY", info.City);
+        }
+
+        [Fact]
+        public async Task QueryAsyncPopulatesGeo() {
+            var analysis = new DnsPropagationAnalysis {
+                DnsQueryOverride = (_, _, _, _) => Task.FromResult<IEnumerable<string>>(new[] { "1.2.3.4" }),
+                GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", City = "Test" })
+            };
+            var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = "Test", Enabled = true };
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, new[] { server }, includeGeo: true);
+            var result = Assert.Single(results);
+            Assert.NotNull(result.Geo);
+            Assert.Equal("Test", result.Geo!["1.2.3.4"].City);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestGeoLookup.cs
+++ b/DomainDetective.Tests/TestGeoLookup.cs
@@ -28,5 +28,17 @@ namespace DomainDetective.Tests {
             Assert.NotNull(result.Geo);
             Assert.Equal("Test", result.Geo!["1.2.3.4"].City);
         }
+
+        [Fact]
+        public async Task QueryAsyncWithoutGeoProducesNull() {
+            var analysis = new DnsPropagationAnalysis {
+                DnsQueryOverride = (_, _, _, _) => Task.FromResult<IEnumerable<string>>(new[] { "1.2.3.4" }),
+                GeoLookupOverride = (_, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", City = "Nope" })
+            };
+            var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = "Test", Enabled = true };
+            var results = await analysis.QueryAsync("example.com", DnsRecordType.A, new[] { server }, includeGeo: false);
+            var result = Assert.Single(results);
+            Assert.Null(result.Geo);
+        }
     }
 }

--- a/DomainDetective/DnsPropagationResult.cs
+++ b/DomainDetective/DnsPropagationResult.cs
@@ -19,5 +19,8 @@ namespace DomainDetective {
         public bool Success { get; init; }
         /// <summary>Gets an error message if the query failed.</summary>
         public string Error { get; init; }
+
+        /// <summary>Gets geolocation information for returned IP addresses.</summary>
+        public IReadOnlyDictionary<string, GeoLocationInfo>? Geo { get; init; }
     }
 }

--- a/DomainDetective/GeoLocationInfo.cs
+++ b/DomainDetective/GeoLocationInfo.cs
@@ -1,0 +1,13 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Geolocation information for an IP address.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public sealed class GeoLocationInfo {
+    /// <summary>Country where the IP is located.</summary>
+    public string? Country { get; init; }
+
+    /// <summary>City where the IP is located.</summary>
+    public string? City { get; init; }
+}


### PR DESCRIPTION
## Summary
- resolve DNS results to country/city via ipwho.is
- expose geolocation data on `DnsPropagationResult`
- enable geolocation lookup with `--geo` flag in CLI
- add example for geolocation usage
- add tests for new geolocation API

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_686e2eb5cf8c832ea64d03bd34c41ac4