### PR TITLE
Add VirusTotal client and models

### DIFF
--- a/DomainDetective.Example/ExampleVirusTotal.cs
+++ b/DomainDetective.Example/ExampleVirusTotal.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>Demonstrates querying VirusTotal.</summary>
+    public static async Task ExampleVirusTotalClient()
+    {
+        var client = new VirusTotalClient("YOUR_API_KEY");
+        var result = await client.GetDomain("example.com");
+        if (result?.Data?.Attributes?.LastAnalysisStats is { } stats)
+        {
+            Helpers.ShowPropertiesTable("VirusTotal stats", stats);
+        }
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -76,6 +76,7 @@ public static partial class Program {
         await ExampleAnalyseGeoIp();
         await ExamplePortScan();
         await ExampleCtLogAggregator();
+        await ExampleVirusTotalClient();
 
         await ExampleCheckDomainAvailability();
         await ExampleCheckLabelAcrossTlds();

--- a/DomainDetective.Tests/TestVirusTotalModels.cs
+++ b/DomainDetective.Tests/TestVirusTotalModels.cs
@@ -1,0 +1,32 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using RichardSzalay.MockHttp;
+
+namespace DomainDetective.Tests;
+
+public class TestVirusTotalModels
+{
+    [Fact]
+    public void ResponseSerializationRoundTrip()
+    {
+        const string json = "{\"data\":{\"id\":\"1\",\"type\":\"domain\",\"attributes\":{\"last_analysis_stats\":{\"malicious\":1},\"reputation\":42}}}";
+        var resp = JsonSerializer.Deserialize<VirusTotalResponse>(json, VirusTotalJson.Options)!;
+        Assert.Equal("1", resp.Data?.Id);
+        Assert.Equal(VirusTotalObjectType.Domain, resp.Data?.Type);
+        Assert.Equal(1, resp.Data?.Attributes?.LastAnalysisStats?.Malicious);
+        Assert.Equal(42, resp.Data?.Attributes?.Reputation);
+
+        var round = JsonSerializer.Deserialize<VirusTotalResponse>(JsonSerializer.Serialize(resp, VirusTotalJson.Options), VirusTotalJson.Options)!;
+        Assert.Equal(resp.Data?.Type, round.Data?.Type);
+    }
+
+    [Fact]
+    public async Task ClientQueriesEndpoint()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.When("https://api/v3/domains/*").Respond("application/json", "{\"data\":{\"id\":\"x\",\"type\":\"domain\",\"attributes\":{\"last_analysis_stats\":{\"malicious\":0}}}}");
+        var client = new VirusTotalClient(baseUrl: "https://api/v3") { HttpHandlerFactory = () => handler };
+        var result = await client.GetDomain("example.com");
+        Assert.Equal("x", result?.Data?.Id);
+    }
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalAttributes.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalAttributes.cs
@@ -1,0 +1,17 @@
+namespace DomainDetective;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Attributes for VirusTotal objects.
+/// </summary>
+public sealed class VirusTotalAttributes
+{
+    /// <summary>Last analysis statistics.</summary>
+    [JsonPropertyName("last_analysis_stats")]
+    public VirusTotalStats? LastAnalysisStats { get; set; }
+
+    /// <summary>Reputation score.</summary>
+    [JsonPropertyName("reputation")]
+    public int? Reputation { get; set; }
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalClient.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalClient.cs
@@ -1,0 +1,84 @@
+namespace DomainDetective;
+
+using System;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Client for querying VirusTotal API.
+/// </summary>
+public sealed class VirusTotalClient
+{
+    /// <summary>Base URL of the service.</summary>
+    public string BaseUrl { get; }
+
+    /// <summary>API key for authentication.</summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>Factory for creating custom HTTP handlers.</summary>
+    internal Func<HttpMessageHandler>? HttpHandlerFactory { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VirusTotalClient"/> class.
+    /// </summary>
+    /// <param name="apiKey">VirusTotal API key.</param>
+    /// <param name="baseUrl">Optional base URL.</param>
+    public VirusTotalClient(string? apiKey = null, string? baseUrl = null)
+    {
+        ApiKey = apiKey;
+        BaseUrl = string.IsNullOrWhiteSpace(baseUrl)
+            ? "https://www.virustotal.com/api/v3"
+            : baseUrl.TrimEnd('/');
+    }
+
+    private HttpClient GetClient(out bool dispose)
+    {
+        if (HttpHandlerFactory != null)
+        {
+            dispose = true;
+            return new HttpClient(HttpHandlerFactory(), disposeHandler: true);
+        }
+
+        dispose = false;
+        return SharedHttpClient.Instance;
+    }
+
+    private async Task<T?> QueryAsync<T>(string path, CancellationToken ct)
+    {
+        var client = GetClient(out var dispose);
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, $"{BaseUrl}/{path}");
+            if (!string.IsNullOrEmpty(ApiKey))
+            {
+                request.Headers.Add("x-apikey", ApiKey);
+            }
+
+            using var resp = await client.SendAsync(request, ct).ConfigureAwait(false);
+            resp.EnsureSuccessStatusCode();
+            var json = await resp.Content.ReadAsStringAsync().ConfigureAwait(false);
+            return JsonSerializer.Deserialize<T>(json, VirusTotalJson.Options);
+        }
+        finally
+        {
+            if (dispose)
+            {
+                client.Dispose();
+            }
+        }
+    }
+
+    /// <summary>Gets domain information.</summary>
+    public Task<VirusTotalResponse?> GetDomain(string domain, CancellationToken ct = default)
+        => QueryAsync<VirusTotalResponse>($"domains/{domain}", ct);
+
+    /// <summary>Gets IP address information.</summary>
+    public Task<VirusTotalResponse?> GetIpAddress(string ipAddress, CancellationToken ct = default)
+        => QueryAsync<VirusTotalResponse>($"ip_addresses/{ipAddress}", ct);
+
+    /// <summary>Gets URL information.</summary>
+    public Task<VirusTotalResponse?> GetUrl(string urlId, CancellationToken ct = default)
+        => QueryAsync<VirusTotalResponse>($"urls/{urlId}", ct);
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalJson.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalJson.cs
@@ -1,0 +1,18 @@
+namespace DomainDetective;
+
+using System.Text.Json;
+
+/// <summary>
+/// Provides JSON serializer options for VirusTotal objects.
+/// </summary>
+public static class VirusTotalJson
+{
+    /// <summary>Default serializer options.</summary>
+    public static readonly JsonSerializerOptions Options;
+
+    static VirusTotalJson()
+    {
+        Options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        Options.Converters.Add(new VirusTotalObjectTypeConverter());
+    }
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalObject.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalObject.cs
@@ -1,0 +1,21 @@
+namespace DomainDetective;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// VirusTotal object container.
+/// </summary>
+public sealed class VirusTotalObject
+{
+    /// <summary>Identifier.</summary>
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    /// <summary>Object type.</summary>
+    [JsonPropertyName("type")]
+    public VirusTotalObjectType Type { get; set; }
+
+    /// <summary>Object attributes.</summary>
+    [JsonPropertyName("attributes")]
+    public VirusTotalAttributes? Attributes { get; set; }
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalObjectType.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalObjectType.cs
@@ -1,0 +1,19 @@
+namespace DomainDetective;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// VirusTotal object types.
+/// </summary>
+[JsonConverter(typeof(VirusTotalObjectTypeConverter))]
+public enum VirusTotalObjectType
+{
+    /// <summary>Unknown or unsupported type.</summary>
+    Unknown,
+    /// <summary>IP address object.</summary>
+    IpAddress,
+    /// <summary>Domain object.</summary>
+    Domain,
+    /// <summary>URL object.</summary>
+    Url
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalObjectTypeConverter.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalObjectTypeConverter.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Converts <see cref="VirusTotalObjectType"/> values to and from JSON.
+/// </summary>
+internal sealed class VirusTotalObjectTypeConverter : JsonConverter<VirusTotalObjectType>
+{
+    public override VirusTotalObjectType Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return value switch
+        {
+            "ip_address" => VirusTotalObjectType.IpAddress,
+            "domain" => VirusTotalObjectType.Domain,
+            "url" => VirusTotalObjectType.Url,
+            _ => VirusTotalObjectType.Unknown
+        };
+    }
+
+    public override void Write(Utf8JsonWriter writer, VirusTotalObjectType value, JsonSerializerOptions options)
+    {
+        var str = value switch
+        {
+            VirusTotalObjectType.IpAddress => "ip_address",
+            VirusTotalObjectType.Domain => "domain",
+            VirusTotalObjectType.Url => "url",
+            _ => "unknown"
+        };
+        writer.WriteStringValue(str);
+    }
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalResponse.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalResponse.cs
@@ -1,0 +1,13 @@
+namespace DomainDetective;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Response wrapper returned by VirusTotal API.
+/// </summary>
+public sealed class VirusTotalResponse
+{
+    /// <summary>Data portion of the response.</summary>
+    [JsonPropertyName("data")]
+    public VirusTotalObject? Data { get; set; }
+}

--- a/DomainDetective/Protocols/VirusTotal/VirusTotalStats.cs
+++ b/DomainDetective/Protocols/VirusTotal/VirusTotalStats.cs
@@ -1,0 +1,33 @@
+namespace DomainDetective;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Statistics returned by VirusTotal analysis.
+/// </summary>
+public sealed class VirusTotalStats
+{
+    /// <summary>Count of harmless detections.</summary>
+    [JsonPropertyName("harmless")]
+    public int Harmless { get; set; }
+
+    /// <summary>Count of malicious detections.</summary>
+    [JsonPropertyName("malicious")]
+    public int Malicious { get; set; }
+
+    /// <summary>Count of suspicious detections.</summary>
+    [JsonPropertyName("suspicious")]
+    public int Suspicious { get; set; }
+
+    /// <summary>Count of undetected results.</summary>
+    [JsonPropertyName("undetected")]
+    public int Undetected { get; set; }
+
+    /// <summary>Count of timeout results.</summary>
+    [JsonPropertyName("timeout")]
+    public int Timeout { get; set; }
+
+    /// <summary>Count of unsupported type results.</summary>
+    [JsonPropertyName("type-unsupported")]
+    public int TypeUnsupported { get; set; }
+}


### PR DESCRIPTION
## Summary
- add VirusTotal protocol classes and client
- provide example usage
- test VirusTotal serialization and client behavior

## Testing
- `dotnet test` *(fails: 14 failed, 618 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687913015bb4832eaf64465df2a12727