### PR TITLE
Fix SMTP client disposal and test connections

### DIFF
--- a/DomainDetective.Tests/TestEmailNotificationSender.cs
+++ b/DomainDetective.Tests/TestEmailNotificationSender.cs
@@ -1,0 +1,74 @@
+using DomainDetective.Monitoring;
+using MailKit.Net.Smtp;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestEmailNotificationSender {
+    private class CountingSmtpClient : SmtpClient {
+        public int ConnectCount { get; private set; }
+        public int DisposeCount { get; private set; }
+
+        public CountingSmtpClient() {
+            Connected += (_, _) => ConnectCount++;
+        }
+
+        protected override void Dispose(bool disposing) {
+            if (disposing) {
+                DisposeCount++;
+            }
+            base.Dispose(disposing);
+        }
+    }
+
+    [Fact]
+    public async Task DisposesClientAndConnectsOnce() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var serverTask = Task.Run(async () => {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            using var reader = new StreamReader(stream);
+            using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220 local ESMTP");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("250 hello");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("250 OK");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("250 OK");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("354 Start mail input; end with <CRLF>.<CRLF>");
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != ".") { }
+            await writer.WriteLineAsync("250 OK");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("221 bye");
+        });
+
+        var client = new CountingSmtpClient();
+        var original = EmailNotificationSender.CreateClient;
+        EmailNotificationSender.CreateClient = () => client;
+        try {
+            var sender = new EmailNotificationSender {
+                SmtpHost = "localhost",
+                Port = port,
+                From = "from@example.com",
+                To = "to@example.com"
+            };
+            await sender.SendAsync("test");
+        } finally {
+            EmailNotificationSender.CreateClient = original;
+            listener.Stop();
+            await serverTask;
+        }
+
+        Assert.Equal(1, client.ConnectCount);
+        Assert.Equal(1, client.DisposeCount);
+    }
+}

--- a/DomainDetective/Monitoring/NotificationSender.cs
+++ b/DomainDetective/Monitoring/NotificationSender.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Net.Http;
 using System.Text;
+using MailKit;
 using MailKit.Net.Smtp;
 using MimeKit;
 using System.Threading;
@@ -46,6 +48,7 @@ public class WebhookNotificationSender : INotificationSender
 /// </remarks>
 public class EmailNotificationSender : INotificationSender
 {
+    internal static Func<ISmtpClient> CreateClient { get; set; } = () => new SmtpClient();
     public string SmtpHost { get; set; } = "localhost";
     public int Port { get; set; } = 25;
     public bool UseSsl { get; set; }
@@ -62,7 +65,7 @@ public class EmailNotificationSender : INotificationSender
         email.Subject = "DomainDetective Notification";
         email.Body = new TextPart("plain") { Text = message };
 
-        using var client = new SmtpClient();
+        using var client = CreateClient();
         await client.ConnectAsync(SmtpHost, Port, UseSsl, ct);
         if (!string.IsNullOrEmpty(Username))
         {


### PR DESCRIPTION
## Summary
- ensure `EmailNotificationSender` creates `SmtpClient` via a factory
- cover SMTP disposal and connect count with unit test

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --logger "console;verbosity=minimal" --filter DisposesClientAndConnectsOnce`

------
https://chatgpt.com/codex/tasks/task_e_68796668f78c832ebbd85fd0b621e1c6