### PR TITLE
Normalize DNSBL config line parsing

### DIFF
--- a/DomainDetective.Tests/TestDNSBLConfig.cs
+++ b/DomainDetective.Tests/TestDNSBLConfig.cs
@@ -105,4 +105,30 @@ namespace DomainDetective.Tests {
                 File.Delete(file);
             }
         }
-    }}
+
+        [Fact]
+        public void LoadConfigUnixLineEndings() {
+            var lines = new[] {
+                "{",
+                "  \"providers\": [",
+                "    { \"domain\": \"unix.example\" }",
+                "  ]",
+                "}"
+            };
+            var file = Path.GetTempFileName();
+            try {
+                File.WriteAllText(file, string.Join("\n", lines));
+
+                var analysis = new DNSBLAnalysis();
+                analysis.LoadDnsblConfig(file, clearExisting: true);
+                using (File.Open(file, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+
+                var entry = Assert.Single(analysis.GetDNSBL());
+                Assert.Equal("unix.example", entry.Domain);
+            }
+            finally {
+                File.Delete(file);
+            }
+        }
+    }
+}

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -525,10 +525,10 @@ namespace DomainDetective {
                 throw new FileNotFoundException($"DNSBL config file not found: {filePath}");
             }
 
-            using var stream = File.OpenRead(filePath);
+            var lines = File.ReadAllLines(filePath);
+            var json = string.Join("\n", lines);
             var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var config = JsonSerializer.DeserializeAsync<DnsblConfiguration>(stream, options)
-                .GetAwaiter().GetResult();
+            var config = JsonSerializer.Deserialize<DnsblConfiguration>(json, options);
             if (config != null) {
                 ApplyDnsblConfiguration(config, overwriteExisting, clearExisting);
             }


### PR DESCRIPTION
## Summary
- load DNSBL configuration using `File.ReadAllLines`
- verify Unix formatted JSON loads correctly

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0` *(fails: Assert.True() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_6879d7c63c24832e960f10bb23ad6c8b