### PR TITLE
Add CNAME takeover scan

### DIFF
--- a/DomainDetective.CLI.Tests/TestCheckDomainSettings.cs
+++ b/DomainDetective.CLI.Tests/TestCheckDomainSettings.cs
@@ -1,0 +1,13 @@
+using DomainDetective.CLI;
+
+namespace DomainDetective.CLI.Tests;
+
+public class TestCheckDomainSettings
+{
+    [Fact]
+    public void DefaultTakeoverOptionFalse()
+    {
+        var settings = new CheckDomainSettings();
+        Assert.False(settings.CheckTakeover);
+    }
+}

--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -24,6 +24,10 @@ internal sealed class CheckDomainSettings : CommandSettings {
     [CommandOption("--check-http")]
     public bool CheckHttp { get; set; }
 
+    /// <summary>Check for takeover vulnerable CNAMEs.</summary>
+    [CommandOption("--check-takeover")]
+    public bool CheckTakeover { get; set; }
+
     /// <summary>Show condensed summary instead of full results.</summary>
     [CommandOption("--summary")]
     public bool Summary { get; set; }
@@ -115,6 +119,7 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
             settings.Domains,
             selected.Count > 0 ? selected.ToArray() : null,
             settings.CheckHttp,
+            settings.CheckTakeover,
             settings.Json,
             settings.Summary,
             settings.SubdomainPolicy,

--- a/DomainDetective.Example/ExampleAnalyseTakeover.cs
+++ b/DomainDetective.Example/ExampleAnalyseTakeover.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Example demonstrating CNAME takeover risk analysis.
+    /// </summary>
+    public static async Task ExampleAnalyseTakeover()
+    {
+        var healthCheck = new DomainHealthCheck { Verbose = false };
+        await healthCheck.VerifyTakeoverCname("example.com");
+        Helpers.ShowPropertiesTable("Takeover risk for example.com", healthCheck.TakeoverCnameAnalysis);
+    }
+}

--- a/DomainDetective.Tests/TestTakeoverCnameAnalysis.cs
+++ b/DomainDetective.Tests/TestTakeoverCnameAnalysis.cs
@@ -1,0 +1,53 @@
+using DnsClientX;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestTakeoverCnameAnalysis
+{
+    private static TakeoverCnameAnalysis Create(string cname)
+    {
+        return new TakeoverCnameAnalysis
+        {
+            QueryDnsOverride = (name, type) =>
+            {
+                if (type == DnsRecordType.CNAME)
+                {
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = cname } });
+                }
+                return Task.FromResult(Array.Empty<DnsAnswer>());
+            }
+        };
+    }
+
+    [Fact]
+    public async Task DetectsTakeoverRisk()
+    {
+        var analysis = Create("alias.azurewebsites.net");
+        await analysis.Analyze("example.com", new InternalLogger());
+        Assert.True(analysis.IsTakeoverRisk);
+    }
+
+    [Fact]
+    public async Task IgnoresSafeCname()
+    {
+        var analysis = Create("alias.example.net");
+        await analysis.Analyze("example.com", new InternalLogger());
+        Assert.False(analysis.IsTakeoverRisk);
+    }
+
+    [Fact]
+    public async Task HonorsCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        var analysis = new TakeoverCnameAnalysis
+        {
+            QueryDnsOverride = (name, type) => Task.Delay(Timeout.Infinite, cts.Token).ContinueWith(_ => Array.Empty<DnsAnswer>(), cts.Token)
+        };
+
+        var task = analysis.Analyze("example.com", new InternalLogger(), cts.Token);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => task);
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -988,6 +988,15 @@ namespace DomainDetective {
             await DanglingCnameAnalysis.Analyze(domainName, _logger, cancellationToken);
         }
 
+        /// <summary>
+        /// Checks for CNAMEs pointing to takeover prone providers.
+        /// </summary>
+        public async Task VerifyTakeoverCname(string domainName, CancellationToken cancellationToken = default) {
+            domainName = NormalizeDomain(domainName);
+            TakeoverCnameAnalysis = new TakeoverCnameAnalysis { DnsConfiguration = DnsConfiguration };
+            await TakeoverCnameAnalysis.Analyze(domainName, _logger, cancellationToken);
+        }
+
         /// Queries Autodiscover related records for a domain.
         /// </summary>
         /// <param name="domainName">Domain to verify.</param>

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -319,6 +319,12 @@ namespace DomainDetective {
         /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
         public FlatteningServiceAnalysis FLATTENINGSERVICEAnalysis => FlatteningServiceAnalysis;
 
+        /// <summary>Gets the takeover CNAME analysis.</summary>
+        /// <value>Information about risky cloud provider aliases.</value>
+        public TakeoverCnameAnalysis TakeoverCnameAnalysis { get; private set; } = new TakeoverCnameAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public TakeoverCnameAnalysis TAKEOVERCNAMEAnalysis => TakeoverCnameAnalysis;
+
         // Settings properties moved to DomainHealthCheck.Settings.cs
 
         /// <summary>
@@ -398,6 +404,7 @@ namespace DomainDetective {
             WildcardDnsAnalysis.DnsConfiguration = DnsConfiguration;
             EdnsSupportAnalysis.DnsConfiguration = DnsConfiguration;
             FlatteningServiceAnalysis.DnsConfiguration = DnsConfiguration;
+            TakeoverCnameAnalysis.DnsConfiguration = DnsConfiguration;
 
             _logger.WriteVerbose("DomainHealthCheck initialized.");
             _logger.WriteVerbose("DnsEndpoint: {0}", DnsEndpoint);

--- a/DomainDetective/Protocols/TakeoverCnameAnalysis.cs
+++ b/DomainDetective/Protocols/TakeoverCnameAnalysis.cs
@@ -1,0 +1,73 @@
+using DnsClientX;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Detects CNAME records pointing to cloud providers prone to subdomain takeover.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class TakeoverCnameAnalysis
+{
+    /// <summary>DNS configuration for lookups.</summary>
+    public DnsConfiguration DnsConfiguration { get; set; } = new();
+    /// <summary>Override DNS query logic.</summary>
+    public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+    /// <summary>Indicates whether a CNAME record exists.</summary>
+    public bool CnameRecordExists { get; private set; }
+    /// <summary>CNAME target if found.</summary>
+    public string? Target { get; private set; }
+    /// <summary>True when the CNAME points to a known takeover risk provider.</summary>
+    public bool IsTakeoverRisk { get; private set; }
+
+    private static readonly string[] _providerDomains = new[]
+    {
+        "azurewebsites.net",
+        "cloudfront.net",
+        "herokudns.com",
+        "github.io",
+        "amazonaws.com"
+    };
+
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
+    {
+        if (QueryDnsOverride != null)
+        {
+            return await QueryDnsOverride(name, type);
+        }
+
+        return await DnsConfiguration.QueryDNS(name, type);
+    }
+
+    /// <summary>
+    /// Queries the domain CNAME and determines if it belongs to a risky provider.
+    /// </summary>
+    public async Task Analyze(string domainName, InternalLogger logger, CancellationToken ct = default)
+    {
+        CnameRecordExists = false;
+        Target = null;
+        IsTakeoverRisk = false;
+        ct.ThrowIfCancellationRequested();
+
+        var cname = await QueryDns(domainName, DnsRecordType.CNAME);
+        if (cname == null || cname.Length == 0)
+        {
+            logger?.WriteVerbose("No CNAME record found.");
+            return;
+        }
+
+        Target = cname[0].Data.TrimEnd('.');
+        CnameRecordExists = true;
+        logger?.WriteVerbose("CNAME target {0}", Target);
+
+        IsTakeoverRisk = _providerDomains.Any(d => Target.EndsWith(d, StringComparison.OrdinalIgnoreCase));
+        if (IsTakeoverRisk)
+        {
+            logger?.WriteWarning("CNAME target {0} is hosted on a takeover prone provider", Target);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `TakeoverCnameAnalysis` for scanning risky cloud CNAMEs
- hook takeover check into `DomainHealthCheck` and CLI
- expose `--check-takeover` option in `check` command
- add example usage and unit tests

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Assert failures)*

------
https://chatgpt.com/codex/tasks/task_e_68741213dfc0832e88deedb6a74186af