### PR TITLE
Add DNS snapshot comparison

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDnsSnapshots.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsSnapshots.cs
@@ -1,0 +1,19 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseDnsSnapshots() {
+        var analysis = new DnsPropagationAnalysis { SnapshotDirectory = "snapshots" };
+        analysis.LoadBuiltinServers();
+        var servers = analysis.FilterServers(take: 2);
+        var results = await analysis.QueryAsync("example.com", DnsClientX.DnsRecordType.A, servers, maxParallelism: 2);
+        var diff = analysis.GetSnapshotChanges("example.com", DnsClientX.DnsRecordType.A, results);
+        analysis.SaveSnapshot("example.com", DnsClientX.DnsRecordType.A, results);
+        foreach (var line in diff) {
+            Console.WriteLine(line);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDnsSnapshots.cs
+++ b/DomainDetective.Tests/TestDnsSnapshots.cs
@@ -1,0 +1,45 @@
+using DnsClientX;
+using DomainDetective;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnsSnapshots {
+        [Fact]
+        public void DetectsSnapshotChanges() {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            try {
+                var analysis = new DnsPropagationAnalysis { SnapshotDirectory = dir };
+                var first = new List<DnsPropagationResult> {
+                    new() {
+                        Server = new PublicDnsEntry { IPAddress = IPAddress.Parse("1.1.1.1"), Enabled = true },
+                        RecordType = DnsRecordType.A,
+                        Records = new[] { "1.2.3.4" },
+                        Success = true
+                    }
+                };
+                analysis.SaveSnapshot("example.com", DnsRecordType.A, first);
+
+                var second = new List<DnsPropagationResult> {
+                    new() {
+                        Server = new PublicDnsEntry { IPAddress = IPAddress.Parse("1.1.1.1"), Enabled = true },
+                        RecordType = DnsRecordType.A,
+                        Records = new[] { "4.5.6.7" },
+                        Success = true
+                    }
+                };
+                var diff = analysis.GetSnapshotChanges("example.com", DnsRecordType.A, second).ToList();
+                analysis.SaveSnapshot("example.com", DnsRecordType.A, second);
+                Assert.Contains("- 1.1.1.1:1.2.3.4", diff);
+                Assert.Contains("+ 1.1.1.1:4.5.6.7", diff);
+            } finally {
+                Directory.Delete(dir, true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add snapshot save/load for DNS results
- support snapshot diff in `ddcli`
- show DNS snapshot example
- test snapshot functionality

## Testing
- `dotnet restore`
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: 14 tests)*
- `pwsh ./Module/DomainDetective.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68716d29223c832ea90c268ac4d9a030