### PR TITLE
Add TLSA enum descriptions

### DIFF
--- a/DomainDetective.Tests/TestDANEAnalysis.cs
+++ b/DomainDetective.Tests/TestDANEAnalysis.cs
@@ -433,5 +433,30 @@ namespace DomainDetective.Tests {
             Assert.False(healthCheck.DaneAnalysis.HasInvalidRecords);
             Assert.Equal(2, healthCheck.DaneAnalysis.AnalysisResults.Count);
         }
+
+        [Fact]
+        public async Task EnumValuesAreReturned() {
+            var record = $"3 1 1 {new string('A', 64)}";
+            var healthCheck = new DomainHealthCheck { Verbose = false };
+            await healthCheck.CheckDANE(record);
+
+            var result = healthCheck.DaneAnalysis.AnalysisResults[0];
+            Assert.Equal(TlsaUsage.DaneEe, result.CertificateUsage);
+            Assert.Equal(TlsaSelector.Spki, result.SelectorField);
+            Assert.Equal(TlsaMatchingType.Sha256, result.MatchingTypeField);
+        }
+
+        [Fact]
+        public void EnumDescriptionsAreAvailable() {
+            Assert.Equal(
+                "PKIX-TA: CA Constraint",
+                TlsaUsage.PkixTa.GetDescription());
+            Assert.Equal(
+                "SPKI: SubjectPublicKeyInfo",
+                TlsaSelector.Spki.GetDescription());
+            Assert.Equal(
+                "SHA-256: SHA-256 of Certificate or SPKI",
+                TlsaMatchingType.Sha256.GetDescription());
+        }
     }
 }

--- a/DomainDetective/Definitions/TlsaMatchingType.cs
+++ b/DomainDetective/Definitions/TlsaMatchingType.cs
@@ -1,0 +1,18 @@
+namespace DomainDetective;
+
+using System.ComponentModel;
+
+/// <summary>
+/// TLSA matching type values defined in RFC 6698.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public enum TlsaMatchingType {
+    /// <summary>Matching type not recognized.</summary>
+    [Description("Unknown")] Unknown = -1,
+    /// <summary>Full: Full Certificate or SPKI.</summary>
+    [Description("Full: Full Certificate or SPKI")] Full = 0,
+    /// <summary>SHA-256: SHA-256 of Certificate or SPKI.</summary>
+    [Description("SHA-256: SHA-256 of Certificate or SPKI")] Sha256 = 1,
+    /// <summary>SHA-512: SHA-512 of Certificate or SPKI.</summary>
+    [Description("SHA-512: SHA-512 of Certificate or SPKI")] Sha512 = 2
+}

--- a/DomainDetective/Definitions/TlsaSelector.cs
+++ b/DomainDetective/Definitions/TlsaSelector.cs
@@ -1,0 +1,16 @@
+namespace DomainDetective;
+
+using System.ComponentModel;
+
+/// <summary>
+/// TLSA selector values defined in RFC 6698.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public enum TlsaSelector {
+    /// <summary>Selector value not recognized.</summary>
+    [Description("Unknown")] Unknown = -1,
+    /// <summary>Cert: Full Certificate.</summary>
+    [Description("Cert: Full Certificate")] Cert = 0,
+    /// <summary>SPKI: SubjectPublicKeyInfo.</summary>
+    [Description("SPKI: SubjectPublicKeyInfo")] Spki = 1
+}

--- a/DomainDetective/Definitions/TlsaUsage.cs
+++ b/DomainDetective/Definitions/TlsaUsage.cs
@@ -1,0 +1,20 @@
+namespace DomainDetective;
+
+using System.ComponentModel;
+
+/// <summary>
+/// TLSA certificate usage values defined in RFC 6698.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public enum TlsaUsage {
+    /// <summary>Usage value not recognized.</summary>
+    [Description("Unknown")] Unknown = -1,
+    /// <summary>PKIX-TA: CA Constraint.</summary>
+    [Description("PKIX-TA: CA Constraint")] PkixTa = 0,
+    /// <summary>PKIX-EE: Service Certificate Constraint.</summary>
+    [Description("PKIX-EE: Service Certificate Constraint")] PkixEe = 1,
+    /// <summary>DANE-TA: Trust Anchor Assertion.</summary>
+    [Description("DANE-TA: Trust Anchor Assertion")] DaneTa = 2,
+    /// <summary>DANE-EE: Domain Issued Certificate.</summary>
+    [Description("DANE-EE: Domain Issued Certificate")] DaneEe = 3
+}

--- a/DomainDetective/EnumExtensions.cs
+++ b/DomainDetective/EnumExtensions.cs
@@ -1,0 +1,25 @@
+namespace DomainDetective;
+
+using System;
+using System.ComponentModel;
+using System.Reflection;
+
+/// <summary>
+/// Provides helper methods for working with enum types.
+/// </summary>
+public static class EnumExtensions {
+    /// <summary>
+    /// Returns the <see cref="DescriptionAttribute"/> text for the enum value.
+    /// </summary>
+    /// <param name="value">Enum value.</param>
+    /// <returns>Description text or the value name.</returns>
+    public static string GetDescription(this Enum value) {
+        var member = value.GetType().GetMember(value.ToString());
+        if (member.Length > 0 &&
+            Attribute.GetCustomAttribute(member[0], typeof(DescriptionAttribute)) is DescriptionAttribute attr) {
+            return attr.Description;
+        }
+
+        return value.ToString();
+    }
+}

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -185,30 +185,30 @@ namespace DomainDetective {
             };
         }
 
-        private string TranslateUsage(int usage) {
+        private TlsaUsage TranslateUsage(int usage) {
             return usage switch {
-                0 => "PKIX-TA: CA Constraint",
-                1 => "PKIX-EE: Service Certificate Constraint",
-                2 => "DANE-TA: Trust Anchor Assertion",
-                3 => "DANE-EE: Domain Issued Certificate",
-                _ => "Unknown",
+                0 => TlsaUsage.PkixTa,
+                1 => TlsaUsage.PkixEe,
+                2 => TlsaUsage.DaneTa,
+                3 => TlsaUsage.DaneEe,
+                _ => TlsaUsage.Unknown,
             };
         }
 
-        private string TranslateSelector(int selector) {
+        private TlsaSelector TranslateSelector(int selector) {
             return selector switch {
-                0 => "Cert: Full Certificate",
-                1 => "SPKI: SubjectPublicKeyInfo",
-                _ => "Unknown",
+                0 => TlsaSelector.Cert,
+                1 => TlsaSelector.Spki,
+                _ => TlsaSelector.Unknown,
             };
         }
 
-        private string TranslateMatchingType(int matchingType) {
+        private TlsaMatchingType TranslateMatchingType(int matchingType) {
             return matchingType switch {
-                0 => "Full: Full Certificate or SPKI",
-                1 => "SHA-256: SHA-256 of Certificate or SPKI",
-                2 => "SHA-512: SHA-512 of Certificate or SPKI",
-                _ => "Unknown",
+                0 => TlsaMatchingType.Full,
+                1 => TlsaMatchingType.Sha256,
+                2 => TlsaMatchingType.Sha512,
+                _ => TlsaMatchingType.Unknown,
             };
         }
 
@@ -244,12 +244,12 @@ namespace DomainDetective {
         public bool IsValidChoiceForSmtp { get; set; }
         /// <summary>Gets or sets a value indicating whether this configuration is recommended for HTTPS.</summary>
         public bool IsValidChoiceForHttps { get; set; }
-        /// <summary>Gets or sets the textual description of the certificate usage.</summary>
-        public string CertificateUsage { get; set; }
-        /// <summary>Gets or sets the textual description of the selector field.</summary>
-        public string SelectorField { get; set; }
-        /// <summary>Gets or sets the textual description of the matching type.</summary>
-        public string MatchingTypeField { get; set; }
+        /// <summary>Gets or sets the certificate usage value.</summary>
+        public TlsaUsage CertificateUsage { get; set; }
+        /// <summary>Gets or sets the selector value.</summary>
+        public TlsaSelector SelectorField { get; set; }
+        /// <summary>Gets or sets the matching type value.</summary>
+        public TlsaMatchingType MatchingTypeField { get; set; }
         /// <summary>Gets or sets the certificate association data.</summary>
         public string CertificateAssociationData { get; set; }
         /// <summary>Gets or sets a value indicating whether the record contains four fields.</summary>


### PR DESCRIPTION
## Summary
- decorate TLSA enums with `DescriptionAttribute`
- introduce `EnumExtensions.GetDescription()` helper
- test enum descriptions are accessible

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: 9 failed, 655 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687ca0bdc990832e8bf90e288842615b