### PR TITLE
Implement async PublishRecord

### DIFF
--- a/DomainDetective.PowerShell/CmdletNewDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletNewDmarcRecord.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Management.Automation;
 using System.Net.Http;
+using System.Threading.Tasks;
 using DomainDetective;
 using Spectre.Console;
 
@@ -109,11 +110,11 @@ namespace DomainDetective.PowerShell {
             WriteObject(record);
             AnsiConsole.MarkupLine($"[green]{Markup.Escape(record)}[/]");
             if (Publish) {
-                PublishRecord(record);
+                PublishRecord(record).GetAwaiter().GetResult();
             }
         }
 
-        private void PublishRecord(string record) {
+        private async Task PublishRecord(string record) {
             if (DnsApiUrl == null || string.IsNullOrWhiteSpace(DomainName)) {
                 WriteWarning("DnsApiUrl and DomainName are required for publishing.");
                 return;
@@ -124,7 +125,8 @@ namespace DomainDetective.PowerShell {
                     ["domain"] = DomainName,
                     ["record"] = record
                 };
-                var response = client.PostAsync(DnsApiUrl, new FormUrlEncodedContent(data)).GetAwaiter().GetResult();
+                using var content = new FormUrlEncodedContent(data);
+                var response = await client.PostAsync(DnsApiUrl, content);
                 if (!response.IsSuccessStatusCode) {
                     WriteWarning($"Publish failed: {response.StatusCode}");
                 }

--- a/DomainDetective.Tests/TestCmdletNewDmarcRecord.cs
+++ b/DomainDetective.Tests/TestCmdletNewDmarcRecord.cs
@@ -1,0 +1,43 @@
+using DomainDetective.PowerShell;
+using Pwsh = System.Management.Automation.PowerShell;
+using System.IO;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestCmdletNewDmarcRecord {
+    [Fact]
+    public async Task PublishesRecordViaDnsApi() {
+        using var listener = new HttpListener();
+        int port = PortHelper.GetFreePort();
+        string prefix = $"http://localhost:{port}/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        var requestTask = Task.Run(async () => {
+            var ctx = await listener.GetContextAsync();
+            using var reader = new StreamReader(ctx.Request.InputStream);
+            string body = await reader.ReadToEndAsync();
+            ctx.Response.StatusCode = 200;
+            ctx.Response.Close();
+            return body;
+        });
+
+        using var ps = Pwsh.Create();
+        ps.AddCommand("Import-Module").AddArgument(typeof(CmdletNewDmarcRecord).Assembly.Location).Invoke();
+        ps.Commands.Clear();
+        ps.AddCommand("New-DmarcRecord")
+            .AddParameter("Policy", "reject")
+            .AddParameter("DomainName", "example.com")
+            .AddParameter("DnsApiUrl", new Uri(prefix))
+            .AddParameter("Publish");
+        var results = ps.Invoke();
+        string body = await requestTask;
+        listener.Stop();
+
+        Assert.Empty(ps.Streams.Error);
+        Assert.Single(results);
+        Assert.Contains("domain=example.com", body);
+        Assert.Contains("record=v%3DDMARC1%3B+p%3Dreject%3B", body);
+    }
+}


### PR DESCRIPTION
## Summary
- make `PublishRecord` async
- update `New-DmarcRecord` to wait for async publish
- test DMARC record publishing via HTTP

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --filter FullyQualifiedName~TestCmdletNewDmarcRecord`

------
https://chatgpt.com/codex/tasks/task_e_6874116a4b68832ea627bb5b5a34c94e