### PR TITLE
Add async versions for ARC and DNS tunneling checks

### DIFF
--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -88,7 +88,7 @@ internal static class CommandUtilities {
         }
 
         var hc = new DomainHealthCheck();
-        var result = hc.VerifyARCAsync(headerText).GetAwaiter().GetResult();
+        var result = hc.VerifyARC(headerText).GetAwaiter().GetResult();
 
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
@@ -106,7 +106,7 @@ internal static class CommandUtilities {
         }
         var lines = File.ReadAllLines(filePath);
         var hc = new DomainHealthCheck { DnsTunnelingLogs = lines };
-        hc.CheckDnsTunnelingAsync(domain).GetAwaiter().GetResult();
+        hc.CheckDnsTunneling(domain).GetAwaiter().GetResult();
         var result = hc.DnsTunnelingAnalysis;
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);

--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -88,7 +88,7 @@ internal static class CommandUtilities {
         }
 
         var hc = new DomainHealthCheck();
-        var result = hc.VerifyARC(headerText);
+        var result = hc.VerifyARCAsync(headerText).GetAwaiter().GetResult();
 
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
@@ -106,7 +106,7 @@ internal static class CommandUtilities {
         }
         var lines = File.ReadAllLines(filePath);
         var hc = new DomainHealthCheck { DnsTunnelingLogs = lines };
-        hc.CheckDnsTunneling(domain);
+        hc.CheckDnsTunnelingAsync(domain).GetAwaiter().GetResult();
         var result = hc.DnsTunnelingAnalysis;
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);

--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -88,7 +88,7 @@ internal static class CommandUtilities {
         }
 
         var hc = new DomainHealthCheck();
-        var result = hc.VerifyARC(headerText).GetAwaiter().GetResult();
+        var result = hc.VerifyARCAsync(headerText).GetAwaiter().GetResult();
 
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
@@ -106,7 +106,7 @@ internal static class CommandUtilities {
         }
         var lines = File.ReadAllLines(filePath);
         var hc = new DomainHealthCheck { DnsTunnelingLogs = lines };
-        hc.CheckDnsTunneling(domain).GetAwaiter().GetResult();
+        hc.CheckDnsTunnelingAsync(domain).GetAwaiter().GetResult();
         var result = hc.DnsTunnelingAnalysis;
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);

--- a/DomainDetective.PowerShell/CmdletTestArc.cs
+++ b/DomainDetective.PowerShell/CmdletTestArc.cs
@@ -49,7 +49,7 @@ namespace DomainDetective.PowerShell {
             var text = ParameterSetName == "File"
                 ? System.IO.File.ReadAllText(File)
                 : HeaderText;
-            var result = await _healthCheck.VerifyARC(text, CancelToken);
+            var result = await _healthCheck.VerifyARCAsync(text, CancelToken);
             WriteObject(result);
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestArc.cs
+++ b/DomainDetective.PowerShell/CmdletTestArc.cs
@@ -45,13 +45,12 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
-        protected override Task ProcessRecordAsync() {
+        protected override async Task ProcessRecordAsync() {
             var text = ParameterSetName == "File"
                 ? System.IO.File.ReadAllText(File)
                 : HeaderText;
-            var result = _healthCheck.VerifyARC(text, CancelToken);
+            var result = await _healthCheck.VerifyARCAsync(text, CancelToken);
             WriteObject(result);
-            return Task.CompletedTask;
         }
     }
 }

--- a/DomainDetective.PowerShell/CmdletTestArc.cs
+++ b/DomainDetective.PowerShell/CmdletTestArc.cs
@@ -49,7 +49,7 @@ namespace DomainDetective.PowerShell {
             var text = ParameterSetName == "File"
                 ? System.IO.File.ReadAllText(File)
                 : HeaderText;
-            var result = await _healthCheck.VerifyARCAsync(text, CancelToken);
+            var result = await _healthCheck.VerifyARC(text, CancelToken);
             WriteObject(result);
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
@@ -31,7 +31,7 @@ namespace DomainDetective.PowerShell {
 
             var lines = File.ReadAllLines(Path);
             _hc.DnsTunnelingLogs = lines;
-            await _hc.CheckDnsTunneling(DomainName, CancelToken);
+            await _hc.CheckDnsTunnelingAsync(DomainName, CancelToken);
             WriteObject(_hc.DnsTunnelingAnalysis);
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
@@ -31,7 +31,7 @@ namespace DomainDetective.PowerShell {
 
             var lines = File.ReadAllLines(Path);
             _hc.DnsTunnelingLogs = lines;
-            await _hc.CheckDnsTunnelingAsync(DomainName, CancelToken);
+            await _hc.CheckDnsTunneling(DomainName, CancelToken);
             WriteObject(_hc.DnsTunnelingAnalysis);
         }
     }

--- a/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
@@ -23,17 +23,16 @@ namespace DomainDetective.PowerShell {
 
         private DomainHealthCheck _hc = new();
 
-        protected override Task ProcessRecordAsync() {
+        protected override async Task ProcessRecordAsync() {
             if (!File.Exists(Path)) {
                 WriteError(new ErrorRecord(new FileNotFoundException("File not found", Path), "NotFound", ErrorCategory.InvalidArgument, Path));
-                return Task.CompletedTask;
+                return;
             }
 
             var lines = File.ReadAllLines(Path);
             _hc.DnsTunnelingLogs = lines;
-            _hc.CheckDnsTunneling(DomainName);
+            await _hc.CheckDnsTunnelingAsync(DomainName, CancelToken);
             WriteObject(_hc.DnsTunnelingAnalysis);
-            return Task.CompletedTask;
         }
     }
 }

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -1,57 +1,58 @@
 using System.IO;
+using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
     public class TestARCAnalysis {
         [Fact]
-        public void ValidArcChain() {
+        public async Task ValidArcChain() {
             var raw = File.ReadAllText("Data/arc-valid.txt");
             var hc = new DomainHealthCheck();
-            var result = hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.True(result.ValidChain);
         }
 
         [Fact]
-        public void InvalidArcChain() {
+        public async Task InvalidArcChain() {
             var raw = File.ReadAllText("Data/arc-invalid.txt");
             var hc = new DomainHealthCheck();
-            var result = hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
 
         [Fact]
-        public void MissingSignatureInvalidatesChain() {
+        public async Task MissingSignatureInvalidatesChain() {
             var raw = File.ReadAllText("Data/arc-missing-sig.txt");
             var hc = new DomainHealthCheck();
-            var result = hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
 
         [Fact]
-        public void EmptySignatureInvalidatesChain() {
+        public async Task EmptySignatureInvalidatesChain() {
             var raw = File.ReadAllText("Data/arc-empty-sig.txt");
             var hc = new DomainHealthCheck();
-            var result = hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
 
         [Fact]
-        public void OutOfOrderChainIsInvalid() {
+        public async Task OutOfOrderChainIsInvalid() {
             var raw = File.ReadAllText("Data/arc-out-of-order.txt");
             var hc = new DomainHealthCheck();
-            var result = hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
 
         [Fact]
-        public void RfcExampleIsValid() {
+        public async Task RfcExampleIsValid() {
             var raw = File.ReadAllText("Data/arc-rfc-example.txt");
             var hc = new DomainHealthCheck();
-            var result = hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.True(result.ValidChain);
         }

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Tests {
         public async Task ValidArcChain() {
             var raw = File.ReadAllText("Data/arc-valid.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARCAsync(raw);
+            var result = await hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.True(result.ValidChain);
         }
@@ -16,7 +16,7 @@ namespace DomainDetective.Tests {
         public async Task InvalidArcChain() {
             var raw = File.ReadAllText("Data/arc-invalid.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARCAsync(raw);
+            var result = await hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -25,7 +25,7 @@ namespace DomainDetective.Tests {
         public async Task MissingSignatureInvalidatesChain() {
             var raw = File.ReadAllText("Data/arc-missing-sig.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARCAsync(raw);
+            var result = await hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -34,7 +34,7 @@ namespace DomainDetective.Tests {
         public async Task EmptySignatureInvalidatesChain() {
             var raw = File.ReadAllText("Data/arc-empty-sig.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARCAsync(raw);
+            var result = await hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -43,7 +43,7 @@ namespace DomainDetective.Tests {
         public async Task OutOfOrderChainIsInvalid() {
             var raw = File.ReadAllText("Data/arc-out-of-order.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARCAsync(raw);
+            var result = await hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -52,7 +52,7 @@ namespace DomainDetective.Tests {
         public async Task RfcExampleIsValid() {
             var raw = File.ReadAllText("Data/arc-rfc-example.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARCAsync(raw);
+            var result = await hc.VerifyARC(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.True(result.ValidChain);
         }

--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.Tests {
         public async Task ValidArcChain() {
             var raw = File.ReadAllText("Data/arc-valid.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.True(result.ValidChain);
         }
@@ -16,7 +16,7 @@ namespace DomainDetective.Tests {
         public async Task InvalidArcChain() {
             var raw = File.ReadAllText("Data/arc-invalid.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -25,7 +25,7 @@ namespace DomainDetective.Tests {
         public async Task MissingSignatureInvalidatesChain() {
             var raw = File.ReadAllText("Data/arc-missing-sig.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -34,7 +34,7 @@ namespace DomainDetective.Tests {
         public async Task EmptySignatureInvalidatesChain() {
             var raw = File.ReadAllText("Data/arc-empty-sig.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -43,7 +43,7 @@ namespace DomainDetective.Tests {
         public async Task OutOfOrderChainIsInvalid() {
             var raw = File.ReadAllText("Data/arc-out-of-order.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.False(result.ValidChain);
         }
@@ -52,7 +52,7 @@ namespace DomainDetective.Tests {
         public async Task RfcExampleIsValid() {
             var raw = File.ReadAllText("Data/arc-rfc-example.txt");
             var hc = new DomainHealthCheck();
-            var result = await hc.VerifyARC(raw);
+            var result = await hc.VerifyARCAsync(raw);
             Assert.True(result.ArcHeadersFound);
             Assert.True(result.ValidChain);
         }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -308,7 +308,7 @@ namespace DomainDetective {
                         await CheckIPNeighbors(domainName, cancellationToken);
                         break;
                     case HealthCheckType.DNSTUNNELING:
-                        await CheckDnsTunneling(domainName, cancellationToken);
+                        await CheckDnsTunnelingAsync(domainName, cancellationToken);
                         break;
                     case HealthCheckType.TYPOSQUATTING:
                         await VerifyTyposquatting(domainName, cancellationToken);
@@ -616,7 +616,11 @@ namespace DomainDetective {
         }
 
         /// <summary>Analyzes DNS logs for tunneling patterns.</summary>
-        public async Task CheckDnsTunneling(string domainName, CancellationToken ct = default) {
+        public void CheckDnsTunneling(string domainName, CancellationToken ct = default) {
+            CheckDnsTunnelingAsync(domainName, ct).GetAwaiter().GetResult();
+        }
+
+        public async Task CheckDnsTunnelingAsync(string domainName, CancellationToken ct = default) {
             ct.ThrowIfCancellationRequested();
             var lines = DnsTunnelingLogs ?? Array.Empty<string>();
             await Task.Run(() => DnsTunnelingAnalysis.Analyze(domainName, lines), ct);
@@ -743,7 +747,11 @@ namespace DomainDetective {
         /// <param name="rawHeaders">Raw message headers.</param>
         /// <param name="ct">Token to cancel the operation.</param>
         /// <returns>Populated <see cref="ARCAnalysis"/> instance.</returns>
-        public async Task<ARCAnalysis> VerifyARC(string rawHeaders, CancellationToken ct = default) {
+        public ARCAnalysis VerifyARC(string rawHeaders, CancellationToken ct = default) {
+            return VerifyARCAsync(rawHeaders, ct).GetAwaiter().GetResult();
+        }
+
+        public async Task<ARCAnalysis> VerifyARCAsync(string rawHeaders, CancellationToken ct = default) {
             ct.ThrowIfCancellationRequested();
             return await Task.Run(() => {
                 ArcAnalysis = new ARCAnalysis();

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -308,7 +308,7 @@ namespace DomainDetective {
                         await CheckIPNeighbors(domainName, cancellationToken);
                         break;
                     case HealthCheckType.DNSTUNNELING:
-                        await CheckDnsTunnelingAsync(domainName, cancellationToken);
+                        await CheckDnsTunneling(domainName, cancellationToken);
                         break;
                     case HealthCheckType.TYPOSQUATTING:
                         await VerifyTyposquatting(domainName, cancellationToken);
@@ -616,15 +616,10 @@ namespace DomainDetective {
         }
 
         /// <summary>Analyzes DNS logs for tunneling patterns.</summary>
-        public async Task CheckDnsTunnelingAsync(string domainName, CancellationToken ct = default) {
+        public async Task CheckDnsTunneling(string domainName, CancellationToken ct = default) {
             ct.ThrowIfCancellationRequested();
             var lines = DnsTunnelingLogs ?? Array.Empty<string>();
             await Task.Run(() => DnsTunnelingAnalysis.Analyze(domainName, lines), ct);
-        }
-
-        /// <summary>Analyzes DNS logs for tunneling patterns.</summary>
-        public void CheckDnsTunneling(string domainName) {
-            CheckDnsTunnelingAsync(domainName).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -748,17 +743,13 @@ namespace DomainDetective {
         /// <param name="rawHeaders">Raw message headers.</param>
         /// <param name="ct">Token to cancel the operation.</param>
         /// <returns>Populated <see cref="ARCAnalysis"/> instance.</returns>
-        public async Task<ARCAnalysis> VerifyARCAsync(string rawHeaders, CancellationToken ct = default) {
+        public async Task<ARCAnalysis> VerifyARC(string rawHeaders, CancellationToken ct = default) {
             ct.ThrowIfCancellationRequested();
             return await Task.Run(() => {
                 ArcAnalysis = new ARCAnalysis();
                 ArcAnalysis.Analyze(rawHeaders, _logger);
                 return ArcAnalysis;
             }, ct);
-        }
-
-        public ARCAnalysis VerifyARC(string rawHeaders, CancellationToken ct = default) {
-            return VerifyARCAsync(rawHeaders, ct).GetAwaiter().GetResult();
         }
 
 


### PR DESCRIPTION
## Summary
- add `VerifyARCAsync` and `CheckDnsTunnelingAsync`
- update cmdlets and CLI utilities to call the async APIs
- provide sync wrappers for legacy calls
- convert ARC analysis tests to async

## Testing
- `dotnet test --no-build` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_68716d708350832ebaf16c0980430ac8