### PR TITLE
Update Pester tests to use TestDrive

### DIFF
--- a/Module/Tests/Arc.Tests.ps1
+++ b/Module/Tests/Arc.Tests.ps1
@@ -1,8 +1,10 @@
 Describe 'Test-EmailArc cmdlet' {
     It 'supports pipeline input' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $path = "$PSScriptRoot/../../DomainDetective.Tests/Data/arc-valid.txt"
-        $headers = Get-Content $path -Raw
+        $source = Join-Path $PSScriptRoot '../../DomainDetective.Tests/Data/arc-valid.txt'
+        $path = Join-Path $TestDrive 'arc-valid.txt'
+        Copy-Item -Path $source -Destination $path
+        $headers = Get-Content -Path $path -Raw
         $result = $headers | Test-EmailArc
         $result | Should -Not -BeNullOrEmpty
     }

--- a/Module/Tests/DnsblProviderManagement.Tests.ps1
+++ b/Module/Tests/DnsblProviderManagement.Tests.ps1
@@ -35,7 +35,9 @@ Describe 'Clear-DnsblProvider cmdlet' {
 Describe 'Import-DnsblConfig cmdlet' {
     It 'executes and returns analysis' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $path = "$PSScriptRoot/../../DnsblProviders.sample.json"
+        $source = Join-Path $PSScriptRoot '../../DnsblProviders.sample.json'
+        $path = Join-Path $TestDrive 'DnsblProviders.sample.json'
+        Copy-Item -Path $source -Destination $path
         $result = Import-DnsblConfig -Path $path -OverwriteExisting
         $result | Should -Not -BeNullOrEmpty
     }
@@ -47,8 +49,7 @@ Describe 'Import-DnsblConfig cmdlet' {
     It 'skips duplicate domains' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
         $json = '{"providers":[{"domain":"dup.test"},{"domain":"DUP.test"}]}'
-        $temp = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
-        $path = Join-Path $temp ([guid]::NewGuid().ToString() + '.json')
+        $path = Join-Path $TestDrive (([guid]::NewGuid()).ToString() + '.json')
         $json | Set-Content -Path $path
         try {
             $result = Import-DnsblConfig -Path $path -ClearExisting

--- a/Module/Tests/ImportDmarcForensic.Tests.ps1
+++ b/Module/Tests/ImportDmarcForensic.Tests.ps1
@@ -1,11 +1,15 @@
 Describe 'Import-DmarcForensic cmdlet' {
     It 'parses forensic report' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $b64 = Get-Content "$PSScriptRoot/../../DomainDetective.Tests/Data/dmarc_forensic.b64" -Raw
-        $tmp = [IO.Path]::GetTempFileName()
+        $source = Join-Path $PSScriptRoot '../../DomainDetective.Tests/Data/dmarc_forensic.b64'
+        $b64 = Get-Content -Path $source -Raw
+        $tmp = Join-Path $TestDrive ([IO.Path]::GetRandomFileName())
         [IO.File]::WriteAllBytes($tmp, [Convert]::FromBase64String($b64))
-        $result = Import-DmarcForensic -Path $tmp
-        Remove-Item $tmp -Force
-        $result.SourceIp | Should -Be '192.0.2.1'
+        try {
+            $result = Import-DmarcForensic -Path $tmp
+            $result.SourceIp | Should -Be '192.0.2.1'
+        } finally {
+            Remove-Item $tmp -Force
+        }
     }
 }

--- a/Module/Tests/RdapObject.Tests.ps1
+++ b/Module/Tests/RdapObject.Tests.ps1
@@ -1,14 +1,20 @@
 Describe 'Get-RdapObject cmdlet' {
     It 'retrieves domain data' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $data = Join-Path $PSScriptRoot 'Data'
+        $source = Join-Path $PSScriptRoot 'Data'
+        $data = Join-Path $TestDrive 'Data'
+        Copy-Item -Path $source -Destination $data -Recurse
         $result = Get-RdapObject -Domain 'example.com' -ServiceEndpoint $data
+        Remove-Item -Path $data -Recurse -Force
         $result | Should -Not -BeNullOrEmpty
     }
     It 'retrieves IP data' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $data = Join-Path $PSScriptRoot 'Data'
+        $source = Join-Path $PSScriptRoot 'Data'
+        $data = Join-Path $TestDrive 'Data'
+        Copy-Item -Path $source -Destination $data -Recurse
         $result = Get-RdapObject -Ip '192.0.2.1' -ServiceEndpoint $data
+        Remove-Item -Path $data -Recurse -Force
         $result | Should -Not -BeNullOrEmpty
     }
 }


### PR DESCRIPTION
## Summary
- update Arc pester test to use TestDrive
- use TestDrive paths in DnsblProviderManagement tests
- create temp files in TestDrive for forensic data
- copy RdapObject test data to TestDrive

## Testing
- `dotnet build -c Release`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"`

------
https://chatgpt.com/codex/tasks/task_e_687de0e83b94832e8fc0991575368cac