### PR TITLE
Fix progress completion with empty server list

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagationProgress.cs
+++ b/DomainDetective.Tests/TestDnsPropagationProgress.cs
@@ -1,0 +1,18 @@
+using DnsClientX;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsPropagationProgress {
+    [Fact]
+    public async Task ProgressCompletesWhenNoServers() {
+        var analysis = new DnsPropagationAnalysis();
+        var values = new List<double>();
+        var progress = new Progress<double>(v => values.Add(v));
+        var results = await analysis.QueryAsync("example.com", DnsRecordType.A, Enumerable.Empty<PublicDnsEntry>(), progress: progress);
+        Assert.Empty(results);
+        Assert.Contains(100, values.Select(v => (int)v));
+    }
+}

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -384,6 +384,7 @@ namespace DomainDetective {
             bool includeGeo = false) {
             var serverList = servers?.ToList() ?? new List<PublicDnsEntry>();
             if (serverList.Count == 0) {
+                progress?.Report(100);
                 return new List<DnsPropagationResult>();
             }
             maxParallelism = maxParallelism <= 0 ? serverList.Count : Math.Min(maxParallelism, serverList.Count);


### PR DESCRIPTION
## Summary
- complete progress when no DNS servers are provided
- test progress completion on empty queries

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "FullyQualifiedName~TestDnsPropagationProgress"`
- `dotnet build DomainDetective.sln -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_68796632195c832e8153315dface3707