### PR TITLE
Add takeover provider list

### DIFF
--- a/Data/takeover.json
+++ b/Data/takeover.json
@@ -1,0 +1,7 @@
+[
+    "azurewebsites.net",
+    "cloudfront.net",
+    "herokudns.com",
+    "github.io",
+    "amazonaws.com"
+]

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -44,6 +44,9 @@
         <None Include="..\Data\hsts_preload.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="..\Data\takeover.json">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
         <None Include="Data/smime.pem">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -30,6 +30,7 @@
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="..\Data\public_suffix_list.dat" />
+        <EmbeddedResource Include="..\Data\takeover.json" />
         <None Include="..\Data\hsts_preload.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>


### PR DESCRIPTION
## Summary
- load takeover service list from `Data/takeover.json`
- expose API to load takeover providers from file
- copy takeover list in test project

## Testing
- `dotnet test`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6877fe573c0c832e9a353f0e48ec8852