### PR TITLE
Enforce BIMI logo size limit

### DIFF
--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -124,6 +124,7 @@ namespace DomainDetective.Tests {
 
                 Assert.True(analysis.SvgFetched);
                 Assert.False(analysis.SvgValid);
+                Assert.Equal("Root element is not 'svg'", analysis.SvgInvalidReason);
             } finally {
                 cts.Cancel();
                 listener.Stop();
@@ -177,6 +178,7 @@ namespace DomainDetective.Tests {
 
                 Assert.True(analysis.SvgFetched);
                 Assert.False(analysis.SvgValid);
+                Assert.Equal("Malformed SVG", analysis.SvgInvalidReason);
             } finally {
                 cts.Cancel();
                 listener.Stop();
@@ -235,6 +237,8 @@ namespace DomainDetective.Tests {
 
                 Assert.True(analysis.SvgFetched);
                 Assert.False(analysis.SvgSizeValid);
+                Assert.False(analysis.SvgValid);
+                Assert.Contains("32 KB", analysis.SvgInvalidReason);
                 Assert.Contains(warnings, w => w.FullMessage.Contains("exceeds"));
             } finally {
                 cts.Cancel();


### PR DESCRIPTION
## Summary
- expose `SvgInvalidReason` to explain invalid BIMI indicators
- record oversize, malformed and non-SVG reasons in `ValidateSvg`
- update tests to assert invalid reasons

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~TestBimiAnalysis --verbosity minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: many unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_6874124648a8832e90e5a59bff68b588