### PR TITLE
Add domain search presets

### DIFF
--- a/DomainDetective.CLI/Commands/SearchDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/SearchDomainCommand.cs
@@ -1,0 +1,138 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.CLI;
+
+/// <summary>
+/// Settings for <see cref="SearchDomainCommand"/>.
+/// </summary>
+internal sealed class SearchDomainSettings : CommandSettings
+{
+    /// <summary>Keywords used to generate domains.</summary>
+    [CommandArgument(0, "[keywords]")]
+    public string[] Keywords { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional prefix list.</summary>
+    [CommandOption("--prefixes")]
+    public string[] Prefixes { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional suffix list.</summary>
+    [CommandOption("--suffixes")]
+    public string[] Suffixes { get; set; } = Array.Empty<string>();
+
+    /// <summary>TLDs to use.</summary>
+    [CommandOption("--tlds")]
+    public string[] Tlds { get; set; } = new[] { "com" };
+
+    /// <summary>TLD preset name.</summary>
+    [CommandOption("--preset")]
+    public string? Preset { get; set; }
+
+    /// <summary>Output format: text, json, json-stream, json-array, csv.</summary>
+    [CommandOption("--output")]
+    public string Output { get; set; } = "text";
+
+    /// <summary>Minimum length for the domain label.</summary>
+    [CommandOption("--min-length")]
+    public int MinLength { get; set; }
+
+    /// <summary>Maximum length for the domain label.</summary>
+    [CommandOption("--max-length")]
+    public int MaxLength { get; set; } = int.MaxValue;
+
+    /// <summary>Number of concurrent RDAP requests.</summary>
+    [CommandOption("--concurrency")]
+    public int Concurrency { get; set; } = 10;
+}
+
+/// <summary>
+/// Searches domain availability using RDAP.
+/// </summary>
+internal sealed class SearchDomainCommand : AsyncCommand<SearchDomainSettings>
+{
+    /// <inheritdoc />
+    public override async Task<int> ExecuteAsync(CommandContext context, SearchDomainSettings settings)
+    {
+        if (settings.Keywords.Length == 0)
+        {
+            AnsiConsole.MarkupLine("[red]No keywords provided.[/]");
+            return 1;
+        }
+
+        var search = new DomainAvailabilitySearch
+        {
+            Prefixes = settings.Prefixes,
+            Suffixes = settings.Suffixes,
+            Tlds = settings.Tlds,
+            MinLength = settings.MinLength,
+            MaxLength = settings.MaxLength,
+            Concurrency = settings.Concurrency
+        };
+
+        if (!string.IsNullOrWhiteSpace(settings.Preset))
+        {
+            search.TldPreset = settings.Preset;
+        }
+
+        var results = search.SearchAsync(settings.Keywords, Program.CancellationToken);
+
+        switch (settings.Output.ToLowerInvariant())
+        {
+            case "json":
+            {
+                var list = new List<DomainAvailabilityResult>();
+                await foreach (var r in results)
+                {
+                    list.Add(r);
+                }
+                var json = JsonSerializer.Serialize(list, new JsonSerializerOptions { WriteIndented = true });
+                Console.WriteLine(json);
+                break;
+            }
+            case "json-stream":
+            {
+                await foreach (var r in results)
+                {
+                    Console.WriteLine(JsonSerializer.Serialize(r));
+                }
+                break;
+            }
+            case "json-array":
+            {
+                var list = new List<DomainAvailabilityResult>();
+                await foreach (var r in results)
+                {
+                    list.Add(r);
+                }
+                Console.WriteLine(JsonSerializer.Serialize(list));
+                break;
+            }
+            case "csv":
+            {
+                Console.WriteLine("Domain,Available");
+                await foreach (var r in results)
+                {
+                    Console.WriteLine($"{r.Domain},{r.Available}");
+                }
+                break;
+            }
+            default:
+            {
+                await foreach (var r in results)
+                {
+                    var color = r.Available ? "green" : "red";
+                    AnsiConsole.MarkupLine($"[{color}]{r.Domain} - {(r.Available ? "available" : "taken")}[/]");
+                }
+                break;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -46,6 +46,9 @@ internal static class Program {
             config.AddCommand<RefreshSuffixListCommand>("RefreshSuffixList")
                 .WithDescription("Download the latest public suffix list")
                 .WithExample(new[] { "RefreshSuffixList", "--force" });
+            config.AddCommand<SearchDomainCommand>("SearchDomain")
+                .WithDescription("Search for available domains")
+                .WithExample(new[] { "SearchDomain", "mykeyword" });
             config.AddCommand<TestSmimeaCommand>("TestSMIMEA")
                 .WithDescription("Query SMIMEA record for an email address")
                 .WithExample(new[] { "TestSMIMEA", "user@example.com" });

--- a/DomainDetective.Example/ExampleDomainSearch.cs
+++ b/DomainDetective.Example/ExampleDomainSearch.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    public static async Task ExampleDomainSearch()
+    {
+        var search = new DomainAvailabilitySearch
+        {
+            Prefixes = new[] { "get" },
+            Suffixes = new[] { "app" },
+            Concurrency = 5,
+            TldPreset = "all"
+        };
+
+        await foreach (var result in search.SearchAsync(new[] { "example" }))
+        {
+            var state = result.Available ? "available" : "taken";
+            Console.WriteLine($"{result.Domain} - {state}");
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDomainAvailabilitySearch.cs
+++ b/DomainDetective.Tests/TestDomainAvailabilitySearch.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestDomainAvailabilitySearch
+{
+    [Fact]
+    public void GeneratesPermutations()
+    {
+        var search = new DomainAvailabilitySearch
+        {
+            Prefixes = new[] { "my" },
+            Suffixes = new[] { "app" },
+            Tlds = new[] { "com" }
+        };
+
+        var domains = search.Generate(new[] { "test" }).ToArray();
+
+        Assert.Contains("test.com", domains);
+        Assert.Contains("mytest.com", domains);
+        Assert.Contains("testapp.com", domains);
+        Assert.Contains("mytestapp.com", domains);
+    }
+
+    [Fact]
+    public async Task FiltersByLengthAndUsesOverride()
+    {
+        var search = new DomainAvailabilitySearch
+        {
+            Tlds = new[] { "com" },
+            MinLength = 3,
+            MaxLength = 10,
+            AvailabilityOverride = (d, _) => Task.FromResult(!d.StartsWith("taken"))
+        };
+
+        var results = new List<DomainAvailabilityResult>();
+        await foreach (var result in search.SearchAsync(new[] { "free", "taken" }))
+        {
+            results.Add(result);
+        }
+
+        Assert.Contains(results, r => r.Domain == "free.com" && r.Available);
+        Assert.Contains(results, r => r.Domain == "taken.com" && !r.Available);
+    }
+
+    [Fact]
+    public void AppliesPreset()
+    {
+        var search = new DomainAvailabilitySearch
+        {
+            TldPreset = "tech"
+        };
+
+        Assert.Contains("io", search.Tlds);
+        Assert.Contains("dev", search.Tlds);
+    }
+
+    [Fact]
+    public void AppliesAllPreset()
+    {
+        var search = new DomainAvailabilitySearch
+        {
+            TldPreset = "all"
+        };
+
+        Assert.Contains("com", search.Tlds);
+        Assert.True(search.Tlds.Count > 100);
+    }
+}

--- a/DomainDetective/DomainAvailabilitySearch.cs
+++ b/DomainDetective/DomainAvailabilitySearch.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Collection of predefined TLD presets.
+/// </summary>
+public static class DomainAvailabilityPresets
+{
+    /// <summary>Mapping of preset names to TLD arrays.</summary>
+    public static readonly IReadOnlyDictionary<string, string[]> TldPresets;
+
+    /// <summary>Complete list of TLDs from the embedded public suffix list.</summary>
+    public static readonly string[] All;
+
+    static DomainAvailabilityPresets()
+    {
+        All = LoadAllTlds();
+        TldPresets = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["common"] = new[] { "com", "net", "org", "co", "io", "app", "dev" },
+            ["tech"] = new[] { "dev", "io", "app", "ai", "tech" },
+            ["fun"] = new[] { "lol", "fun", "xyz", "site" },
+            ["all"] = All
+        };
+    }
+
+    private static string[] LoadAllTlds()
+    {
+        using var stream = typeof(DomainAvailabilityPresets).Assembly
+            .GetManifestResourceStream("DomainDetective.public_suffix_list.dat");
+        if (stream == null)
+        {
+            return Array.Empty<string>();
+        }
+
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        using var reader = new StreamReader(stream);
+        while (reader.ReadLine() is { } line)
+        {
+            var trimmed = line.Trim();
+            if (string.IsNullOrEmpty(trimmed) || trimmed.StartsWith("//"))
+            {
+                continue;
+            }
+
+            if (trimmed.StartsWith("!"))
+            {
+                trimmed = trimmed.Substring(1);
+            }
+
+            if (trimmed.StartsWith("*."))
+            {
+                trimmed = trimmed.Substring(2);
+            }
+
+            var idx = trimmed.LastIndexOf('.');
+            var tld = idx >= 0 ? trimmed.Substring(idx + 1) : trimmed;
+            set.Add(tld);
+        }
+
+        return set.ToArray();
+    }
+}
+
+/// <summary>
+/// Result of a single domain availability check.
+/// </summary>
+public sealed record DomainAvailabilityResult(string Domain, bool Available);
+
+/// <summary>
+/// Generates domain permutations and checks availability using RDAP.
+/// </summary>
+public class DomainAvailabilitySearch
+{
+    /// <summary>Prefixes used to generate permutations.</summary>
+    public IReadOnlyList<string> Prefixes { get; set; } = Array.Empty<string>();
+
+    /// <summary>Suffixes used to generate permutations.</summary>
+    public IReadOnlyList<string> Suffixes { get; set; } = Array.Empty<string>();
+
+    /// <summary>TLDs used to generate permutations.</summary>
+    public IReadOnlyList<string> Tlds { get; set; } = new[] { "com" };
+
+    /// <summary>Name of the active TLD preset.</summary>
+    public string? TldPreset
+    {
+        get => _preset;
+        set
+        {
+            _preset = value;
+            if (!string.IsNullOrWhiteSpace(value) && DomainAvailabilityPresets.TldPresets.TryGetValue(value!, out var preset))
+            {
+                Tlds = preset;
+            }
+        }
+    }
+
+    private string? _preset;
+
+    /// <summary>Minimum length for the domain label.</summary>
+    public int MinLength { get; set; }
+
+    /// <summary>Maximum length for the domain label.</summary>
+    public int MaxLength { get; set; } = int.MaxValue;
+
+    /// <summary>Maximum concurrent RDAP queries.</summary>
+    public int Concurrency { get; set; } = 10;
+
+    /// <summary>Override to simulate RDAP queries for testing.</summary>
+    internal Func<string, CancellationToken, Task<bool>>? AvailabilityOverride { private get; set; }
+        
+
+    /// <summary>
+    /// Generates domain permutations for specified keywords.
+    /// </summary>
+    /// <param name="keywords">Keywords used to build domain names.</param>
+    /// <returns>Enumeration of domain names.</returns>
+    public IEnumerable<string> Generate(IEnumerable<string> keywords)
+    {
+        foreach (var keyword in keywords.Where(k => !string.IsNullOrWhiteSpace(k)))
+        {
+            var key = keyword.Trim().ToLowerInvariant();
+            foreach (var tld in Tlds)
+            {
+                foreach (var domain in EnumerateForKeyword(key, tld))
+                {
+                    yield return domain;
+                }
+            }
+        }
+    }
+
+    private IEnumerable<string> EnumerateForKeyword(string keyword, string tld)
+    {
+        var baseLabel = keyword;
+        yield return $"{baseLabel}.{tld}";
+
+        foreach (var prefix in Prefixes)
+        {
+            yield return $"{prefix}{baseLabel}.{tld}";
+        }
+
+        foreach (var suffix in Suffixes)
+        {
+            yield return $"{baseLabel}{suffix}.{tld}";
+        }
+
+        foreach (var prefix in Prefixes)
+        {
+            foreach (var suffix in Suffixes)
+            {
+                yield return $"{prefix}{baseLabel}{suffix}.{tld}";
+            }
+        }
+    }
+
+    private async Task<bool> IsAvailableAsync(string domain, CancellationToken ct)
+    {
+        if (AvailabilityOverride != null)
+        {
+            return await AvailabilityOverride(domain, ct).ConfigureAwait(false);
+        }
+
+        using var response = await SharedHttpClient.Instance
+            .GetAsync($"https://rdap.org/domain/{domain}", ct)
+            .ConfigureAwait(false);
+        return response.StatusCode == HttpStatusCode.NotFound;
+    }
+
+    /// <summary>
+    /// Asynchronously checks availability for generated domain names.
+    /// </summary>
+    /// <param name="keywords">Keywords used to generate domains.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Stream of availability results.</returns>
+    public async IAsyncEnumerable<DomainAvailabilityResult> SearchAsync(
+        IEnumerable<string> keywords,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var domains = new Queue<string>(Generate(keywords)
+            .Where(d =>
+            {
+                var idx = d.LastIndexOf('.');
+                var label = idx > 0 ? d.Substring(0, idx) : d;
+                return label.Length >= MinLength && label.Length <= MaxLength;
+            })
+            .Distinct(StringComparer.OrdinalIgnoreCase));
+
+        var tasks = new List<Task<DomainAvailabilityResult>>();
+
+        async Task<DomainAvailabilityResult> Check(string dom)
+        {
+            var available = await IsAvailableAsync(dom, ct).ConfigureAwait(false);
+            return new DomainAvailabilityResult(dom, available);
+        }
+
+        for (var i = 0; i < Concurrency && domains.Count > 0; i++)
+        {
+            tasks.Add(Check(domains.Dequeue()));
+        }
+
+        while (tasks.Count > 0)
+        {
+            var finished = await Task.WhenAny(tasks).ConfigureAwait(false);
+            tasks.Remove(finished);
+            yield return await finished.ConfigureAwait(false);
+            if (domains.Count > 0)
+            {
+                tasks.Add(Check(domains.Dequeue()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `All` TLD preset loaded from the embedded public suffix list
- enable `all` preset in domain search example
- test that preset returns more than 100 TLDs

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: 15 tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6877e727c47c832e8e33ab262bc026ce