### PR TITLE
Ensure UTF-8 summary encoding

### DIFF
--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -38,6 +38,11 @@
         <ProjectReference Include="..\DomainDetective.Reports\DomainDetective.Reports.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
+        <Reference Include="System.IO.Compression" />
+        <Reference Include="System.IO.Compression.FileSystem" />
+    </ItemGroup>
+
     <ItemGroup>
         <None Include="..\Data\public_suffix_list.dat">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -35,6 +35,7 @@
     <ItemGroup>
         <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
         <ProjectReference Include="..\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj" />
+        <ProjectReference Include="..\DomainDetective.Reports\DomainDetective.Reports.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DomainDetective.Tests/TestDmarcReportParser.cs
+++ b/DomainDetective.Tests/TestDmarcReportParser.cs
@@ -1,0 +1,29 @@
+using DomainDetective.Reports;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDmarcReportParser {
+        [Fact]
+        public void ParseUnicodeDomain() {
+            const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback><record><identifiers><header_from>bücher.de</header_from></identifiers><row><policy_evaluated><dkim>pass</dkim></policy_evaluated></row></record></feedback>";
+            var tmp = Path.GetTempFileName();
+            File.Delete(tmp);
+            using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
+                var entry = archive.CreateEntry("report.xml");
+                using var stream = entry.Open();
+                using var writer = new StreamWriter(stream, Encoding.UTF8);
+                writer.Write(xml);
+            }
+            var summaries = DmarcReportParser.ParseZip(tmp).ToList();
+            File.Delete(tmp);
+            Assert.Single(summaries);
+            Assert.Equal("xn--bcher-kva.de", summaries[0].Domain);
+            Assert.Equal(1, summaries[0].PassCount);
+            Assert.Equal(0, summaries[0].FailCount);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDomainSummary.cs
+++ b/DomainDetective.Tests/TestDomainSummary.cs
@@ -36,6 +36,7 @@ namespace DomainDetective.Tests {
             const string dkimRecord = "v=DKIM1; k=rsa; p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqrIpQkyykYEQbNzvHfgGsiYfoyX3b3Z6CPMHa5aNn/Bd8skLaqwK9vj2fHn70DA+X67L/pV2U5VYDzb5AUfQeD6NPDwZ7zLRc0XtX+5jyHWhHueSQT8uo6acMA+9JrVHdRfvtlQo8Oag8SLIkhaUea3xqZpijkQR/qHmo3GIfnQIDAQAB;";
 
             var healthCheck = new DomainHealthCheck();
+            healthCheck.SpfAnalysis.TestSpfRecords["_spf.google.com"] = "v=spf1 -all";
             await healthCheck.CheckSPF(spfRecord);
             await healthCheck.CheckDMARC(dmarcRecord);
             await healthCheck.CheckDKIM(dkimRecord);

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text.Json;
+using System.Text;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -569,7 +570,7 @@ namespace DomainDetective {
             var safe = domain.Replace(Path.DirectorySeparatorChar, '-').Replace(Path.AltDirectorySeparatorChar, '-');
             var file = Path.Combine(SnapshotDirectory, $"{safe}_{recordType}_{DateTime.UtcNow:yyyyMMddHHmmss}.json");
             var json = JsonSerializer.Serialize(results, DomainHealthCheck.JsonOptions);
-            File.WriteAllText(file, json);
+            File.WriteAllText(file, json, Encoding.UTF8);
         }
 
         /// <summary>

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
+using System.Text;
 using System.Globalization;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -551,7 +552,7 @@ namespace DomainDetective {
 
                 Directory.CreateDirectory(cacheDir);
                 var xml = await _client.GetStringAsync(url).ConfigureAwait(false);
-                File.WriteAllText(cacheFile, xml);
+                File.WriteAllText(cacheFile, xml, Encoding.UTF8);
                 return ParseTrustAnchors(xml);
             } catch (Exception ex) {
                 logger?.WriteVerbose("Trust anchor download failed: {0}", ex.Message);

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -1125,7 +1125,7 @@ public class WhoisAnalysis {
         }
         Directory.CreateDirectory(SnapshotDirectory);
         var file = Path.Combine(SnapshotDirectory, $"{DomainName}_{DateTime.UtcNow:yyyyMMddHHmmss}.whois");
-        File.WriteAllText(file, WhoisData);
+        File.WriteAllText(file, WhoisData, Encoding.UTF8);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- enforce UTF-8 when writing snapshots
- add reference to Reports project for tests
- test DMARC parser with Unicode domain

## Testing
- `dotnet test DomainDetective.sln -v minimal` *(fails: 13 tests, 642 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6879d7cc7660832ebd79fbd06b2789ca