### PR TITLE
Fix Codecov action to be informational

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -59,6 +59,7 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
 
     test-ubuntu:
         name: 'Ubuntu'
@@ -100,6 +101,7 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false
 
     test-macos:
         if: false # Temporarily disabled
@@ -142,3 +144,4 @@ jobs:
               uses: codecov/codecov-action@v3
               with:
                   files: '**/coverage.cobertura.xml'
+                  fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- modify GitHub Actions to prevent Codecov from failing the workflow

## Testing
- `dotnet build DomainDetective.sln --no-restore -c Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0 --no-build` *(fails: "Failed!  - Failed: 9, Passed: 658, Skipped: 0, Total: 667")*

------
https://chatgpt.com/codex/tasks/task_e_687cf002b50c832e8a374a25a08df020