### PR TITLE
Add domain RDAP helpers

### DIFF
--- a/DomainDetective.Example/ExampleCheckDomainAvailability.cs
+++ b/DomainDetective.Example/ExampleCheckDomainAvailability.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates checking a single domain using RDAP.
+    /// </summary>
+    public static async Task ExampleCheckDomainAvailability()
+    {
+        var search = new DomainAvailabilitySearch();
+        var result = await search.CheckAsync("example.com");
+        Console.WriteLine(result.Available
+            ? $"{result.Domain} is available"
+            : $"{result.Domain} is taken");
+    }
+}

--- a/DomainDetective.Example/ExampleCheckLabelAcrossTlds.cs
+++ b/DomainDetective.Example/ExampleCheckLabelAcrossTlds.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates checking availability for a label across multiple TLDs.
+    /// </summary>
+    public static async Task ExampleCheckLabelAcrossTlds()
+    {
+        var search = new DomainAvailabilitySearch
+        {
+            Tlds = new[] { "pl", "xyz", "be" }
+        };
+
+        await foreach (var result in search.CheckTldsAsync("evotec"))
+        {
+            var state = result.Available ? "available" : "taken";
+            Console.WriteLine($"{result.Domain} - {state}");
+        }
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -3,7 +3,6 @@ using System;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
-using DomainDetective;
 using DomainDetective.Helpers;
 
 namespace DomainDetective.Example;
@@ -76,6 +75,9 @@ public static partial class Program {
         await ExampleAnalyseGeoIp();
         await ExamplePortScan();
         await ExampleCtLogAggregator();
+
+        await ExampleCheckDomainAvailability();
+        await ExampleCheckLabelAcrossTlds();
 
         //await ExampleQueryDNS();
         //await ExampleAnalyseByStringWHOIS();


### PR DESCRIPTION
## Summary
- integrate IDN normalization in `DomainAvailabilitySearch`
- add example calls for domain availability checks

## Testing
- `dotnet build --no-restore`
- `dotnet test -v minimal` *(fails: 13 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6878abb5bd0c832eb0623f3a13f6a108