### PR TITLE
Fix DNSBL default port

### DIFF
--- a/DomainDetective.Tests/TestDNSBLConfig.cs
+++ b/DomainDetective.Tests/TestDNSBLConfig.cs
@@ -66,5 +66,23 @@ namespace DomainDetective.Tests {
                 File.Delete(file);
             }
         }
-    }
-}
+
+        [Fact]
+        public void DefaultPortIs53() {
+            var json = "{\"providers\":[{\"domain\":\"test.port\"}]}";
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, json);
+
+                var analysis = new DNSBLAnalysis();
+                analysis.LoadDnsblConfig(file, clearExisting: true);
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+
+                var entry = Assert.Single(analysis.GetDNSBL());
+                Assert.Equal(53, entry.Port);
+            }
+            finally {
+                File.Delete(file);
+            }
+        }
+    }}


### PR DESCRIPTION
## Summary
- set default DNSBL port to 53 and expose property
- load and store port values when importing config
- test that new Port property defaults to 53

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -v minimal` *(fails: Exceeds lookups should be true, as we expect it over the board)*
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686eadd75c9c832e8b8beb302ebe7b39