### PR TITLE
Add domain suggestion feature

### DIFF
--- a/DomainDetective.CLI/Commands/SuggestDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/SuggestDomainCommand.cs
@@ -1,0 +1,36 @@
+using Spectre.Console;
+using Spectre.Console.Cli;
+using System.Threading.Tasks;
+
+namespace DomainDetective.CLI;
+
+/// <summary>
+/// Settings for <see cref="SuggestDomainCommand"/>.
+/// </summary>
+internal sealed class SuggestDomainSettings : CommandSettings
+{
+    /// <summary>Domain to check.</summary>
+    [CommandArgument(0, "<domain>")]
+    public string Domain { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Suggests available domains using alternative TLDs.
+/// </summary>
+internal sealed class SuggestDomainCommand : AsyncCommand<SuggestDomainSettings>
+{
+    /// <inheritdoc />
+    public override async Task<int> ExecuteAsync(CommandContext context, SuggestDomainSettings settings)
+    {
+        var search = new DomainAvailabilitySearch();
+        await foreach (var result in search.CheckTldAlternativesAsync(settings.Domain, Program.CancellationToken))
+        {
+            if (result.Available)
+            {
+                AnsiConsole.MarkupLine($"[green]{result.Domain}[/]");
+            }
+        }
+
+        return 0;
+    }
+}

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -52,6 +52,9 @@ internal static class Program {
             config.AddCommand<SearchDomainCommand>("SearchDomain")
                 .WithDescription("Search for available domains")
                 .WithExample(new[] { "SearchDomain", "mykeyword" });
+            config.AddCommand<SuggestDomainCommand>("SuggestDomain")
+                .WithDescription("Suggest available domains")
+                .WithExample(new[] { "SuggestDomain", "example.com" });
             config.AddCommand<TestSmimeaCommand>("TestSMIMEA")
                 .WithDescription("Query SMIMEA record for an email address")
                 .WithExample(new[] { "TestSMIMEA", "user@example.com" });

--- a/DomainDetective.Example/ExampleSuggestDomain.cs
+++ b/DomainDetective.Example/ExampleSuggestDomain.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    public static async Task ExampleSuggestDomain()
+    {
+        var search = new DomainAvailabilitySearch();
+        await foreach (var result in search.CheckTldAlternativesAsync("example.com"))
+        {
+            if (result.Available)
+            {
+                Console.WriteLine($"{result.Domain} is available");
+            }
+        }
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -79,6 +79,7 @@ public static partial class Program {
 
         await ExampleCheckDomainAvailability();
         await ExampleCheckLabelAcrossTlds();
+        await ExampleSuggestDomain();
 
         //await ExampleQueryDNS();
         //await ExampleAnalyseByStringWHOIS();

--- a/DomainDetective.Tests/TestDomainSuggestions.cs
+++ b/DomainDetective.Tests/TestDomainSuggestions.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestDomainSuggestions
+{
+    [Fact]
+    public async Task SuggestsAvailableAlternative()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var serverTask = Task.Run(async () =>
+        {
+            for (int i = 0; i < 4; i++)
+            {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream);
+                var line = await reader.ReadLineAsync();
+                using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                if (line != null && line.Contains("test.net"))
+                {
+                    await writer.WriteAsync("NOT FOUND");
+                }
+                else
+                {
+                    await writer.WriteAsync("Domain Name: test.com");
+                }
+            }
+        });
+
+        try
+        {
+            var search = new DomainAvailabilitySearch
+            {
+                AvailabilityOverride = async (d, _) =>
+                {
+                    using var tcp = new TcpClient();
+                    await tcp.ConnectAsync(IPAddress.Loopback, port);
+                    using var s = tcp.GetStream();
+                    using var w = new StreamWriter(s) { AutoFlush = true, NewLine = "\r\n" };
+                    await w.WriteLineAsync(d);
+                    using var r = new StreamReader(s);
+                    var resp = await r.ReadToEndAsync();
+                    return resp.Contains("NOT FOUND");
+                }
+            };
+
+            var results = new List<DomainAvailabilityResult>();
+            await foreach (var r in search.CheckTldAlternativesAsync("test.com"))
+            {
+                results.Add(r);
+            }
+
+            Assert.Contains(results, r => r.Domain == "test.net" && r.Available);
+        }
+        finally
+        {
+            listener.Stop();
+            await serverTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add support for TLD alternatives in `DomainAvailabilitySearch`
- implement `SuggestDomainCommand` for CLI
- provide example usage
- test domain suggestion with a mocked WHOIS server

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter TestDomainSuggestions --framework net8.0`

------
https://chatgpt.com/codex/tasks/task_e_687910674da0832ebe48d2e9f807919b