### PR TITLE
Add TcpListener fixture for tests

### DIFF
--- a/DomainDetective.Tests/Fixtures/TcpListenerFixture.cs
+++ b/DomainDetective.Tests/Fixtures/TcpListenerFixture.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests.Fixtures;
+
+public sealed class TcpListenerFixture : IAsyncLifetime
+{
+    private readonly Func<TcpListener, CancellationToken, Task> _server;
+    private readonly TcpListener _listener;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _serverTask;
+
+    public int Port { get; private set; }
+
+    public TcpListenerFixture(Func<TcpListener, CancellationToken, Task> server)
+    {
+        _server = server;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+    }
+
+    public Task InitializeAsync()
+    {
+        _listener.Start();
+        Port = ((IPEndPoint)_listener.LocalEndpoint).Port;
+        _serverTask = _server(_listener, _cts.Token);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _cts.Cancel();
+        _listener.Stop();
+        if (_serverTask != null)
+        {
+            try { await _serverTask; } catch { }
+        }
+
+        _cts.Dispose();
+    }
+}

--- a/DomainDetective.Tests/Fixtures/UdpClientFixture.cs
+++ b/DomainDetective.Tests/Fixtures/UdpClientFixture.cs
@@ -1,0 +1,41 @@
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests.Fixtures;
+
+public sealed class UdpClientFixture : IAsyncLifetime
+{
+    private readonly Func<UdpClient, CancellationToken, Task> _server;
+    private readonly UdpClient _client;
+    private readonly CancellationTokenSource _cts = new();
+    private Task? _serverTask;
+
+    public IPEndPoint LocalEndpoint { get; }
+
+    public UdpClientFixture(Func<UdpClient, CancellationToken, Task> server)
+    {
+        _server = server;
+        _client = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        LocalEndpoint = (IPEndPoint)_client.Client.LocalEndPoint!;
+    }
+
+    public Task InitializeAsync()
+    {
+        _serverTask = _server(_client, _cts.Token);
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        _cts.Cancel();
+        _client.Dispose();
+        if (_serverTask != null)
+        {
+            try { await _serverTask; } catch { }
+        }
+
+        _cts.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `TcpListenerFixture` and `UdpClientFixture` for async server setup
- update HTTP certificate tests to use the new fixture
- update BIMI analysis tests to use the fixture

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal` *(fails: Should exceed DNS lookups due to many includes)*

------
https://chatgpt.com/codex/tasks/task_e_687d547345e4832e964a02359ed7360f