### PR TITLE
Add XML docs for PowerShell cmdlets

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -28,6 +28,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -36,6 +38,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DMARC record for domain: {0}", DomainName);
             await healthCheck.VerifyDMARC(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -72,6 +72,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DnsPropagationAnalysis _analysis;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -93,6 +95,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             IEnumerable<PublicDnsEntry> servers;
             if (CountryCount != null && CountryCount.Count > 0) {

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -29,6 +29,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -37,6 +39,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DNSSEC for domain: {0}", DomainName);
             await healthCheck.VerifyDNSSEC(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying TTL for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.TTL });

--- a/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
@@ -23,6 +23,8 @@ namespace DomainDetective.PowerShell {
 
         private DomainHealthCheck _hc = new();
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             if (!File.Exists(Path)) {
                 WriteError(new ErrorRecord(new FileNotFoundException("File not found", Path), "NotFound", ErrorCategory.InvalidArgument, Path));

--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -40,6 +40,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -55,6 +57,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying domain health for domain: {0}", DomainName);
             await _healthCheck.Verify(DomainName, HealthCheckType, DkimSelectors, DaneServiceType, DanePorts);

--- a/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
+++ b/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
@@ -26,6 +26,8 @@ public sealed class CmdletTestEdnsSupport : AsyncPSCmdlet
     private InternalLogger _logger;
     private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync()
     {
         _logger = new InternalLogger(false);
@@ -35,6 +37,8 @@ public sealed class CmdletTestEdnsSupport : AsyncPSCmdlet
         return Task.CompletedTask;
     }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync()
     {
         _logger.WriteVerbose("Querying EDNS support for domain: {0}", DomainName);

--- a/DomainDetective.PowerShell/CmdletTestFCrDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestFCrDns.cs
@@ -25,6 +25,8 @@ public sealed class CmdletTestFCrDns : AsyncPSCmdlet
     private InternalLogger _logger;
     private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync()
     {
         _logger = new InternalLogger(false);
@@ -41,6 +43,8 @@ public sealed class CmdletTestFCrDns : AsyncPSCmdlet
         return Task.CompletedTask;
     }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync()
     {
         _logger.WriteVerbose("Querying FCrDNS for domain: {0}", DomainName);

--- a/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
+++ b/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -39,6 +41,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying IP neighbors for domain: {0}", DomainName);
             await _healthCheck.Verify(DomainName, new[] { HealthCheckType.IPNEIGHBOR });

--- a/DomainDetective.PowerShell/CmdletTestImapTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestImapTls.cs
@@ -25,6 +25,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -33,6 +35,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking IMAP TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckImapTlsHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestMailLatency.cs
+++ b/DomainDetective.PowerShell/CmdletTestMailLatency.cs
@@ -22,6 +22,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var helper = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -30,6 +32,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Measuring mail latency for {0}:{1}", HostName, Port);
             await _healthCheck.CheckMailLatency(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -20,6 +20,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -35,6 +37,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task ProcessRecordAsync() {
             var result = _healthCheck.CheckMessageHeaders(HeaderText, CancelToken);
             WriteObject(result);

--- a/DomainDetective.PowerShell/CmdletTestMxRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestMxRecord.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying MX record for domain: {0}", DomainName);
             await healthCheck.VerifyMX(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestNsRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestNsRecord.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying NS record for domain: {0}", DomainName);
             await healthCheck.VerifyNS(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking open relay for {0}:{1}", HostName, Port);
             await _healthCheck.CheckOpenRelayHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
+++ b/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
@@ -25,6 +25,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -33,6 +35,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking POP3 TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckPop3TlsHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
+++ b/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
@@ -22,6 +22,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -30,6 +32,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking ports on {0}", HostName);
             await _healthCheck.CheckPortAvailability(HostName, Ports);

--- a/DomainDetective.PowerShell/CmdletTestReverseDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestReverseDns.cs
@@ -23,6 +23,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -38,6 +40,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying reverse DNS for domain: {0}", DomainName);
             await _healthCheck.Verify(DomainName, new[] { HealthCheckType.REVERSEDNS });

--- a/DomainDetective.PowerShell/CmdletTestRpki.cs
+++ b/DomainDetective.PowerShell/CmdletTestRpki.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var psLogger = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying RPKI for domain: {0}", DomainName);
             await _healthCheck.VerifyRPKI(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying security.txt for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.SECURITYTXT });

--- a/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var psLogger = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying SMIMEA record for {0}", EmailAddress);
             await _healthCheck.VerifySMIMEA(EmailAddress);

--- a/DomainDetective.PowerShell/CmdletTestSmtpBanner.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpBanner.cs
@@ -29,6 +29,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -37,6 +39,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking SMTP banner for {0}:{1}", HostName, Port);
             _healthCheck.SmtpBannerAnalysis.ExpectedHostname = ExpectedHostname;

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -26,6 +26,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -34,6 +36,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking SMTP TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckSmtpTlsHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying SOA record for domain: {0}", DomainName);
             await healthCheck.VerifySOA(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
@@ -28,6 +28,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
             _logger = new InternalLogger(false);
@@ -37,6 +39,8 @@ namespace DomainDetective.PowerShell {
             healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
             return Task.CompletedTask;
         }
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying SPF record for domain: {0}", DomainName);
             await healthCheck.VerifySPF(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -28,6 +28,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -36,6 +38,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying STARTTLS for domain: {0} on port {1}", DomainName, Port);
             await healthCheck.VerifySTARTTLS(DomainName, Port);

--- a/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
+++ b/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
@@ -32,6 +32,8 @@ public sealed class CmdletTestThreatIntel : AsyncPSCmdlet {
     private InternalLogger _logger;
     private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync() {
         _logger = new InternalLogger(false);
         var loggerPs = new InternalLoggerPowerShell(
@@ -47,6 +49,8 @@ public sealed class CmdletTestThreatIntel : AsyncPSCmdlet {
         return Task.CompletedTask;
     }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         _healthCheck.GoogleSafeBrowsingApiKey = GoogleApiKey;
         _healthCheck.PhishTankApiKey = PhishTankApiKey;

--- a/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
@@ -24,6 +24,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -32,6 +34,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying TLSRPT record for domain: {0}", DomainName);
             await healthCheck.VerifyTLSRPT(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -31,6 +31,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -39,6 +41,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Verifying website certificate for {0}", Url);
             _healthCheck.CertificateAnalysis.SkipRevocation = SkipRevocation;

--- a/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
@@ -26,6 +26,8 @@ public sealed class CmdletTestWildcardDns : AsyncPSCmdlet
     private InternalLogger _logger;
     private DomainHealthCheck healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync()
     {
         _logger = new InternalLogger(false);
@@ -35,6 +37,8 @@ public sealed class CmdletTestWildcardDns : AsyncPSCmdlet
         return Task.CompletedTask;
     }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync()
     {
         _logger.WriteVerbose("Querying wildcard DNS for domain: {0}", DomainName);

--- a/DomainDetective.PowerShell/CmdletTestZoneTransfer.cs
+++ b/DomainDetective.PowerShell/CmdletTestZoneTransfer.cs
@@ -23,6 +23,8 @@ namespace DomainDetective.PowerShell {
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
+        /// <summary>Initializes logging and helper classes.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var psLogger = new InternalLoggerPowerShell(
@@ -38,6 +40,8 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
 
+        /// <summary>Executes the cmdlet operation.</summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking zone transfer for domain: {0}", DomainName);
             await _healthCheck.VerifyZoneTransfer(DomainName);

--- a/DomainDetective.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/DomainDetective.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -9,6 +9,9 @@ namespace DomainDetective.PowerShell {
     /// Base class for asynchronous PowerShell cmdlets.
     /// </summary>
     public abstract class AsyncPSCmdlet : PSCmdlet, IDisposable {
+        /// <summary>
+        /// Types of pipeline messages handled by <see cref="AsyncPSCmdlet"/>.
+        /// </summary>
         private enum PipelineType {
             Output,
             OutputEnumerate,
@@ -29,24 +32,50 @@ namespace DomainDetective.PowerShell {
         /// </summary>
         protected CancellationToken CancelToken { get => _cancelSource.Token; }
 
+        /// <summary>
+        /// Invoked when the cmdlet begins execution.
+        /// Runs <see cref="BeginProcessingAsync"/> within the asynchronous pipeline.
+        /// </summary>
         protected override void BeginProcessing()
             => RunBlockInAsync(BeginProcessingAsync);
 
+        /// <summary>
+        /// Performs initialization logic for the cmdlet.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual Task BeginProcessingAsync()
             => Task.CompletedTask;
 
+        /// <summary>
+        /// Processes input records synchronously and dispatches <see cref="ProcessRecordAsync"/>.
+        /// </summary>
         protected override void ProcessRecord()
             => RunBlockInAsync(ProcessRecordAsync);
 
+        /// <summary>
+        /// Executes the main cmdlet logic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual Task ProcessRecordAsync()
             => Task.CompletedTask;
 
+        /// <summary>
+        /// Invoked once when processing has completed.
+        /// Runs <see cref="EndProcessingAsync"/> within the asynchronous pipeline.
+        /// </summary>
         protected override void EndProcessing()
             => RunBlockInAsync(EndProcessingAsync);
 
+        /// <summary>
+        /// Performs cleanup logic for the cmdlet.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected virtual Task EndProcessingAsync()
             => Task.CompletedTask;
 
+        /// <summary>
+        /// Requests cancellation of the cmdlet execution.
+        /// </summary>
         protected override void StopProcessing()
             => _cancelSource?.Cancel();
 


### PR DESCRIPTION
## Summary
- document async pipeline helpers
- add basic docs for BeginProcessingAsync and ProcessRecordAsync across PowerShell cmdlets

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6875fe7a8294832eb7c079d8d226183c