### PR TITLE
Add directory exposure analysis

### DIFF
--- a/Data/directory_paths.json
+++ b/Data/directory_paths.json
@@ -1,0 +1,10 @@
+[
+    ".git/",
+    ".svn/",
+    "config/",
+    "backup/",
+    "admin/",
+    "logs/",
+    "tmp/",
+    ".env"
+]

--- a/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
+++ b/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestDirectoryExposureAnalysis
+{
+    [Fact]
+    public async Task DetectsAccessibleDirectories()
+    {
+        using var listener = new HttpListener();
+        var prefix = $"http://localhost:{GetFreePort()}/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        var serverTask = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                var ctx = await listener.GetContextAsync();
+                if (ctx.Request.Url.AbsolutePath.StartsWith("/.git"))
+                {
+                    ctx.Response.StatusCode = 200;
+                }
+                else
+                {
+                    ctx.Response.StatusCode = 404;
+                }
+                ctx.Response.Close();
+            }
+        });
+
+        try
+        {
+            var hc = new DomainHealthCheck();
+            await hc.VerifyDirectoryExposure(prefix.Replace("http://", string.Empty).TrimEnd('/'));
+            Assert.Contains(".git/", hc.DirectoryExposureAnalysis.ExposedPaths);
+        }
+        finally
+        {
+            listener.Stop();
+            await Task.Delay(50);
+        }
+    }
+
+    [Fact]
+    public async Task NoExposedDirectoriesWhenNoneAccessible()
+    {
+        using var listener = new HttpListener();
+        var prefix = $"http://localhost:{GetFreePort()}/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        var serverTask = Task.Run(async () =>
+        {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 404;
+            ctx.Response.Close();
+        });
+
+        try
+        {
+            var hc = new DomainHealthCheck();
+            await hc.VerifyDirectoryExposure(prefix.Replace("http://", string.Empty).TrimEnd('/'));
+            Assert.Empty(hc.DirectoryExposureAnalysis.ExposedPaths);
+        }
+        finally
+        {
+            listener.Stop();
+            await Task.Delay(50);
+        }
+    }
+
+    private static int GetFreePort() => PortHelper.GetFreePort();
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -233,7 +233,11 @@ public static class CheckDescriptions {
             [HealthCheckType.RDAP] = new(
                 "Query RDAP registration data.",
                 null,
-                "Inspect RDAP for registration details.")
+                "Inspect RDAP for registration details."),
+            [HealthCheckType.DIRECTORYEXPOSURE] = new(
+                "Check for exposed directories on HTTP servers.",
+                null,
+                "Remove or secure publicly accessible directories.")
         };
 
     /// <summary>Gets the description for the specified check type.</summary>

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -98,5 +98,7 @@ public enum HealthCheckType {
     /// <summary>Detect CNAMEs pointing to flattening services.</summary>
     FLATTENINGSERVICE,
     /// <summary>Query RDAP registration information.</summary>
-    RDAP
+    RDAP,
+    /// <summary>Check for exposed directories.</summary>
+    DIRECTORYEXPOSURE
 }

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -31,6 +31,7 @@
     <ItemGroup>
         <EmbeddedResource Include="..\Data\public_suffix_list.dat" />
         <EmbeddedResource Include="..\Data\takeover.json" />
+        <EmbeddedResource Include="..\Data\directory_paths.json" />
         <None Include="..\Data\hsts_preload.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -330,6 +330,9 @@ namespace DomainDetective {
                     case HealthCheckType.THREATINTEL:
                         await VerifyThreatIntel(domainName, cancellationToken);
                         break;
+                    case HealthCheckType.DIRECTORYEXPOSURE:
+                        await VerifyDirectoryExposure(domainName, cancellationToken);
+                        break;
                 default:
                     _logger.WriteError("Unknown health check type: {0}", healthCheckType);
                     throw new NotSupportedException("Health check type not implemented.");
@@ -1007,6 +1010,16 @@ namespace DomainDetective {
             await TakeoverCnameAnalysis.Analyze(domainName, _logger, cancellationToken);
         }
 
+        /// <summary>
+        /// Scans common directories for public exposure.
+        /// </summary>
+        public async Task VerifyDirectoryExposure(string domainName, CancellationToken cancellationToken = default) {
+            domainName = ValidateHostName(domainName);
+            UpdateIsPublicSuffix(domainName);
+            DirectoryExposureAnalysis = new DirectoryExposureAnalysis();
+            await DirectoryExposureAnalysis.Analyze($"http://{domainName}", _logger, cancellationToken);
+        }
+
         /// Queries Autodiscover related records for a domain.
         /// </summary>
         /// <param name="domainName">Domain to verify.</param>
@@ -1500,6 +1513,7 @@ namespace DomainDetective {
             filtered.WildcardDnsAnalysis = active.Contains(HealthCheckType.WILDCARDDNS) ? CloneAnalysis(WildcardDnsAnalysis) : null;
             filtered.EdnsSupportAnalysis = active.Contains(HealthCheckType.EDNSSUPPORT) ? CloneAnalysis(EdnsSupportAnalysis) : null;
             filtered.FlatteningServiceAnalysis = active.Contains(HealthCheckType.FLATTENINGSERVICE) ? CloneAnalysis(FlatteningServiceAnalysis) : null;
+            filtered.DirectoryExposureAnalysis = active.Contains(HealthCheckType.DIRECTORYEXPOSURE) ? CloneAnalysis(DirectoryExposureAnalysis) : null;
 
             return filtered;
         }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -335,6 +335,12 @@ namespace DomainDetective {
         /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
         public TakeoverCnameAnalysis TAKEOVERCNAMEAnalysis => TakeoverCnameAnalysis;
 
+        /// <summary>Gets the directory exposure analysis.</summary>
+        /// <value>Results of exposed directory checks.</value>
+        public DirectoryExposureAnalysis DirectoryExposureAnalysis { get; private set; } = new DirectoryExposureAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public DirectoryExposureAnalysis DIRECTORYEXPOSUREAnalysis => DirectoryExposureAnalysis;
+
         // Settings properties moved to DomainHealthCheck.Settings.cs
 
         /// <summary>

--- a/DomainDetective/Protocols/DirectoryExposureAnalysis.cs
+++ b/DomainDetective/Protocols/DirectoryExposureAnalysis.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Scans common directories on a web server looking for inadvertent exposure.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class DirectoryExposureAnalysis
+{
+    private static readonly string[] _defaultPaths = LoadDefaultPaths();
+
+    private static string[] LoadDefaultPaths()
+    {
+        try
+        {
+            using var stream = Assembly.GetExecutingAssembly()
+                .GetManifestResourceStream("DomainDetective.directory_paths.json");
+            if (stream != null)
+            {
+                using var reader = new StreamReader(stream);
+                var json = reader.ReadToEnd();
+                var items = JsonSerializer.Deserialize<string[]>(json)
+                    ?.Where(p => !string.IsNullOrWhiteSpace(p))
+                    ?? Enumerable.Empty<string>();
+                return items.ToArray();
+            }
+        }
+        catch
+        {
+            // ignore malformed resource
+        }
+
+        return Array.Empty<string>();
+    }
+
+    /// <summary>HTTP client timeout for each request.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>List of directories detected as accessible.</summary>
+    public List<string> ExposedPaths { get; private set; } = new();
+
+    /// <summary>
+    /// Checks the target host for exposed directories.
+    /// </summary>
+    /// <param name="baseUrl">Base URL, e.g. http://example.com</param>
+    /// <param name="logger">Logger for verbose output.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task Analyze(string baseUrl, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            throw new ArgumentNullException(nameof(baseUrl));
+        }
+
+        if (!baseUrl.StartsWith("http://", StringComparison.OrdinalIgnoreCase) &&
+            !baseUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            baseUrl = "http://" + baseUrl.TrimEnd('/');
+        }
+        else
+        {
+            baseUrl = baseUrl.TrimEnd('/');
+        }
+
+        ExposedPaths.Clear();
+
+        using var client = new HttpClient { Timeout = Timeout };
+        foreach (var path in _defaultPaths)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var url = $"{baseUrl}/{path}";
+            try
+            {
+                var response = await client.GetAsync(url, cancellationToken);
+                if (response.IsSuccessStatusCode)
+                {
+                    ExposedPaths.Add(path);
+                    logger?.WriteWarning("Exposed directory {0}", url);
+                }
+            }
+            catch (Exception ex) when (ex is HttpRequestException || ex is TaskCanceledException)
+            {
+                logger?.WriteDebug("Failed to query {0}: {1}", url, ex.Message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement DirectoryExposureAnalysis for scanning common paths
- expose analysis via new `DIRECTORYEXPOSURE` health check
- wire into DomainHealthCheck and verification routines
- embed directory path list and add tests using local HTTP listeners

## Testing
- `dotnet test` *(fails: Should exceed DNS lookups due to many includes)*

------
https://chatgpt.com/codex/tasks/task_e_6878a0cd4c10832e8d5c397494bd0075