### PR TITLE
Fix HttpClient disposal and add connection failure test

### DIFF
--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -52,6 +52,16 @@ namespace DomainDetective.Tests {
                 await healthCheck.VerifyPlainHttp(domain));
         }
 
+        [Fact]
+        public async Task VerifyPlainHttpSetsFailureReasonOnConnectionFailure() {
+            var port = GetFreePort();
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.VerifyPlainHttp($"localhost:{port}");
+
+            Assert.False(healthCheck.HttpAnalysis.IsReachable);
+            Assert.False(string.IsNullOrEmpty(healthCheck.HttpAnalysis.FailureReason));
+        }
+
         private static int GetFreePort() {
             return PortHelper.GetFreePort();
         }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -467,7 +467,7 @@ namespace DomainDetective {
                 return;
             }
 
-            var client = HttpClientFactory.CreateClient();
+            using var client = HttpClientFactory.CreateClient();
             using var responseStream = await client.GetStreamAsync(url);
             using var memory = new MemoryStream();
             await responseStream.CopyToAsync(memory);


### PR DESCRIPTION
## Summary
- dispose HttpClient when refreshing the public suffix list
- test connection failure handling for `VerifyPlainHttp`

## Testing
- `dotnet test` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6879d7bc9ce8832e8c52ff75b3e39473