### PR TITLE
Replace timers with PeriodicTimer

### DIFF
--- a/DomainDetective.Tests/TestCertificateMonitor.cs
+++ b/DomainDetective.Tests/TestCertificateMonitor.cs
@@ -21,5 +21,17 @@ namespace DomainDetective.Tests {
             monitor.Dispose();
             Assert.False(monitor.IsRunning);
         }
+
+        [Fact]
+        public void CanStartAndStopMultipleTimes() {
+            var monitor = new CertificateMonitor();
+            var timerField = typeof(CertificateMonitor).GetField("_timer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+            for (int i = 0; i < 3; i++) {
+                monitor.Start(Array.Empty<string>(), TimeSpan.FromMilliseconds(1));
+                Assert.NotNull(timerField.GetValue(monitor));
+                monitor.Stop();
+                Assert.Null(timerField.GetValue(monitor));
+            }
+        }
     }
 }

--- a/DomainDetective.Tests/TestMonitorScheduler.cs
+++ b/DomainDetective.Tests/TestMonitorScheduler.cs
@@ -100,4 +100,15 @@ public class TestMonitorScheduler
 
         Assert.Contains(notifier.Messages, m => m.Contains("changed"));
     }
+
+    [Fact]
+    public void CanStartAndStop()
+    {
+        var scheduler = new MonitorScheduler();
+        var timerField = typeof(MonitorScheduler).GetField("_timer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        scheduler.Start();
+        Assert.NotNull(timerField.GetValue(scheduler));
+        scheduler.Stop();
+        Assert.Null(timerField.GetValue(scheduler));
+    }
 }

--- a/DomainDetective/PeriodicTimer.cs
+++ b/DomainDetective/PeriodicTimer.cs
@@ -1,0 +1,50 @@
+#if !NET6_0_OR_GREATER
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Threading
+{
+    /// <summary>
+    /// Provides a simple timer that signals at a fixed period.
+    /// </summary>
+    internal sealed class PeriodicTimer : IDisposable
+    {
+        private readonly TimeSpan _period;
+        private readonly CancellationTokenSource _cts = new();
+
+        /// <summary>Creates the timer.</summary>
+        /// <param name="period">The interval between ticks.</param>
+        /// <exception cref="ArgumentOutOfRangeException"/>
+        public PeriodicTimer(TimeSpan period)
+        {
+            if (period <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(nameof(period));
+            }
+            _period = period;
+        }
+
+        /// <summary>Waits for the next tick or cancellation.</summary>
+        public async ValueTask<bool> WaitForNextTickAsync(CancellationToken cancellationToken = default)
+        {
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, cancellationToken);
+            try
+            {
+                await Task.Delay(_period, linked.Token).ConfigureAwait(false);
+                return true;
+            }
+            catch (OperationCanceledException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>Stops the timer.</summary>
+        public void Dispose()
+        {
+            _cts.Cancel();
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add PeriodicTimer shim for older frameworks
- refactor CertificateMonitor to use PeriodicTimer
- refactor monitoring classes to use PeriodicTimer
- adjust MonitorScheduler timer disposal
- add start/stop tests

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: CertificateHTTP, DkimAnalysis, CAAAnalysis, CertificateMonitor, TestAll, SPFAnalysis, SOAAnalysis, DMARCAnalysis, DkimGuess)*

------
https://chatgpt.com/codex/tasks/task_e_6879663de8e0832e93f38abc4b8e27ec