### PR TITLE
Add MailTls timeout test

### DIFF
--- a/DomainDetective.Tests/TestMailTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestMailTlsAnalysis.cs
@@ -87,6 +87,16 @@ public class TestMailTlsAnalysis
         }
     }
 
+    [Fact]
+    public async Task ConnectionTimeoutReturnsDefault()
+    {
+        var analysis = new IMAPTLSAnalysis { Timeout = TimeSpan.FromMilliseconds(300) };
+        await analysis.AnalyzeServer("203.0.113.1", 143, new InternalLogger());
+        var result = analysis.ServerResults["203.0.113.1:143"];
+        Assert.False(result.StartTlsAdvertised);
+        Assert.Null(result.Certificate);
+    }
+
     private static async Task RunImapServer(TcpListener listener, X509Certificate2 cert, SslProtocols protocol, CancellationToken token)
     {
         try


### PR DESCRIPTION
## Summary
- add IMAP TLS timeout test

## Testing
- `dotnet test` *(fails: System.Security.Permissions package download 503)*

------
https://chatgpt.com/codex/tasks/task_e_686eadb0c094832e92ee389106e502c7