### PR TITLE
Add Spamhaus block list modules

### DIFF
--- a/Data/dnsbl.json
+++ b/Data/dnsbl.json
@@ -641,5 +641,19 @@
             "Enabled": true,
             "Comment": null
         }
+    ],
+    "ipBlockLists": [
+        {
+            "Name": "spamhaus-drop",
+            "Url": "https://www.spamhaus.org/drop/drop.txt",
+            "Enabled": true,
+            "Comment": null
+        },
+        {
+            "Name": "spamhaus-edrop",
+            "Url": "https://www.spamhaus.org/drop/edrop.txt",
+            "Enabled": true,
+            "Comment": null
+        }
     ]
 }

--- a/DomainDetective.Tests/TestDNSBLConfig.cs
+++ b/DomainDetective.Tests/TestDNSBLConfig.cs
@@ -85,4 +85,24 @@ namespace DomainDetective.Tests {
                 File.Delete(file);
             }
         }
+
+        [Fact]
+        public void LoadsIpBlockLists() {
+            var json = "{\"ipBlockLists\":[{\"name\":\"drop\",\"url\":\"http://example.com/drop.txt\"}]}";
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, json);
+
+                var analysis = new DNSBLAnalysis();
+                analysis.LoadDnsblConfig(file, clearExisting: true);
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+
+                var entry = Assert.Single(analysis.GetIpBlockLists());
+                Assert.Equal("drop", entry.Name);
+                Assert.Equal("http://example.com/drop.txt", entry.Url);
+            }
+            finally {
+                File.Delete(file);
+            }
+        }
     }}

--- a/DomainDetective.Tests/TestIpBlockList.cs
+++ b/DomainDetective.Tests/TestIpBlockList.cs
@@ -1,0 +1,25 @@
+using System.Net;
+using System.Net.Http;
+using RichardSzalay.MockHttp;
+
+namespace DomainDetective.Tests {
+    public class TestIpBlockList {
+        [Fact]
+        public async Task UpdateParsesRanges() {
+            var analysis = new IpBlockListAnalysis();
+            analysis.Entries.Add(new BlockListEntry {
+                Name = "test",
+                Url = "http://example.com/list.txt"
+            });
+
+            var handler = new MockHttpMessageHandler();
+            handler.When("http://example.com/list.txt").Respond("text/plain", "1.2.3.0/24\n1.2.4.5/32");
+            using var client = handler.ToHttpClient();
+
+            await analysis.UpdateAsync(client: client);
+
+            Assert.Contains("test", analysis.ListsContaining(IPAddress.Parse("1.2.3.4")));
+            Assert.Contains("test", analysis.ListsContaining(IPAddress.Parse("1.2.4.5")));
+        }
+    }
+}

--- a/DomainDetective/BlockListEntry.cs
+++ b/DomainDetective/BlockListEntry.cs
@@ -1,0 +1,15 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Represents an HTTP based IP block list source.
+/// </summary>
+public class BlockListEntry {
+    /// <summary>Gets or sets the list name.</summary>
+    public string Name { get; set; }
+    /// <summary>Gets or sets the source URL.</summary>
+    public string Url { get; set; }
+    /// <summary>Gets or sets whether the list is queried.</summary>
+    public bool Enabled { get; set; } = true;
+    /// <summary>Gets or sets optional descriptive text.</summary>
+    public string Comment { get; set; }
+}

--- a/DomainDetective/DnsblConfiguration.cs
+++ b/DomainDetective/DnsblConfiguration.cs
@@ -11,5 +11,8 @@ using System.Collections.Generic;
 
         /// <summary>Gets or sets domain based block lists.</summary>
         public List<DnsblEntry> DomainBlockLists { get; set; } = new();
+
+        /// <summary>Gets or sets IP based block lists.</summary>
+        public List<BlockListEntry> IpBlockLists { get; set; } = new();
     }
 }

--- a/DomainDetective/IpCidrRange.cs
+++ b/DomainDetective/IpCidrRange.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Represents an IP network in CIDR notation.
+/// </summary>
+public readonly struct IpCidrRange {
+    /// <summary>Base network address.</summary>
+    public IPAddress Network { get; }
+    /// <summary>Prefix length.</summary>
+    public int PrefixLength { get; }
+
+    public IpCidrRange(IPAddress network, int prefixLength) {
+        Network = network;
+        PrefixLength = prefixLength;
+    }
+
+    /// <summary>Checks if the range contains the specified address.</summary>
+    public bool Contains(IPAddress address) {
+        if (address.AddressFamily != Network.AddressFamily)
+            return false;
+        var addressBytes = address.GetAddressBytes();
+        var networkBytes = Network.GetAddressBytes();
+        var fullBytes = PrefixLength / 8;
+        var remainingBits = PrefixLength % 8;
+        for (int i = 0; i < fullBytes; i++) {
+            if (addressBytes[i] != networkBytes[i])
+                return false;
+        }
+        if (remainingBits == 0)
+            return true;
+        int mask = 0xFF << (8 - remainingBits);
+        return (addressBytes[fullBytes] & mask) == (networkBytes[fullBytes] & mask);
+    }
+
+    /// <summary>Parses a CIDR string.</summary>
+    public static bool TryParse(string text, out IpCidrRange range) {
+        range = default;
+        if (string.IsNullOrWhiteSpace(text))
+            return false;
+        var parts = text.Split('/');
+        if (parts.Length != 2)
+            return false;
+        if (!IPAddress.TryParse(parts[0], out var addr))
+            return false;
+        if (!int.TryParse(parts[1], out var prefix))
+            return false;
+        range = new IpCidrRange(addr, prefix);
+        return true;
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.BlockList.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.BlockList.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Provides IP based block list functionality.
+/// </summary>
+public partial class DNSBLAnalysis {
+    internal IpBlockListAnalysis BlockLists { get; } = new();
+
+    /// <summary>Returns configured IP block lists.</summary>
+    public IReadOnlyList<BlockListEntry> GetIpBlockLists() => BlockLists.Entries.AsReadOnly();
+
+    /// <summary>Determines which lists contain the address.</summary>
+    public IEnumerable<string> QueryIpBlockLists(IPAddress address) => BlockLists.ListsContaining(address);
+}

--- a/DomainDetective/Protocols/IpBlockListAnalysis.cs
+++ b/DomainDetective/Protocols/IpBlockListAnalysis.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace DomainDetective;
 
@@ -37,6 +39,15 @@ public class IpBlockListAnalysis {
             if (IpCidrRange.TryParse(token, out var range)) {
                 ranges.Add(range);
             }
+        }
+    }
+
+    /// <summary>Downloads and parses all enabled lists.</summary>
+    public async Task UpdateAsync(bool overwriteExisting = true, HttpClient? client = null) {
+        client ??= SharedHttpClient.Instance;
+        foreach (var entry in Entries.Where(e => e.Enabled && !string.IsNullOrEmpty(e.Url))) {
+            var content = await client.GetStringAsync(entry.Url);
+            LoadFromString(entry.Name, content, overwriteExisting);
         }
     }
 }

--- a/DomainDetective/Protocols/IpBlockListAnalysis.cs
+++ b/DomainDetective/Protocols/IpBlockListAnalysis.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Loads and evaluates IP block lists from text sources.
+/// </summary>
+public class IpBlockListAnalysis {
+    private readonly Dictionary<string, List<IpCidrRange>> _lists = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>Configured block list entries.</summary>
+    public List<BlockListEntry> Entries { get; } = new();
+
+    /// <summary>Gets the names of lists containing the address.</summary>
+    public IEnumerable<string> ListsContaining(IPAddress address) {
+        foreach (var pair in _lists) {
+            if (pair.Value.Any(r => r.Contains(address))) {
+                yield return pair.Key;
+            }
+        }
+    }
+
+    /// <summary>Adds ranges from plain text.</summary>
+    public void LoadFromString(string name, string content, bool clearExisting = true) {
+        if (clearExisting || !_lists.TryGetValue(name, out var ranges)) {
+            ranges = new List<IpCidrRange>();
+            _lists[name] = ranges;
+        }
+        foreach (var line in content.Split('\n')) {
+            var trimmed = line.Trim();
+            if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("#") || trimmed.StartsWith(";"))
+                continue;
+            var token = trimmed.Split(new[] { ' ', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries)[0];
+            if (IpCidrRange.TryParse(token, out var range)) {
+                ranges.Add(range);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extend DNSBL configuration for IP-based block lists
- add Spamhaus DROP/EDROP lists to built-in configuration
- implement `IpBlockListAnalysis` and related helpers
- load IP block lists in `DNSBLAnalysis`
- cover configuration updates with unit tests

## Testing
- `dotnet test --filter TestDnsblConfig`

------
https://chatgpt.com/codex/tasks/task_e_68741203458c832e8ab3a3d16c5fd28c