### PR TITLE
Deduplicate DNSBL providers

### DIFF
--- a/DomainDetective.Tests/TestDNSBLLoadDuplicates.cs
+++ b/DomainDetective.Tests/TestDNSBLLoadDuplicates.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Linq;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblLoadDuplicates {
+        [Fact]
+        public void LoadFileSkipsDuplicateEntries() {
+            var lines = new[] {
+                "duplicate.test",
+                "duplicate.test",
+                "unique.test"
+            };
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllLines(file, lines);
+
+                var analysis = new DNSBLAnalysis();
+                analysis.LoadDNSBL(file, clearExisting: true);
+
+                var duplicates = analysis.GetDNSBL()
+                    .Where(e => e.Domain == "duplicate.test")
+                    .ToList();
+                Assert.Single(duplicates);
+                Assert.Contains(analysis.GetDNSBL(), e => e.Domain == "unique.test");
+            } finally {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.Domain.cs
@@ -16,6 +16,7 @@ namespace DomainDetective {
         internal List<string> DomainDNSBLLists => _domainBlockLists
             .Where(e => e.Enabled)
             .Select(e => e.Domain)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         /// <summary>

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -164,6 +164,7 @@ namespace DomainDetective {
         internal List<string> DNSBLLists => DnsblEntries
             .Where(e => e.Enabled)
             .Select(e => e.Domain)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToList();
 
         /// <summary>Gets a value indicating whether any query returned a listing.</summary>


### PR DESCRIPTION
## Summary
- avoid repeated queries by deduplicating provider domains
- deduplicate domain-based block lists too
- test that duplicates in load file are ignored

## Testing
- `dotnet test` *(fails: 13, passed: 624)*

------
https://chatgpt.com/codex/tasks/task_e_687932fe2014832e94f0321441a6c220