### PR TITLE
Handle unknown critical CAA tags

### DIFF
--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -226,6 +226,26 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task UnknownCriticalTagFailsCheck() {
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckCAA("128 foo \"bar\"");
+
+            Assert.True(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidTag);
+            Assert.False(healthCheck.CAAAnalysis.Valid);
+        }
+
+        [Fact]
+        public async Task UnknownNonCriticalTagIsIgnored() {
+            var healthCheck = new DomainHealthCheck();
+
+            await healthCheck.CheckCAA("0 foo \"bar\"");
+
+            Assert.False(healthCheck.CAAAnalysis.AnalysisResults[0].InvalidTag);
+            Assert.True(healthCheck.CAAAnalysis.Valid);
+        }
+
+        [Fact]
         public async Task ReservedFlagBitsTriggerWarning() {
             var logger = new InternalLogger();
             var warnings = new List<LogEventArgs>();

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -149,9 +149,9 @@ As an illustration, a CAA record that is set on example.com is also applicable t
                         analysis.Tag = tagType;
                     } else {
                         analysis.Tag = CAATagType.Unknown;
-                        analysis.InvalidTag = true;
                         if (analysis.Critical) {
-                            logger?.WriteWarning("Unknown CAA property tag '{0}' flagged as critical", tag);
+                            analysis.InvalidTag = true;
+                            logger?.WriteWarning($"Unknown CAA property tag '{tag}' flagged as critical");
                         }
                     }
 


### PR DESCRIPTION
## Summary
- fail health check if a critical CAA tag is unknown
- verify unknown critical tags invalidate analysis
- verify non-critical unknown tags are ignored

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build -c Release --verbosity minimal` *(fails: TestDKIMByDomain, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0a28498832e889f3fdaa85e6bbc