### PR TITLE
Add DomainHelper.ValidateIdn utility

### DIFF
--- a/DomainDetective.CLI/CliHelpers.cs
+++ b/DomainDetective.CLI/CliHelpers.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Linq;
 using System.Text;
 using System.Globalization;
+using DomainDetective.Helpers;
 
 namespace DomainDetective.CLI;
 
@@ -42,7 +43,7 @@ internal static class CliHelpers
 
         try
         {
-            return _idn.GetAscii(domain.Trim().Trim('.'));
+            return DomainHelper.ValidateIdn(domain);
         }
         catch (ArgumentException)
         {

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using DomainDetective;
+using DomainDetective.Helpers;
 
 namespace DomainDetective.Example;
 
@@ -11,9 +12,8 @@ public static partial class Program {
         if (args.Length > 0 && args.Any(a => !a.StartsWith("-"))) {
             var outputJson = args.Contains("--json");
             var domain = args.First(a => !a.StartsWith("-"));
-            var idn = new IdnMapping();
             try {
-                domain = idn.GetAscii(domain.Trim().Trim('.'));
+                domain = DomainHelper.ValidateIdn(domain);
             } catch (ArgumentException) {
             }
             var healthCheck = new DomainHealthCheck();

--- a/DomainDetective.PowerShell/CmdletTestDmarcAggregate.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcAggregate.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Globalization;
+using DomainDetective.Helpers;
 using System.Management.Automation;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -17,7 +18,6 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DmarcAggregate")]
     public sealed class CmdletTestDmarcAggregate : AsyncPSCmdlet {
-        private static readonly IdnMapping _idn = new();
         /// <param name="Path">Path to the aggregate report.</param>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
@@ -48,7 +48,7 @@ namespace DomainDetective.PowerShell {
                     continue;
                 }
                 try {
-                    domain = _idn.GetAscii(domain.Trim().Trim('.'));
+                    domain = DomainHelper.ValidateIdn(domain);
                 } catch (ArgumentException) {
                     continue;
                 }

--- a/DomainDetective.Reports/DmarcReportParser.cs
+++ b/DomainDetective.Reports/DmarcReportParser.cs
@@ -5,12 +5,12 @@ using System.IO.Compression;
 using System.Linq;
 using System.Xml.Linq;
 using System.Globalization;
+using DomainDetective.Helpers;
 
 namespace DomainDetective.Reports;
 
 /// <summary>Parser for zipped DMARC feedback reports.</summary>
 public static class DmarcReportParser {
-    private static readonly IdnMapping _idn = new();
     /// <summary>Parses the specified zip file and returns per-domain statistics.</summary>
     /// <param name="path">Path to the zipped XML feedback report.</param>
     public static IEnumerable<DmarcFeedbackSummary> ParseZip(string path) {
@@ -29,7 +29,7 @@ public static class DmarcReportParser {
                 continue;
             }
             try {
-                domain = _idn.GetAscii(domain.Trim().Trim('.'));
+                domain = DomainHelper.ValidateIdn(domain);
             } catch (ArgumentException) {
                 continue;
             }

--- a/DomainDetective.Reports/DomainDetective.Reports.csproj
+++ b/DomainDetective.Reports/DomainDetective.Reports.csproj
@@ -7,4 +7,7 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
+  </ItemGroup>
 </Project>

--- a/DomainDetective.Tests/TestDomainHelper.cs
+++ b/DomainDetective.Tests/TestDomainHelper.cs
@@ -1,0 +1,27 @@
+using DomainDetective.Helpers;
+using System;
+
+namespace DomainDetective.Tests;
+
+public class TestDomainHelper
+{
+    [Fact]
+    public void ValidateIdnConvertsUnicode()
+    {
+        var result = DomainHelper.ValidateIdn("bücher.de");
+        Assert.Equal("xn--bcher-kva.de", result);
+    }
+
+    [Fact]
+    public void ValidateIdnTrimsWhitespace()
+    {
+        var result = DomainHelper.ValidateIdn("  bücher.de.  ");
+        Assert.Equal("xn--bcher-kva.de", result);
+    }
+
+    [Fact]
+    public void ValidateIdnNullThrows()
+    {
+        Assert.Throws<ArgumentNullException>(() => DomainHelper.ValidateIdn(null!));
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Linq.Expressions;
 using System.Globalization;
 using DomainDetective.Network;
+using DomainDetective.Helpers;
 
 namespace DomainDetective {
     /// <summary>
@@ -17,11 +18,10 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public partial class DomainHealthCheck {
-        private static readonly IdnMapping _idn = new();
 
         private static string NormalizeDomain(string input)
         {
-            return _idn.GetAscii(input.Trim().Trim('.')).ToLowerInvariant();
+            return DomainHelper.ValidateIdn(input).ToLowerInvariant();
         }
 
         private static string CreateServiceQuery(int port, string domain) {
@@ -56,7 +56,7 @@ namespace DomainDetective {
                 host = uri.Host;
             } else {
                 try {
-                    host = _idn.GetAscii(domainName.Trim().Trim('.'));
+                    host = DomainHelper.ValidateIdn(domainName);
                 } catch (ArgumentException) {
                 }
             }
@@ -1361,7 +1361,7 @@ namespace DomainDetective {
                 }
 
                 try {
-                    host = _idn.GetAscii(host.Trim().Trim('.'));
+                    host = DomainHelper.ValidateIdn(host);
                 } catch (ArgumentException) {
                     throw new ArgumentException("Invalid host name.", nameof(domainName));
                 }

--- a/DomainDetective/Helpers/DomainHelper.cs
+++ b/DomainDetective/Helpers/DomainHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Globalization;
+
+namespace DomainDetective.Helpers
+{
+    public static class DomainHelper
+    {
+        private static readonly IdnMapping _idn = new();
+
+        public static string ValidateIdn(string domain)
+        {
+            if (string.IsNullOrWhiteSpace(domain))
+            {
+                throw new ArgumentNullException(nameof(domain));
+            }
+
+            try
+            {
+                return _idn.GetAscii(domain.Trim().Trim('.'));
+            }
+            catch (ArgumentException e)
+            {
+                throw new ArgumentException("Invalid domain name.", nameof(domain), e);
+            }
+        }
+    }
+}

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Globalization;
 using System.Text.Json;
+using DomainDetective.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -20,7 +21,6 @@ namespace DomainDetective;
 /// <para>Part of the DomainDetective project.</para>
 public class WhoisAnalysis {
     private string TLD { get; set; }
-    private static readonly IdnMapping _idn = new();
     private string _domainName;
 
     /// <summary>The domain name being queried.</summary>
@@ -28,7 +28,7 @@ public class WhoisAnalysis {
         get => _domainName;
         set {
             try {
-                _domainName = _idn.GetAscii(value.Trim().Trim('.'));
+                _domainName = DomainHelper.ValidateIdn(value);
             } catch (ArgumentException) {
                 _domainName = value;
             }

--- a/DomainDetective/PublicSuffixList.cs
+++ b/DomainDetective/PublicSuffixList.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DomainDetective.Helpers;
 
 namespace DomainDetective {
     /// <summary>
@@ -14,7 +15,6 @@ namespace DomainDetective {
         private readonly HashSet<string> _exactRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _wildcardRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _exceptionRules = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        private static readonly IdnMapping _idn = new();
         private const int MaxLabelLength = 63;
 
         internal PublicSuffixList() { }
@@ -76,7 +76,7 @@ namespace DomainDetective {
                 return false;
             }
 
-            domain = _idn.GetAscii(domain.Trim().Trim('.'));
+            domain = DomainHelper.ValidateIdn(domain);
             ValidateLabels(domain);
             domain = domain.ToLowerInvariant();
             if (_exceptionRules.Contains(domain)) {
@@ -107,7 +107,7 @@ namespace DomainDetective {
                 throw new ArgumentNullException(nameof(domain));
             }
 
-            var clean = _idn.GetAscii(domain.Trim().Trim('.')).ToLowerInvariant();
+            var clean = DomainHelper.ValidateIdn(domain).ToLowerInvariant();
             var parts = clean.Split('.');
             if (parts.Length <= 1) {
                 return clean;


### PR DESCRIPTION
## Summary
- add DomainHelper with ValidateIdn
- convert various components to use DomainHelper.ValidateIdn
- reference DomainDetective from Reports project
- test DomainHelper behavior

## Testing
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6872d538d5b8832eb6b079aa4eb64c20