### PR TITLE
Implement cross-domain policy header check

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -57,6 +57,7 @@ namespace DomainDetective.Tests {
                 Assert.Equal("geolocation=()", analysis.SecurityHeaders["Permissions-Policy"].Value);
                 Assert.Equal("max-age=31536000", analysis.SecurityHeaders["Strict-Transport-Security"].Value);
                 Assert.Equal("none", analysis.SecurityHeaders["X-Permitted-Cross-Domain-Policies"].Value);
+                Assert.Equal("none", analysis.XPermittedCrossDomainPolicies);
                 Assert.Equal("same-origin", analysis.SecurityHeaders["Cross-Origin-Opener-Policy"].Value);
                 Assert.Equal("require-corp", analysis.SecurityHeaders["Cross-Origin-Embedder-Policy"].Value);
                 Assert.Equal("same-origin", analysis.SecurityHeaders["Cross-Origin-Resource-Policy"].Value);
@@ -142,6 +143,7 @@ namespace DomainDetective.Tests {
                 Assert.Empty(analysis.PermissionsPolicy);
                 Assert.Null(analysis.ReferrerPolicy);
                 Assert.Null(analysis.XFrameOptions);
+                Assert.Null(analysis.XPermittedCrossDomainPolicies);
             } finally {
                 listener.Stop();
                 await serverTask;
@@ -330,6 +332,8 @@ namespace DomainDetective.Tests {
                 Assert.True(analysis.HstsTooShort);
                 Assert.Contains("Content-Security-Policy", analysis.MissingSecurityHeaders);
                 Assert.Contains("Origin-Agent-Cluster", analysis.MissingSecurityHeaders);
+                Assert.Contains("X-Permitted-Cross-Domain-Policies", analysis.MissingSecurityHeaders);
+                Assert.Null(analysis.XPermittedCrossDomainPolicies);
             } finally {
                 listener.Stop();
                 await serverTask;

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -149,9 +149,9 @@ public static class CheckDescriptions {
                 "Enable secure authentication methods and disable weak ones."),
             // Verify Website Connectivity
             [HealthCheckType.HTTP] = new(
-                "Verify website connectivity.",
+                "Verify website connectivity and X-Permitted-Cross-Domain-Policies header.",
                 null,
-                "Serve websites over HTTPS and respond correctly."),
+                "Serve websites over HTTPS, respond correctly and configure X-Permitted-Cross-Domain-Policies."),
             // Verify HPKP
             [HealthCheckType.HPKP] = new(
                 "Verify HPKP configuration.",

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -82,6 +82,8 @@ namespace DomainDetective {
         public string? CrossOriginEmbedderPolicy { get; private set; }
         /// <summary>Gets the value of the Cross-Origin-Resource-Policy header if present.</summary>
         public string? CrossOriginResourcePolicy { get; private set; }
+        /// <summary>Gets the value of the X-Permitted-Cross-Domain-Policies header if present.</summary>
+        public string? XPermittedCrossDomainPolicies { get; private set; }
         /// <summary>Gets a value indicating whether the Origin-Agent-Cluster header was present.</summary>
         public bool OriginAgentClusterPresent { get; private set; }
         /// <summary>Gets a value indicating whether Origin-Agent-Cluster is enabled.</summary>
@@ -191,6 +193,7 @@ namespace DomainDetective {
             CrossOriginOpenerPolicy = null;
             CrossOriginEmbedderPolicy = null;
             CrossOriginResourcePolicy = null;
+            XPermittedCrossDomainPolicies = null;
             OriginAgentClusterPresent = false;
             OriginAgentClusterEnabled = false;
             SecurityHeaders.Clear();
@@ -316,6 +319,9 @@ namespace DomainDetective {
                     }
                     if (SecurityHeaders.TryGetValue("Cross-Origin-Resource-Policy", out var corp)) {
                         CrossOriginResourcePolicy = corp.Value;
+                    }
+                    if (SecurityHeaders.TryGetValue("X-Permitted-Cross-Domain-Policies", out var xpcdp)) {
+                        XPermittedCrossDomainPolicies = xpcdp.Value;
                     }
                     if (SecurityHeaders.TryGetValue("Origin-Agent-Cluster", out var oac)) {
                         ParseOriginAgentCluster(oac.Value);


### PR DESCRIPTION
## Summary
- track the `X-Permitted-Cross-Domain-Policies` header in `HttpAnalysis`
- expose parsed value in results
- assert this in HTTP analysis tests
- update HTTP check description

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln --no-build --verbosity minimal` *(fails: `TestDANEnalysis.EmptyServiceTypesDefaultsToSmtpHttps`, `TestDANEnalysis.TestDANERecordByDomain`, `TestCertificateMonitor.ProducesSummaryCounts`, `TestAll.TestAllHealthChecks`, `TestSOAAnalysis.VerifySoaByDomain`, `TestSpfAnalysis.TestSpfOver255`, `TestDkimAnalysis.TestDKIMByDomain`, `TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups`, `TestSpfAnalysis.QueryDomainBySPF`, `TestDkimGuess.GuessSelectorsForDomain`, `TestCAAAnalysis.TestCAARecordByDomain`, `TestCertificateHTTP.UnreachableHostLogsExceptionType`, `TestCertificateHTTP.CapturesCipherSuiteWhenEnabled`, `TestDMARCAnalysis.TestDMARCByDomain`)*

------
https://chatgpt.com/codex/tasks/task_e_687173286048832e97dcd68366145fb8