### PR TITLE
Change DnsComparisonEntry to use enum identifiers

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -253,5 +253,33 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, groups.First().Value.Count);
             Assert.Equal(IPAddress.Parse("fe80::1%2").ToString(), groups.Keys.First());
         }
+
+        [Fact]
+        public void CompareResultsParsesEnumValues() {
+            var results = new[] {
+                new DnsPropagationResult {
+                    Server = new PublicDnsEntry {
+                        IPAddress = IPAddress.Parse("1.1.1.1"),
+                        Country = "Afghanistan",
+                        Location = "Kabul"
+                    },
+                    RecordType = DnsRecordType.A,
+                    Records = new[] { "1.2.3.4" },
+                    Success = true
+                }
+            };
+
+            var groups = DnsPropagationAnalysis.CompareResults(results);
+            var entry = Assert.Single(groups.Single().Value);
+            Assert.True(entry.Country.HasValue);
+            Assert.Equal("Afghanistan", entry.Country!.Value.ToName());
+            Assert.True(entry.Location.HasValue);
+            Assert.Equal("Kabul", entry.Location!.Value.ToName());
+
+            var details = DnsPropagationAnalysis.GetComparisonDetails(results);
+            var json = System.Text.Json.JsonSerializer.Serialize(details, DomainHealthCheck.JsonOptions);
+            Assert.Contains("Afghanistan", json);
+            Assert.Contains("Kabul", json);
+        }
     }
 }

--- a/DomainDetective/CountryIdConverter.cs
+++ b/DomainDetective/CountryIdConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Converts <see cref="CountryId"/> values to and from JSON using extension helpers.
+/// </summary>
+internal sealed class CountryIdConverter : JsonConverter<CountryId>
+{
+    /// <inheritdoc/>
+    public override CountryId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return CountryIdExtensions.TryParse(value, out var id) ? id : default;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, CountryId value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToName());
+    }
+}

--- a/DomainDetective/DnsComparisonEntry.cs
+++ b/DomainDetective/DnsComparisonEntry.cs
@@ -9,8 +9,8 @@ public sealed class DnsComparisonEntry {
     public string IPAddress { get; init; } = string.Empty;
 
     /// <summary>Country of the server.</summary>
-    public string? Country { get; init; }
+    public CountryId? Country { get; init; }
 
     /// <summary>Location of the server.</summary>
-    public string? Location { get; init; }
+    public LocationId? Location { get; init; }
 }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -522,10 +522,18 @@ namespace DomainDetective {
                     list = new List<DnsComparisonEntry>();
                     comparison[key] = list;
                 }
+                CountryId? countryId = null;
+                if (CountryIdExtensions.TryParse(res.Server.Country, out var cid)) {
+                    countryId = cid;
+                }
+                LocationId? locationId = null;
+                if (LocationIdExtensions.TryParse(res.Server.Location, out var lid)) {
+                    locationId = lid;
+                }
                 list.Add(new DnsComparisonEntry {
                     IPAddress = res.Server.IPAddress.ToString(),
-                    Country = res.Server.Country,
-                    Location = res.Server.Location
+                    Country = countryId,
+                    Location = locationId
                 });
             }
             return comparison;
@@ -544,8 +552,8 @@ namespace DomainDetective {
                     details.Add(new DnsComparisonDetail {
                         Records = kvp.Key,
                         IPAddress = entry.IPAddress,
-                        Country = entry.Country,
-                        Location = entry.Location
+                        Country = entry.Country?.ToName(),
+                        Location = entry.Location?.ToName()
                     });
                 }
             }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -24,7 +24,12 @@ namespace DomainDetective {
         public static readonly JsonSerializerOptions JsonOptions = new()
         {
             WriteIndented = true,
-            Converters = { new IPAddressJsonConverter() }
+            Converters =
+            {
+                new IPAddressJsonConverter(),
+                new CountryIdConverter(),
+                new LocationIdConverter()
+            }
         };
 
         /// <summary>Factory used to obtain <see cref="HttpClient"/> instances.</summary>

--- a/DomainDetective/LocationIdConverter.cs
+++ b/DomainDetective/LocationIdConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Converts <see cref="LocationId"/> values to and from JSON using extension helpers.
+/// </summary>
+internal sealed class LocationIdConverter : JsonConverter<LocationId>
+{
+    /// <inheritdoc/>
+    public override LocationId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return LocationIdExtensions.TryParse(value, out var id) ? id : default;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, LocationId value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToName());
+    }
+}


### PR DESCRIPTION
## Summary
- use `CountryId` and `LocationId` for `DnsComparisonEntry`
- parse enum values when comparing propagation results
- output names via new JSON converters
- add unit test verifying enum handling

## Testing
- `dotnet build --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter CompareResultsParsesEnumValues`

------
https://chatgpt.com/codex/tasks/task_e_687c970cc650832e83ba6b4d7b6822c5