### PR TITLE
Fix HELO host placeholder

### DIFF
--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -66,7 +66,7 @@ namespace DomainDetective {
 
                 await ReadResponseAsync(reader, timeoutCts.Token);
                 timeoutCts.Token.ThrowIfCancellationRequested();
-                await writer.WriteLineAsync($"HELO example.com");
+                await writer.WriteLineAsync($"HELO {host}");
                 await ReadResponseAsync(reader, timeoutCts.Token);
                 timeoutCts.Token.ThrowIfCancellationRequested();
                 await writer.WriteLineAsync("MAIL FROM:<test@example.com>");


### PR DESCRIPTION
## Summary
- send the HELO command with the actual host name

## Testing
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_686eade26514832eaa8d0a9d7c2d5a26