### PR TITLE
Fix XML doc tags in PowerShell cmdlets

### DIFF
--- a/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletAddDnsblProvider.cs
@@ -10,20 +10,20 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsCommon.Add, "DDDnsblProvider")]
 [Alias("Add-DnsblProvider")]
     public sealed class CmdletAddDnsblProvider : PSCmdlet {
-        /// <param name="Domain">Domain name of the DNSBL provider.</param>
+        /// <para>Domain name of the DNSBL provider.</para>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Domain { get; set; }
 
-        /// <param name="Enabled">Sets the provider as enabled.</param>
+        /// <para>Sets the provider as enabled.</para>
         [Parameter(Mandatory = false)]
         public bool Enabled { get; set; } = true;
 
-        /// <param name="Comment">Optional descriptive comment.</param>
+        /// <para>Optional descriptive comment.</para>
         [Parameter(Mandatory = false)]
         public string Comment { get; set; }
 
-        /// <param name="InputObject">Analysis object to add the provider to.</param>
+        /// <para>Analysis object to add the provider to.</para>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletGetCertificateInfo.cs
+++ b/DomainDetective.PowerShell/CmdletGetCertificateInfo.cs
@@ -11,16 +11,16 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsCommon.Get, "CertificateInfo")]
     public sealed class CmdletGetCertificateInfo : AsyncPSCmdlet {
-        /// <param name="Path">Path to a PEM or DER encoded certificate.</param>
+        /// <para>Path to a PEM or DER encoded certificate.</para>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Path;
 
-        /// <param name="ShowChain">Include certificate chain in the output.</param>
+        /// <para>Include certificate chain in the output.</para>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 
-        /// <param name="SkipRevocation">Do not check certificate revocation status.</param>
+        /// <para>Do not check certificate revocation status.</para>
         [Parameter(Mandatory = false)]
         public SwitchParameter SkipRevocation;
 

--- a/DomainDetective.PowerShell/CmdletGetDomainSummary.cs
+++ b/DomainDetective.PowerShell/CmdletGetDomainSummary.cs
@@ -14,12 +14,12 @@ namespace DomainDetective.PowerShell {
 [Alias("Get-DomainSummary")]
     [OutputType(typeof(DomainSummary))]
     public sealed class CmdletGetDomainSummary : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to analyze.</param>
+        /// <para>Domain to analyze.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletGetFlattenedSpfIp.cs
+++ b/DomainDetective.PowerShell/CmdletGetFlattenedSpfIp.cs
@@ -14,16 +14,16 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsCommon.Get, "DDFlattenedSpfIp", DefaultParameterSetName = "ServerName")]
 [Alias("Get-DomainFlattenedSpfIp")]
     public sealed class CmdletGetFlattenedSpfIp : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
 
-        /// <param name="TestSpfRecord">Optional SPF record used for testing to avoid DNS lookups.</param>
+        /// <para>Optional SPF record used for testing to avoid DNS lookups.</para>
         [Parameter(Mandatory = false)]
         public string TestSpfRecord;
 

--- a/DomainDetective.PowerShell/CmdletGetRdapObject.cs
+++ b/DomainDetective.PowerShell/CmdletGetRdapObject.cs
@@ -15,37 +15,37 @@ namespace DomainDetective.PowerShell {
 [OutputType(typeof(object))]
 public sealed class CmdletGetRdapObject : AsyncPSCmdlet
 {
-    /// <param name="Domain">Domain name to query.</param>
+    /// <para>Domain name to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "Domain", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Domain { get; set; } = string.Empty;
 
-    /// <param name="Tld">Top-level domain to query.</param>
+    /// <para>Top-level domain to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "Tld", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Tld { get; set; } = string.Empty;
 
-    /// <param name="Ip">IP address or CIDR to query.</param>
+    /// <para>IP address or CIDR to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "Ip", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Ip { get; set; } = string.Empty;
 
-    /// <param name="AsNumber">Autonomous system number to query.</param>
+    /// <para>Autonomous system number to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "As", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string AsNumber { get; set; } = string.Empty;
 
-    /// <param name="Entity">Entity handle to query.</param>
+    /// <para>Entity handle to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "Entity", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Entity { get; set; } = string.Empty;
 
-    /// <param name="Registrar">Registrar handle to query.</param>
+    /// <para>Registrar handle to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "Registrar", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Registrar { get; set; } = string.Empty;
 
-    /// <param name="Nameserver">Nameserver host to query.</param>
+    /// <para>Nameserver host to query.</para>
     [Parameter(Mandatory = true, ParameterSetName = "Nameserver", Position = 0)]
     [ValidateNotNullOrEmpty]
     public string Nameserver { get; set; } = string.Empty;

--- a/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
+++ b/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
@@ -13,20 +13,20 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsCommon.Get, "DDDomainWhois", DefaultParameterSetName = "ServerName")]
 [Alias("Get-DomainWhois")]
     public sealed class CmdletGetWhoisInfo : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to retrieve WHOIS information for.</param>
+        /// <para>Domain to retrieve WHOIS information for.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="SnapshotPath">Directory used to store WHOIS snapshots.</param>
+        /// <para>Directory used to store WHOIS snapshots.</para>
         [Parameter(Mandatory = false)]
         public string SnapshotPath;
 
-        /// <param name="Diff">Return changes since last snapshot.</param>
+        /// <para>Return changes since last snapshot.</para>
         [Parameter(Mandatory = false)]
         public SwitchParameter Diff;
 

--- a/DomainDetective.PowerShell/CmdletImportDmarcForensic.cs
+++ b/DomainDetective.PowerShell/CmdletImportDmarcForensic.cs
@@ -12,7 +12,7 @@ namespace DomainDetective.PowerShell {
     [Alias("Import-DmarcForensic")]
     [OutputType(typeof(DmarcForensicReport))]
     public sealed class CmdletImportDmarcForensic : PSCmdlet {
-        /// <param name="Path">Path to the zipped report.</param>
+        /// <para>Path to the zipped report.</para>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string Path { get; set; }

--- a/DomainDetective.PowerShell/CmdletImportDmarcReport.cs
+++ b/DomainDetective.PowerShell/CmdletImportDmarcReport.cs
@@ -11,7 +11,7 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsData.Import, "DDDmarcReport")]
 [Alias("Import-DmarcReport")]
     public sealed class CmdletImportDmarcReport : PSCmdlet {
-        /// <param name="Path">Path to the zipped XML file.</param>
+        /// <para>Path to the zipped XML file.</para>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string Path { get; set; }

--- a/DomainDetective.PowerShell/CmdletImportDnsblConfig.cs
+++ b/DomainDetective.PowerShell/CmdletImportDnsblConfig.cs
@@ -10,20 +10,20 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsData.Import, "DDDnsblConfig")]
 [Alias("Import-DnsblConfig")]
     public sealed class CmdletImportDnsblConfig : PSCmdlet {
-        /// <param name="Path">Path to the configuration file.</param>
+        /// <para>Path to the configuration file.</para>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Path { get; set; }
 
-        /// <param name="OverwriteExisting">Replace existing providers.</param>
+        /// <para>Replace existing providers.</para>
         [Parameter(Mandatory = false)]
         public SwitchParameter OverwriteExisting { get; set; }
 
-        /// <param name="ClearExisting">Remove current providers before import.</param>
+        /// <para>Remove current providers before import.</para>
         [Parameter(Mandatory = false)]
         public SwitchParameter ClearExisting { get; set; }
 
-        /// <param name="InputObject">Analysis object to modify.</param>
+        /// <para>Analysis object to modify.</para>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletTestArc.cs
+++ b/DomainDetective.PowerShell/CmdletTestArc.cs
@@ -17,12 +17,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailArcRecord", DefaultParameterSetName = "Text")]
 [Alias("Test-EmailArc")]
     public sealed class CmdletTestArc : AsyncPSCmdlet {
-        /// <param name="HeaderText">Raw header text.</param>
+        /// <para>Raw header text.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Text", ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string HeaderText { get; set; } = string.Empty;
 
-        /// <param name="File">Path to a file containing ARC headers.</param>
+        /// <para>Path to a file containing ARC headers.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "File")]
         [ValidateNotNullOrEmpty]
         public string File { get; set; } = string.Empty;

--- a/DomainDetective.PowerShell/CmdletTestAutodiscover.cs
+++ b/DomainDetective.PowerShell/CmdletTestAutodiscover.cs
@@ -11,12 +11,12 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "Autodiscover", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestAutodiscover : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailBimiRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailBimi")]
     public sealed class CmdletTestBimiRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestBlackList.cs
+++ b/DomainDetective.PowerShell/CmdletTestBlackList.cs
@@ -13,16 +13,16 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsDomainBlacklist", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsDomainBlacklist")]
     public sealed class CmdletTestBlackList : AsyncPSCmdlet {
-        /// <param name="NameOrIpAddress">Domain names or IP addresses to check.</param>
+        /// <para>Domain names or IP addresses to check.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string[] NameOrIpAddress;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="FullResponse">Return full analysis result.</param>
+        /// <para>Return full analysis result.</para>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 

--- a/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsCaaRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsCaa")]
     public sealed class CmdletTestCaaRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestContactRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestContactRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDomainContactRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DomainContact")]
     public sealed class CmdletTestContactRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsBlacklistRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsBlacklist")]
     public sealed class CmdletTestDNSBLRecord : AsyncPSCmdlet {
-        /// <param name="NameOrIpAddress">Domain or IP to query.</param>
+        /// <para>Domain or IP to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string NameOrIpAddress;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDanglingCname.cs
+++ b/DomainDetective.PowerShell/CmdletTestDanglingCname.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsDanglingCname", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsDanglingCname")]
     public sealed class CmdletTestDanglingCname : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDelegation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDelegation.cs
@@ -10,12 +10,12 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "Delegation", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestDelegation : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
@@ -13,25 +13,25 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailDkimRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailDkim")]
     public sealed class CmdletTestDkimRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <para>Domain to query.</para>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="Selectors">Selectors to validate.</param>
+        /// <para>Selectors to validate.</para>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string[] Selectors;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <para>DNS server used for queries.</para>
         [Parameter(Mandatory = false, Position = 2, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="FullResponse">Return full analysis result.</param>
+        /// <para>Return full analysis result.</para>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 
-        /// <param name="Raw">Return raw response objects.</param>
+        /// <para>Return raw response objects.</para>
         [Parameter(Mandatory = false)]
         public SwitchParameter Raw;
 

--- a/DomainDetective.PowerShell/CmdletTestDmarcAggregate.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcAggregate.cs
@@ -18,7 +18,7 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DmarcAggregate")]
     public sealed class CmdletTestDmarcAggregate : AsyncPSCmdlet {
-        /// <param name="Path">Path to the aggregate report.</param>
+        /// <para>Path to the aggregate report.</para>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string Path { get; set; }


### PR DESCRIPTION
## Summary
- replace invalid `<param>` XML tags with `<para>` on 20 cmdlet files
- clean up remaining param comments

## Testing
- `dotnet build DomainDetective.PowerShell/DomainDetective.PowerShell.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6878ace07e6c832e832c056d6b523d24