### PR TITLE
Move CheckDomainSettings to dedicated file

### DIFF
--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -10,67 +10,6 @@ using System.Security.Cryptography.X509Certificates;
 namespace DomainDetective.CLI;
 
 /// <summary>
-/// Settings for <see cref="CheckDomainCommand"/>.
-/// </summary>
-internal sealed class CheckDomainSettings : CommandSettings {
-    /// <summary>Domains to analyze.</summary>
-    [CommandArgument(0, "[domains]")]
-    public string[] Domains { get; set; } = Array.Empty<string>();
-
-    /// <summary>Comma separated list of checks.</summary>
-    [CommandOption("--checks")]
-    public string[] Checks { get; set; } = Array.Empty<string>();
-
-    /// <summary>Perform plain HTTP check.</summary>
-    [CommandOption("--check-http")]
-    public bool CheckHttp { get; set; }
-
-    /// <summary>Check for takeover vulnerable CNAMEs.</summary>
-    [CommandOption("--check-takeover")]
-    public bool CheckTakeover { get; set; }
-
-    /// <summary>Show condensed summary instead of full results.</summary>
-    [CommandOption("--summary")]
-    public bool Summary { get; set; }
-
-    /// <summary>Output JSON to the console.</summary>
-    [CommandOption("--json")]
-    public bool Json { get; set; }
-
-    /// <summary>Show output using Unicode characters.</summary>
-    [CommandOption("--unicode")]
-    public bool Unicode { get; set; }
-
-    /// <summary>Evaluate subdomain policy on DMARC record.</summary>
-    [CommandOption("--subdomain-policy")]
-    public bool SubdomainPolicy { get; set; }
-
-    /// <summary>Comma separated list of ports for DANE checks.</summary>
-    [CommandOption("--dane-ports")]
-    public string? DanePorts { get; set; }
-
-    /// <summary>Comma separated list of port scan profiles.</summary>
-    [CommandOption("--port-profiles")]
-    public string? PortProfiles { get; set; }
-
-    /// <summary>Path to S/MIME certificate.</summary>
-    [CommandOption("--smime")]
-    public FileInfo? Smime { get; set; }
-
-    /// <summary>Path to certificate to analyze.</summary>
-    [CommandOption("--cert")]
-    public FileInfo? Cert { get; set; }
-
-    /// <summary>Suppress progress output.</summary>
-    [CommandOption("--no-progress")]
-    public bool NoProgress { get; set; }
-
-    /// <summary>Skip certificate revocation checks.</summary>
-    [CommandOption("--skip-revocation")]
-    public bool SkipRevocation { get; set; }
-}
-
-/// <summary>
 /// Performs health checks against specified domains.
 /// </summary>
 internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {

--- a/DomainDetective.CLI/Commands/CheckDomainSettings.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainSettings.cs
@@ -1,0 +1,65 @@
+using Spectre.Console.Cli;
+using System.IO;
+
+namespace DomainDetective.CLI;
+
+/// <summary>
+/// Settings for <see cref="CheckDomainCommand"/>.
+/// </summary>
+internal sealed class CheckDomainSettings : CommandSettings {
+    /// <summary>Domains to analyze.</summary>
+    [CommandArgument(0, "[domains]")]
+    public string[] Domains { get; set; } = Array.Empty<string>();
+
+    /// <summary>Comma separated list of checks.</summary>
+    [CommandOption("--checks")]
+    public string[] Checks { get; set; } = Array.Empty<string>();
+
+    /// <summary>Perform plain HTTP check.</summary>
+    [CommandOption("--check-http")]
+    public bool CheckHttp { get; set; }
+
+    /// <summary>Check for takeover vulnerable CNAMEs.</summary>
+    [CommandOption("--check-takeover")]
+    public bool CheckTakeover { get; set; }
+
+    /// <summary>Show condensed summary instead of full results.</summary>
+    [CommandOption("--summary")]
+    public bool Summary { get; set; }
+
+    /// <summary>Output JSON to the console.</summary>
+    [CommandOption("--json")]
+    public bool Json { get; set; }
+
+    /// <summary>Show output using Unicode characters.</summary>
+    [CommandOption("--unicode")]
+    public bool Unicode { get; set; }
+
+    /// <summary>Evaluate subdomain policy on DMARC record.</summary>
+    [CommandOption("--subdomain-policy")]
+    public bool SubdomainPolicy { get; set; }
+
+    /// <summary>Comma separated list of ports for DANE checks.</summary>
+    [CommandOption("--dane-ports")]
+    public string? DanePorts { get; set; }
+
+    /// <summary>Comma separated list of port scan profiles.</summary>
+    [CommandOption("--port-profiles")]
+    public string? PortProfiles { get; set; }
+
+    /// <summary>Path to S/MIME certificate.</summary>
+    [CommandOption("--smime")]
+    public FileInfo? Smime { get; set; }
+
+    /// <summary>Path to certificate to analyze.</summary>
+    [CommandOption("--cert")]
+    public FileInfo? Cert { get; set; }
+
+    /// <summary>Suppress progress output.</summary>
+    [CommandOption("--no-progress")]
+    public bool NoProgress { get; set; }
+
+    /// <summary>Skip certificate revocation checks.</summary>
+    [CommandOption("--skip-revocation")]
+    public bool SkipRevocation { get; set; }
+}


### PR DESCRIPTION
## Summary
- split out `CheckDomainSettings` from `CheckDomainCommand`
- keep command implementation intact

## Testing
- `dotnet build DomainDetective.CLI/DomainDetective.CLI.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_687e640726c8832ea3a3d66b2901f842