### PR TITLE
Fix UDP port detection

### DIFF
--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -97,6 +97,23 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task UdpPortClosedWhenNoReply() {
+            using var udpServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+            var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+            var udpTask = udpServer.ReceiveAsync();
+
+            try {
+                var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+                await analysis.Scan("127.0.0.1", new[] { udpPort }, new InternalLogger());
+
+                Assert.False(analysis.Results[udpPort].UdpOpen);
+            } finally {
+                udpServer.Close();
+                try { await udpTask; } catch { }
+            }
+        }
+
+        [Fact]
         public async Task DetectsTcpClosedPort() {
             var port = GetFreePort();
             var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };

--- a/DomainDetective/Network/PortScanAnalysis.cs
+++ b/DomainDetective/Network/PortScanAnalysis.cs
@@ -204,8 +204,8 @@ public class PortScanAnalysis
                     var receiveTask = udp.ReceiveAsync();
                     try
                     {
-                        await receiveTask.WaitWithCancellation(cts.Token).ConfigureAwait(false);
-                        udpOpen = true;
+                        var result = await receiveTask.WaitWithCancellation(cts.Token).ConfigureAwait(false);
+                        udpOpen = result.Buffer.Length > 0;
                     }
                     catch
                     {


### PR DESCRIPTION
## Summary
- only mark UDP port open when receiving a response
- add a unit test for no-reply UDP behavior

## Testing
- `dotnet test` *(fails: 13 failed, 642 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6879d7d6adb8832e85671c7b57896535