### PR TITLE
Add ThreatFeed analysis

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseThreatFeed.cs
+++ b/DomainDetective.Example/ExampleAnalyseThreatFeed.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseThreatFeed() {
+        var healthCheck = new DomainHealthCheck();
+        healthCheck.Verbose = false;
+        healthCheck.VirusTotalApiKey = "YOUR_API_KEY"; // replace with your key
+        healthCheck.AbuseIpDbApiKey = "YOUR_API_KEY"; // replace with your key
+        await healthCheck.VerifyThreatFeed("8.8.8.8");
+        Helpers.ShowPropertiesTable("Threat feed for 8.8.8.8", healthCheck.ThreatFeedAnalysis);
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -71,6 +71,7 @@ public static partial class Program {
         await ExampleAnalyseDnsTtl();
         await ExampleDomainSummary();
         await ExampleAnalyseThreatIntel();
+        await ExampleAnalyseThreatFeed();
         await ExampleAnalyseTyposquatting();
         await ExampleAnalyseEdnsSupport();
         await ExampleAnalyseGeoIp();

--- a/DomainDetective.Tests/TestThreatFeedAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatFeedAnalysis.cs
@@ -1,0 +1,53 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestThreatFeedAnalysis {
+    [Fact]
+    public async Task FlagsListings() {
+        var analysis = new ThreatFeedAnalysis {
+            VirusTotalOverride = _ => Task.FromResult("{\"data\":{\"attributes\":{\"last_analysis_stats\":{\"malicious\":1}}}}"),
+            AbuseIpDbOverride = _ => Task.FromResult("{\"data\":{\"abuseConfidenceScore\":20}}")
+        };
+
+        await analysis.Analyze("8.8.8.8", "v", "a", new InternalLogger());
+
+        Assert.True(analysis.ListedByVirusTotal);
+        Assert.True(analysis.ListedByAbuseIpDb);
+    }
+
+    [Fact]
+    public async Task IntegratesWithHealthCheck() {
+        var health = new DomainHealthCheck();
+        health.VirusTotalApiKey = "v";
+        health.AbuseIpDbApiKey = "a";
+        health.ThreatFeedAnalysis.VirusTotalOverride = _ => Task.FromResult("{\"data\":{\"attributes\":{\"last_analysis_stats\":{\"malicious\":1}}}}");
+        health.ThreatFeedAnalysis.AbuseIpDbOverride = _ => Task.FromResult("{\"data\":{\"abuseConfidenceScore\":20}}");
+
+        await health.VerifyThreatFeed("8.8.8.8");
+
+        Assert.True(health.ThreatFeedAnalysis.ListedByVirusTotal);
+        Assert.True(health.ThreatFeedAnalysis.ListedByAbuseIpDb);
+    }
+
+    [Fact]
+    public void ReusesHttpClient() {
+        var a1 = new ThreatFeedAnalysis();
+        var a2 = new ThreatFeedAnalysis();
+
+        Assert.Same(a1.Client, a2.Client);
+    }
+
+    [Fact]
+    public async Task FeedFailureSetsFailureReason() {
+        var analysis = new ThreatFeedAnalysis {
+            VirusTotalOverride = _ => Task.FromException<string>(new HttpRequestException("offline"))
+        };
+
+        await analysis.Analyze("8.8.8.8", "v", null, new InternalLogger());
+
+        Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
+        Assert.False(analysis.ListedByVirusTotal);
+    }
+}

--- a/DomainDetective/CheckDescriptions.cs
+++ b/DomainDetective/CheckDescriptions.cs
@@ -220,6 +220,10 @@ public static class CheckDescriptions {
                 "Query reputation services for threats.",
                 null,
                 "Review listed threats and request delisting"),
+            [HealthCheckType.THREATFEED] = new(
+                "Query threat feeds for IP reputation.",
+                null,
+                "Investigate malicious activity for listed IPs."),
             // Detect wildcard DNS catch-all
             [HealthCheckType.WILDCARDDNS] = new(
                 "Detect wildcard DNS catch-all.",

--- a/DomainDetective/Definitions/HealthCheckType.cs
+++ b/DomainDetective/Definitions/HealthCheckType.cs
@@ -91,6 +91,8 @@ public enum HealthCheckType {
     TYPOSQUATTING,
     /// <summary>Query reputation services for threats.</summary>
     THREATINTEL,
+    /// <summary>Query threat feeds for IP reputation.</summary>
+    THREATFEED,
     /// <summary>Detect wildcard DNS responses.</summary>
     WILDCARDDNS,
     /// <summary>Test EDNS support on name servers.</summary>

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -50,6 +50,9 @@ namespace DomainDetective {
         /// <summary>API key for VirusTotal.</summary>
         public string? VirusTotalApiKey { get; set; }
 
+        /// <summary>API key for AbuseIPDB.</summary>
+        public string? AbuseIpDbApiKey { get; set; }
+
         /// <summary>Log lines used for DNS tunneling analysis.</summary>
         public IEnumerable<string>? DnsTunnelingLogs { get; set; }
 

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -333,6 +333,9 @@ namespace DomainDetective {
                     case HealthCheckType.THREATINTEL:
                         await VerifyThreatIntel(domainName, cancellationToken);
                         break;
+                    case HealthCheckType.THREATFEED:
+                        await VerifyThreatFeed(domainName, cancellationToken);
+                        break;
                     case HealthCheckType.DIRECTORYEXPOSURE:
                         await VerifyDirectoryExposure(domainName, cancellationToken);
                         break;
@@ -683,6 +686,17 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
             await ThreatIntelAnalysis.Analyze(domainName, GoogleSafeBrowsingApiKey, PhishTankApiKey, VirusTotalApiKey, _logger, cancellationToken);
+        }
+
+        /// <summary>Queries threat feeds for IP reputation.</summary>
+        /// <param name="ipAddress">IP address to check.</param>
+        /// <param name="cancellationToken">Token to cancel the operation.</param>
+        public async Task VerifyThreatFeed(string ipAddress, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(ipAddress)) {
+                throw new ArgumentNullException(nameof(ipAddress));
+            }
+
+            await ThreatFeedAnalysis.Analyze(ipAddress, VirusTotalApiKey, AbuseIpDbApiKey, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -1525,6 +1539,7 @@ namespace DomainDetective {
             filtered.DnsTunnelingAnalysis = active.Contains(HealthCheckType.DNSTUNNELING) ? CloneAnalysis(DnsTunnelingAnalysis) : null;
             filtered.TyposquattingAnalysis = active.Contains(HealthCheckType.TYPOSQUATTING) ? CloneAnalysis(TyposquattingAnalysis) : null;
             filtered.ThreatIntelAnalysis = active.Contains(HealthCheckType.THREATINTEL) ? CloneAnalysis(ThreatIntelAnalysis) : null;
+            filtered.ThreatFeedAnalysis = active.Contains(HealthCheckType.THREATFEED) ? CloneAnalysis(ThreatFeedAnalysis) : null;
             filtered.WildcardDnsAnalysis = active.Contains(HealthCheckType.WILDCARDDNS) ? CloneAnalysis(WildcardDnsAnalysis) : null;
             filtered.EdnsSupportAnalysis = active.Contains(HealthCheckType.EDNSSUPPORT) ? CloneAnalysis(EdnsSupportAnalysis) : null;
             filtered.FlatteningServiceAnalysis = active.Contains(HealthCheckType.FLATTENINGSERVICE) ? CloneAnalysis(FlatteningServiceAnalysis) : null;

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -317,6 +317,12 @@ namespace DomainDetective {
         /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
         public ThreatIntelAnalysis THREATINTELAnalysis => ThreatIntelAnalysis;
 
+        /// <summary>Gets the threat feed analysis.</summary>
+        /// <value>Results from external threat feeds.</value>
+        public ThreatFeedAnalysis ThreatFeedAnalysis { get; private set; } = new ThreatFeedAnalysis();
+        /// <summary>Alias used by <see cref="GetAnalysisMap"/>.</summary>
+        public ThreatFeedAnalysis THREATFEEDAnalysis => ThreatFeedAnalysis;
+
         /// <summary>Gets the wildcard DNS analysis.</summary>
         /// <value>Results of wildcard detection.</value>
         public WildcardDnsAnalysis WildcardDnsAnalysis { get; private set; } = new WildcardDnsAnalysis();

--- a/DomainDetective/Protocols/ThreatFeedAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatFeedAnalysis.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Queries threat feed APIs for IP reputation data.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class ThreatFeedAnalysis {
+    /// <summary>Override VirusTotal query.</summary>
+    public Func<string, Task<string>>? VirusTotalOverride { private get; set; }
+    /// <summary>Override AbuseIPDB query.</summary>
+    public Func<string, Task<string>>? AbuseIpDbOverride { private get; set; }
+
+    /// <summary>True when VirusTotal lists the IP as malicious.</summary>
+    public bool ListedByVirusTotal { get; private set; }
+    /// <summary>True when AbuseIPDB lists the IP as malicious.</summary>
+    public bool ListedByAbuseIpDb { get; private set; }
+    /// <summary>If feed queries fail, explains why.</summary>
+    public string? FailureReason { get; private set; }
+
+    private static readonly HttpClient _staticClient = new();
+    private readonly HttpClient _client;
+
+    internal HttpClient Client => _client;
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="ThreatFeedAnalysis"/>.
+    /// </summary>
+    /// <param name="client">Optional HTTP client for requests.</param>
+    public ThreatFeedAnalysis(HttpClient? client = null) {
+        _client = client ?? _staticClient;
+    }
+
+    private static async Task<string> ReadAsStringAsync(HttpResponseMessage resp) {
+        resp.EnsureSuccessStatusCode();
+        return await resp.Content.ReadAsStringAsync();
+    }
+
+    private async Task<string> QueryVirusTotal(string ip, string apiKey, CancellationToken ct) {
+        if (VirusTotalOverride != null) {
+            return await VirusTotalOverride(ip);
+        }
+
+        var url = $"https://www.virustotal.com/api/v3/ip_addresses/{ip}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("x-apikey", apiKey);
+        using var resp = await _client.SendAsync(request, ct);
+        return await ReadAsStringAsync(resp);
+    }
+
+    private async Task<string> QueryAbuseIpDb(string ip, string apiKey, CancellationToken ct) {
+        if (AbuseIpDbOverride != null) {
+            return await AbuseIpDbOverride(ip);
+        }
+
+        var url = $"https://api.abuseipdb.com/api/v2/check?ipAddress={ip}&maxAgeInDays=90";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Add("Key", apiKey);
+        request.Headers.Add("Accept", "application/json");
+        using var resp = await _client.SendAsync(request, ct);
+        return await ReadAsStringAsync(resp);
+    }
+
+    private static bool ParseVirusTotal(string json) {
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("data", out var data)) {
+            return false;
+        }
+        if (!data.TryGetProperty("attributes", out var attr)) {
+            return false;
+        }
+        if (!attr.TryGetProperty("last_analysis_stats", out var stats)) {
+            return false;
+        }
+        return stats.TryGetProperty("malicious", out var mal) && mal.GetInt32() > 0;
+    }
+
+    private static bool ParseAbuseIpDb(string json) {
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("data", out var data)) {
+            return false;
+        }
+        return data.TryGetProperty("abuseConfidenceScore", out var score) && score.GetInt32() > 0;
+    }
+
+    /// <summary>Queries all enabled threat feeds.</summary>
+    public async Task Analyze(string ip, string? virusTotalApiKey, string? abuseIpDbApiKey, InternalLogger logger, CancellationToken ct = default) {
+        ListedByVirusTotal = false;
+        ListedByAbuseIpDb = false;
+        FailureReason = null;
+
+        if (!string.IsNullOrWhiteSpace(virusTotalApiKey)) {
+            try {
+                var json = await QueryVirusTotal(ip, virusTotalApiKey, ct);
+                ListedByVirusTotal = ParseVirusTotal(json);
+            } catch (Exception ex) {
+                logger?.WriteError("VirusTotal query failed: {0}", ex.Message);
+                FailureReason = $"VirusTotal query failed: {ex.Message}";
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(abuseIpDbApiKey)) {
+            try {
+                var json = await QueryAbuseIpDb(ip, abuseIpDbApiKey, ct);
+                ListedByAbuseIpDb = ParseAbuseIpDb(json);
+            } catch (Exception ex) {
+                logger?.WriteError("AbuseIPDB query failed: {0}", ex.Message);
+                FailureReason = $"AbuseIPDB query failed: {ex.Message}";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThreatFeedAnalysis` for querying threat feeds
- support `THREATFEED` in `HealthCheckType`
- expose AbuseIPDB API key on health check settings
- integrate with verification pipeline and examples
- test the new analysis with mocked HTTP responses

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0 --no-build` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6878abd01a3c832eae3183efc9681535