### PR TITLE
Add DNSBL entry collections

### DIFF
--- a/DomainDetective.Example/ExampleDnsblCollections.cs
+++ b/DomainDetective.Example/ExampleDnsblCollections.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Demonstrates creation of DNSBL configuration with custom collections.
+    /// </summary>
+    public static Task ExampleDnsblCollections() {
+        var config = new DnsblConfiguration {
+            Providers = new DnsblEntryCollection {
+                new("zen.spamhaus.org"),
+                new("bl.example", enabled: false)
+            },
+            DomainBlockLists = new DnsblEntryCollection {
+                new("dbl.example")
+            },
+            IpBlockLists = new BlockListEntryCollection {
+                new BlockListEntry { Name = "drop", Url = "http://example.com/drop.txt" }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(config);
+        Console.WriteLine(json);
+        return Task.CompletedTask;
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -61,6 +61,7 @@ public static partial class Program {
         await ExampleAnalyseByArrayDNSBL();
         await ExampleAnalyseByDomainDNSBL();
         await ExampleManageDnsbl();
+        await ExampleDnsblCollections();
         await ExampleAnalyseOpenRelay();
         await ExampleAnalyseOpenResolver();
         await ExampleAnalyseSecurityTXT();

--- a/DomainDetective.Tests/TestDnsblEntryCollection.cs
+++ b/DomainDetective.Tests/TestDnsblEntryCollection.cs
@@ -1,0 +1,17 @@
+using System;
+namespace DomainDetective.Tests {
+    public class TestDnsblEntryCollection {
+        [Fact]
+        public void AddNullThrows() {
+            var collection = new DnsblEntryCollection();
+            Assert.Throws<ArgumentNullException>(() => collection.Add(null!));
+        }
+
+        [Fact]
+        public void AddInvalidDomainThrows() {
+            var collection = new DnsblEntryCollection();
+            var entry = new DnsblEntry { Domain = "" };
+            Assert.Throws<ArgumentException>(() => collection.Add(entry));
+        }
+    }
+}

--- a/DomainDetective/BlockListEntryCollection.cs
+++ b/DomainDetective/BlockListEntryCollection.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Collection of <see cref="BlockListEntry"/> ensuring entries are valid.
+/// </summary>
+public class BlockListEntryCollection : Collection<BlockListEntry> {
+    public BlockListEntryCollection() : base() { }
+
+    public BlockListEntryCollection(IEnumerable<BlockListEntry> items) {
+        if (items == null)
+            return;
+        foreach (var item in items)
+            Add(item);
+    }
+
+    protected override void InsertItem(int index, BlockListEntry item) {
+        ValidateItem(item);
+        base.InsertItem(index, item);
+    }
+
+    protected override void SetItem(int index, BlockListEntry item) {
+        ValidateItem(item);
+        base.SetItem(index, item);
+    }
+
+    private static void ValidateItem(BlockListEntry item) {
+        if (item == null)
+            throw new ArgumentNullException(nameof(item));
+        if (string.IsNullOrWhiteSpace(item.Name))
+            throw new ArgumentException("Name cannot be null or whitespace.", nameof(item));
+    }
+}

--- a/DomainDetective/DnsblConfiguration.cs
+++ b/DomainDetective/DnsblConfiguration.cs
@@ -11,12 +11,12 @@ using System.Collections.Generic;
     /// </remarks>
     public class DnsblConfiguration {
         /// <summary>Gets or sets the list of DNSBL providers.</summary>
-        public List<DnsblEntry> Providers { get; set; } = new();
+        public DnsblEntryCollection Providers { get; set; } = new();
 
         /// <summary>Gets or sets domain based block lists.</summary>
-        public List<DnsblEntry> DomainBlockLists { get; set; } = new();
+        public DnsblEntryCollection DomainBlockLists { get; set; } = new();
 
         /// <summary>Gets or sets IP based block lists.</summary>
-        public List<BlockListEntry> IpBlockLists { get; set; } = new();
+        public BlockListEntryCollection IpBlockLists { get; set; } = new();
     }
 }

--- a/DomainDetective/DnsblEntryCollection.cs
+++ b/DomainDetective/DnsblEntryCollection.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Collection of <see cref="DnsblEntry"/> ensuring entries are valid.
+/// </summary>
+public class DnsblEntryCollection : Collection<DnsblEntry> {
+    public DnsblEntryCollection() : base() { }
+
+    public DnsblEntryCollection(IEnumerable<DnsblEntry> items) {
+        if (items == null)
+            return;
+        foreach (var item in items)
+            Add(item);
+    }
+
+    protected override void InsertItem(int index, DnsblEntry item) {
+        ValidateItem(item);
+        base.InsertItem(index, item);
+    }
+
+    protected override void SetItem(int index, DnsblEntry item) {
+        ValidateItem(item);
+        base.SetItem(index, item);
+    }
+
+    private static void ValidateItem(DnsblEntry item) {
+        if (item == null)
+            throw new ArgumentNullException(nameof(item));
+        if (string.IsNullOrWhiteSpace(item.Domain))
+            throw new ArgumentException("Domain cannot be null or whitespace.", nameof(item));
+    }
+}


### PR DESCRIPTION
## Summary
- add `DnsblEntryCollection` and `BlockListEntryCollection` to validate entries
- update `DnsblConfiguration` to use the new collections
- show example usage in Example project
- cover collection validation with unit tests

## Testing
- `dotnet build DomainDetective.sln -c Debug`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Debug --no-build -v minimal` *(fails: Host not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ca02da764832e826fcca8ced494c6