### PR TITLE
Fix enum parsing in DNS comparison

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -261,8 +261,8 @@ namespace DomainDetective.Tests {
                 new DnsPropagationResult {
                     Server = new PublicDnsEntry {
                         IPAddress = IPAddress.Parse("1.1.1.1"),
-                        Country = "Afghanistan",
-                        Location = "Kabul"
+                        Country = CountryIdExtensions.TryParse("Afghanistan", out var c) ? c : null,
+                        Location = LocationIdExtensions.TryParse("Kabul", out var l) ? l : null
                     },
                     RecordType = DnsRecordType.A,
                     Records = new[] { "1.2.3.4" },

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -522,18 +522,10 @@ namespace DomainDetective {
                     list = new List<DnsComparisonEntry>();
                     comparison[key] = list;
                 }
-                CountryId? countryId = null;
-                if (CountryIdExtensions.TryParse(res.Server.Country, out var cid)) {
-                    countryId = cid;
-                }
-                LocationId? locationId = null;
-                if (LocationIdExtensions.TryParse(res.Server.Location, out var lid)) {
-                    locationId = lid;
-                }
                 list.Add(new DnsComparisonEntry {
                     IPAddress = res.Server.IPAddress.ToString(),
-                    Country = countryId,
-                    Location = locationId
+                    Country = res.Server.Country,
+                    Location = res.Server.Location
                 });
             }
             return comparison;
@@ -552,8 +544,8 @@ namespace DomainDetective {
                     details.Add(new DnsComparisonDetail {
                         Records = kvp.Key,
                         IPAddress = entry.IPAddress,
-                        Country = entry.Country?.ToName(),
-                        Location = entry.Location?.ToName()
+                        Country = entry.Country,
+                        Location = entry.Location
                     });
                 }
             }


### PR DESCRIPTION
## Summary
- fix CountryId/LocationId parsing when comparing DNS results
- update test to use enum parsing

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: Hosts not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_687d1c35572c832e9e8fdafaf7625240