### PR TITLE
Fix flaky CAAAnalysis test

### DIFF
--- a/DomainDetective.Tests/TestCAAAnalysis.cs
+++ b/DomainDetective.Tests/TestCAAAnalysis.cs
@@ -176,7 +176,22 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task TestCAARecordByDomain() {
-            var healthCheck = new DomainHealthCheck();
+            var caaRecords = new List<DnsAnswer> {
+                new() { DataRaw = "0 issue \"ssl.com\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issue \"digicert.com; cansignhttpexchanges=yes\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issuewild \"comodoca.com\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issue \"pki.goog; cansignhttpexchanges=yes\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issuewild \"ssl.com\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issuewild \"letsencrypt.org\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issuewild \"pki.goog; cansignhttpexchanges=yes\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issuewild \"digicert.com; cansignhttpexchanges=yes\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issue \"comodoca.com\"", Type = DnsRecordType.CAA },
+                new() { DataRaw = "0 issue \"letsencrypt.org\"", Type = DnsRecordType.CAA }
+            };
+
+            var healthCheck = new DomainHealthCheck {
+                DnsConfiguration = { QueryDnsOverride = (name, type) => Task.FromResult(type == DnsRecordType.CAA ? caaRecords.ToArray() : Array.Empty<DnsAnswer>()) }
+            };
             healthCheck.Verbose = false;
             await healthCheck.Verify("evotec.pl", [HealthCheckType.CAA]);
 


### PR DESCRIPTION
## Summary
- make TestCAARecordByDomain deterministic by mocking DNS results

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --framework net8.0` *(fails: CS1503 in DnsPropagationAnalysis.cs)*

------
https://chatgpt.com/codex/tasks/task_e_687cfda516f8832e96b95ca1fe47b902