### PR TITLE
Fix CS1572 warnings in PowerShell cmdlets

### DIFF
--- a/DomainDetective.PowerShell/CmdletImportTlsRpt.cs
+++ b/DomainDetective.PowerShell/CmdletImportTlsRpt.cs
@@ -10,7 +10,7 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsData.Import, "TlsRpt")]
     [OutputType(typeof(TlsRptSummary))]
     public sealed class CmdletImportTlsRpt : PSCmdlet {
-        /// <param name="Path">Path to the JSON report.</param>
+        /// <summary>Path to the JSON report.</summary>
         [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         public string Path { get; set; }

--- a/DomainDetective.PowerShell/CmdletNewDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletNewDmarcRecord.cs
@@ -15,60 +15,60 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsCommon.New, "DmarcRecord")]
     [OutputType(typeof(string))]
     public sealed class CmdletNewDmarcRecord : PSCmdlet {
-        /// <param name="Policy">Main DMARC policy.</param>
+        /// <summary>Main DMARC policy.</summary>
         [Parameter(Position = 0)]
         [ValidateSet("none", "quarantine", "reject")]
         public string Policy { get; set; }
 
-        /// <param name="SubPolicy">Policy applied to subdomains.</param>
+        /// <summary>Policy applied to subdomains.</summary>
         [Parameter]
         [ValidateSet("none", "quarantine", "reject")]
         public string SubPolicy { get; set; }
 
-        /// <param name="AggregateUri">Aggregate report URI(s).</param>
+        /// <summary>Aggregate report URI(s).</summary>
         [Parameter]
         public string AggregateUri { get; set; }
 
-        /// <param name="ForensicUri">Forensic report URI(s).</param>
+        /// <summary>Forensic report URI(s).</summary>
         [Parameter]
         public string ForensicUri { get; set; }
 
-        /// <param name="Percent">Percentage of mail subjected to the policy.</param>
+        /// <summary>Percentage of mail subjected to the policy.</summary>
         [Parameter]
         [ValidateRange(0, 100)]
         public int? Percent { get; set; }
 
-        /// <param name="DkimAlignment">DKIM alignment mode.</param>
+        /// <summary>DKIM alignment mode.</summary>
         [Parameter]
         [ValidateSet("r", "s")]
         public string DkimAlignment { get; set; }
 
-        /// <param name="SpfAlignment">SPF alignment mode.</param>
+        /// <summary>SPF alignment mode.</summary>
         [Parameter]
         [ValidateSet("r", "s")]
         public string SpfAlignment { get; set; }
 
-        /// <param name="FailureOptions">Failure reporting options.</param>
+        /// <summary>Failure reporting options.</summary>
         [Parameter]
         public string FailureOptions { get; set; }
 
-        /// <param name="ReportingInterval">Reporting interval in seconds.</param>
+        /// <summary>Reporting interval in seconds.</summary>
         [Parameter]
         public int? ReportingInterval { get; set; }
 
-        /// <param name="DomainName">Domain name for publishing.</param>
+        /// <summary>Domain name for publishing.</summary>
         [Parameter]
         public string DomainName { get; set; }
 
-        /// <param name="DnsApiUrl">DNS provider API endpoint.</param>
+        /// <summary>DNS provider API endpoint.</summary>
         [Parameter]
         public Uri DnsApiUrl { get; set; }
 
-        /// <param name="Publish">Publish the record via DNS provider.</param>
+        /// <summary>Publish the record via DNS provider.</summary>
         [Parameter]
         public SwitchParameter Publish { get; set; }
 
-        /// <param name="StepByStep">Prompt step by step for all options.</param>
+        /// <summary>Prompt step by step for all options.</summary>
         [Parameter]
         public SwitchParameter StepByStep { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
+++ b/DomainDetective.PowerShell/CmdletRemoveDnsblProvider.cs
@@ -10,12 +10,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsCommon.Remove, "DDDnsblProvider")]
 [Alias("Remove-DnsblProvider")]
     public sealed class CmdletRemoveDnsblProvider : PSCmdlet {
-        /// <param name="Domain">Domain name of the provider to remove.</param>
+        /// <summary>Domain name of the provider to remove.</summary>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Domain { get; set; }
 
-        /// <param name="InputObject">Analysis object to modify.</param>
+        /// <summary>Analysis object to modify.</summary>
         [Parameter(ValueFromPipeline = true)]
         public DNSBLAnalysis InputObject { get; set; }
 

--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -20,43 +20,45 @@ namespace DomainDetective.PowerShell {
         SupportsShouldProcess = false,
         DefaultParameterSetName = "File")]
     public sealed class CmdletStartDnsPropagationMonitor : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to monitor.</param>
+        /// <summary>Domain to monitor.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "File")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Custom")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="RecordType">DNS record type.</param>
+        /// <summary>DNS record type.</summary>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "File")]
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "Custom")]
         public DnsRecordType RecordType;
 
-        /// <param name="ServersFile">Path to JSON file with DNS servers. If omitted the file
-        /// <c>Data/DNS/PublicDNS.json</c> in the module directory is used when present.</param>
+        /// <summary>
+        /// Path to JSON file with DNS servers. If omitted the file
+        /// <c>Data/DNS/PublicDNS.json</c> in the module directory is used when present.
+        /// </summary>
         [Parameter(Mandatory = false, ParameterSetName = "File")]
         public string? ServersFile;
 
-        /// <param name="DnsServer">One or more custom DNS servers.</param>
+        /// <summary>One or more custom DNS servers.</summary>
         [Parameter(Mandatory = false, ParameterSetName = "Custom")]
         public string[] DnsServer = Array.Empty<string>();
 
-        /// <param name="Country">Filter builtin servers by country.</param>
+        /// <summary>Filter builtin servers by country.</summary>
         [Parameter(Mandatory = false)]
         public CountryId? Country;
 
-        /// <param name="Location">Filter builtin servers by location.</param>
+        /// <summary>Filter builtin servers by location.</summary>
         [Parameter(Mandatory = false)]
         public LocationId? Location;
 
-        /// <param name="IntervalSeconds">Polling interval in seconds.</param>
+        /// <summary>Polling interval in seconds.</summary>
         [Parameter(Mandatory = false)]
         public int IntervalSeconds = 300;
 
-        /// <param name="WebhookUrl">Webhook URL for notifications.</param>
+        /// <summary>Webhook URL for notifications.</summary>
         [Parameter(Mandatory = false)]
         public string? WebhookUrl;
 
-        /// <param name="MaxParallelism">Maximum concurrent DNS queries.</param>
+        /// <summary>Maximum concurrent DNS queries.</summary>
         [Parameter(Mandatory = false)]
         public int MaxParallelism = 0;
 

--- a/DomainDetective.PowerShell/CmdletStopDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStopDnsPropagationMonitor.cs
@@ -11,7 +11,7 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsLifecycle.Stop, "DnsPropagationMonitor")]
     public sealed class CmdletStopDnsPropagationMonitor : AsyncPSCmdlet {
-        /// <param name="Monitor">Monitor instance returned by Start-DnsPropagationMonitor.</param>
+        /// <summary>Monitor instance returned by Start-DnsPropagationMonitor.</summary>
         [Parameter(Mandatory = true, Position = 0)]
         public DnsPropagationMonitor Monitor = null!;
 

--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -13,20 +13,20 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDTlsDaneRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-TlsDane")]
     public sealed class CmdletTestDaneRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="Ports">Custom ports to query.</param>
+        /// <summary>Custom ports to query.</summary>
         [Parameter(Mandatory = false, Position = 2, ParameterSetName = "ServerName")]
         public int[]? Ports;
 
-        /// <param name="FullResponse">Return full analysis object.</param>
+        /// <summary>Return full analysis object.</summary>
         [Parameter(Mandatory = false, ParameterSetName = "ServerName")]
         public SwitchParameter FullResponse;
 

--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -12,16 +12,16 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailDmarcRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailDmarc")]
     public sealed class CmdletTestDmarcRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="Raw">Return raw analysis object.</param>
+        /// <summary>Return raw analysis object.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter Raw;
 

--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -26,46 +26,46 @@ namespace DomainDetective.PowerShell {
         DefaultParameterSetName = "Builtin")]
 [Alias("Test-DnsPropagation")]
     public sealed class CmdletTestDnsPropagation : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Builtin")]
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServersFile")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="RecordType">DNS record type to test.</param>
+        /// <summary>DNS record type to test.</summary>
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "Builtin")]
         [Parameter(Mandatory = true, Position = 1, ParameterSetName = "ServersFile")]
         public DnsRecordType RecordType;
 
-        /// <param name="ServersFile">Path to JSON file with DNS servers.</param>
+        /// <summary>Path to JSON file with DNS servers.</summary>
         [Parameter(Mandatory = true, Position = 2, ParameterSetName = "ServersFile")]
         public string ServersFile;
 
-        /// <param name="Country">Filter servers by country.</param>
+        /// <summary>Filter servers by country.</summary>
         [Parameter(Mandatory = false)]
         public CountryId? Country;
 
-        /// <param name="Location">Filter servers by location.</param>
+        /// <summary>Filter servers by location.</summary>
         [Parameter(Mandatory = false)]
         public LocationId? Location;
 
-        /// <param name="Take">Limit the number of servers queried.</param>
+        /// <summary>Limit the number of servers queried.</summary>
         [Parameter(Mandatory = false)]
         public int? Take;
 
-        /// <param name="CountryCount">Select number of servers per country.</param>
+        /// <summary>Select number of servers per country.</summary>
         [Parameter(Mandatory = false)]
         public Hashtable? CountryCount;
 
-        /// <param name="CompareResults">Return aggregated comparison of results.</param>
+        /// <summary>Return aggregated comparison of results.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter CompareResults;
 
-        /// <param name="SnapshotPath">Directory used to store DNS snapshots.</param>
+        /// <summary>Directory used to store DNS snapshots.</summary>
         [Parameter(Mandatory = false)]
         public string SnapshotPath;
 
-        /// <param name="Diff">Return changes since last snapshot.</param>
+        /// <summary>Return changes since last snapshot.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter Diff;
 

--- a/DomainDetective.PowerShell/CmdletTestDnsSec.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsSec.cs
@@ -13,16 +13,16 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsSecStatus", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsSec")]
     public sealed class CmdletTestDnsSec : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="Raw">Return raw analysis object.</param>
+        /// <summary>Return raw analysis object.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter Raw;
 

--- a/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTtl.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsTtl", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsTtl")]
     public sealed class CmdletTestDnsTtl : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsTunneling.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsTunneling", DefaultParameterSetName = "File")]
 [Alias("Test-DnsTunneling")]
     public sealed class CmdletTestDnsTunneling : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to inspect.</param>
+        /// <summary>Domain to inspect.</summary>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="Path">Log file path.</param>
+        /// <summary>Log file path.</summary>
         [Parameter(Mandatory = true, Position = 1)]
         public string Path;
 

--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -14,35 +14,35 @@ namespace DomainDetective.PowerShell {
 [Alias("Test-DomainHealth")]
     [OutputType(typeof(DomainHealthCheck))]
     public sealed class CmdletTestDomainHealth : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to analyze.</param>
+        /// <summary>Domain to analyze.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="HealthCheckType">Specific tests to run.</param>
+        /// <summary>Specific tests to run.</summary>
         [Parameter(Mandatory = false)]
         public HealthCheckType[]? HealthCheckType;
 
-        /// <param name="DkimSelectors">DKIM selectors used when testing DKIM.</param>
+        /// <summary>DKIM selectors used when testing DKIM.</summary>
         [Parameter(Mandatory = false)]
         public string[]? DkimSelectors;
 
-        /// <param name="DaneServiceType">Service types to check for DANE. HTTPS (port 443) is queried by default.</param>
+        /// <summary>Service types to check for DANE. HTTPS (port 443) is queried by default.</summary>
         [Parameter(Mandatory = false)]
         public ServiceType[]? DaneServiceType;
 
-        /// <param name="DanePorts">Custom ports to check for DANE.</param>
+        /// <summary>Custom ports to check for DANE.</summary>
         [Parameter(Mandatory = false)]
         public int[]? DanePorts;
 
-        /// <param name="BrandKeyword">Protected brand terms for typosquatting analysis.</param>
+        /// <summary>Protected brand terms for typosquatting analysis.</summary>
         [Parameter(Mandatory = false)]
         public string[]? BrandKeyword;
         
-        /// <param name="PortScanProfile">Port scan profiles to use.</param>
+        /// <summary>Port scan profiles to use.</summary>
         [Parameter(Mandatory = false)]
         public PortScanProfile[]? PortScanProfile;
 

--- a/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
+++ b/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
@@ -14,12 +14,12 @@ namespace DomainDetective.PowerShell;
 [Alias("Test-DnsEdnsSupport")]
 public sealed class CmdletTestEdnsSupport : AsyncPSCmdlet
 {
-    /// <param name="DomainName">Domain to query.</param>
+    /// <summary>Domain to query.</summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
     [ValidateNotNullOrEmpty]
     public string DomainName;
 
-    /// <param name="DnsEndpoint">DNS server used for queries.</param>
+    /// <summary>DNS server used for queries.</summary>
     [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
     public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestFCrDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestFCrDns.cs
@@ -13,12 +13,12 @@ namespace DomainDetective.PowerShell;
 [Alias("Test-DnsFcrDns")]
 public sealed class CmdletTestFCrDns : AsyncPSCmdlet
 {
-    /// <param name="DomainName">Domain to analyze.</param>
+    /// <summary>Domain to analyze.</summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
     [ValidateNotNullOrEmpty]
     public string DomainName;
 
-    /// <param name="DnsEndpoint">DNS server used for queries.</param>
+    /// <summary>DNS server used for queries.</summary>
     [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
     public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
+++ b/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDIpNeighbor", DefaultParameterSetName = "ServerName")]
 [Alias("Test-NetworkIpNeighbor")]
     public sealed class CmdletTestIPNeighbor : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestImapTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestImapTls.cs
@@ -10,15 +10,15 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "ImapTls", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestImapTls : AsyncPSCmdlet {
-        /// <param name="HostName">IMAP host to check.</param>
+        /// <summary>IMAP host to check.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
-        /// <param name="Port">IMAP port number.</param>
+        /// <summary>IMAP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 143;
 
-        /// <param name="ShowChain">Output certificate chain information.</param>
+        /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 

--- a/DomainDetective.PowerShell/CmdletTestMailLatency.cs
+++ b/DomainDetective.PowerShell/CmdletTestMailLatency.cs
@@ -11,11 +11,11 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDMailLatency", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailLatency")]
     public sealed class CmdletTestMailLatency : AsyncPSCmdlet {
-        /// <param name="HostName">SMTP host to check.</param>
+        /// <summary>SMTP host to check.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
-        /// <param name="Port">SMTP port number.</param>
+        /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 

--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -12,7 +12,7 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsCommon.Get, "DDEmailMessageHeaderInfo")]
 [Alias("Get-EmailHeaderInfo")]
     public sealed class CmdletTestMessageHeader : AsyncPSCmdlet {
-        /// <param name="HeaderText">Raw header text.</param>
+        /// <summary>Raw header text.</summary>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string HeaderText;

--- a/DomainDetective.PowerShell/CmdletTestMxRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestMxRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DDDnsMxRecord", DefaultParameterSetName = "ServerName")]
     [Alias("Test-MxRecord")]
     public sealed class CmdletTestMxRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestNsRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestNsRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsNsRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsNs")]
     public sealed class CmdletTestNsRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailOpenRelay", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailOpenRelay")]
     public sealed class CmdletTestOpenRelay : AsyncPSCmdlet {
-        /// <param name="HostName">SMTP host name to check.</param>
+        /// <summary>SMTP host name to check.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string HostName;
 
-        /// <param name="Port">SMTP port number.</param>
+        /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 

--- a/DomainDetective.PowerShell/CmdletTestOpenResolver.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenResolver.cs
@@ -11,12 +11,12 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DDDnsOpenResolver")]
     [Alias("Test-OpenResolver")]
     public sealed class CmdletTestOpenResolver : AsyncPSCmdlet {
-        /// <param name="Server">DNS server to check.</param>
+        /// <summary>DNS server to check.</summary>
         [Parameter(Mandatory = true, Position = 0)]
         [ValidateNotNullOrEmpty]
         public string Server;
 
-        /// <param name="Port">DNS port.</param>
+        /// <summary>DNS port.</summary>
         [Parameter(Mandatory = false, Position = 1)]
         public int Port = 53;
 

--- a/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
+++ b/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
@@ -10,15 +10,15 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "Pop3Tls", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestPop3Tls : AsyncPSCmdlet {
-        /// <param name="HostName">POP3 host to check.</param>
+        /// <summary>POP3 host to check.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
-        /// <param name="Port">POP3 port number.</param>
+        /// <summary>POP3 port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 110;
 
-        /// <param name="ShowChain">Output certificate chain information.</param>
+        /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 

--- a/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
+++ b/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
@@ -11,11 +11,11 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDPortAvailability", DefaultParameterSetName = "ServerName")]
 [Alias("Test-NetworkPortAvailability")]
     public sealed class CmdletTestPortAvailability : AsyncPSCmdlet {
-        /// <param name="HostName">Host to test.</param>
+        /// <summary>Host to test.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
-        /// <param name="Ports">Ports to check.</param>
+        /// <summary>Ports to check.</summary>
         [Parameter(Mandatory = false)]
         public int[] Ports = new[] { 25, 80, 443, 465, 587 };
 

--- a/DomainDetective.PowerShell/CmdletTestRdap.cs
+++ b/DomainDetective.PowerShell/CmdletTestRdap.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DDRdap", DefaultParameterSetName = "ServerName")]
     [Alias("Test-Rdap")]
     public sealed class CmdletTestRdap : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestReverseDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestReverseDns.cs
@@ -11,12 +11,12 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "ReverseDns", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestReverseDns : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to analyze.</param>
+        /// <summary>Domain to analyze.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestRpki.cs
+++ b/DomainDetective.PowerShell/CmdletTestRpki.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
     [Cmdlet(VerbsDiagnostic.Test, "DDRpki", DefaultParameterSetName = "ServerName")]
     [Alias("Test-Rpki")]
     public sealed class CmdletTestRpki : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDomainSecurityTxt", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DomainSecurityTxt")]
     public sealed class CmdletTestSecurityTXT : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDSmimeaRecord", DefaultParameterSetName = "Email")]
 [Alias("Test-DnsSmimea")]
     public sealed class CmdletTestSmimeaRecord : AsyncPSCmdlet {
-        /// <param name="EmailAddress">Email address to query.</param>
+        /// <summary>Email address to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Email")]
         [ValidateNotNullOrEmpty]
         public string EmailAddress;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Email")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestSmtpBanner.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpBanner.cs
@@ -10,19 +10,19 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "SmtpBanner", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestSmtpBanner : AsyncPSCmdlet {
-        /// <param name="HostName">SMTP host to check.</param>
+        /// <summary>SMTP host to check.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
-        /// <param name="Port">SMTP port number.</param>
+        /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 
-        /// <param name="ExpectedHostname">Hostname expected in the banner.</param>
+        /// <summary>Hostname expected in the banner.</summary>
         [Parameter(Mandatory = false)]
         public string ExpectedHostname;
 
-        /// <param name="ExpectedSoftware">Software string expected in the banner.</param>
+        /// <summary>Software string expected in the banner.</summary>
         [Parameter(Mandatory = false)]
         public string ExpectedSoftware;
 

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -11,15 +11,15 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailSmtpTls", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailSmtpTls")]
     public sealed class CmdletTestSmtpTls : AsyncPSCmdlet {
-        /// <param name="HostName">SMTP host to check.</param>
+        /// <summary>SMTP host to check.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         public string HostName;
 
-        /// <param name="Port">SMTP port number.</param>
+        /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
 
-        /// <param name="ShowChain">Output certificate chain information.</param>
+        /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 

--- a/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsSoaRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsSoa")]
     public sealed class CmdletTestSoaRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
@@ -13,12 +13,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailSpfRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailSpf")]
     public sealed class CmdletTestSpfRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -12,16 +12,16 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailStartTls", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailStartTls")]
     public sealed class CmdletTestStartTls : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to test.</param>
+        /// <summary>Domain to test.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
-        /// <param name="Port">SMTP port number.</param>
+        /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false)]
         public int Port = 25;
 

--- a/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
+++ b/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
@@ -12,20 +12,20 @@ namespace DomainDetective.PowerShell;
 [Cmdlet(VerbsDiagnostic.Test, "DDThreatIntel")]
 [Alias("Test-DomainThreatIntel")]
 public sealed class CmdletTestThreatIntel : AsyncPSCmdlet {
-    /// <param name="NameOrIpAddress">Domain or IP address to query.</param>
+    /// <summary>Domain or IP address to query.</summary>
     [Parameter(Mandatory = true, Position = 0)]
     [ValidateNotNullOrEmpty]
     public string NameOrIpAddress;
 
-    /// <param name="GoogleApiKey">Google Safe Browsing API key.</param>
+    /// <summary>Google Safe Browsing API key.</summary>
     [Parameter(Mandatory = false)]
     public string? GoogleApiKey;
 
-    /// <param name="PhishTankApiKey">PhishTank API key.</param>
+    /// <summary>PhishTank API key.</summary>
     [Parameter(Mandatory = false)]
     public string? PhishTankApiKey;
 
-    /// <param name="VirusTotalApiKey">VirusTotal API key.</param>
+    /// <summary>VirusTotal API key.</summary>
     [Parameter(Mandatory = false)]
     public string? VirusTotalApiKey;
 

--- a/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
@@ -12,12 +12,12 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailTlsRptRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailTlsRpt")]
     public sealed class CmdletTestTlsRptRecord : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -11,20 +11,20 @@ namespace DomainDetective.PowerShell {
 [Cmdlet(VerbsDiagnostic.Test, "DDDomainCertificate", DefaultParameterSetName = "Url")]
 [Alias("Test-DomainCertificate")]
     public sealed class CmdletTestWebsiteCertificate : AsyncPSCmdlet {
-        /// <param name="Url">Website URL.</param>
+        /// <summary>Website URL.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "Url")]
         [ValidateNotNullOrEmpty]
         public string Url;
 
-        /// <param name="Port">TCP port used for connection.</param>
+        /// <summary>TCP port used for connection.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "Url")]
         public int Port = 443;
 
-        /// <param name="ShowChain">Output certificate chain information.</param>
+        /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter ShowChain;
 
-        /// <param name="SkipRevocation">Do not check certificate revocation status.</param>
+        /// <summary>Do not check certificate revocation status.</summary>
         [Parameter(Mandatory = false)]
         public SwitchParameter SkipRevocation;
 

--- a/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
@@ -14,12 +14,12 @@ namespace DomainDetective.PowerShell;
 [Alias("Test-DnsWildcard")]
 public sealed class CmdletTestWildcardDns : AsyncPSCmdlet
 {
-    /// <param name="DomainName">Domain to query.</param>
+    /// <summary>Domain to query.</summary>
     [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
     [ValidateNotNullOrEmpty]
     public string DomainName;
 
-    /// <param name="DnsEndpoint">DNS server used for queries.</param>
+    /// <summary>DNS server used for queries.</summary>
     [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
     public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 

--- a/DomainDetective.PowerShell/CmdletTestZoneTransfer.cs
+++ b/DomainDetective.PowerShell/CmdletTestZoneTransfer.cs
@@ -11,12 +11,12 @@ namespace DomainDetective.PowerShell {
     /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "ZoneTransfer", DefaultParameterSetName = "ServerName")]
     public sealed class CmdletTestZoneTransfer : AsyncPSCmdlet {
-        /// <param name="DomainName">Domain to query.</param>
+        /// <summary>Domain to query.</summary>
         [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName")]
         [ValidateNotNullOrEmpty]
         public string DomainName;
 
-        /// <param name="DnsEndpoint">DNS server used for queries.</param>
+        /// <summary>DNS server used for queries.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 


### PR DESCRIPTION
## Summary
- replace invalid `<param>` tags with `<summary>` on cmdlet fields
- keep valid `<param>` tags for method parameters

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: `$XunitDynamicSkip$DNS queries unavailable`, `$XunitDynamicSkip$Hosts not reachable`)*

------
https://chatgpt.com/codex/tasks/task_e_687a91fe282c832ea0184bbcacabf646