### PR TITLE
Fix domain TLD validation

### DIFF
--- a/DomainDetective.Tests/TestIdnValidation.cs
+++ b/DomainDetective.Tests/TestIdnValidation.cs
@@ -23,4 +23,13 @@ public class TestIdnValidation
         var result = (string)method.Invoke(null, new object[] { "bücher.de:25" })!;
         Assert.Equal("xn--bcher-kva.de:25", result);
     }
+
+    [Fact]
+    public void ValidateHostNameRejectsNumericTld()
+    {
+        var method = typeof(DomainHealthCheck)
+            .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { "example.123" }));
+        Assert.IsType<ArgumentException>(ex.InnerException);
+    }
 }

--- a/DomainDetective/Helpers/DomainHelper.cs
+++ b/DomainDetective/Helpers/DomainHelper.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace DomainDetective.Helpers
 {
     public static class DomainHelper
     {
         private static readonly IdnMapping _idn = new();
+        private static readonly Regex _tldRegex = new(
+            "^[A-Za-z](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$",
+            RegexOptions.Compiled);
 
         public static string ValidateIdn(string domain)
         {
@@ -23,5 +27,8 @@ namespace DomainDetective.Helpers
                 throw new ArgumentException("Invalid domain name.", nameof(domain), e);
             }
         }
+
+        public static bool IsValidTld(string tld) =>
+            _tldRegex.IsMatch(tld ?? string.Empty);
     }
 }


### PR DESCRIPTION
## Summary
- validate TLDs with new regex requiring a leading letter
- reject numeric TLDs in host validation
- test host validation rejects numeric TLDs

## Testing
- `dotnet test -v:m` *(fails: TestCertificateHTTP.ValidCertificateProvidesExpirationInfo, TestCertificateHTTP.ValidHostSetsProtocolVersion, TestCertificateHTTP.CapturesCipherSuiteWhenEnabled, TestCertificateMonitor.ProducesSummaryCounts, TestSpfAnalysis.TestSpfOver255, TestDkimAnalysis.TestDKIMByDomain, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups, TestSpfAnalysis.QueryDomainBySPF, TestSecurityTXTAnalysis.ValidSecurityTxtIsParsed, TestCAAAnalysis.TestCAARecordByDomain, TestDMARCAnalysis.TestDMARCByDomain, TestDkimGuess.GuessSelectorsForDomain, TestSOAAnalysis.VerifySoaByDomain, TestAll.TestAllHealthChecks)*

------
https://chatgpt.com/codex/tasks/task_e_6879d7de19fc832e84ce641708d8641a