### PR TITLE
Fix STARTTLS connection close race

### DIFF
--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -252,6 +252,7 @@ namespace DomainDetective.Tests {
             try {
                 var analysis = new STARTTLSAnalysis();
                 await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                await serverTask;
                 var ipProps = System.Net.NetworkInformation.IPGlobalProperties.GetIPGlobalProperties();
                 bool anyEstablished = ipProps.GetActiveTcpConnections().Any(c =>
                     (c.LocalEndPoint.Port == port || c.RemoteEndPoint.Port == port) &&


### PR DESCRIPTION
## Summary
- ensure the server task completes before verifying connection closure in `ConnectionIsClosedAfterCheck`

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Debug --no-build --verbosity minimal --filter "FullyQualifiedName~TestSTARTTLSAnalysis.ConnectionIsClosedAfterCheck"`
- ❌ `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Debug --no-build --verbosity minimal` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_687807971024832e8e847d11772d3920