### PR TITLE
Add VirusTotal direct usage example

### DIFF
--- a/DomainDetective.Example/ExampleVirusTotalDirect.cs
+++ b/DomainDetective.Example/ExampleVirusTotalDirect.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>Shows direct VirusTotalClient usage.</summary>
+    public static async Task ExampleVirusTotalDirect()
+    {
+        var client = new VirusTotalClient("YOUR_API_KEY");
+
+        var domain = await client.GetDomain("example.com");
+        Console.WriteLine($"Domain reputation: {domain?.Data?.Attributes?.Reputation}");
+        if (domain?.Data?.Attributes?.LastAnalysisStats is { } domainStats)
+        {
+            Helpers.ShowPropertiesTable("Domain stats", domainStats);
+        }
+
+        var ip = await client.GetIpAddress("8.8.8.8");
+        Console.WriteLine($"IP reputation: {ip?.Data?.Attributes?.Reputation}");
+        if (ip?.Data?.Attributes?.LastAnalysisStats is { } ipStats)
+        {
+            Helpers.ShowPropertiesTable("IP stats", ipStats);
+        }
+
+        var url = "https://example.com/";
+        var urlId = Convert.ToBase64String(Encoding.UTF8.GetBytes(url))
+            .TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+        var urlResp = await client.GetUrl(urlId);
+        if (urlResp?.Data?.Attributes?.LastAnalysisStats is { } urlStats)
+        {
+            Helpers.ShowPropertiesTable("URL stats", urlStats);
+        }
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -77,6 +77,7 @@ public static partial class Program {
         await ExamplePortScan();
         await ExampleCtLogAggregator();
         await ExampleVirusTotalClient();
+        await ExampleVirusTotalDirect();
 
         await ExampleCheckDomainAvailability();
         await ExampleCheckLabelAcrossTlds();

--- a/DomainDetective.Tests/TestVirusTotalModels.cs
+++ b/DomainDetective.Tests/TestVirusTotalModels.cs
@@ -29,4 +29,26 @@ public class TestVirusTotalModels
         var result = await client.GetDomain("example.com");
         Assert.Equal("x", result?.Data?.Id);
     }
+
+    [Fact]
+    public async Task ClientQueriesDomainIpAndUrl()
+    {
+        var handler = new MockHttpMessageHandler();
+        handler.When("https://api/v3/domains/*").Respond("application/json", "{\"data\":{\"id\":\"d\",\"type\":\"domain\",\"attributes\":{\"reputation\":2,\"last_analysis_stats\":{\"malicious\":1}}}}");
+        handler.When("https://api/v3/ip_addresses/*").Respond("application/json", "{\"data\":{\"id\":\"i\",\"type\":\"ip_address\",\"attributes\":{\"reputation\":3}}}");
+        handler.When("https://api/v3/urls/*").Respond("application/json", "{\"data\":{\"id\":\"u\",\"type\":\"url\",\"attributes\":{\"last_analysis_stats\":{\"malicious\":4}}}}");
+
+        var client = new VirusTotalClient(baseUrl: "https://api/v3") { HttpHandlerFactory = () => handler };
+
+        var domainResp = await client.GetDomain("example.com");
+        Assert.Equal(2, domainResp?.Data?.Attributes?.Reputation);
+
+        var ipResp = await client.GetIpAddress("8.8.8.8");
+        Assert.Equal("i", ipResp?.Data?.Id);
+        Assert.Equal(3, ipResp?.Data?.Attributes?.Reputation);
+
+        var urlResp = await client.GetUrl("abc");
+        Assert.Equal("u", urlResp?.Data?.Id);
+        Assert.Equal(4, urlResp?.Data?.Attributes?.LastAnalysisStats?.Malicious);
+    }
 }


### PR DESCRIPTION
## Summary
- demo direct VirusTotalClient calls for domain, IP and URL
- call the new example from Program
- cover direct calls with new unit test

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: CertificateHTTP, DMARC, DKIM, DNSSEC, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68793222023c832e9b98cd65e3273323