### PR TITLE
Fix UDP port status handling

### DIFF
--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -90,10 +90,20 @@ namespace DomainDetective.Tests {
                 await analysis.Scan("127.0.0.1", new[] { udpPort }, new InternalLogger());
 
                 Assert.False(analysis.Results[udpPort].UdpOpen);
-                Assert.False(string.IsNullOrEmpty(analysis.Results[udpPort].Error));
+                Assert.Equal("No response", analysis.Results[udpPort].Error);
             } finally {
                 await udpTask;
             }
+        }
+
+        [Fact]
+        public async Task UdpPortClosedWithIcmpUnreachable() {
+            var port = GetFreePort();
+            var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+            await analysis.Scan("127.0.0.1", new[] { port }, new InternalLogger());
+
+            Assert.False(analysis.Results[port].UdpOpen);
+            Assert.Equal("ICMP unreachable", analysis.Results[port].Error);
         }
 
         [Fact]

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -193,24 +193,33 @@ public class PortScanAnalysis
                 udp.Client.ReceiveTimeout = (int)Timeout.TotalMilliseconds;
                 udp.Connect(address, port);
                 await udp.SendAsync(Array.Empty<byte>(), 0).ConfigureAwait(false);
+                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
+                {
+                    cts.CancelAfter(Timeout);
 #if NET8_0_OR_GREATER
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
-                {
-                    cts.CancelAfter(Timeout);
                     var result = await udp.ReceiveAsync(cts.Token).ConfigureAwait(false);
-                    udpOpen = result.Buffer.Length > 0;
-                }
 #else
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(token))
-                {
-                    cts.CancelAfter(Timeout);
                     var receiveTask = udp.ReceiveAsync();
-                    await receiveTask.WaitWithCancellation(cts.Token).ConfigureAwait(false);
-                    udpOpen = true;
-                }
+                    var result = await receiveTask.WaitWithCancellation(cts.Token).ConfigureAwait(false);
 #endif
+                    udpOpen = result.Buffer.Length > 0;
+                    if (!udpOpen)
+                    {
+                        error = "No response";
+                    }
+                }
             }
-            catch (Exception ex) when (ex is SocketException || ex is OperationCanceledException)
+            catch (SocketException ex) when (ex.SocketErrorCode == SocketError.ConnectionReset || ex.SocketErrorCode == SocketError.ConnectionRefused)
+            {
+                logger?.WriteVerbose("UDP {0}:{1} unreachable - {2}", address, port, ex.Message);
+                error = "ICMP unreachable";
+            }
+            catch (OperationCanceledException)
+            {
+                logger?.WriteVerbose("UDP {0}:{1} timed out", address, port);
+                error = "No response";
+            }
+            catch (SocketException ex)
             {
                 logger?.WriteVerbose("UDP {0}:{1} closed - {2}", address, port, ex.Message);
                 error = ex.Message;


### PR DESCRIPTION
## Summary
- improve UDP scanner to tell apart timeouts and unreachable ports
- update tests for UDP port analysis

## Testing
- `dotnet test --no-build --filter FullyQualifiedName~TestPortScanAnalysis --verbosity minimal`
- `dotnet test --no-build --verbosity minimal` *(fails: Assert.True() Failure, SocketException)*

------
https://chatgpt.com/codex/tasks/task_e_68793310723c832e80e8b755ebe7ccb6