### PR TITLE
Add DKIM key age tracking

### DIFF
--- a/DomainDetective.PowerShell/Helpers/OutputHelper.cs
+++ b/DomainDetective.PowerShell/Helpers/OutputHelper.cs
@@ -39,6 +39,7 @@ namespace DomainDetective.PowerShell {
                     KeyType = result.KeyType,
                     HashAlgorithm = result.HashAlgorithm,
                     CreationDate = result.CreationDate,
+                    KeyAgeDays = result.KeyAgeDays,
                     OldKey = result.OldKey,
                     DeprecatedTags = result.DeprecatedTags
                 };
@@ -138,6 +139,9 @@ namespace DomainDetective.PowerShell {
 
         /// <summary>Date the record appears to have been created.</summary>
         public DateTime? CreationDate { get; set; }
+
+        /// <summary>Age of the key in days.</summary>
+        public int KeyAgeDays { get; set; }
 
         /// <summary>True when <see cref="CreationDate"/> is over 12 months old.</summary>
         public bool OldKey { get; set; }


### PR DESCRIPTION
## Summary
- track DKIM key age in days
- allow configurable age warning threshold
- expose key age in PowerShell output
- tests for key age parsing and threshold warnings

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Assert.True() Failure)*
- `dotnet build DomainDetective/DomainDetective.csproj -f net472`

------
https://chatgpt.com/codex/tasks/task_e_6877ee1899dc832eb4579c1d1b9cda80