### PR TITLE
Introduce threat intel findings

### DIFF
--- a/DomainDetective.Tests/TestThreatFeedAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatFeedAnalysis.cs
@@ -21,8 +21,8 @@ public class TestThreatFeedAnalysis {
 
         await analysis.Analyze("8.8.8.8", "v", "a", new InternalLogger());
 
-        Assert.True(analysis.ListedByVirusTotal);
-        Assert.True(analysis.ListedByAbuseIpDb);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && f.IsListed);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.AbuseIpDb && f.IsListed);
     }
 
     [Fact]
@@ -42,8 +42,8 @@ public class TestThreatFeedAnalysis {
 
         await health.VerifyThreatFeed("8.8.8.8");
 
-        Assert.True(health.ThreatFeedAnalysis.ListedByVirusTotal);
-        Assert.True(health.ThreatFeedAnalysis.ListedByAbuseIpDb);
+        Assert.Contains(health.ThreatFeedAnalysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && f.IsListed);
+        Assert.Contains(health.ThreatFeedAnalysis.Listings, f => f.Source == ThreatIntelSource.AbuseIpDb && f.IsListed);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class TestThreatFeedAnalysis {
         await analysis.Analyze("8.8.8.8", "v", null, new InternalLogger());
 
         Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
-        Assert.False(analysis.ListedByVirusTotal);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && !f.IsListed);
     }
 
     [Fact]
@@ -79,6 +79,6 @@ public class TestThreatFeedAnalysis {
 
         await analysis.Analyze("8.8.8.8", "v", null, new InternalLogger());
 
-        Assert.True(analysis.ListedByVirusTotal);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && f.IsListed);
     }
 }

--- a/DomainDetective.Tests/TestThreatIntelAnalysis.cs
+++ b/DomainDetective.Tests/TestThreatIntelAnalysis.cs
@@ -27,9 +27,9 @@ public class TestThreatIntelAnalysis
 
         await analysis.Analyze("example.com", "g", "p", "v", new InternalLogger());
 
-        Assert.True(analysis.ListedByGoogle);
-        Assert.True(analysis.ListedByPhishTank);
-        Assert.True(analysis.ListedByVirusTotal);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.GoogleSafeBrowsing && f.IsListed);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.PhishTank && f.IsListed);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && f.IsListed);
     }
 
     [Fact]
@@ -52,9 +52,9 @@ public class TestThreatIntelAnalysis
 
         await health.VerifyThreatIntel("example.com");
 
-        Assert.True(health.ThreatIntelAnalysis.ListedByGoogle);
-        Assert.True(health.ThreatIntelAnalysis.ListedByPhishTank);
-        Assert.True(health.ThreatIntelAnalysis.ListedByVirusTotal);
+        Assert.Contains(health.ThreatIntelAnalysis.Listings, f => f.Source == ThreatIntelSource.GoogleSafeBrowsing && f.IsListed);
+        Assert.Contains(health.ThreatIntelAnalysis.Listings, f => f.Source == ThreatIntelSource.PhishTank && f.IsListed);
+        Assert.Contains(health.ThreatIntelAnalysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && f.IsListed);
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class TestThreatIntelAnalysis
         await analysis.Analyze("example.com", "g", null, null, new InternalLogger());
 
         Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
-        Assert.False(analysis.ListedByGoogle);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.GoogleSafeBrowsing && !f.IsListed);
     }
 
     [Fact]
@@ -123,7 +123,7 @@ public class TestThreatIntelAnalysis
 
         await analysis.Analyze("example.com", null, null, "v", new InternalLogger());
 
-        Assert.True(analysis.ListedByVirusTotal);
+        Assert.Contains(analysis.Listings, f => f.Source == ThreatIntelSource.VirusTotal && f.IsListed);
         Assert.Equal(42, analysis.RiskScore);
     }
 }

--- a/DomainDetective/Definitions/ThreatIntelSource.cs
+++ b/DomainDetective/Definitions/ThreatIntelSource.cs
@@ -1,0 +1,16 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Supported threat intelligence sources.
+/// </summary>
+public enum ThreatIntelSource
+{
+    /// <summary>Google Safe Browsing service.</summary>
+    GoogleSafeBrowsing,
+    /// <summary>PhishTank phishing URL database.</summary>
+    PhishTank,
+    /// <summary>VirusTotal reputation service.</summary>
+    VirusTotal,
+    /// <summary>AbuseIPDB IP reputation database.</summary>
+    AbuseIpDb
+}

--- a/DomainDetective/ThreatIntelFinding.cs
+++ b/DomainDetective/ThreatIntelFinding.cs
@@ -1,0 +1,19 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Represents the result from a single threat intelligence source.
+/// </summary>
+public readonly struct ThreatIntelFinding
+{
+    /// <summary>Origin of the finding.</summary>
+    public ThreatIntelSource Source { get; init; }
+
+    /// <summary>Indicates whether the source reported a listing.</summary>
+    public bool IsListed { get; init; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return $"{Source}: {(IsListed ? "Listed" : "Not listed")}";
+    }
+}


### PR DESCRIPTION
## Summary
- add `ThreatIntelSource` enumeration
- add new `ThreatIntelFinding` struct
- replace individual boolean flags with a `Listings` collection
- adapt threat intel and feed analysis to populate `Listings`
- update unit tests

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln --no-build -c Release` *(fails: Hosts not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_687ca06d5520832e9d9c3a864034a213