### PR TITLE
Add typed RDAP converter fixes

### DIFF
--- a/DomainDetective.Example/ExampleDeserializeRdap.cs
+++ b/DomainDetective.Example/ExampleDeserializeRdap.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates deserializing RDAP JSON into strongly typed objects.
+    /// </summary>
+    public static async Task ExampleDeserializeRdap()
+    {
+        var hc = new DomainHealthCheck { Verbose = false };
+        await hc.QueryRDAP("example.com");
+        if (hc.RdapAnalysis.DomainData is {} domain)
+        {
+            Helpers.ShowPropertiesTable("RDAP domain data", domain);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestRdapModels.cs
+++ b/DomainDetective.Tests/TestRdapModels.cs
@@ -1,0 +1,22 @@
+using System.Text.Json;
+
+namespace DomainDetective.Tests;
+
+public class TestRdapModels
+{
+    [Fact]
+    public void DomainSerializationRoundTrip()
+    {
+        const string json = "{\"ldhName\":\"example.com\",\"nameservers\":[{\"ldhName\":\"ns1.example.net\"},{\"ldhName\":\"ns2.example.net\"}],\"events\":[{\"eventAction\":\"registration\",\"eventDate\":\"2000-01-01T00:00:00Z\"},{\"eventAction\":\"expiration\",\"eventDate\":\"2030-01-01T00:00:00Z\"}],\"entities\":[{\"handle\":\"123\",\"roles\":[\"registrar\"],\"vcardArray\":[\"vcard\",[[\"fn\",{},\"text\",\"Registrar Inc\"]]]}]}";
+
+        var domain = JsonSerializer.Deserialize<RdapDomain>(json, RdapJson.Options)!;
+        Assert.Equal("example.com", domain.LdhName);
+        Assert.Equal("ns1.example.net", domain.Nameservers[0].LdhName);
+        Assert.Equal(RdapEventAction.Registration, domain.Events[0].Action);
+
+        var serialized = JsonSerializer.Serialize(domain, RdapJson.Options);
+        var round = JsonSerializer.Deserialize<RdapDomain>(serialized, RdapJson.Options)!;
+        Assert.Equal(domain.LdhName, round.LdhName);
+        Assert.Equal(domain.Nameservers[1].LdhName, round.Nameservers[1].LdhName);
+    }
+}

--- a/DomainDetective/Protocols/Rdap/RdapAutnum.cs
+++ b/DomainDetective/Protocols/Rdap/RdapAutnum.cs
@@ -1,0 +1,26 @@
+namespace DomainDetective
+{
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents an autonomous system number object in RDAP.
+/// </summary>
+public sealed class RdapAutnum
+{
+    /// <summary>Autonomous system handle.</summary>
+    [JsonPropertyName("handle")]
+    public string? Handle { get; set; }
+
+    /// <summary>Starting ASN.</summary>
+    [JsonPropertyName("startAutnum")]
+    public int? Start { get; set; }
+
+    /// <summary>Ending ASN.</summary>
+    [JsonPropertyName("endAutnum")]
+    public int? End { get; set; }
+
+    /// <summary>Autonomous system name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapDomain.cs
+++ b/DomainDetective/Protocols/Rdap/RdapDomain.cs
@@ -1,0 +1,39 @@
+namespace DomainDetective
+{
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents a domain object in RDAP.
+/// </summary>
+public sealed class RdapDomain
+{
+    /// <summary>LDH name of the domain.</summary>
+    [JsonPropertyName("ldhName")]
+    public string? LdhName { get; set; }
+
+    /// <summary>Unicode representation.</summary>
+    [JsonPropertyName("unicodeName")]
+    public string? UnicodeName { get; set; }
+
+    /// <summary>Domain handle.</summary>
+    [JsonPropertyName("handle")]
+    public string? Handle { get; set; }
+
+    /// <summary>Status values reported for the domain.</summary>
+    [JsonPropertyName("status")]
+    public List<RdapStatus> Status { get; set; } = new();
+
+    /// <summary>Event list.</summary>
+    [JsonPropertyName("events")]
+    public List<RdapEvent> Events { get; set; } = new();
+
+    /// <summary>Associated entities.</summary>
+    [JsonPropertyName("entities")]
+    public List<RdapEntity> Entities { get; set; } = new();
+
+    /// <summary>Authoritative nameservers.</summary>
+    [JsonPropertyName("nameservers")]
+    public List<RdapNameserver> Nameservers { get; set; } = new();
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapEntity.cs
+++ b/DomainDetective/Protocols/Rdap/RdapEntity.cs
@@ -1,0 +1,24 @@
+namespace DomainDetective
+{
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents an RDAP entity object.
+/// </summary>
+public sealed class RdapEntity
+{
+    /// <summary>Entity handle.</summary>
+    [JsonPropertyName("handle")]
+    public string? Handle { get; set; }
+
+    /// <summary>Roles assigned to the entity.</summary>
+    [JsonPropertyName("roles")]
+    public List<string> Roles { get; set; } = new();
+
+    /// <summary>Raw vCard array.</summary>
+    [JsonPropertyName("vcardArray")]
+    public JsonElement? VcardArray { get; set; }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapEvent.cs
+++ b/DomainDetective/Protocols/Rdap/RdapEvent.cs
@@ -1,0 +1,18 @@
+namespace DomainDetective
+{
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents an RDAP event entry.
+/// </summary>
+public sealed class RdapEvent
+{
+    /// <summary>Action type for the event.</summary>
+    [JsonPropertyName("eventAction")]
+    public RdapEventAction Action { get; set; }
+
+    /// <summary>Date of the event.</summary>
+    [JsonPropertyName("eventDate")]
+    public string? Date { get; set; }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapEventAction.cs
+++ b/DomainDetective/Protocols/Rdap/RdapEventAction.cs
@@ -1,0 +1,34 @@
+namespace DomainDetective
+{
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// RDAP event action types.
+/// </summary>
+[JsonConverter(typeof(RdapEventActionConverter))]
+public enum RdapEventAction
+{
+    /// <summary>Unknown or unsupported action.</summary>
+    Unknown,
+    /// <summary>The object was registered.</summary>
+    Registration,
+    /// <summary>The object was re-registered.</summary>
+    Reregistration,
+    /// <summary>The object was last modified.</summary>
+    LastChanged,
+    /// <summary>The object expires.</summary>
+    Expiration,
+    /// <summary>The object was deleted.</summary>
+    Deletion,
+    /// <summary>The object was reinstated.</summary>
+    Reinstantiation,
+    /// <summary>The object was transferred.</summary>
+    Transfer,
+    /// <summary>The object was locked.</summary>
+    Locked,
+    /// <summary>The object was unlocked.</summary>
+    Unlocked,
+    /// <summary>Registrar expiration occurred.</summary>
+    RegistrarExpiration
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapEventActionConverter.cs
+++ b/DomainDetective/Protocols/Rdap/RdapEventActionConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective
+{
+/// <summary>
+/// Converts <see cref="RdapEventAction"/> values to and from JSON.
+/// </summary>
+internal sealed class RdapEventActionConverter : JsonConverter<RdapEventAction>
+{
+    public override RdapEventAction Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrEmpty(value))
+        {
+            return RdapEventAction.Unknown;
+        }
+        var normalized = value.Replace("-", string.Empty).Replace(" ", string.Empty);
+        if (Enum.TryParse(normalized, true, out RdapEventAction action))
+        {
+            return action;
+        }
+        return RdapEventAction.Unknown;
+    }
+
+    public override void Write(Utf8JsonWriter writer, RdapEventAction value, JsonSerializerOptions options)
+    {
+        var name = value.ToString();
+        var camel = char.ToLowerInvariant(name[0]) + name.Substring(1);
+        writer.WriteStringValue(camel);
+    }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapIpNetwork.cs
+++ b/DomainDetective/Protocols/Rdap/RdapIpNetwork.cs
@@ -1,0 +1,22 @@
+namespace DomainDetective
+{
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents an IP network object in RDAP.
+/// </summary>
+public sealed class RdapIpNetwork
+{
+    /// <summary>Starting IP address.</summary>
+    [JsonPropertyName("startAddress")]
+    public string? StartAddress { get; set; }
+
+    /// <summary>Ending IP address.</summary>
+    [JsonPropertyName("endAddress")]
+    public string? EndAddress { get; set; }
+
+    /// <summary>CIDR notation for the network.</summary>
+    [JsonPropertyName("cidr")]
+    public string? Cidr { get; set; }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapJson.cs
+++ b/DomainDetective/Protocols/Rdap/RdapJson.cs
@@ -1,0 +1,20 @@
+namespace DomainDetective
+{
+using System.Text.Json;
+
+/// <summary>
+/// Provides JSON serializer options for RDAP objects.
+/// </summary>
+public static class RdapJson
+{
+    /// <summary>Default serializer options.</summary>
+    public static readonly JsonSerializerOptions Options;
+
+    static RdapJson()
+    {
+        Options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        Options.Converters.Add(new RdapStatusConverter());
+        Options.Converters.Add(new RdapEventActionConverter());
+    }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapNameserver.cs
+++ b/DomainDetective/Protocols/Rdap/RdapNameserver.cs
@@ -1,0 +1,14 @@
+namespace DomainDetective
+{
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents an RDAP nameserver object.
+/// </summary>
+public sealed class RdapNameserver
+{
+    /// <summary>LDH name of the nameserver.</summary>
+    [JsonPropertyName("ldhName")]
+    public string? LdhName { get; set; }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapRegistrar.cs
+++ b/DomainDetective/Protocols/Rdap/RdapRegistrar.cs
@@ -1,0 +1,14 @@
+namespace DomainDetective
+{
+/// <summary>
+/// Represents registrar details extracted from an RDAP entity.
+/// </summary>
+public sealed class RdapRegistrar
+{
+    /// <summary>Registrar identifier.</summary>
+    public string? Handle { get; set; }
+
+    /// <summary>Registrar display name.</summary>
+    public string? Name { get; set; }
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapStatus.cs
+++ b/DomainDetective/Protocols/Rdap/RdapStatus.cs
@@ -1,0 +1,52 @@
+namespace DomainDetective
+{
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// RDAP status values defined in RFC 9083.
+/// </summary>
+[JsonConverter(typeof(RdapStatusConverter))]
+public enum RdapStatus
+{
+    /// <summary>Unknown or unmapped status.</summary>
+    Unknown,
+    /// <summary>The object is active.</summary>
+    Active,
+    /// <summary>The object is inactive.</summary>
+    Inactive,
+    /// <summary>The object is locked.</summary>
+    Locked,
+    /// <summary>Creation is pending.</summary>
+    PendingCreate,
+    /// <summary>Deletion is pending.</summary>
+    PendingDelete,
+    /// <summary>Renewal is pending.</summary>
+    PendingRenew,
+    /// <summary>Transfer is pending.</summary>
+    PendingTransfer,
+    /// <summary>Update is pending.</summary>
+    PendingUpdate,
+    /// <summary>Client hold is active.</summary>
+    ClientHold,
+    /// <summary>Client renewal prohibited.</summary>
+    ClientRenewProhibited,
+    /// <summary>Client transfer prohibited.</summary>
+    ClientTransferProhibited,
+    /// <summary>Client update prohibited.</summary>
+    ClientUpdateProhibited,
+    /// <summary>Client deletion prohibited.</summary>
+    ClientDeleteProhibited,
+    /// <summary>Server hold is active.</summary>
+    ServerHold,
+    /// <summary>Server renewal prohibited.</summary>
+    ServerRenewProhibited,
+    /// <summary>Server transfer prohibited.</summary>
+    ServerTransferProhibited,
+    /// <summary>Server update prohibited.</summary>
+    ServerUpdateProhibited,
+    /// <summary>Server deletion prohibited.</summary>
+    ServerDeleteProhibited,
+    /// <summary>The object has been validated.</summary>
+    Validated
+}
+}

--- a/DomainDetective/Protocols/Rdap/RdapStatusConverter.cs
+++ b/DomainDetective/Protocols/Rdap/RdapStatusConverter.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective
+{
+/// <summary>
+/// Converts <see cref="RdapStatus"/> values to and from JSON.
+/// </summary>
+internal sealed class RdapStatusConverter : JsonConverter<RdapStatus>
+{
+    public override RdapStatus Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrEmpty(value))
+        {
+            return RdapStatus.Unknown;
+        }
+        var normalized = value.Replace("-", string.Empty).Replace(" ", string.Empty);
+        if (Enum.TryParse(normalized, true, out RdapStatus status))
+        {
+            return status;
+        }
+        return RdapStatus.Unknown;
+    }
+
+    public override void Write(Utf8JsonWriter writer, RdapStatus value, JsonSerializerOptions options)
+    {
+        var name = value.ToString();
+        var camel = char.ToLowerInvariant(name[0]) + name.Substring(1);
+        writer.WriteStringValue(camel);
+    }
+}
+}


### PR DESCRIPTION
## Summary
- adjust RDAP converters for .NET Framework compatibility
- switch RDAP model classes to block scoped namespaces
- update RDAP analysis to avoid range operators
- tweak RDAP example to display properties instead of JSON

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: network-dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_6877fa5c50e4832e9384724d9b0d7de8