### PR TITLE
Add ASN validation for DNS servers

### DIFF
--- a/DomainDetective.Tests/TestBgpValidation.cs
+++ b/DomainDetective.Tests/TestBgpValidation.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestBgpValidation {
+        [Fact]
+        public async Task ValidateServerAsnsWarnsOnMismatch() {
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+
+            var analysis = new DnsPropagationAnalysis {
+                BgpLookupOverride = (ip, ct) => Task.FromResult<int?>(65001)
+            };
+
+            analysis.AddServer(new PublicDnsEntry {
+                IPAddress = IPAddress.Parse("1.2.3.4"),
+                Country = "Test",
+                ASN = "65000"
+            });
+
+            await analysis.ValidateServerAsnsAsync(logger);
+
+            Assert.Contains(warnings, w => w.FullMessage.Contains("expected ASN"));
+        }
+
+        [Fact]
+        public async Task ValidateServerAsnsIgnoresMatches() {
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+
+            var analysis = new DnsPropagationAnalysis {
+                BgpLookupOverride = (ip, ct) => Task.FromResult<int?>(65000)
+            };
+
+            analysis.AddServer(new PublicDnsEntry {
+                IPAddress = IPAddress.Parse("1.2.3.4"),
+                Country = "Test",
+                ASN = "65000"
+            });
+
+            await analysis.ValidateServerAsnsAsync(logger);
+
+            Assert.Empty(warnings);
+        }
+    }
+}
+

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -38,6 +38,9 @@ namespace DomainDetective {
         /// <summary>Override geolocation lookup for testing.</summary>
         internal Func<string, CancellationToken, Task<GeoLocationInfo?>>? GeoLookupOverride { get; set; }
 
+        /// <summary>Override BGP lookup for testing.</summary>
+        internal Func<string, CancellationToken, Task<int?>>? BgpLookupOverride { get; set; }
+
         /// <summary>
         /// Loads DNS server definitions from a JSON file.
         /// </summary>
@@ -325,6 +328,46 @@ namespace DomainDetective {
             var country = doc.RootElement.TryGetProperty("country", out var cElem) ? cElem.GetString() : null;
             var city = doc.RootElement.TryGetProperty("city", out var cityElem) ? cityElem.GetString() : null;
             return new GeoLocationInfo { Country = country, City = city };
+        }
+
+        internal async Task<int?> LookupAsnAsync(string ip, CancellationToken ct) {
+            if (BgpLookupOverride != null) {
+                return await BgpLookupOverride(ip, ct).ConfigureAwait(false);
+            }
+
+            var url = $"https://stat.ripe.net/data/prefix-overview/data.json?resource={ip}";
+            using var request = new HttpRequestMessage(HttpMethod.Get, url);
+            using var response = await SharedHttpClient.Instance.SendAsync(request, ct).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode) {
+                return null;
+            }
+#if NET6_0_OR_GREATER
+            using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+#else
+            using var stream = await response.Content.ReadAsStreamAsync().WaitWithCancellation(ct).ConfigureAwait(false);
+#endif
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
+            if (!doc.RootElement.TryGetProperty("data", out var data) || !data.TryGetProperty("asns", out var asns)) {
+                return null;
+            }
+            if (asns.GetArrayLength() == 0) {
+                return null;
+            }
+            return asns[0].GetProperty("asn").GetInt32();
+        }
+
+        public async Task ValidateServerAsnsAsync(InternalLogger? logger = null, CancellationToken ct = default) {
+            foreach (var server in _servers) {
+                ct.ThrowIfCancellationRequested();
+                if (string.IsNullOrWhiteSpace(server.ASN)) {
+                    continue;
+                }
+
+                var asn = await LookupAsnAsync(server.IPAddress.ToString(), ct).ConfigureAwait(false);
+                if (asn.HasValue && !string.Equals(server.ASN, asn.Value.ToString(), StringComparison.OrdinalIgnoreCase)) {
+                    logger?.WriteWarning("Server {0} expected ASN {1} but is announced by AS{2}", server.IPAddress, server.ASN, asn.Value);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- add optional BGP lookup override in `DnsPropagationAnalysis`
- implement `LookupAsnAsync` and `ValidateServerAsnsAsync` to warn when server ASN mismatches
- test warning logic in `TestBgpValidation`

## Testing
- `dotnet build DomainDetective.sln -c Debug`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build` *(fails: 15 failed, 560 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872d50ce280832e8d56df66359b4404