### PR TITLE
Fix MTASTS ParseDnsRecord port conflicts

### DIFF
--- a/DomainDetective.Tests/PortHelper.cs
+++ b/DomainDetective.Tests/PortHelper.cs
@@ -3,18 +3,20 @@ namespace DomainDetective.Tests;
 using System.Net;
 using System.Net.Sockets;
 
-internal static class PortHelper
-{
+internal static class PortHelper {
     private static readonly object PortLock = new();
+    private static readonly HashSet<int> UsedPorts = new();
 
-    public static int GetFreePort()
-    {
-        lock (PortLock)
-        {
-            var listener = new TcpListener(IPAddress.Loopback, 0);
-            listener.Start();
-            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
-            listener.Stop();
+    public static int GetFreePort() {
+        lock (PortLock) {
+            int port;
+            do {
+                var listener = new TcpListener(IPAddress.Loopback, 0);
+                listener.Start();
+                port = ((IPEndPoint)listener.LocalEndpoint).Port;
+                listener.Stop();
+            } while (!UsedPorts.Add(port));
+
             return port;
         }
     }


### PR DESCRIPTION
## Summary
- ensure unique ports in tests via static hash set

## Testing
- `dotnet test DomainDetective.Tests --filter "FullyQualifiedName~TestMTASTSAnalysis.ParseDnsRecord" -v n`


------
https://chatgpt.com/codex/tasks/task_e_6877f3038278832ebc6a23bb917be6c1