### PR TITLE
Fix XML check for trust anchor download

### DIFF
--- a/DomainDetective.Tests/TestDownloadTrustAnchors.cs
+++ b/DomainDetective.Tests/TestDownloadTrustAnchors.cs
@@ -1,5 +1,8 @@
+using System;
+using System.IO;
 using System.Threading.Tasks;
 using DomainDetective;
+using Xunit;
 
 namespace DomainDetective.Tests {
     public class TestDownloadTrustAnchors {
@@ -7,6 +10,22 @@ namespace DomainDetective.Tests {
         public async Task FetchesAnchors() {
             var anchors = await DnsSecAnalysis.DownloadTrustAnchors();
             Assert.NotEmpty(anchors);
+        }
+
+        [Fact]
+        public async Task MalformedXmlReturnsEmpty() {
+            string cacheDir = Path.Combine(Path.GetTempPath(), "DomainDetective");
+            string cacheFile = Path.Combine(cacheDir, "root-anchors.xml");
+            Directory.CreateDirectory(cacheDir);
+            File.WriteAllText(cacheFile, "<trustanchors><bad></trust>");
+            File.SetLastWriteTimeUtc(cacheFile, DateTime.UtcNow);
+
+            try {
+                var anchors = await DnsSecAnalysis.DownloadTrustAnchors();
+                Assert.Empty(anchors);
+            } finally {
+                File.Delete(cacheFile);
+            }
         }
     }
 }

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -10,6 +10,7 @@ using System.Text.Json;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Xml.Linq;
+using System.Xml;
 
 namespace DomainDetective {
     /// <summary>
@@ -477,6 +478,10 @@ namespace DomainDetective {
         }
 
         private static IReadOnlyList<string> ParseTrustAnchors(string xml) {
+            if (string.IsNullOrWhiteSpace(xml) || !IsXmlWellFormed(xml)) {
+                return Array.Empty<string>();
+            }
+
             try {
                 var doc = XDocument.Parse(xml);
                 List<string> anchors = new();
@@ -492,6 +497,18 @@ namespace DomainDetective {
                 return anchors;
             } catch {
                 return Array.Empty<string>();
+            }
+        }
+
+        private static bool IsXmlWellFormed(string xml) {
+            try {
+                using var reader = XmlReader.Create(new StringReader(xml));
+                while (reader.Read()) {
+                    // Just read through to validate well-formedness
+                }
+                return true;
+            } catch {
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary
- guard against empty or malformed trust anchor XML before parsing
- add test to ensure malformed XML returns empty list

## Testing
- `dotnet test -c Release` *(fails: 15, passed: 567, skipped: 0)*

------
https://chatgpt.com/codex/tasks/task_e_6874117af9b4832e835000eccdcec182