### PR TITLE
Handle IDN domains correctly

### DIFF
--- a/DomainDetective.Tests/TestIdnValidation.cs
+++ b/DomainDetective.Tests/TestIdnValidation.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Reflection;
+using DomainDetective;
+
+namespace DomainDetective.Tests;
+
+public class TestIdnValidation
+{
+    [Fact]
+    public void ValidateHostNameConvertsUnicode()
+    {
+        var method = typeof(DomainHealthCheck)
+            .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = (string)method.Invoke(null, new object[] { "bücher.de" })!;
+        Assert.Equal("xn--bcher-kva.de", result);
+    }
+
+    [Fact]
+    public void ValidateHostNamePreservesPort()
+    {
+        var method = typeof(DomainHealthCheck)
+            .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = (string)method.Invoke(null, new object[] { "bücher.de:25" })!;
+        Assert.Equal("xn--bcher-kva.de:25", result);
+    }
+}


### PR DESCRIPTION
## Summary
- convert unicode host names to ASCII when validating
- ensure public suffix check accepts IDN
- test IDN parsing

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_686e2e927548832eab66af518756e5c1