### PR TITLE
Handle invalid ri values in DMARC analysis

### DIFF
--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -376,5 +376,4 @@ namespace DomainDetective.Tests {
             Assert.Equal("86400", healthCheck.DmarcAnalysis.ReportingIntervalShort);
             Assert.Contains(warnings, w => w.FullMessage.Contains("Invalid reporting interval"));
             Assert.Equal("1 days", healthCheck.DmarcAnalysis.ReportingInterval);
-        }
-    }}
+        }}

--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -362,5 +362,19 @@ namespace DomainDetective.Tests {
 
             Assert.True(healthCheck.DmarcAnalysis.ExceedsCharacterLimit);
         }
-    }
-}
+
+        [Fact]
+        public async Task InvalidReportingIntervalDefaultsToOneDay() {
+            var record = "v=DMARC1; p=none; ri=bad";
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+            var healthCheck = new DomainHealthCheck(internalLogger: logger);
+
+            await healthCheck.CheckDMARC(record);
+
+            Assert.Equal("86400", healthCheck.DmarcAnalysis.ReportingIntervalShort);
+            Assert.Contains(warnings, w => w.FullMessage.Contains("Invalid reporting interval"));
+            Assert.Equal("1 days", healthCheck.DmarcAnalysis.ReportingInterval);
+        }
+    }}

--- a/DomainDetective.Tests/TestDMARCAnalysis.cs
+++ b/DomainDetective.Tests/TestDMARCAnalysis.cs
@@ -144,7 +144,7 @@ namespace DomainDetective.Tests {
 
             Assert.Contains(warnings, w => w.FullMessage.Contains("reports@external.com") && w.FullMessage.Contains("example.com"));
         }
-        
+
         [Fact]
         public async Task InvalidAlignmentFlags() {
             var dmarcRecord = "v=DMARC1; p=none; adkim=x; aspf=y";
@@ -376,4 +376,6 @@ namespace DomainDetective.Tests {
             Assert.Equal("86400", healthCheck.DmarcAnalysis.ReportingIntervalShort);
             Assert.Contains(warnings, w => w.FullMessage.Contains("Invalid reporting interval"));
             Assert.Equal("1 days", healthCheck.DmarcAnalysis.ReportingInterval);
-        }}
+        }
+    }
+}

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -159,7 +159,8 @@ namespace DomainDetective {
                             break;
                         case "ri":
                             // RFC 7489 section 6.3 defines 'ri' as the reporting
-                            // interval in seconds. It must be a numeric value.
+                            // interval in seconds. Invalid or zero values default
+                            // to 86400 seconds.
                             ReportingIntervalShort = value;
                             _ = TranslateReportingInterval(ReportingIntervalShort, logger);
                             break;

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -33,7 +33,7 @@ namespace DomainDetective {
 
         public string Policy => TranslatePolicy(PolicyShort);
         public string SubPolicy => TranslateSubPolicy();
-        public string ReportingInterval => TranslateReportingInterval(ReportingIntervalShort, _logger);
+        public string ReportingInterval => TranslateReportingInterval(ReportingIntervalShort);
         public string Percent => TranslatePercentage();
         public string SpfAlignment => TranslateAlignment(SpfAShort);
         public string DkimAlignment => TranslateAlignment(DkimAShort);
@@ -75,8 +75,6 @@ namespace DomainDetective {
         public bool IsPctValid { get; private set; }
         public string ReportingIntervalShort { get; private set; }
 
-        private InternalLogger? _logger;
-
         private const int DefaultReportingInterval = 86400;
 
         public async Task AnalyzeDmarcRecords(
@@ -85,7 +83,6 @@ namespace DomainDetective {
             string? domainName = null,
             Func<string, string>? getOrgDomain = null) {
             // reset all properties so repeated calls don't accumulate data
-            _logger = logger;
             DnsConfiguration ??= new DnsConfiguration();
             DmarcRecord = null;
             DmarcRecordExists = false;

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -388,7 +388,11 @@ namespace DomainDetective {
             }
 
             if (seconds <= 0) {
+                logger?.WriteWarning(
+                    "Reporting interval is zero or negative. Resetting to default value of {0} seconds.",
+                    DefaultReportingInterval);
                 seconds = DefaultReportingInterval;
+                ReportingIntervalShort = DefaultReportingInterval.ToString();
             }
 
             return $"{seconds / 86400} days";

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -159,8 +159,9 @@ namespace DomainDetective {
                             break;
                         case "ri":
                             // RFC 7489 section 6.3 defines 'ri' as the reporting
-                            // interval in seconds. Invalid or zero values default
-                            // to 86400 seconds.
+                            // interval in seconds. The raw value is stored here.
+                            // TranslateReportingInterval will warn and default to
+                            // 86400 seconds if parsing fails or the value is zero.
                             ReportingIntervalShort = value;
                             _ = TranslateReportingInterval(ReportingIntervalShort, logger);
                             break;
@@ -376,8 +377,12 @@ namespace DomainDetective {
         }
 
         private string TranslateReportingInterval(string interval, InternalLogger? logger = null) {
+            // convert the raw 'ri' tag value to days
             if (!int.TryParse(interval, out var seconds)) {
-                logger?.WriteWarning("Invalid reporting interval '{0}'. Defaulting to {1} seconds.", interval, DefaultReportingInterval);
+                logger?.WriteWarning(
+                    "Invalid reporting interval '{0}'. Defaulting to {1} seconds.",
+                    interval,
+                    DefaultReportingInterval);
                 seconds = DefaultReportingInterval;
                 ReportingIntervalShort = DefaultReportingInterval.ToString();
             }

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -464,5 +464,4 @@ namespace DomainDetective {
 
 
 
-    }
-}
+    }}

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -164,6 +164,7 @@ namespace DomainDetective {
                             // RFC 7489 section 6.3 defines 'ri' as the reporting
                             // interval in seconds. It must be a numeric value.
                             ReportingIntervalShort = value;
+                            _ = TranslateReportingInterval(ReportingIntervalShort, logger);
                             break;
                         case "fo":
                             FoShort = value;


### PR DESCRIPTION
## Summary
- capture logger within `AnalyzeDmarcRecords`
- store raw reporting interval and parse via `TranslateReportingInterval`
- default `ri` value to one day when parsing fails
- test example for invalid reporting interval

## Testing
- `dotnet test` *(fails: Failed to download package 'PgpCore.6.5.2' from 'https://api.nuget.org/v3-flatcontainer/pgpcore/6.5.2/pgpcore.6.5.2.nupkg'.)*

------
https://chatgpt.com/codex/tasks/task_e_686eada99e7c832e9aa426a8f02442b7