### PR TITLE
Fix MXAnalysis record ordering

### DIFF
--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -98,7 +98,13 @@ namespace DomainDetective {
                 HasBackupServers = preferences.Distinct().Count() > 1;
             }
 
-            foreach (var (_, host) in parsed) {
+            var evaluationList = parsed
+                .GroupBy(p => p.Host, StringComparer.OrdinalIgnoreCase)
+                .Select(g => (Preference: g.Min(x => x.Preference), Host: g.Key))
+                .OrderBy(p => p.Preference)
+                .ToList();
+
+            foreach (var (_, host) in evaluationList) {
                 var cnameResults = await QueryDns(host, DnsRecordType.CNAME);
                 PointsToCname = PointsToCname || (cnameResults != null && cnameResults.Any());
 


### PR DESCRIPTION
## Summary
- ensure MX records are evaluated in ascending order without duplicates
- verify unique ordered evaluation in MXAnalysis tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6874123689b8832ea3ffcfbbff1b972b