### PR TITLE
Integrate VirusTotal client into threat analyses

### DIFF
--- a/DomainDetective.Tests/TestThreatFeedAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatFeedAnalysis.cs
@@ -50,4 +50,20 @@ public class TestThreatFeedAnalysis {
         Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
         Assert.False(analysis.ListedByVirusTotal);
     }
+
+    [Fact]
+    public async Task UsesObjectOverride() {
+        var obj = new VirusTotalObject {
+            Attributes = new VirusTotalAttributes {
+                LastAnalysisStats = new VirusTotalStats { Malicious = 1 }
+            }
+        };
+        var analysis = new ThreatFeedAnalysis {
+            VirusTotalObjectOverride = _ => Task.FromResult<VirusTotalObject?>(obj)
+        };
+
+        await analysis.Analyze("8.8.8.8", "v", null, new InternalLogger());
+
+        Assert.True(analysis.ListedByVirusTotal);
+    }
 }

--- a/DomainDetective.Tests/TestThreatIntelAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatIntelAnalysis.cs
@@ -81,4 +81,26 @@ public class TestThreatIntelAnalysis
         Assert.Equal(90, analysis.RiskScore);
         Assert.Contains(warnings, w => w.FullMessage.Contains("risk score"));
     }
+
+    [Fact]
+    public async Task UsesObjectOverride()
+    {
+        var obj = new VirusTotalObject
+        {
+            Attributes = new VirusTotalAttributes
+            {
+                LastAnalysisStats = new VirusTotalStats { Malicious = 1 },
+                Reputation = 42
+            }
+        };
+        var analysis = new ThreatIntelAnalysis
+        {
+            VirusTotalObjectOverride = _ => Task.FromResult<VirusTotalObject?>(obj)
+        };
+
+        await analysis.Analyze("example.com", null, null, "v", new InternalLogger());
+
+        Assert.True(analysis.ListedByVirusTotal);
+        Assert.Equal(42, analysis.RiskScore);
+    }
 }


### PR DESCRIPTION
## Summary
- inject `VirusTotalClient` into threat intel and threat feed analyses
- return `VirusTotalObject` instead of raw JSON
- record VirusTotal risk scores and listing status from the model
- support overriding with `VirusTotalObject` for testing
- add unit tests for the new overrides

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: TestCertificateMonitor.ProducesSummaryCounts, TestDkimAnalysis.TestDKIMByDomain, TestSpfAnalysis.TestSpfOver255, TestCAAAnalysis.TestCAARecordByDomain, TestCertificateHTTP.ValidCertificateProvidesExpirationInfo, TestCertificateHTTP.ValidHostSetsProtocolVersion, TestCertificateHTTP.CapturesCipherSuiteWhenEnabled, TestAll.TestAllHealthChecks, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestSOAAnalysis.VerifySoaByDomain, TestDMARCAnalysis.TestDMARCByDomain, TestDkimGuess.GuessSelectorsForDomain)*

------
https://chatgpt.com/codex/tasks/task_e_68792b945884832eaf74d558f6928f6f