### PR TITLE
Add CT log aggregator

### DIFF
--- a/DomainDetective.Example/ExampleCtLogs.cs
+++ b/DomainDetective.Example/ExampleCtLogs.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>Demonstrates retrieving CT log entries for a certificate.</summary>
+    public static async Task ExampleCtLogAggregator()
+    {
+        var analysis = await CertificateAnalysis.CheckWebsiteCertificate("https://google.com");
+        Helpers.ShowPropertiesTable("CT log entries", analysis.CtLogEntries);
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -74,6 +74,7 @@ public static partial class Program {
         await ExampleAnalyseEdnsSupport();
         await ExampleAnalyseGeoIp();
         await ExamplePortScan();
+        await ExampleCtLogAggregator();
 
         //await ExampleQueryDNS();
         //await ExampleAnalyseByStringWHOIS();

--- a/DomainDetective.Tests/TestCtLogAggregator.cs
+++ b/DomainDetective.Tests/TestCtLogAggregator.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using DomainDetective;
+using RichardSzalay.MockHttp;
+
+namespace DomainDetective.Tests;
+
+public class TestCtLogAggregator
+{
+    [Fact]
+    public async Task AggregatesEntriesFromApis()
+    {
+        var mock = new MockHttpMessageHandler();
+        mock.When("https://api1/*").Respond("application/json", "[{\"id\":1}]");
+        mock.When("https://api2/*").Respond("application/json", "[{\"id\":2}]");
+
+        var aggregator = new CtLogAggregator { HttpHandlerFactory = () => mock };
+        aggregator.ApiTemplates.Clear();
+        aggregator.ApiTemplates.Add("https://api1/{0}");
+        aggregator.ApiTemplates.Add("https://api2/{0}");
+
+        var entries = await aggregator.QueryAsync("abc");
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal(1, entries[0].GetProperty("id").GetInt32());
+        Assert.Equal(2, entries[1].GetProperty("id").GetInt32());
+    }
+}

--- a/DomainDetective.Tests/TestCtLogIntegration.cs
+++ b/DomainDetective.Tests/TestCtLogIntegration.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using DomainDetective;
+
+namespace DomainDetective.Tests;
+
+public class TestCtLogIntegration
+{
+    [Fact]
+    public async Task CertificateAnalysisExposesEntries()
+    {
+        var cert = new X509Certificate2("Data/wildcard.pem");
+        var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[{\"id\":5}]") };
+        await analysis.AnalyzeCertificate(cert);
+        Assert.True(analysis.PresentInCtLogs);
+        Assert.Single(analysis.CtLogEntries);
+        Assert.Equal(5, analysis.CtLogEntries[0].GetProperty("id").GetInt32());
+    }
+}

--- a/DomainDetective/CtLogAggregator.cs
+++ b/DomainDetective/CtLogAggregator.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Retrieves certificate transparency log entries from multiple APIs.
+/// </summary>
+public sealed class CtLogAggregator
+{
+    /// <summary>CT log API templates containing a {0} placeholder for the fingerprint.</summary>
+    public List<string> ApiTemplates { get; } = new() { "https://crt.sh/?sha256={0}&output=json" };
+
+    /// <summary>Optional HTTP handler factory for testing.</summary>
+    internal Func<HttpMessageHandler>? HttpHandlerFactory { get; set; }
+
+    /// <summary>Optional override returning the JSON content for a fingerprint.</summary>
+    public Func<string, Task<string>>? QueryOverride { get; set; }
+
+    /// <summary>
+    /// Queries all configured APIs for the specified SHA-256 fingerprint.
+    /// </summary>
+    /// <param name="fingerprint">SHA-256 certificate fingerprint.</param>
+    /// <param name="cancellationToken">Token used to cancel the operation.</param>
+    /// <returns>List of JSON elements describing log entries.</returns>
+    public async Task<IReadOnlyList<JsonElement>> QueryAsync(string fingerprint, CancellationToken cancellationToken = default)
+    {
+        var results = new List<JsonElement>();
+        if (string.IsNullOrWhiteSpace(fingerprint))
+        {
+            return results;
+        }
+
+        if (QueryOverride != null)
+        {
+            var json = await QueryOverride(fingerprint).ConfigureAwait(false);
+            AppendEntries(json, results);
+            return results;
+        }
+
+        var client = CreateClient(out var dispose);
+        try
+        {
+            foreach (var template in ApiTemplates)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var url = string.Format(template, fingerprint);
+                using var resp = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+                if (!resp.IsSuccessStatusCode)
+                {
+                    continue;
+                }
+                var json = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+                AppendEntries(json, results);
+            }
+        }
+        finally
+        {
+            if (dispose)
+            {
+                client.Dispose();
+            }
+        }
+
+        return results;
+    }
+
+    private static void AppendEntries(string json, ICollection<JsonElement> results)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return;
+        }
+
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            if (doc.RootElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var entry in doc.RootElement.EnumerateArray())
+                {
+                    results.Add(entry.Clone());
+                }
+            }
+            else if (doc.RootElement.ValueKind != JsonValueKind.Undefined && doc.RootElement.ValueKind != JsonValueKind.Null)
+            {
+                results.Add(doc.RootElement.Clone());
+            }
+        }
+        catch
+        {
+            // ignore parse errors
+        }
+    }
+
+    private HttpClient CreateClient(out bool dispose)
+    {
+        if (HttpHandlerFactory != null)
+        {
+            dispose = true;
+            return new HttpClient(HttpHandlerFactory(), disposeHandler: true);
+        }
+
+        dispose = false;
+        return SharedHttpClient.Instance;
+    }
+}


### PR DESCRIPTION
## Summary
- create `CtLogAggregator` to gather results from CT log APIs
- surface aggregated entries through `CertificateAnalysis`
- provide an example to display CT log entries
- test the aggregator with mocked HTTP responses

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Assert.True() in several tests)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0beb440832eb5b1c5e6213709b8