### PR TITLE
Update DNS entry models

### DIFF
--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -110,7 +110,9 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
                 Console.WriteLine(JsonSerializer.Serialize(details, DomainHealthCheck.JsonOptions));
             } else {
                 foreach (var d in details) {
-                    Console.WriteLine($"{d.Records}: {d.IPAddress} ({d.Country}/{d.Location})");
+                    var country = d.Country?.ToName() ?? string.Empty;
+                    var location = d.Location?.ToName() ?? string.Empty;
+                    Console.WriteLine($"{d.Records}: {d.IPAddress} ({country}/{location})");
                 }
             }
         } else {

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagation.cs
@@ -24,7 +24,9 @@ namespace DomainDetective.Example {
 
             var details = DnsPropagationAnalysis.GetComparisonDetails(results);
             foreach (var d in details) {
-                Console.WriteLine($"{d.Records}: {d.IPAddress} ({d.Country}/{d.Location})");
+                var country = d.Country?.ToName() ?? string.Empty;
+                var location = d.Location?.ToName() ?? string.Empty;
+                Console.WriteLine($"{d.Records}: {d.IPAddress} ({country}/{location})");
             }
         }
     }

--- a/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
+++ b/DomainDetective.Example/ExampleAnalyseDnsPropagationRegions.cs
@@ -25,7 +25,7 @@ namespace DomainDetective.Example {
 
             var grouped = results.GroupBy(r => r.Server.Country);
             foreach (var group in grouped) {
-                Console.WriteLine($"--- {group.Key} ---");
+                Console.WriteLine($"--- {group.Key?.ToName()} ---");
                 foreach (var result in group) {
                     var records = string.Join(',', result.Records);
                     Console.WriteLine($"{result.Server.IPAddress} - Success:{result.Success} Records:{records} Time:{result.Duration.TotalMilliseconds}ms");
@@ -35,7 +35,9 @@ namespace DomainDetective.Example {
             var details = DnsPropagationAnalysis.GetComparisonDetails(results);
             Console.WriteLine("\nSummary by record set:");
             foreach (var d in details) {
-                Console.WriteLine($"{d.Records}: {d.IPAddress} ({d.Country}/{d.Location})");
+                var country = d.Country?.ToName() ?? string.Empty;
+                var location = d.Location?.ToName() ?? string.Empty;
+                Console.WriteLine($"{d.Records}: {d.IPAddress} ({country}/{location})");
             }
         }
     }

--- a/DomainDetective.Tests/TestBgpValidation.cs
+++ b/DomainDetective.Tests/TestBgpValidation.cs
@@ -18,7 +18,7 @@ namespace DomainDetective.Tests {
 
             analysis.AddServer(new PublicDnsEntry {
                 IPAddress = IPAddress.Parse("1.2.3.4"),
-                Country = "Test",
+                Country = null,
                 ASN = "65000"
             });
 
@@ -39,7 +39,7 @@ namespace DomainDetective.Tests {
 
             analysis.AddServer(new PublicDnsEntry {
                 IPAddress = IPAddress.Parse("1.2.3.4"),
-                Country = "Test",
+                Country = null,
                 ASN = "65000"
             });
 

--- a/DomainDetective.Tests/TestDnsServerQuery.cs
+++ b/DomainDetective.Tests/TestDnsServerQuery.cs
@@ -10,7 +10,8 @@ namespace DomainDetective.Tests {
             var query = DnsServerQuery.Create().FromCountry("Poland");
             var servers = analysis.FilterServers(query).ToList();
             Assert.NotEmpty(servers);
-            Assert.All(servers, s => Assert.Equal("Poland", s.Country));
+            CountryIdExtensions.TryParse("Poland", out CountryId pl);
+            Assert.All(servers, s => Assert.Equal(pl, s.Country));
         }
 
         [Fact]
@@ -29,7 +30,8 @@ namespace DomainDetective.Tests {
             var query = DnsServerQuery.Create().FromCountry("Poland").Take(2);
             var servers = analysis.FilterServers(query).ToList();
             Assert.True(servers.Count <= 2);
-            Assert.All(servers, s => Assert.Equal("Poland", s.Country));
+            CountryIdExtensions.TryParse("Poland", out CountryId pl);
+            Assert.All(servers, s => Assert.Equal(pl, s.Country));
         }
 
         [Fact]
@@ -39,7 +41,8 @@ namespace DomainDetective.Tests {
             var query = DnsServerQuery.Create().FromCountry("poland");
             var servers = analysis.FilterServers(query).ToList();
             Assert.NotEmpty(servers);
-            Assert.All(servers, s => Assert.Equal("Poland", s.Country));
+            CountryIdExtensions.TryParse("Poland", out CountryId pl);
+            Assert.All(servers, s => Assert.Equal(pl, s.Country));
         }
 
         [Fact]
@@ -49,7 +52,8 @@ namespace DomainDetective.Tests {
             var query = DnsServerQuery.Create().FromLocation("kabul");
             var servers = analysis.FilterServers(query).ToList();
             Assert.NotEmpty(servers);
-            Assert.All(servers, s => Assert.Contains("Kabul", s.Location!, StringComparison.OrdinalIgnoreCase));
+            LocationIdExtensions.TryParse("Kabul", out var kab);
+            Assert.All(servers, s => Assert.Equal(kab, s.Location));
         }
     }
 }

--- a/DomainDetective.Tests/TestGeoLookup.cs
+++ b/DomainDetective.Tests/TestGeoLookup.cs
@@ -22,7 +22,7 @@ namespace DomainDetective.Tests {
                 DnsQueryOverride = (_, _, _, _) => Task.FromResult<IEnumerable<string>>(new[] { "1.2.3.4" }),
                 GeoLookupOverride = (ip, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", Region = "Test" })
             };
-            var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = "Test", Enabled = true };
+            var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = null, Enabled = true };
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, new[] { server }, includeGeo: true);
             var result = Assert.Single(results);
             Assert.NotNull(result.Geo);
@@ -35,7 +35,7 @@ namespace DomainDetective.Tests {
                 DnsQueryOverride = (_, _, _, _) => Task.FromResult<IEnumerable<string>>(new[] { "1.2.3.4" }),
                 GeoLookupOverride = (_, _) => Task.FromResult<GeoLocationInfo?>(new GeoLocationInfo { Country = "US", Region = "Nope" })
             };
-            var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = "Test", Enabled = true };
+            var server = new PublicDnsEntry { IPAddress = IPAddress.Loopback, Country = null, Enabled = true };
             var results = await analysis.QueryAsync("example.com", DnsRecordType.A, new[] { server }, includeGeo: false);
             var result = Assert.Single(results);
             Assert.Null(result.Geo);

--- a/DomainDetective.Tests/TestSelectServers.cs
+++ b/DomainDetective.Tests/TestSelectServers.cs
@@ -10,8 +10,10 @@ namespace DomainDetective.Tests {
             analysis.LoadBuiltinServers();
             var servers = analysis.SelectServers(new Dictionary<string, int> { ["PL"] = 2, ["DE"] = 1 });
             Assert.Equal(3, servers.Count);
-            Assert.Equal(2, servers.Count(s => s.Country == "Poland"));
-            Assert.Equal(1, servers.Count(s => s.Country == "Germany"));
+            CountryIdExtensions.TryParse("Poland", out var pl);
+            CountryIdExtensions.TryParse("Germany", out var de);
+            Assert.Equal(2, servers.Count(s => s.Country == pl));
+            Assert.Equal(1, servers.Count(s => s.Country == de));
         }
     }
 }

--- a/DomainDetective/CountryLocationJsonConverters.cs
+++ b/DomainDetective/CountryLocationJsonConverters.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DomainDetective;
+
+/// <summary>
+/// JSON converter for <see cref="CountryId"/> values.
+/// </summary>
+internal sealed class CountryIdJsonConverter : JsonConverter<CountryId>
+{
+    /// <inheritdoc/>
+    public override CountryId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value) || !CountryIdExtensions.TryParse(value, out var id))
+        {
+            return default;
+        }
+        return id;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, CountryId value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToName());
+    }
+}
+
+/// <summary>
+/// JSON converter for <see cref="LocationId"/> values.
+/// </summary>
+internal sealed class LocationIdJsonConverter : JsonConverter<LocationId>
+{
+    /// <inheritdoc/>
+    public override LocationId Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        if (string.IsNullOrWhiteSpace(value) || !LocationIdExtensions.TryParse(value, out var id))
+        {
+            return default;
+        }
+        return id;
+    }
+
+    /// <inheritdoc/>
+    public override void Write(Utf8JsonWriter writer, LocationId value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToName());
+    }
+}

--- a/DomainDetective/DnsComparisonDetail.cs
+++ b/DomainDetective/DnsComparisonDetail.cs
@@ -12,8 +12,8 @@ public sealed class DnsComparisonDetail {
     public string IPAddress { get; init; } = string.Empty;
 
     /// <summary>Country of the server.</summary>
-    public string? Country { get; init; }
+    public CountryId? Country { get; init; }
 
     /// <summary>Location of the server.</summary>
-    public string? Location { get; init; }
+    public LocationId? Location { get; init; }
 }

--- a/DomainDetective/DnsComparisonEntry.cs
+++ b/DomainDetective/DnsComparisonEntry.cs
@@ -9,8 +9,8 @@ public sealed class DnsComparisonEntry {
     public string IPAddress { get; init; } = string.Empty;
 
     /// <summary>Country of the server.</summary>
-    public string? Country { get; init; }
+    public CountryId? Country { get; init; }
 
     /// <summary>Location of the server.</summary>
-    public string? Location { get; init; }
+    public LocationId? Location { get; init; }
 }

--- a/DomainDetective/PublicDnsEntry.cs
+++ b/DomainDetective/PublicDnsEntry.cs
@@ -5,13 +5,13 @@ namespace DomainDetective {
     /// <para>Part of the DomainDetective project.</para>
     public class PublicDnsEntry {
         /// <summary>Gets the country of the DNS server.</summary>
-        public string Country { get; init; }
+        public CountryId? Country { get; init; }
         /// <summary>Gets the IP address of the DNS server.</summary>
         public System.Net.IPAddress IPAddress { get; init; }
         /// <summary>Gets the host name of the DNS server.</summary>
         public string HostName { get; init; }
         /// <summary>Gets the location description.</summary>
-        public string Location { get; init; }
+        public LocationId? Location { get; init; }
         /// <summary>Gets the ASN of the DNS server.</summary>
         public string ASN { get; init; }
         /// <summary>Gets the ASN name of the DNS server.</summary>


### PR DESCRIPTION
## Summary
- map server country and location to new enums
- convert JSON values using CountryIdJsonConverter and LocationIdJsonConverter
- update filtering logic and examples
- adjust tests for enum properties

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: TestCAAAnalysis.TestCAARecordByDomain, TestAllHealthChecks etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c96ff4968832ea6b378694d48e894