### PR TITLE
Fix DANE port handling

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -347,6 +347,24 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task NonDefaultPortIsPreserved() {
+            var answers = new[] {
+                new DnsAnswer {
+                    Name = "_444._tcp.example.com",
+                    DataRaw = $"3 1 1 {new string('A', 64)}",
+                    Type = DnsRecordType.TLSA
+                }
+            };
+
+            var analysis = new DANEAnalysis();
+            await analysis.AnalyzeDANERecords(answers, new InternalLogger());
+
+            var result = analysis.AnalysisResults[0];
+            Assert.True(result.ValidDANERecord);
+            Assert.Equal((ServiceType)444, result.ServiceType);
+        }
+
+        [Fact]
         public async Task MultipleRecordsAreValidated() {
             var records = new[] {
                 $"3 1 1 {new string('A', 64)}",
@@ -360,5 +378,4 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
             Assert.Equal(2, healthCheck.DaneAnalysis.AnalysisResults.Count);
         }
-    }
-}
+    }}

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -53,9 +53,7 @@ namespace DomainDetective {
                 if (!string.IsNullOrEmpty(record.Name)) {
                     var match = System.Text.RegularExpressions.Regex.Match(record.Name, @"^_(\d+)\._(tcp|udp)\.");
                     if (match.Success && int.TryParse(match.Groups[1].Value, out var port)) {
-                        if (Enum.IsDefined(typeof(ServiceType), port)) {
-                            analysis.ServiceType = (ServiceType)port;
-                        }
+                        analysis.ServiceType = (ServiceType)port;
                     }
                 }
                 logger.WriteVerbose($"Analyzing DANE record {record.Data}");


### PR DESCRIPTION
## Summary
- preserve provided port in DANE analysis
- add test ensuring port is kept

## Testing
- `dotnet test` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_686eadcc88a0832ea912bdc179be650c