### PR TITLE
Add HttpListener support checks in tests

### DIFF
--- a/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
+++ b/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests;
 
@@ -8,6 +9,10 @@ public class TestDirectoryExposureAnalysis
     [Fact]
     public async Task DetectsAccessibleDirectories()
     {
+        if (!HttpListener.IsSupported)
+        {
+            throw SkipException.ForSkip("HttpListener not supported");
+        }
         using var listener = new HttpListener();
         var prefix = $"http://localhost:{GetFreePort()}/";
         listener.Prefixes.Add(prefix);
@@ -45,6 +50,10 @@ public class TestDirectoryExposureAnalysis
     [Fact]
     public async Task NoExposedDirectoriesWhenNoneAccessible()
     {
+        if (!HttpListener.IsSupported)
+        {
+            throw SkipException.ForSkip("HttpListener not supported");
+        }
         using var listener = new HttpListener();
         var prefix = $"http://localhost:{GetFreePort()}/";
         listener.Prefixes.Add(prefix);

--- a/DomainDetective.Tests/TestDuplicateHealthChecks.cs
+++ b/DomainDetective.Tests/TestDuplicateHealthChecks.cs
@@ -3,11 +3,15 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestDuplicateHealthChecks {
         [Fact]
         public async Task DuplicatesExecuteOnce() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);

--- a/DomainDetective.Tests/TestHPKPAnalysis.cs
+++ b/DomainDetective.Tests/TestHPKPAnalysis.cs
@@ -4,11 +4,15 @@ using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestHPKPAnalysis {
         [Fact]
         public async Task DetectsHeaderAndValidPins() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -42,6 +46,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task InvalidPinFormat() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -66,6 +73,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DetectsIncludeSubDomains() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -93,6 +103,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task SelfSignedAllowsSinglePin() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -120,6 +133,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task WarnsOnHpKPHeader() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -148,6 +164,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task HeaderMissing() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -170,6 +189,9 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task CachedHeaderReusedUntilExpiration() {
             HPKPAnalysis.ClearCache();
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -208,6 +230,9 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task CachedMissingHeaderReusedUntilExpiration() {
             HPKPAnalysis.ClearCache();
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);

--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -3,11 +3,15 @@ using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestHPKPHealthCheck {
         [Fact]
         public async Task VerifyViaHealthCheck() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -11,6 +11,9 @@ namespace DomainDetective.Tests {
     public class TestHTTPAnalysis {
         [Fact]
         public async Task DetectStatusCodeAndHsts() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -85,6 +88,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task NotFoundStatusSetsIsReachableFalse() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -119,6 +125,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DoesNotCollectHeadersWhenDisabled() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -152,6 +161,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task FollowsRedirectsWhenUsingHttp3() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener1 = new HttpListener();
             var prefix1 = $"http://localhost:{GetFreePort()}/";
             listener1.Prefixes.Add(prefix1);
@@ -191,6 +203,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task LogsWarningWhenHttp3Downgraded() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -216,6 +231,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task ThrowsWhenMaxRedirectsExceeded() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -251,6 +269,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DetectsRedirectLoop() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener1 = new HttpListener();
             var prefix1 = $"http://localhost:{GetFreePort()}/";
             listener1.Prefixes.Add(prefix1);
@@ -289,6 +310,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task TimeoutSetsFailureReason() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -315,6 +339,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DetectsHstsTooShortAndIncludesSubDomains() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -345,6 +372,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task HstsHeaderFromPreloadSiteIsEligible() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -370,6 +400,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task HstsHeaderFiveMinutesNotEligibleForPreload() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -395,6 +428,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DetectsUnsafeContentSecurityPolicyDirectives() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -418,6 +454,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task ParsesExpectCtReportUri() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -443,6 +482,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task ParsesPermissionsPolicyDirectives() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -468,6 +510,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task ParsesOriginAgentClusterDisabled() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -492,6 +537,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DetectsPublicKeyPinsHeaderWithWarning() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -519,6 +567,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task CollectsUnknownHstsDirectives() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -543,6 +594,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task InvalidHstsMaxAgeIsCollected() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -571,6 +625,9 @@ namespace DomainDetective.Tests {
             File.WriteAllText(preloadPath, "[\"localhost\"]");
             HttpAnalysis.LoadHstsPreloadList(preloadPath);
             using (File.Open(preloadPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -601,6 +658,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task DoesNotDetectMixedContentOnHttpPage() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);
@@ -625,6 +685,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task CapturesServerHeader() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var prefix = $"http://localhost:{GetFreePort()}/";
             listener.Prefixes.Add(prefix);

--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -4,6 +4,7 @@ using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestMTASTSAnalysis {
@@ -71,6 +72,9 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task FetchPolicyFromServer() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var port = GetFreePort();
             var prefix = $"http://localhost:{port}/";
@@ -118,6 +122,9 @@ namespace DomainDetective.Tests {
         public async Task ParseDnsRecord() {
             const string policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";
             var answers = new[] { new DnsAnswer { DataRaw = "v=STSv1; id=123" , Type = DnsRecordType.TXT } };
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var port = GetFreePort();
             var prefix = $"http://localhost:{port}/";
@@ -267,6 +274,9 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task CachedPolicyReusedUntilExpiration() {
             MTASTSAnalysis.ClearCache();
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var port = GetFreePort();
             var prefix = $"http://localhost:{port}/";
@@ -317,6 +327,9 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task CachedPolicyRespectsMaxAge() {
             MTASTSAnalysis.ClearCache();
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var port = GetFreePort();
             var prefix = $"http://localhost:{port}/";

--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -1,11 +1,15 @@
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestPlainHttpHealthCheck {
         [Fact]
         public async Task VerifyPlainHttpDetectsStatusWithoutHsts() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             using var listener = new HttpListener();
             var port = GetFreePort();
             var prefix = $"http://localhost:{port}/";

--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestSecurityTXTAnalysis {
@@ -203,6 +204,9 @@ namespace DomainDetective.Tests {
         }
 
         private static HttpListener StartListener(out string prefix) {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
             while (true) {
                 prefix = $"http://127.0.0.1:{GetFreePort()}/";
                 var l = new HttpListener();


### PR DESCRIPTION
## Summary
- skip HttpListener-based tests when the feature isn't available
- add `Xunit.Sdk` import for SkipException use

## Testing
- `dotnet test --no-build` *(fails: Assert failures in unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a801d5578832e8a26db4aeb162cbe