### PR TITLE
Fix MX priority ordering

### DIFF
--- a/DomainDetective.Tests/TestMXAnalysis.cs
+++ b/DomainDetective.Tests/TestMXAnalysis.cs
@@ -80,5 +80,30 @@ namespace DomainDetective.Tests {
             Assert.False(analysis.ValidMxConfiguration);
             Assert.True(analysis.PointsToIpAddress);
         }
-    }
-}
+
+        [Fact]
+        public async Task DetectStableOrderingWithDuplicates() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "10 mail1.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "20 mail2.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "20 mail3.example.com", Type = DnsRecordType.MX }
+            };
+            var analysis = CreateAnalysis();
+            await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+
+            Assert.True(analysis.PrioritiesInOrder);
+        }
+
+        [Fact]
+        public async Task DetectOutOfOrderWithDuplicate() {
+            var answers = new List<DnsAnswer> {
+                new DnsAnswer { DataRaw = "10 mail1.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "20 mail2.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "10 mail3.example.com", Type = DnsRecordType.MX }
+            };
+            var analysis = CreateAnalysis();
+            await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+
+            Assert.False(analysis.PrioritiesInOrder);
+        }
+    }}

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -87,8 +87,14 @@ namespace DomainDetective {
 
             var preferences = parsed.Select(p => p.Preference).ToList();
             if (preferences.Count > 1) {
-                var sorted = preferences.OrderBy(p => p).ToList();
-                PrioritiesInOrder = preferences.SequenceEqual(sorted);
+                var ordered = true;
+                for (var i = 1; i < preferences.Count; i++) {
+                    if (preferences[i] < preferences[i - 1]) {
+                        ordered = false;
+                        break;
+                    }
+                }
+                PrioritiesInOrder = ordered;
                 HasBackupServers = preferences.Distinct().Count() > 1;
             }
 

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -87,14 +87,14 @@ namespace DomainDetective {
 
             var preferences = parsed.Select(p => p.Preference).ToList();
             if (preferences.Count > 1) {
-                var ordered = true;
-                for (var i = 1; i < preferences.Count; i++) {
-                    if (preferences[i] < preferences[i - 1]) {
-                        ordered = false;
-                        break;
-                    }
-                }
-                PrioritiesInOrder = ordered;
+                var stableSorted = parsed
+                    .Select((p, index) => (p.Preference, index))
+                    .OrderBy(p => p.Preference)
+                    .ThenBy(p => p.index)
+                    .Select(p => p.Preference)
+                    .ToList();
+
+                PrioritiesInOrder = preferences.SequenceEqual(stableSorted);
                 HasBackupServers = preferences.Distinct().Count() > 1;
             }
 


### PR DESCRIPTION
## Summary
- check MX priorities with a stable comparison
- add MXAnalysis tests for duplicate priority ordering

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter FullyQualifiedName~DomainDetective.Tests.TestMXAnalysis --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_686ead9195f8832e9651364e4946647d