### PR TITLE
feat(powershell): ✨ add DNS snapshot support

### DIFF
--- a/Module/Examples/Example.TestDnsSnapshots.ps1
+++ b/Module/Examples/Example.TestDnsSnapshots.ps1
@@ -1,0 +1,6 @@
+# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$diff = Test-DnsPropagation -DomainName 'example.com' -RecordType A -SnapshotPath 'snapshots' -Diff
+$diff

--- a/Module/Tests/DnsPropagation.Tests.ps1
+++ b/Module/Tests/DnsPropagation.Tests.ps1
@@ -4,4 +4,19 @@ Describe 'Test-DnsPropagation cmdlet' {
         $result = Test-DnsPropagation -DomainName 'example.com' -RecordType A -CountryCount @{PL=0}
         $result | Should -BeNullOrEmpty
     }
+
+    It 'creates snapshot file' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        $dir = Join-Path $TestDrive 'snapshots'
+        $null = Test-DnsPropagation -DomainName 'example.com' -RecordType A -CountryCount @{PL=0} -SnapshotPath $dir
+        (Get-ChildItem $dir).Count | Should -Be 1
+    }
+
+    It 'returns diff output' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        $dir = Join-Path $TestDrive 'snapshots'
+        $first = Test-DnsPropagation -DomainName 'example.com' -RecordType A -CountryCount @{PL=0} -SnapshotPath $dir
+        $diff = Test-DnsPropagation -DomainName 'example.com' -RecordType A -CountryCount @{PL=0} -SnapshotPath $dir -Diff
+        $diff | Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
This pull request enhances the `Test-DnsPropagation` cmdlet by introducing new features for managing and comparing DNS snapshots. Key changes include the addition of parameters for snapshot handling, implementation of snapshot comparison logic, and corresponding updates to examples and tests.

### Enhancements to `Test-DnsPropagation` cmdlet:

* Added two new parameters: `SnapshotPath` to specify the directory for storing DNS snapshots and `Diff` to enable comparison of the current results with the last snapshot. (`DomainDetective.PowerShell/CmdletTestDnsPropagation.cs`, [DomainDetective.PowerShell/CmdletTestDnsPropagation.csR64-R71](diffhunk://#diff-4ba456039feda046e71b1cec3a8c8f29b7ad176f309eb6f71f84762cfa684840R64-R71))
* Updated `BeginProcessingAsync` to set the snapshot directory if `SnapshotPath` is provided. (`DomainDetective.PowerShell/CmdletTestDnsPropagation.cs`, [DomainDetective.PowerShell/CmdletTestDnsPropagation.csR90-R92](diffhunk://#diff-4ba456039feda046e71b1cec3a8c8f29b7ad176f309eb6f71f84762cfa684840R90-R92))
* Enhanced `ProcessRecordAsync` to:
  * Save snapshots using the `SnapshotPath` parameter.
  * Compare results with the previous snapshot when `Diff` is specified and return the differences. (`DomainDetective.PowerShell/CmdletTestDnsPropagation.cs`, [DomainDetective.PowerShell/CmdletTestDnsPropagation.csR123-R138](diffhunk://#diff-4ba456039feda046e71b1cec3a8c8f29b7ad176f309eb6f71f84762cfa684840R123-R138))

### Example script updates:

* Added an example script demonstrating the use of the `SnapshotPath` and `Diff` parameters to save snapshots and retrieve differences. (`Module/Examples/Example.TestDnsSnapshots.ps1`, [Module/Examples/Example.TestDnsSnapshots.ps1R1-R6](diffhunk://#diff-922fef79ed20eb5a0b7f696be990809e1fad9053cdb2a21863a78d3cb370be2fR1-R6))

### Test coverage improvements:

* Added tests to verify:
  * Snapshot file creation when using the `SnapshotPath` parameter.
  * Diff output functionality when the `Diff` parameter is specified. (`Module/Tests/DnsPropagation.Tests.ps1`, [Module/Tests/DnsPropagation.Tests.ps1R7-R21](diffhunk://#diff-0ab6dbafb8c98b6bbc06b9f25f782ae828454e0795c192db6aa05e4e7305c598R7-R21))