### PR TITLE
Fix ambiguous Task cref references

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -29,7 +29,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -39,7 +39,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DMARC record for domain: {0}", DomainName);
             await healthCheck.VerifyDMARC(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -73,7 +73,7 @@ namespace DomainDetective.PowerShell {
         private DnsPropagationAnalysis _analysis;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -96,7 +96,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             IEnumerable<PublicDnsEntry> servers;
             if (CountryCount != null && CountryCount.Count > 0) {

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -30,7 +30,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -40,7 +40,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DNSSEC for domain: {0}", DomainName);
             await healthCheck.VerifyDNSSEC(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying TTL for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.TTL });

--- a/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
@@ -24,7 +24,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _hc = new();
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             if (!File.Exists(Path)) {
                 WriteError(new ErrorRecord(new FileNotFoundException("File not found", Path), "NotFound", ErrorCategory.InvalidArgument, Path));

--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -50,7 +50,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -71,7 +71,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying domain health for domain: {0}", DomainName);
             if (BrandKeyword != null) {

--- a/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
+++ b/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
@@ -27,7 +27,7 @@ public sealed class CmdletTestEdnsSupport : AsyncPSCmdlet
     private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync()
     {
         _logger = new InternalLogger(false);
@@ -38,7 +38,7 @@ public sealed class CmdletTestEdnsSupport : AsyncPSCmdlet
     }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync()
     {
         _logger.WriteVerbose("Querying EDNS support for domain: {0}", DomainName);

--- a/DomainDetective.PowerShell/CmdletTestFCrDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestFCrDns.cs
@@ -26,7 +26,7 @@ public sealed class CmdletTestFCrDns : AsyncPSCmdlet
     private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync()
     {
         _logger = new InternalLogger(false);
@@ -44,7 +44,7 @@ public sealed class CmdletTestFCrDns : AsyncPSCmdlet
     }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync()
     {
         _logger.WriteVerbose("Querying FCrDNS for domain: {0}", DomainName);

--- a/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
+++ b/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -42,7 +42,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying IP neighbors for domain: {0}", DomainName);
             await _healthCheck.Verify(DomainName, new[] { HealthCheckType.IPNEIGHBOR });

--- a/DomainDetective.PowerShell/CmdletTestImapTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestImapTls.cs
@@ -26,7 +26,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -36,7 +36,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking IMAP TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckImapTlsHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestMailLatency.cs
+++ b/DomainDetective.PowerShell/CmdletTestMailLatency.cs
@@ -23,7 +23,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var helper = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -33,7 +33,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Measuring mail latency for {0}:{1}", HostName, Port);
             await _healthCheck.CheckMailLatency(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -21,7 +21,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -38,7 +38,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task ProcessRecordAsync() {
             var result = _healthCheck.CheckMessageHeaders(HeaderText, CancelToken);
             WriteObject(result);

--- a/DomainDetective.PowerShell/CmdletTestMxRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestMxRecord.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying MX record for domain: {0}", DomainName);
             await healthCheck.VerifyMX(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestNsRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestNsRecord.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying NS record for domain: {0}", DomainName);
             await healthCheck.VerifyNS(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking open relay for {0}:{1}", HostName, Port);
             await _healthCheck.CheckOpenRelayHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
+++ b/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
@@ -26,7 +26,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -36,7 +36,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking POP3 TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckPop3TlsHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
+++ b/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
@@ -23,7 +23,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -33,7 +33,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking ports on {0}", HostName);
             await _healthCheck.CheckPortAvailability(HostName, Ports);

--- a/DomainDetective.PowerShell/CmdletTestReverseDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestReverseDns.cs
@@ -24,7 +24,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -41,7 +41,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying reverse DNS for domain: {0}", DomainName);
             await _healthCheck.Verify(DomainName, new[] { HealthCheckType.REVERSEDNS });

--- a/DomainDetective.PowerShell/CmdletTestRpki.cs
+++ b/DomainDetective.PowerShell/CmdletTestRpki.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var psLogger = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying RPKI for domain: {0}", DomainName);
             await _healthCheck.VerifyRPKI(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying security.txt for domain: {0}", DomainName);
             await healthCheck.Verify(DomainName, new[] { HealthCheckType.SECURITYTXT });

--- a/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var psLogger = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying SMIMEA record for {0}", EmailAddress);
             await _healthCheck.VerifySMIMEA(EmailAddress);

--- a/DomainDetective.PowerShell/CmdletTestSmtpBanner.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpBanner.cs
@@ -30,7 +30,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -40,7 +40,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking SMTP banner for {0}:{1}", HostName, Port);
             _healthCheck.SmtpBannerAnalysis.ExpectedHostname = ExpectedHostname;

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -27,7 +27,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -37,7 +37,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking SMTP TLS for {0}:{1}", HostName, Port);
             await _healthCheck.CheckSmtpTlsHost(HostName, Port);

--- a/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying SOA record for domain: {0}", DomainName);
             await healthCheck.VerifySOA(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
@@ -29,7 +29,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             // Initialize the logger to be able to see verbose, warning, debug, error, progress, and information messages.
             _logger = new InternalLogger(false);
@@ -40,7 +40,7 @@ namespace DomainDetective.PowerShell {
             return Task.CompletedTask;
         }
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying SPF record for domain: {0}", DomainName);
             await healthCheck.VerifySPF(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -29,7 +29,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -39,7 +39,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying STARTTLS for domain: {0} on port {1}", DomainName, Port);
             await healthCheck.VerifySTARTTLS(DomainName, Port);

--- a/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
+++ b/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
@@ -33,7 +33,7 @@ public sealed class CmdletTestThreatIntel : AsyncPSCmdlet {
     private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync() {
         _logger = new InternalLogger(false);
         var loggerPs = new InternalLoggerPowerShell(
@@ -50,7 +50,7 @@ public sealed class CmdletTestThreatIntel : AsyncPSCmdlet {
     }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync() {
         _healthCheck.GoogleSafeBrowsingApiKey = GoogleApiKey;
         _healthCheck.PhishTankApiKey = PhishTankApiKey;

--- a/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -35,7 +35,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying TLSRPT record for domain: {0}", DomainName);
             await healthCheck.VerifyTLSRPT(DomainName);

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -32,7 +32,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var internalLoggerPowerShell = new InternalLoggerPowerShell(_logger, this.WriteVerbose, this.WriteWarning, this.WriteDebug, this.WriteError, this.WriteProgress, this.WriteInformation);
@@ -42,7 +42,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Verifying website certificate for {0}", Url);
             _healthCheck.CertificateAnalysis.SkipRevocation = SkipRevocation;

--- a/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
@@ -27,7 +27,7 @@ public sealed class CmdletTestWildcardDns : AsyncPSCmdlet
     private DomainHealthCheck healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override Task BeginProcessingAsync()
     {
         _logger = new InternalLogger(false);
@@ -38,7 +38,7 @@ public sealed class CmdletTestWildcardDns : AsyncPSCmdlet
     }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
     protected override async Task ProcessRecordAsync()
     {
         _logger.WriteVerbose("Querying wildcard DNS for domain: {0}", DomainName);

--- a/DomainDetective.PowerShell/CmdletTestZoneTransfer.cs
+++ b/DomainDetective.PowerShell/CmdletTestZoneTransfer.cs
@@ -24,7 +24,7 @@ namespace DomainDetective.PowerShell {
         private DomainHealthCheck _healthCheck;
 
         /// <summary>Initializes logging and helper classes.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task BeginProcessingAsync() {
             _logger = new InternalLogger(false);
             var psLogger = new InternalLoggerPowerShell(
@@ -41,7 +41,7 @@ namespace DomainDetective.PowerShell {
         }
 
         /// <summary>Executes the cmdlet operation.</summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking zone transfer for domain: {0}", DomainName);
             await _healthCheck.VerifyZoneTransfer(DomainName);

--- a/DomainDetective.PowerShell/Communication/AsyncPSCmdlet.cs
+++ b/DomainDetective.PowerShell/Communication/AsyncPSCmdlet.cs
@@ -42,7 +42,7 @@ namespace DomainDetective.PowerShell {
         /// <summary>
         /// Performs initialization logic for the cmdlet.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected virtual Task BeginProcessingAsync()
             => Task.CompletedTask;
 
@@ -55,7 +55,7 @@ namespace DomainDetective.PowerShell {
         /// <summary>
         /// Executes the main cmdlet logic.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected virtual Task ProcessRecordAsync()
             => Task.CompletedTask;
 
@@ -69,7 +69,7 @@ namespace DomainDetective.PowerShell {
         /// <summary>
         /// Performs cleanup logic for the cmdlet.
         /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected virtual Task EndProcessingAsync()
             => Task.CompletedTask;
 


### PR DESCRIPTION
## Summary
- disambiguate Task cref references in PowerShell cmdlets

## Testing
- `dotnet build --no-restore -warnaserror:CS0419`

------
https://chatgpt.com/codex/tasks/task_e_6878ddb4f7d4832ea7cdd64b9a248d22