### PR TITLE
Add MessageHeaderIssue enum

### DIFF
--- a/DomainDetective.Tests/TestMessageHeaderDkimInvalid.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDkimInvalid.cs
@@ -10,6 +10,7 @@ namespace DomainDetective.Tests {
 
             Assert.False(analysis.Headers.ContainsKey("DKIM-Signature"));
             Assert.Single(analysis.InvalidDkimSignatures);
+            Assert.Contains(MessageHeaderIssue.InvalidDkim, analysis.Issues);
         }
     }
 }

--- a/DomainDetective.Tests/TestMessageHeaderDkimValidator.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDkimValidator.cs
@@ -12,6 +12,7 @@ namespace DomainDetective.Tests {
             Assert.Single(analysis.ReceivedChain);
             Assert.Contains("v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; s=selector1; t=1615567890; h=from:to:subject:date:message-id:mime-version:content-type; bh=abc123; b=ZGVmNDU2", analysis.Headers["DKIM-Signature"]);
             Assert.Contains("dkim=pass", analysis.Headers["Authentication-Results"]);
+            Assert.Contains(MessageHeaderIssue.MissingArc, analysis.Issues);
         }
     }
 }

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -1,0 +1,21 @@
+using System.IO;
+
+namespace DomainDetective.Tests;
+
+public class TestMessageHeaderIssues {
+    [Fact]
+    public void MissingArcIsReported() {
+        var raw = File.ReadAllText("Data/dkimvalidator-headers.txt");
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        Assert.Contains(MessageHeaderIssue.MissingArc, analysis.Issues);
+    }
+
+    [Fact]
+    public void InvalidDkimSignatureIsReported() {
+        var raw = File.ReadAllText("Data/dkim-bad-padding.txt");
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        Assert.Contains(MessageHeaderIssue.InvalidDkim, analysis.Issues);
+    }
+}

--- a/DomainDetective/Protocols/MessageHeaderIssue.cs
+++ b/DomainDetective/Protocols/MessageHeaderIssue.cs
@@ -1,0 +1,13 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Identifies issues detected during message header analysis.
+/// </summary>
+public enum MessageHeaderIssue {
+    /// <summary>No ARC headers were found.</summary>
+    MissingArc,
+    /// <summary>The ARC chain exists but failed validation.</summary>
+    InvalidArc,
+    /// <summary>One or more DKIM signatures were invalid.</summary>
+    InvalidDkim
+}


### PR DESCRIPTION
## Summary
- add new `MessageHeaderIssue` enum
- track issues in `MessageHeaderAnalysis`
- expose issue data when parsing headers
- update related tests and add new tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Debug` *(fails: The argument /workspace/DomainDetective/DomainDetective.Tests/bin/Debug/net8.0/DomainDetective.Tests.dll is invalid)*
- `dotnet build DomainDetective.sln -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_687ca0245dcc832e9ba81ed667e927dc