### PR TITLE
Add enum-based filter test

### DIFF
--- a/DomainDetective.Tests/TestFilterServersByEnum.cs
+++ b/DomainDetective.Tests/TestFilterServersByEnum.cs
@@ -1,0 +1,20 @@
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Tests {
+    public class TestFilterServersByEnum {
+        [Fact]
+        public void FilterServersByCountryAndLocation() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            CountryIdExtensions.TryParse("Afghanistan", out var af);
+            LocationIdExtensions.TryParse("Kabul", out var kab);
+            var servers = analysis.FilterServers(af, kab).ToList();
+            Assert.NotEmpty(servers);
+            Assert.All(servers, s => {
+                Assert.Equal(af, s.Country);
+                Assert.Equal(kab, s.Location);
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- verify server filtering with `CountryId` and `LocationId` enums

## Testing
- `dotnet test --filter TestFilterServersByEnum`


------
https://chatgpt.com/codex/tasks/task_e_687ca0a00fdc832ead3884beed1864cb