### PR TITLE
Use enum for DNSSEC algorithm mapping

### DIFF
--- a/DomainDetective.Tests/TestAlgorithmNameMapping.cs
+++ b/DomainDetective.Tests/TestAlgorithmNameMapping.cs
@@ -18,20 +18,20 @@ namespace DomainDetective.Tests {
             var converter = typeof(DnsSecConverter);
             var parseDs = converter.GetMethod("ParseDsRecord", BindingFlags.NonPublic | BindingFlags.Static)!;
             var ds = (DsRecordInfo)parseDs.Invoke(null, new object[] { "60485 8 2 ABCD" })!;
-            Assert.Equal("RSASHA256", ds.Algorithm);
+            Assert.Equal(DnsAlgorithm.RSASHA256, ds.Algorithm);
 
             var parseKey = converter.GetMethod("ParseDnsKey", BindingFlags.NonPublic | BindingFlags.Static)!;
             var key = (DnsKeyInfo)parseKey.Invoke(null, new object[] { "257 3 8 AAAA" })!;
-            Assert.Equal("RSASHA256", key.Algorithm);
+            Assert.Equal(DnsAlgorithm.RSASHA256, key.Algorithm);
 
             var analysisType = typeof(DnsSecAnalysis);
             var parseSig = analysisType.GetMethod("ParseRrsig", BindingFlags.NonPublic | BindingFlags.Static)!;
             var sig = (RrsigInfo)parseSig.Invoke(null, new object[] { "DNSKEY 8 2 3600 1755665684 1750395284 2371 example.com. AAAA" })!;
-            Assert.Equal("RSASHA256", sig.Algorithm);
+            Assert.Equal(DnsAlgorithm.RSASHA256, sig.Algorithm);
 
             var mapAlg = converter.GetMethod("MapAlgorithmNumber", BindingFlags.NonPublic | BindingFlags.Static)!;
-            var mapped = (string)mapAlg.Invoke(null, new object[] { 8 })!;
-            Assert.Equal("RSASHA256", mapped);
+            var mapped = (DnsAlgorithm)mapAlg.Invoke(null, new object[] { 8 })!;
+            Assert.Equal(DnsAlgorithm.RSASHA256, mapped);
         }
     }
 }

--- a/DomainDetective.Tests/TestRrsigParsing.cs
+++ b/DomainDetective.Tests/TestRrsigParsing.cs
@@ -10,7 +10,7 @@ namespace DomainDetective.Tests {
             var method = typeof(DnsSecAnalysis).GetMethod("ParseRrsig", BindingFlags.NonPublic | BindingFlags.Static)!;
             var info = (RrsigInfo)method.Invoke(null, new object[] { record })!;
             Assert.Equal(2371, info.KeyTag);
-            Assert.Equal("ECDSAP256SHA256", info.Algorithm);
+            Assert.Equal(DnsAlgorithm.ECDSAP256SHA256, info.Algorithm);
             Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1750395284), info.Inception);
             Assert.Equal(DateTimeOffset.FromUnixTimeSeconds(1755665684), info.Expiration);
         }

--- a/DomainDetective/DnsAlgorithm.cs
+++ b/DomainDetective/DnsAlgorithm.cs
@@ -1,0 +1,55 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Enumerates DNSSEC algorithms used in DS, DNSKEY and RRSIG records.
+/// </summary>
+public enum DnsAlgorithm {
+    /// <summary>Algorithm is unknown.</summary>
+    Unknown = -1,
+    /// <summary>Delete DNSSEC record.</summary>
+    DELETE = 0,
+    /// <summary>RSAMD5 algorithm.</summary>
+    RSAMD5 = 1,
+    /// <summary>DH algorithm.</summary>
+    DH = 2,
+    /// <summary>DSA algorithm.</summary>
+    DSA = 3,
+    /// <summary>ECC algorithm.</summary>
+    ECC = 4,
+    /// <summary>RSASHA1 algorithm.</summary>
+    RSASHA1 = 5,
+    /// <summary>DSANSEC3SHA1 algorithm.</summary>
+    DSANSEC3SHA1 = 6,
+    /// <summary>RSASHA1NSEC3SHA1 algorithm.</summary>
+    RSASHA1NSEC3SHA1 = 7,
+    /// <summary>RSASHA256 algorithm.</summary>
+    RSASHA256 = 8,
+    /// <summary>Reserved algorithm number 9.</summary>
+    RESERVED9 = 9,
+    /// <summary>RSASHA512 algorithm.</summary>
+    RSASHA512 = 10,
+    /// <summary>Reserved algorithm number 11.</summary>
+    RESERVED11 = 11,
+    /// <summary>ECCGOST algorithm.</summary>
+    ECCGOST = 12,
+    /// <summary>ECDSAP256SHA256 algorithm.</summary>
+    ECDSAP256SHA256 = 13,
+    /// <summary>ECDSAP384SHA384 algorithm.</summary>
+    ECDSAP384SHA384 = 14,
+    /// <summary>ED25519 algorithm.</summary>
+    ED25519 = 15,
+    /// <summary>ED448 algorithm.</summary>
+    ED448 = 16,
+    /// <summary>SM2SM3 algorithm.</summary>
+    SM2SM3 = 17,
+    /// <summary>ECC-GOST12 algorithm.</summary>
+    ECC_GOST12 = 23,
+    /// <summary>INDIRECT algorithm.</summary>
+    INDIRECT = 252,
+    /// <summary>PRIVATEDNS algorithm.</summary>
+    PRIVATEDNS = 253,
+    /// <summary>PRIVATEOID algorithm.</summary>
+    PRIVATEOID = 254,
+    /// <summary>Reserved algorithm number 255.</summary>
+    RESERVED255 = 255
+}

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -8,12 +8,32 @@ namespace DomainDetective {
     ///     strongly typed objects.
     /// </summary>
     public static class DnsSecConverter {
-        private static string MapAlgorithmNumber(int number) {
+        private static DnsAlgorithm MapAlgorithmNumber(int number) {
             return number switch {
-                8 => "RSASHA256",
-                13 => "ECDSAP256SHA256",
-                14 => "ECDSAP384SHA384",
-                _ => DNSKeyAnalysis.AlgorithmName(number) ?? string.Empty,
+                0 => DnsAlgorithm.DELETE,
+                1 => DnsAlgorithm.RSAMD5,
+                2 => DnsAlgorithm.DH,
+                3 => DnsAlgorithm.DSA,
+                4 => DnsAlgorithm.ECC,
+                5 => DnsAlgorithm.RSASHA1,
+                6 => DnsAlgorithm.DSANSEC3SHA1,
+                7 => DnsAlgorithm.RSASHA1NSEC3SHA1,
+                8 => DnsAlgorithm.RSASHA256,
+                9 => DnsAlgorithm.RESERVED9,
+                10 => DnsAlgorithm.RSASHA512,
+                11 => DnsAlgorithm.RESERVED11,
+                12 => DnsAlgorithm.ECCGOST,
+                13 => DnsAlgorithm.ECDSAP256SHA256,
+                14 => DnsAlgorithm.ECDSAP384SHA384,
+                15 => DnsAlgorithm.ED25519,
+                16 => DnsAlgorithm.ED448,
+                17 => DnsAlgorithm.SM2SM3,
+                23 => DnsAlgorithm.ECC_GOST12,
+                252 => DnsAlgorithm.INDIRECT,
+                253 => DnsAlgorithm.PRIVATEDNS,
+                254 => DnsAlgorithm.PRIVATEOID,
+                255 => DnsAlgorithm.RESERVED255,
+                _ => DnsAlgorithm.Unknown,
             };
         }
 
@@ -69,12 +89,11 @@ namespace DomainDetective {
 
             _ = int.TryParse(parts[0], out int keyTag);
             _ = int.TryParse(parts[2], out int digestType);
-            string algorithm = parts[1];
+            DnsAlgorithm algorithm = DnsAlgorithm.Unknown;
             if (int.TryParse(parts[1], out int algNum)) {
-                string name = MapAlgorithmNumber(algNum);
-                if (!string.IsNullOrEmpty(name)) {
-                    algorithm = name;
-                }
+                algorithm = MapAlgorithmNumber(algNum);
+            } else if (Enum.TryParse(parts[1].Replace("-", "_"), true, out DnsAlgorithm parsed)) {
+                algorithm = parsed;
             }
             return new DsRecordInfo {
                 KeyTag = keyTag,
@@ -96,12 +115,11 @@ namespace DomainDetective {
 
             _ = int.TryParse(parts[0], out int flags);
             _ = byte.TryParse(parts[1], out byte protocol);
-            string algorithm = parts[2];
+            DnsAlgorithm algorithm = DnsAlgorithm.Unknown;
             if (int.TryParse(parts[2], out int algNum)) {
-                string name = MapAlgorithmNumber(algNum);
-                if (!string.IsNullOrEmpty(name)) {
-                    algorithm = name;
-                }
+                algorithm = MapAlgorithmNumber(algNum);
+            } else if (Enum.TryParse(parts[2].Replace("-", "_"), true, out DnsAlgorithm parsed)) {
+                algorithm = parsed;
             }
             return new DnsKeyInfo {
                 Flags = flags,
@@ -164,8 +182,8 @@ namespace DomainDetective {
         /// <summary>Key tag value.</summary>
         public int KeyTag { get; set; }
 
-        /// <summary>Algorithm name.</summary>
-        public string Algorithm { get; set; }
+        /// <summary>Algorithm used to generate the signature.</summary>
+        public DnsAlgorithm Algorithm { get; set; }
 
         /// <summary>Digest type identifier.</summary>
         public int DigestType { get; set; }
@@ -188,8 +206,8 @@ namespace DomainDetective {
         /// <summary>Protocol value.</summary>
         public byte Protocol { get; set; }
 
-        /// <summary>Algorithm name.</summary>
-        public string Algorithm { get; set; }
+        /// <summary>Algorithm used to generate the key.</summary>
+        public DnsAlgorithm Algorithm { get; set; }
 
         /// <summary>Base64 encoded public key.</summary>
         public string PublicKey { get; set; }
@@ -206,8 +224,8 @@ namespace DomainDetective {
         /// <summary>Key tag value.</summary>
         public int KeyTag { get; set; }
 
-        /// <summary>Algorithm name.</summary>
-        public string Algorithm { get; set; }
+        /// <summary>Algorithm used to sign the record.</summary>
+        public DnsAlgorithm Algorithm { get; set; }
 
         /// <summary>Signature inception time.</summary>
         public DateTimeOffset Inception { get; set; }

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -518,12 +518,36 @@ namespace DomainDetective {
 
             _ = int.TryParse(parts[6], out int keyTag);
 
-            string algorithm = parts[1];
+            DnsAlgorithm algorithm = DnsAlgorithm.Unknown;
             if (int.TryParse(parts[1], out int algNum)) {
-                string name = DNSKeyAnalysis.AlgorithmName(algNum);
-                if (!string.IsNullOrEmpty(name)) {
-                    algorithm = name;
-                }
+                algorithm = algNum switch {
+                    0 => DnsAlgorithm.DELETE,
+                    1 => DnsAlgorithm.RSAMD5,
+                    2 => DnsAlgorithm.DH,
+                    3 => DnsAlgorithm.DSA,
+                    4 => DnsAlgorithm.ECC,
+                    5 => DnsAlgorithm.RSASHA1,
+                    6 => DnsAlgorithm.DSANSEC3SHA1,
+                    7 => DnsAlgorithm.RSASHA1NSEC3SHA1,
+                    8 => DnsAlgorithm.RSASHA256,
+                    9 => DnsAlgorithm.RESERVED9,
+                    10 => DnsAlgorithm.RSASHA512,
+                    11 => DnsAlgorithm.RESERVED11,
+                    12 => DnsAlgorithm.ECCGOST,
+                    13 => DnsAlgorithm.ECDSAP256SHA256,
+                    14 => DnsAlgorithm.ECDSAP384SHA384,
+                    15 => DnsAlgorithm.ED25519,
+                    16 => DnsAlgorithm.ED448,
+                    17 => DnsAlgorithm.SM2SM3,
+                    23 => DnsAlgorithm.ECC_GOST12,
+                    252 => DnsAlgorithm.INDIRECT,
+                    253 => DnsAlgorithm.PRIVATEDNS,
+                    254 => DnsAlgorithm.PRIVATEOID,
+                    255 => DnsAlgorithm.RESERVED255,
+                    _ => DnsAlgorithm.Unknown,
+                };
+            } else if (Enum.TryParse(parts[1].Replace("-", "_"), true, out DnsAlgorithm parsed)) {
+                algorithm = parsed;
             }
 
             return new RrsigInfo {


### PR DESCRIPTION
## Summary
- add `DnsAlgorithm` enum for well-known DNSSEC algorithms
- use `DnsAlgorithm` in `DnsSecConverter` and `DnsSecAnalysis`
- adjust DS, DNSKEY and RRSIG parsing to return the enum
- update tests to check enum values

## Testing
- `dotnet test DomainDetective.sln` *(fails: Should exceed DNS lookups due to many includes)*

------
https://chatgpt.com/codex/tasks/task_e_687ca0584b20832e90f3c5c04f004395