### PR TITLE
Add ARC chain status enum

### DIFF
--- a/DomainDetective.Tests/TestARCAnalysis.cs
+++ b/DomainDetective.Tests/TestARCAnalysis.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
+using DomainDetective;
 
 namespace DomainDetective.Tests {
     public class TestARCAnalysis {
@@ -8,8 +9,7 @@ namespace DomainDetective.Tests {
             var raw = File.ReadAllText("Data/arc-valid.txt");
             var hc = new DomainHealthCheck();
             var result = await hc.VerifyARCAsync(raw);
-            Assert.True(result.ArcHeadersFound);
-            Assert.True(result.ValidChain);
+            Assert.Equal(ArcChainState.Valid, result.ChainState);
         }
 
         [Fact]
@@ -17,8 +17,7 @@ namespace DomainDetective.Tests {
             var raw = File.ReadAllText("Data/arc-invalid.txt");
             var hc = new DomainHealthCheck();
             var result = await hc.VerifyARCAsync(raw);
-            Assert.True(result.ArcHeadersFound);
-            Assert.False(result.ValidChain);
+            Assert.Equal(ArcChainState.Invalid, result.ChainState);
         }
 
         [Fact]
@@ -26,8 +25,7 @@ namespace DomainDetective.Tests {
             var raw = File.ReadAllText("Data/arc-missing-sig.txt");
             var hc = new DomainHealthCheck();
             var result = await hc.VerifyARCAsync(raw);
-            Assert.True(result.ArcHeadersFound);
-            Assert.False(result.ValidChain);
+            Assert.Equal(ArcChainState.Invalid, result.ChainState);
         }
 
         [Fact]
@@ -35,8 +33,7 @@ namespace DomainDetective.Tests {
             var raw = File.ReadAllText("Data/arc-empty-sig.txt");
             var hc = new DomainHealthCheck();
             var result = await hc.VerifyARCAsync(raw);
-            Assert.True(result.ArcHeadersFound);
-            Assert.False(result.ValidChain);
+            Assert.Equal(ArcChainState.Invalid, result.ChainState);
         }
 
         [Fact]
@@ -44,8 +41,7 @@ namespace DomainDetective.Tests {
             var raw = File.ReadAllText("Data/arc-out-of-order.txt");
             var hc = new DomainHealthCheck();
             var result = await hc.VerifyARCAsync(raw);
-            Assert.True(result.ArcHeadersFound);
-            Assert.False(result.ValidChain);
+            Assert.Equal(ArcChainState.Invalid, result.ChainState);
         }
 
         [Fact]
@@ -53,8 +49,15 @@ namespace DomainDetective.Tests {
             var raw = File.ReadAllText("Data/arc-rfc-example.txt");
             var hc = new DomainHealthCheck();
             var result = await hc.VerifyARCAsync(raw);
-            Assert.True(result.ArcHeadersFound);
-            Assert.True(result.ValidChain);
+            Assert.Equal(ArcChainState.Valid, result.ChainState);
+        }
+
+        [Fact]
+        public async Task MissingArcHeadersReturnMissingState() {
+            var raw = File.ReadAllText("Data/sample-headers.txt");
+            var hc = new DomainHealthCheck();
+            var result = await hc.VerifyARCAsync(raw);
+            Assert.Equal(ArcChainState.Missing, result.ChainState);
         }
     }
 }

--- a/DomainDetective/Protocols/ArcChainState.cs
+++ b/DomainDetective/Protocols/ArcChainState.cs
@@ -1,0 +1,14 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Describes the status of an ARC chain.
+/// </summary>
+public enum ArcChainState
+{
+    /// <summary>No ARC headers were present.</summary>
+    Missing,
+    /// <summary>ARC headers were found but the chain is invalid.</summary>
+    Invalid,
+    /// <summary>The ARC chain is valid.</summary>
+    Valid
+}


### PR DESCRIPTION
## Summary
- create `ArcChainState` enum for ARC header analysis
- track ARC chain status in `ARCAnalysis`
- test ARC chain status across scenarios

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: DNS/network dependent tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ca077897c832eb7cddfa702b4798a