### PR TITLE
Add brand keyword typosquat detection

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseTyposquatting.cs
+++ b/DomainDetective.Example/ExampleAnalyseTyposquatting.cs
@@ -6,6 +6,8 @@ public static partial class Program {
     public static async Task ExampleAnalyseTyposquatting() {
         var healthCheck = new DomainHealthCheck();
         healthCheck.Verbose = false;
+        healthCheck.TyposquattingAnalysis.BrandKeywords.Add("paypal");
+        healthCheck.TyposquattingAnalysis.BrandKeywords.Add("google");
         await healthCheck.VerifyTyposquatting("example.com");
         Helpers.ShowPropertiesTable("Typosquatting for example.com", healthCheck.TyposquattingAnalysis);
     }


### PR DESCRIPTION
## Summary
- allow specifying protected brand terms in `TyposquattingAnalysis`
- generate brand based domain variants
- show brand keyword usage in example project
- verify brand impersonation detection

## Testing
- `dotnet build --no-restore DomainDetective.sln`
- `dotnet test --no-build DomainDetective.Tests/DomainDetective.Tests.csproj --filter "FullyQualifiedName~TestTyposquattingAnalysis.DetectsBrandImpersonation"`

------
https://chatgpt.com/codex/tasks/task_e_6877fe4ef24c832e89b263118d211006