### PR TITLE
Add GeoIpAnalysis and local lookup

### DIFF
--- a/Data/geoip.csv
+++ b/Data/geoip.csv
@@ -1,0 +1,4 @@
+ip,country,region
+1.1.1.1,AU,Queensland
+8.8.8.8,US,California
+9.9.9.9,US,New Jersey

--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -108,7 +108,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
                 foreach (var r in results) {
                     var records = r.Records.Select(rec => {
                         if (settings.Geo && r.Geo != null && r.Geo.TryGetValue(rec, out var info)) {
-                            return $"{rec} ({info.Country}/{info.City})";
+                            return $"{rec} ({info.Country}/{info.Region})";
                         }
                         return rec;
                     });

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationGeo.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationGeo.cs
@@ -12,7 +12,7 @@ namespace DomainDetective.Example {
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, servers, includeGeo: true);
             foreach (var result in results) {
                 var records = result.Records.Select(r => result.Geo != null && result.Geo.TryGetValue(r, out var info)
-                    ? $"{r} ({info.Country}/{info.City})" : r);
+                    ? $"{r} ({info.Country}/{info.Region})" : r);
                 Console.WriteLine($"{result.Server.IPAddress} - {string.Join(',', records)}");
             }
         }

--- a/DomainDetective.Example/ExampleAnalyseGeoIp.cs
+++ b/DomainDetective.Example/ExampleAnalyseGeoIp.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseGeoIp() {
+        var analysis = new GeoIpAnalysis();
+        analysis.LoadBuiltinDatabase();
+        var info = await analysis.LookupAsync("8.8.8.8");
+        Helpers.ShowPropertiesTable("Geo IP for 8.8.8.8", info!);
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -70,6 +70,7 @@ public static partial class Program {
         await ExampleAnalyseThreatIntel();
         await ExampleAnalyseTyposquatting();
         await ExampleAnalyseEdnsSupport();
+        await ExampleAnalyseGeoIp();
 
         //await ExampleQueryDNS();
         //await ExampleAnalyseByStringWHOIS();

--- a/DomainDetective.Tests/TestGeoIpAnalysis.cs
+++ b/DomainDetective.Tests/TestGeoIpAnalysis.cs
@@ -1,0 +1,20 @@
+namespace DomainDetective.Tests;
+
+public class TestGeoIpAnalysis {
+    [Fact]
+    public void BuiltinLookupReturnsData() {
+        var analysis = new GeoIpAnalysis();
+        analysis.LoadBuiltinDatabase();
+        var info = analysis.Lookup("1.1.1.1");
+        Assert.NotNull(info);
+        Assert.Equal("AU", info!.Country);
+    }
+
+    [Fact]
+    public void LookupUnknownReturnsNull() {
+        var analysis = new GeoIpAnalysis();
+        analysis.LoadBuiltinDatabase();
+        var info = analysis.Lookup("192.0.2.1");
+        Assert.Null(info);
+    }
+}

--- a/DomainDetective.Tests/TestGeoLookup.cs
+++ b/DomainDetective.Tests/TestGeoLookup.cs
@@ -8,32 +8,32 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task LookupUsesOverride() {
             var analysis = new DnsPropagationAnalysis {
-                GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", City = "NY" })
+                GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", Region = "NY" })
             };
             var info = await analysis.GetGeoLocationAsync("1.1.1.1", CancellationToken.None);
             Assert.NotNull(info);
             Assert.Equal("US", info!.Country);
-            Assert.Equal("NY", info.City);
+            Assert.Equal("NY", info.Region);
         }
 
         [Fact]
         public async Task QueryAsyncPopulatesGeo() {
             var analysis = new DnsPropagationAnalysis {
                 DnsQueryOverride = (_, _, _, _) => Task.FromResult<IEnumerable<string>>(new[] { "1.2.3.4" }),
-                GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", City = "Test" })
+                GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", Region = "Test" })
             };
             var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = "Test", Enabled = true };
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, new[] { server }, includeGeo: true);
             var result = Assert.Single(results);
             Assert.NotNull(result.Geo);
-            Assert.Equal("Test", result.Geo!["1.2.3.4"].City);
+            Assert.Equal("Test", result.Geo!["1.2.3.4"].Region);
         }
 
         [Fact]
         public async Task QueryAsyncWithoutGeoProducesNull() {
             var analysis = new DnsPropagationAnalysis {
                 DnsQueryOverride = (_, _, _, _) => Task.FromResult<IEnumerable<string>>(new[] { "1.2.3.4" }),
-                GeoLookupOverride = (_, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", City = "Nope" })
+                GeoLookupOverride = (_, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", Region = "Nope" })
             };
             var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = "Test", Enabled = true };
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, new[] { server }, includeGeo: false);

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -38,6 +38,14 @@ namespace DomainDetective {
         /// <summary>Override geolocation lookup for testing.</summary>
         internal Func<string, CancellationToken, Task<GeoLocationInfo?>>? GeoLookupOverride { get; set; }
 
+        /// <summary>GeoIP database used for lookups.</summary>
+        public GeoIpAnalysis GeoIp { get; } = new GeoIpAnalysis();
+
+        /// <summary>Initializes a new instance of the class.</summary>
+        public DnsPropagationAnalysis() {
+            GeoIp.LoadBuiltinDatabase();
+        }
+
         /// <summary>
         /// Loads DNS server definitions from a JSON file.
         /// </summary>
@@ -302,29 +310,12 @@ namespace DomainDetective {
                 : ipAddress.ToString();
         }
 
-        internal async Task<GeoLocationInfo?> GetGeoLocationAsync(string ip, CancellationToken ct) {
+        internal Task<GeoLocationInfo?> GetGeoLocationAsync(string ip, CancellationToken ct) {
             if (GeoLookupOverride != null) {
-                return await GeoLookupOverride(ip, ct).ConfigureAwait(false);
+                return GeoLookupOverride(ip, ct);
             }
 
-            var url = $"https://ipwho.is/{ip}";
-            using var request = new HttpRequestMessage(HttpMethod.Get, url);
-            using var response = await SharedHttpClient.Instance.SendAsync(request, ct).ConfigureAwait(false);
-            if (!response.IsSuccessStatusCode) {
-                return null;
-            }
-#if NET6_0_OR_GREATER
-            using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
-#else
-            using var stream = await response.Content.ReadAsStreamAsync().WaitWithCancellation(ct).ConfigureAwait(false);
-#endif
-            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct).ConfigureAwait(false);
-            if (doc.RootElement.TryGetProperty("success", out var success) && success.ValueKind == JsonValueKind.False) {
-                return null;
-            }
-            var country = doc.RootElement.TryGetProperty("country", out var cElem) ? cElem.GetString() : null;
-            var city = doc.RootElement.TryGetProperty("city", out var cityElem) ? cityElem.GetString() : null;
-            return new GeoLocationInfo { Country = country, City = city };
+            return Task.FromResult(GeoIp.Lookup(ip));
         }
 
         /// <summary>

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -19,6 +19,7 @@
         <EmbeddedResource Include="..\Data\dnsbl.json" />
         <EmbeddedResource Include="..\Data\DNS\PublicDNS.json"
             LogicalName="DomainDetective.DNS.PublicDNS.json" />
+        <EmbeddedResource Include="..\Data\geoip.csv" />
         <AdditionalFiles Include="..\Data\DNS\PublicDNS.json" />
     </ItemGroup>
 

--- a/DomainDetective/GeoIpAnalysis.cs
+++ b/DomainDetective/GeoIpAnalysis.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Provides geolocation information using a local IP database.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public sealed class GeoIpAnalysis {
+    private readonly Dictionary<string, GeoLocationInfo> _entries = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Loads entries from a CSV file.</summary>
+    /// <param name="filePath">Path to the CSV file.</param>
+    /// <param name="clearExisting">When true the current database is cleared.</param>
+    public void LoadDatabase(string filePath, bool clearExisting = true) {
+        if (string.IsNullOrWhiteSpace(filePath)) {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+        using var stream = File.OpenRead(filePath);
+        LoadFromStream(stream, clearExisting);
+    }
+
+    /// <summary>Loads entries from the embedded database.</summary>
+    /// <param name="clearExisting">When true the current database is cleared.</param>
+    public void LoadBuiltinDatabase(bool clearExisting = true) {
+        using var stream = typeof(GeoIpAnalysis).Assembly.GetManifestResourceStream("DomainDetective.geoip.csv");
+        if (stream != null) {
+            LoadFromStream(stream, clearExisting);
+        }
+    }
+
+    private void LoadFromStream(Stream stream, bool clearExisting) {
+        if (clearExisting) {
+            _entries.Clear();
+        }
+        using var reader = new StreamReader(stream);
+        string? line;
+        bool first = true;
+        while ((line = reader.ReadLine()) != null) {
+            if (first) {
+                first = false;
+                continue;
+            }
+            if (string.IsNullOrWhiteSpace(line)) {
+                continue;
+            }
+            var parts = line.Split(new[] { ',' }, 3);
+            if (parts.Length < 3) {
+                continue;
+            }
+            var ip = parts[0].Trim();
+            var country = parts[1].Trim();
+            var region = parts[2].Trim();
+            _entries[ip] = new GeoLocationInfo { Country = country, Region = region };
+        }
+    }
+
+    /// <summary>Looks up geolocation information for an IP address.</summary>
+    /// <param name="ip">IP address to query.</param>
+    /// <returns>Geolocation info or null if not found.</returns>
+    public GeoLocationInfo? Lookup(string ip) => _entries.TryGetValue(ip, out var info) ? info : null;
+
+    /// <summary>Asynchronously looks up geolocation information.</summary>
+    /// <param name="ip">IP address to query.</param>
+    /// <param name="ct">Cancellation token.</param>
+    public Task<GeoLocationInfo?> LookupAsync(string ip, CancellationToken ct = default) => Task.FromResult(Lookup(ip));
+}

--- a/DomainDetective/GeoLocationInfo.cs
+++ b/DomainDetective/GeoLocationInfo.cs
@@ -8,6 +8,6 @@ public sealed class GeoLocationInfo {
     /// <summary>Country where the IP is located.</summary>
     public string? Country { get; init; }
 
-    /// <summary>City where the IP is located.</summary>
-    public string? City { get; init; }
+    /// <summary>Region where the IP is located.</summary>
+    public string? Region { get; init; }
 }


### PR DESCRIPTION
## Summary
- add GeoIpAnalysis using embedded CSV
- output region in GeoLocationInfo
- integrate geolocation into DnsPropagationAnalysis
- update CLI to show region
- add GeoIp example and tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build --filter "FullyQualifiedName~TestGeo"`

------
https://chatgpt.com/codex/tasks/task_e_6872d520e4c8832eb39a612191a3c229