### PR TITLE
Add RDAP commands and tests

### DIFF
--- a/DomainDetective.CLI/Commands/TestRdapAsCommand.cs
+++ b/DomainDetective.CLI/Commands/TestRdapAsCommand.cs
@@ -1,0 +1,30 @@
+namespace DomainDetective.CLI;
+
+using DomainDetective;
+using Spectre.Console.Cli;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Settings for <see cref="TestRdapAsCommand"/>.
+/// </summary>
+internal sealed class TestRdapAsSettings : CommandSettings {
+    /// <summary>Autonomous system number.</summary>
+    [CommandArgument(0, "<asn>")]
+    public string Asn { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Queries RDAP information for an autonomous system.
+/// </summary>
+internal sealed class TestRdapAsCommand : AsyncCommand<TestRdapAsSettings> {
+    /// <inheritdoc/>
+    public override async Task<int> ExecuteAsync(CommandContext context, TestRdapAsSettings settings) {
+        var client = new RdapClient();
+        var result = await client.GetAutnum(settings.Asn, Program.CancellationToken);
+        if (result != null) {
+            CliHelpers.ShowPropertiesTable($"RDAP AS {settings.Asn}", result, false);
+        }
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Commands/TestRdapEntityCommand.cs
+++ b/DomainDetective.CLI/Commands/TestRdapEntityCommand.cs
@@ -1,0 +1,30 @@
+namespace DomainDetective.CLI;
+
+using DomainDetective;
+using Spectre.Console.Cli;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Settings for <see cref="TestRdapEntityCommand"/>.
+/// </summary>
+internal sealed class TestRdapEntitySettings : CommandSettings {
+    /// <summary>Entity handle.</summary>
+    [CommandArgument(0, "<handle>")]
+    public string Handle { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Queries RDAP information for an entity.
+/// </summary>
+internal sealed class TestRdapEntityCommand : AsyncCommand<TestRdapEntitySettings> {
+    /// <inheritdoc/>
+    public override async Task<int> ExecuteAsync(CommandContext context, TestRdapEntitySettings settings) {
+        var client = new RdapClient();
+        var result = await client.GetEntity(settings.Handle, Program.CancellationToken);
+        if (result != null) {
+            CliHelpers.ShowPropertiesTable($"RDAP entity {settings.Handle}", result, false);
+        }
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Commands/TestRdapIpCommand.cs
+++ b/DomainDetective.CLI/Commands/TestRdapIpCommand.cs
@@ -1,0 +1,30 @@
+namespace DomainDetective.CLI;
+
+using DomainDetective;
+using Spectre.Console.Cli;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Settings for <see cref="TestRdapIpCommand"/>.
+/// </summary>
+internal sealed class TestRdapIpSettings : CommandSettings {
+    /// <summary>IP address or range.</summary>
+    [CommandArgument(0, "<ip>")]
+    public string Ip { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Queries RDAP information for an IP network.
+/// </summary>
+internal sealed class TestRdapIpCommand : AsyncCommand<TestRdapIpSettings> {
+    /// <inheritdoc/>
+    public override async Task<int> ExecuteAsync(CommandContext context, TestRdapIpSettings settings) {
+        var client = new RdapClient();
+        var result = await client.GetIp(settings.Ip, Program.CancellationToken);
+        if (result != null) {
+            CliHelpers.ShowPropertiesTable($"RDAP IP {settings.Ip}", result, false);
+        }
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Commands/TestRdapNameserverCommand.cs
+++ b/DomainDetective.CLI/Commands/TestRdapNameserverCommand.cs
@@ -1,0 +1,30 @@
+namespace DomainDetective.CLI;
+
+using DomainDetective;
+using Spectre.Console.Cli;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Settings for <see cref="TestRdapNameserverCommand"/>.
+/// </summary>
+internal sealed class TestRdapNameserverSettings : CommandSettings {
+    /// <summary>Nameserver host name.</summary>
+    [CommandArgument(0, "<host>")]
+    public string Host { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Queries RDAP information for a nameserver.
+/// </summary>
+internal sealed class TestRdapNameserverCommand : AsyncCommand<TestRdapNameserverSettings> {
+    /// <inheritdoc/>
+    public override async Task<int> ExecuteAsync(CommandContext context, TestRdapNameserverSettings settings) {
+        var client = new RdapClient();
+        var result = await client.GetNameserver(settings.Host, Program.CancellationToken);
+        if (result != null) {
+            CliHelpers.ShowPropertiesTable($"RDAP nameserver {settings.Host}", result, false);
+        }
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -58,6 +58,18 @@ internal static class Program {
             config.AddCommand<TestRdapCommand>("TestRDAP")
                 .WithDescription("Query RDAP registration information")
                 .WithExample(new[] { "TestRDAP", "example.com" });
+            config.AddCommand<TestRdapIpCommand>("TestRDAP-IP")
+                .WithDescription("Query RDAP information for an IP")
+                .WithExample(new[] { "TestRDAP-IP", "192.0.2.1" });
+            config.AddCommand<TestRdapAsCommand>("TestRDAP-AS")
+                .WithDescription("Query RDAP information for an autonomous system")
+                .WithExample(new[] { "TestRDAP-AS", "AS65536" });
+            config.AddCommand<TestRdapEntityCommand>("TestRDAP-Entity")
+                .WithDescription("Query RDAP information for an entity")
+                .WithExample(new[] { "TestRDAP-Entity", "ABC123" });
+            config.AddCommand<TestRdapNameserverCommand>("TestRDAP-NS")
+                .WithDescription("Query RDAP information for a nameserver")
+                .WithExample(new[] { "TestRDAP-NS", "ns1.example.com" });
         });
         try {
             return await app.RunAsync(args).WaitAsync(cts.Token);

--- a/DomainDetective.Example/ExampleDeserializeRdap.cs
+++ b/DomainDetective.Example/ExampleDeserializeRdap.cs
@@ -1,3 +1,4 @@
+using DomainDetective;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example;
@@ -9,11 +10,30 @@ public static partial class Program
     /// </summary>
     public static async Task ExampleDeserializeRdap()
     {
-        var hc = new DomainHealthCheck { Verbose = false };
-        await hc.QueryRDAP("example.com");
-        if (hc.RdapAnalysis.DomainData is {} domain)
+        var client = new RdapClient();
+        if (await client.GetDomain("example.com") is { } domain)
         {
             Helpers.ShowPropertiesTable("RDAP domain data", domain);
+        }
+
+        if (await client.GetIp("192.0.2.0/24") is { } network)
+        {
+            Helpers.ShowPropertiesTable("RDAP IP data", network);
+        }
+
+        if (await client.GetAutnum("AS65536") is { } asn)
+        {
+            Helpers.ShowPropertiesTable("RDAP AS data", asn);
+        }
+
+        if (await client.GetEntity("ABCDE") is { } entity)
+        {
+            Helpers.ShowPropertiesTable("RDAP entity data", entity);
+        }
+
+        if (await client.GetNameserver("ns1.example.com") is { } ns)
+        {
+            Helpers.ShowPropertiesTable("RDAP nameserver data", ns);
         }
     }
 }

--- a/DomainDetective.Tests/TestRdapModels.cs
+++ b/DomainDetective.Tests/TestRdapModels.cs
@@ -19,4 +19,43 @@ public class TestRdapModels
         Assert.Equal(domain.LdhName, round.LdhName);
         Assert.Equal(domain.Nameservers[1].LdhName, round.Nameservers[1].LdhName);
     }
+
+    [Fact]
+    public void IpNetworkParsing()
+    {
+        const string json = "{\"startAddress\":\"192.0.2.0\",\"endAddress\":\"192.0.2.255\",\"cidr\":\"192.0.2.0/24\"}";
+        var net = JsonSerializer.Deserialize<RdapIpNetwork>(json, RdapJson.Options)!;
+        Assert.Equal("192.0.2.0", net.StartAddress);
+        Assert.Equal("192.0.2.255", net.EndAddress);
+        Assert.Equal("192.0.2.0/24", net.Cidr);
+    }
+
+    [Fact]
+    public void AutnumParsing()
+    {
+        const string json = "{\"handle\":\"AS65536\",\"startAutnum\":65536,\"endAutnum\":65536,\"name\":\"Example ASN\"}";
+        var asn = JsonSerializer.Deserialize<RdapAutnum>(json, RdapJson.Options)!;
+        Assert.Equal("AS65536", asn.Handle);
+        Assert.Equal(65536, asn.Start);
+        Assert.Equal(65536, asn.End);
+        Assert.Equal("Example ASN", asn.Name);
+    }
+
+    [Fact]
+    public void EntityParsing()
+    {
+        const string json = "{\"handle\":\"ABC123\",\"roles\":[\"registrant\"],\"vcardArray\":[\"vcard\",[[\"fn\",{},\"text\",\"John Doe\"]]]}";
+        var entity = JsonSerializer.Deserialize<RdapEntity>(json, RdapJson.Options)!;
+        Assert.Equal("ABC123", entity.Handle);
+        Assert.Contains("registrant", entity.Roles);
+        Assert.True(entity.VcardArray.HasValue);
+    }
+
+    [Fact]
+    public void NameserverParsing()
+    {
+        const string json = "{\"ldhName\":\"ns1.example.com\"}";
+        var ns = JsonSerializer.Deserialize<RdapNameserver>(json, RdapJson.Options)!;
+        Assert.Equal("ns1.example.com", ns.LdhName);
+    }
 }


### PR DESCRIPTION
## Summary
- query RDAP objects (IP, AS, entity and nameserver) via new CLI commands
- parse RDAP objects in unit tests
- demo RDAP object queries in example app

## Testing
- `dotnet test` *(fails: The argument /workspace/DomainDetective/... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68780cb89934832e8b1c3b988605601c