### PR TITLE
Fix duplicate field detection in MTASTS parser

### DIFF
--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -249,6 +249,22 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task DuplicateFieldsInDnsRecordFlagged() {
+            var answers = new[] {
+                new DnsAnswer { DataRaw = "v=STSv1; v=STSv1; id=abc", Type = DnsRecordType.TXT }
+            };
+            var analysis = new MTASTSAnalysis {
+                QueryDnsOverride = (_, _) => Task.FromResult(answers),
+                DnsConfiguration = new DnsConfiguration()
+            };
+            await analysis.AnalyzePolicy("example.com", new InternalLogger());
+
+            Assert.True(analysis.DnsRecordPresent);
+            Assert.True(analysis.HasDuplicateFields);
+            Assert.False(analysis.PolicyValid);
+        }
+
+        [Fact]
         public async Task CachedPolicyReusedUntilExpiration() {
             MTASTSAnalysis.ClearCache();
             using var listener = new HttpListener();

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -266,6 +266,7 @@ public class MTASTSAnalysis {
 
             var parts = record.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
             bool hasVersion = false;
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var part in parts) {
                 var kv = part.Split(new[] { '=' }, 2);
                 if (kv.Length != 2) {
@@ -274,6 +275,11 @@ public class MTASTSAnalysis {
 
                 var key = kv[0].Trim();
                 var value = kv[1].Trim();
+
+                if (!seen.Add(key)) {
+                    HasDuplicateFields = true;
+                }
+
                 switch (key) {
                     case "v":
                         hasVersion = value == "STSv1";
@@ -295,7 +301,6 @@ public class MTASTSAnalysis {
             PolicyValid = true;
             ValidVersion = false;
             VersionPresent = false;
-            HasDuplicateFields = false;
             ValidMode = false;
             ValidMaxAge = false;
             HasMx = false;


### PR DESCRIPTION
## Summary
- track seen keys when parsing MTA‑STS DNS records
- keep previous duplicate state when parsing policy
- test DNS record duplicate detection

## Testing
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Exceeds lookups should be true, as we expect it over the board)*

------
https://chatgpt.com/codex/tasks/task_e_6871720cb0a0832eb27a3d88f4ba685f