### PR TITLE
Add revocation skip option

### DIFF
--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -55,6 +55,10 @@ internal sealed class CheckDomainSettings : CommandSettings {
     /// <summary>Suppress progress output.</summary>
     [CommandOption("--no-progress")]
     public bool NoProgress { get; set; }
+
+    /// <summary>Skip certificate revocation checks.</summary>
+    [CommandOption("--skip-revocation")]
+    public bool SkipRevocation { get; set; }
 }
 
 /// <summary>
@@ -77,7 +81,7 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
             if (!settings.Cert.Exists) {
                 throw new FileNotFoundException("Certificate file not found", settings.Cert.FullName);
             }
-            var certAnalysis = new CertificateAnalysis();
+            var certAnalysis = new CertificateAnalysis { SkipRevocation = settings.SkipRevocation };
             await certAnalysis.AnalyzeCertificate(new X509Certificate2(settings.Cert.FullName));
             CliHelpers.ShowPropertiesTable($"Certificate {settings.Cert.FullName}", certAnalysis, settings.Unicode);
             return 0;
@@ -117,6 +121,7 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
             settings.Unicode,
             danePorts,
             !settings.NoProgress,
+            settings.SkipRevocation,
             Program.CancellationToken);
 
         return 0;

--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -138,14 +138,15 @@ internal static class CommandUtilities {
         var checkHttp = AnsiConsole.Confirm("Perform plain HTTP check?");
         var subPolicy = AnsiConsole.Confirm("Evaluate subdomain policy?");
 
-        await RunChecks(domains, checks, checkHttp, outputJson, summaryOnly, subPolicy, false, null, true, cancellationToken);
+        await RunChecks(domains, checks, checkHttp, outputJson, summaryOnly, subPolicy, false, null, true, false, cancellationToken);
         return 0;
     }
 
-    internal static async Task RunChecks(string[] domains, HealthCheckType[]? checks, bool checkHttp, bool outputJson, bool summaryOnly, bool subdomainPolicy, bool unicodeOutput, int[]? danePorts, bool showProgress, CancellationToken cancellationToken) {
+internal static async Task RunChecks(string[] domains, HealthCheckType[]? checks, bool checkHttp, bool outputJson, bool summaryOnly, bool subdomainPolicy, bool unicodeOutput, int[]? danePorts, bool showProgress, bool skipRevocation, CancellationToken cancellationToken) {
         foreach (var domain in domains) {
             var logger = new InternalLogger { IsProgress = showProgress };
             var hc = new DomainHealthCheck(internalLogger: logger) { Verbose = false, UseSubdomainPolicy = subdomainPolicy, UnicodeOutput = unicodeOutput, Progress = showProgress };
+            hc.CertificateAnalysis.SkipRevocation = skipRevocation;
 
             if (showProgress) {
                 await AnsiConsole.Progress().StartAsync(async ctx => {

--- a/DomainDetective.PowerShell/CmdletGetCertificateInfo.cs
+++ b/DomainDetective.PowerShell/CmdletGetCertificateInfo.cs
@@ -20,10 +20,14 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 
+        /// <param name="SkipRevocation">Do not check certificate revocation status.</param>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter SkipRevocation;
+
         private CertificateAnalysis _analysis;
 
         protected override async Task ProcessRecordAsync() {
-            _analysis = new CertificateAnalysis();
+            _analysis = new CertificateAnalysis { SkipRevocation = SkipRevocation };
             await _analysis.AnalyzeCertificate(new X509Certificate2(Path));
             WriteObject(_analysis);
             if (ShowChain && _analysis.Chain.Count > 0) {

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -24,6 +24,10 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 
+        /// <param name="SkipRevocation">Do not check certificate revocation status.</param>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter SkipRevocation;
+
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
@@ -37,6 +41,7 @@ namespace DomainDetective.PowerShell {
 
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Verifying website certificate for {0}", Url);
+            _healthCheck.CertificateAnalysis.SkipRevocation = SkipRevocation;
             await _healthCheck.VerifyWebsiteCertificate(Url, Port);
             WriteObject(_healthCheck.CertificateAnalysis);
             if (ShowChain && _healthCheck.CertificateAnalysis.Chain.Count > 0) {

--- a/DomainDetective.Tests/TestCertificateInfo.cs
+++ b/DomainDetective.Tests/TestCertificateInfo.cs
@@ -31,5 +31,13 @@ namespace DomainDetective.Tests {
             Assert.True(analysis.IsSelfSigned);
             Assert.Equal(1, analysis.Chain.Count);
         }
+
+        [Fact]
+        public async Task SkipRevocationDisablesChecks() {
+            var cert = new X509Certificate2("Data/wildcard.pem");
+            var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]"), SkipRevocation = true };
+            await analysis.AnalyzeCertificate(cert);
+            Assert.True(analysis.SkipRevocation);
+        }
     }
 }

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -95,6 +95,8 @@ namespace DomainDetective {
         public int DhKeyBits { get; private set; }
         /// <summary>Enable gathering TLS protocol and cipher information.</summary>
         public bool CaptureTlsDetails { get; set; }
+        /// <summary>Skip certificate revocation checks.</summary>
+        public bool SkipRevocation { get; set; }
         /// <summary>Gets a value indicating whether the certificate is present in public CT logs.</summary>
         public bool PresentInCtLogs { get; private set; }
 
@@ -138,7 +140,7 @@ namespace DomainDetective {
             url = builder.ToString();
             Url = url;
             IsSelfSigned = false;
-            using (var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10 }) {
+            using (var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10, CheckCertificateRevocationList = !SkipRevocation }) {
 #if NET8_0_OR_GREATER
                 handler.SslProtocols = SslProtocols.Tls13 | SslProtocols.Tls12;
 #endif
@@ -196,9 +198,10 @@ namespace DomainDetective {
                                 });
 #if NET5_0_OR_GREATER
                                 var authOptions = new SslClientAuthenticationOptions { TargetHost = uri.Host };
+                                authOptions.CertificateRevocationCheckMode = SkipRevocation ? X509RevocationMode.NoCheck : X509RevocationMode.Online;
                                 await ssl.AuthenticateAsClientAsync(authOptions, timeoutCts.Token);
 #else
-                                await ssl.AuthenticateAsClientAsync(uri.Host).WaitWithCancellation(timeoutCts.Token);
+                                await ssl.AuthenticateAsClientAsync(uri.Host, null, SslProtocols.None, !SkipRevocation).WaitWithCancellation(timeoutCts.Token);
 #endif
                                 if (ssl.RemoteCertificate is X509Certificate2 cert) {
                                     Certificate = new X509Certificate2(cert.Export(X509ContentType.Cert));
@@ -390,6 +393,7 @@ namespace DomainDetective {
             Certificate = new X509Certificate2(certificate.RawData);
             IsSelfSigned = false;
             var chain = new X509Chain();
+            chain.ChainPolicy.RevocationMode = SkipRevocation ? X509RevocationMode.NoCheck : X509RevocationMode.Online;
             IsValid = chain.Build(certificate);
             Chain.Clear();
             foreach (var element in chain.ChainElements) {
@@ -494,10 +498,10 @@ namespace DomainDetective {
 #endif
             using var ssl = new SslStream(tcp.GetStream(), false, static (_, _, _, _) => true);
 #if NET8_0_OR_GREATER
-            await ssl.AuthenticateAsClientAsync(uri.Host, null, SslProtocols.Tls13 | SslProtocols.Tls12, false)
+            await ssl.AuthenticateAsClientAsync(uri.Host, null, SslProtocols.Tls13 | SslProtocols.Tls12, !SkipRevocation)
                 .WaitWithCancellation(timeoutCts.Token);
 #else
-            await ssl.AuthenticateAsClientAsync(uri.Host).WaitWithCancellation(timeoutCts.Token);
+            await ssl.AuthenticateAsClientAsync(uri.Host, null, SslProtocols.None, !SkipRevocation).WaitWithCancellation(timeoutCts.Token);
 #endif
             TlsProtocol = ssl.SslProtocol;
 #if NET8_0_OR_GREATER

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -225,7 +225,9 @@ namespace DomainDetective {
                             DaysToExpire = (int)(Certificate.NotAfter - DateTime.Now).TotalDays;
                             DaysValid = (int)(Certificate.NotAfter - Certificate.NotBefore).TotalDays;
                             IsExpired = Certificate.NotAfter < DateTime.Now;
-                            await QueryRevocationEndpoints(cancellationToken);
+                            if (!SkipRevocation) {
+                                await QueryRevocationEndpoints(cancellationToken);
+                            }
                             PopulateSubjectAlternativeNames();
                             await QueryCtLogs(cancellationToken);
                         }
@@ -238,6 +240,9 @@ namespace DomainDetective {
         }
 
         private async Task QueryRevocationEndpoints(CancellationToken cancellationToken) {
+            if (SkipRevocation) {
+                return;
+            }
             OcspUrls.Clear();
             CrlUrls.Clear();
             OcspRevoked = null;
@@ -404,7 +409,9 @@ namespace DomainDetective {
             DaysToExpire = (int)(certificate.NotAfter - DateTime.Now).TotalDays;
             DaysValid = (int)(certificate.NotAfter - certificate.NotBefore).TotalDays;
             IsExpired = certificate.NotAfter < DateTime.Now;
-            await QueryRevocationEndpoints(cancellationToken);
+            if (!SkipRevocation) {
+                await QueryRevocationEndpoints(cancellationToken);
+            }
             PopulateSubjectAlternativeNames();
             await QueryCtLogs(cancellationToken);
         }

--- a/README.MD
+++ b/README.MD
@@ -106,6 +106,7 @@ The `CertificateAnalysis` result now includes:
 - With `CaptureTlsDetails` enabled, `TlsProtocol`, `CipherAlgorithm` and `CipherStrength` describe the negotiated cipher-suite.
 - `PresentInCtLogs` when the certificate appears in public CT logs.
 - `CtLogApiTemplates` allows customizing the list of CT log APIs queried.
+- `SkipRevocation` disables CRL and OCSP checks. Use with care as revoked certificates may appear valid.
 
 ### DKIM Analysis
 `DkimRecordAnalysis` exposes several indicators:


### PR DESCRIPTION
## Summary
- add `SkipRevocation` boolean to `CertificateAnalysis`
- expose `--skip-revocation` in CLI and PowerShell cmdlet
- document potential risk of disabling revocation checks
- add unit test for skip behavior

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: ValidCertificateProvidesExpirationInfo, ValidHostSetsProtocolVersion, CapturesCipherSuiteWhenEnabled, TestDKIMByDomain, VerifySoaByDomain, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68716ce4a990832e80274786773f35f6