### PR TITLE
Add DNS digest type enum

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDNSSEC.cs
+++ b/DomainDetective.Example/ExampleAnalyseDNSSEC.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>Demonstrates DNSSEC queries.</summary>
+    public static async Task ExampleAnalyseDnsSec() {
+        var healthCheck = new DomainHealthCheck();
+        healthCheck.Verbose = false;
+        await healthCheck.VerifyDNSSEC("example.com");
+        DnsSecInfo info = DnsSecConverter.Convert(healthCheck.DnsSecAnalysis);
+        Helpers.ShowPropertiesTable("DNSSEC DS Records", info.DsRecords);
+    }
+}

--- a/DomainDetective.Example/Program.cs
+++ b/DomainDetective.Example/Program.cs
@@ -68,6 +68,7 @@ public static partial class Program {
         await ExampleValidateServerAsn();
         await ExampleAnalyseDnsPropagationRegions();
         await ExampleAnalyseDnsTtl();
+        await ExampleAnalyseDnsSec();
         await ExampleDomainSummary();
         await ExampleAnalyseThreatIntel();
         await ExampleAnalyseThreatFeed();

--- a/DomainDetective.Tests/TestAlgorithmNameMapping.cs
+++ b/DomainDetective.Tests/TestAlgorithmNameMapping.cs
@@ -19,6 +19,7 @@ namespace DomainDetective.Tests {
             var parseDs = converter.GetMethod("ParseDsRecord", BindingFlags.NonPublic | BindingFlags.Static)!;
             var ds = (DsRecordInfo)parseDs.Invoke(null, new object[] { "60485 8 2 ABCD" })!;
             Assert.Equal("RSASHA256", ds.Algorithm);
+            Assert.Equal(DnsDigestType.Sha256, ds.DigestType);
 
             var parseKey = converter.GetMethod("ParseDnsKey", BindingFlags.NonPublic | BindingFlags.Static)!;
             var key = (DnsKeyInfo)parseKey.Invoke(null, new object[] { "257 3 8 AAAA" })!;

--- a/DomainDetective/DnsDigestType.cs
+++ b/DomainDetective/DnsDigestType.cs
@@ -1,0 +1,18 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Well-known DNSSEC digest algorithms.
+/// </summary>
+public enum DnsDigestType
+{
+    /// <summary>Unknown or unsupported digest.</summary>
+    Unknown = 0,
+    /// <summary>SHA-1 digest.</summary>
+    Sha1 = 1,
+    /// <summary>SHA-256 digest.</summary>
+    Sha256 = 2,
+    /// <summary>SHA-384 digest.</summary>
+    Sha384 = 4,
+    /// <summary>SHA-512 digest.</summary>
+    Sha512 = 5,
+}

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -17,6 +17,16 @@ namespace DomainDetective {
             };
         }
 
+        private static DnsDigestType MapDigestTypeNumber(int number) {
+            return number switch {
+                1 => DnsDigestType.Sha1,
+                2 => DnsDigestType.Sha256,
+                4 => DnsDigestType.Sha384,
+                5 => DnsDigestType.Sha512,
+                _ => DnsDigestType.Unknown,
+            };
+        }
+
         /// <summary>
         ///     Builds a <see cref="DnsSecInfo"/> object from analysis data.
         /// </summary>
@@ -68,7 +78,7 @@ namespace DomainDetective {
             }
 
             _ = int.TryParse(parts[0], out int keyTag);
-            _ = int.TryParse(parts[2], out int digestType);
+            _ = int.TryParse(parts[2], out int digestTypeNumber);
             string algorithm = parts[1];
             if (int.TryParse(parts[1], out int algNum)) {
                 string name = MapAlgorithmNumber(algNum);
@@ -79,7 +89,7 @@ namespace DomainDetective {
             return new DsRecordInfo {
                 KeyTag = keyTag,
                 Algorithm = algorithm,
-                DigestType = digestType,
+                DigestType = MapDigestTypeNumber(digestTypeNumber),
                 Digest = parts[3],
             };
         }
@@ -168,7 +178,7 @@ namespace DomainDetective {
         public string Algorithm { get; set; }
 
         /// <summary>Digest type identifier.</summary>
-        public int DigestType { get; set; }
+        public DnsDigestType DigestType { get; set; }
 
         /// <summary>Digest hex string.</summary>
         public string Digest { get; set; }


### PR DESCRIPTION
## Summary
- introduce `DnsDigestType` enum
- return enum from `DsRecordInfo`
- map digest type numbers in `DnsSecConverter`
- test digest type mapping
- show DNSSEC example

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_687ca08fb564832e8d216de4226021c9