### PR TITLE
Fix EDNS TCP retry test

### DIFF
--- a/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
+++ b/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
@@ -67,9 +67,14 @@ public class TestEdnsSupportAnalysis
     [Fact]
     public async Task RetriesOverTcpWhenTruncated()
     {
-        var udpServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
-        var port = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+        var port = PortHelper.GetFreePort();
+        using var udpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+        udpSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+        udpSocket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+        var udpServer = new UdpClient { Client = udpSocket };
+
         var tcpListener = new TcpListener(IPAddress.Loopback, port);
+        tcpListener.Server.ExclusiveAddressUse = false;
         tcpListener.Start();
 
         var udpTask = Task.Run(async () =>


### PR DESCRIPTION
## Summary
- stabilize RetriesOverTcpWhenTruncated test by allocating a free port and setting socket options

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "FullyQualifiedName~DomainDetective.Tests.TestEdnsSupportAnalysis" --verbosity minimal`
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6874c783a854832e9bf3e3d011a6d57a