### PR TITLE
Fix flaky EDNS TCP retry test

### DIFF
--- a/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
+++ b/DomainDetective.Tests/TestEdnsSupportAnalysis.cs
@@ -67,10 +67,10 @@ public class TestEdnsSupportAnalysis
     [Fact]
     public async Task RetriesOverTcpWhenTruncated()
     {
-        var port = PortHelper.GetFreePort();
         using var udpSocket = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
         udpSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-        udpSocket.Bind(new IPEndPoint(IPAddress.Loopback, port));
+        udpSocket.Bind(new IPEndPoint(IPAddress.Loopback, 0));
+        var port = ((IPEndPoint)udpSocket.LocalEndPoint!).Port;
         using var udpServer = new UdpClient { Client = udpSocket };
 
         var tcpListener = new TcpListener(IPAddress.Loopback, port);


### PR DESCRIPTION
## Summary
- avoid port collision by requesting a random UDP port from the OS

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0 --no-build --filter "FullyQualifiedName~TestEdnsSupportAnalysis.RetriesOverTcpWhenTruncated" --verbosity minimal`
- `dotnet build DomainDetective.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_687d2593610c832e880683a2f31433da