### PR TITLE
Centralize JSON options

### DIFF
--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using DomainDetective.Helpers;
 using System.Text.Json;
 using System.Threading;
 
@@ -67,7 +68,7 @@ internal static class CommandUtilities {
         var result = hc.CheckMessageHeaders(headerText);
 
         if (json) {
-            var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
+            var jsonText = JsonSerializer.Serialize(result, JsonOptions.Default);
             Console.WriteLine(jsonText);
         } else {
             CliHelpers.ShowPropertiesTable("Message Header Analysis", result, false);
@@ -96,7 +97,7 @@ internal static class CommandUtilities {
         var result = hc.VerifyARCAsync(headerText).GetAwaiter().GetResult();
 
         if (json) {
-            var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
+            var jsonText = JsonSerializer.Serialize(result, JsonOptions.Default);
             Console.WriteLine(jsonText);
         } else {
             CliHelpers.ShowPropertiesTable("ARC Analysis", result, false);
@@ -114,7 +115,7 @@ internal static class CommandUtilities {
         hc.CheckDnsTunnelingAsync(domain).GetAwaiter().GetResult();
         var result = hc.DnsTunnelingAnalysis;
         if (json) {
-            var jsonText = JsonSerializer.Serialize(result, DomainHealthCheck.JsonOptions);
+            var jsonText = JsonSerializer.Serialize(result, JsonOptions.Default);
             Console.WriteLine(jsonText);
         } else {
             CliHelpers.ShowPropertiesTable($"DNS Tunneling for {domain}", result, false);
@@ -126,7 +127,7 @@ internal static class CommandUtilities {
     internal static void ImportDmarcForensic(string path, bool json) {
         var reports = DmarcForensicParser.ParseZip(path).ToList();
         if (json) {
-            var jsonText = JsonSerializer.Serialize(reports, DomainHealthCheck.JsonOptions);
+            var jsonText = JsonSerializer.Serialize(reports, JsonOptions.Default);
             Console.WriteLine(jsonText);
         } else {
             foreach (var report in reports) {

--- a/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
+++ b/DomainDetective.CLI/Commands/DnsPropagationCommand.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading;
+using DomainDetective.Helpers;
 
 namespace DomainDetective.CLI;
 
@@ -107,7 +108,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
         if (settings.Compare) {
             var details = DnsPropagationAnalysis.GetComparisonDetails(results);
             if (settings.Json) {
-                Console.WriteLine(JsonSerializer.Serialize(details, DomainHealthCheck.JsonOptions));
+                Console.WriteLine(JsonSerializer.Serialize(details, JsonOptions.Default));
             } else {
                 foreach (var d in details) {
                     var country = d.Country?.ToName() ?? string.Empty;
@@ -117,7 +118,7 @@ internal sealed class DnsPropagationCommand : AsyncCommand<DnsPropagationSetting
             }
         } else {
             if (settings.Json) {
-                Console.WriteLine(JsonSerializer.Serialize(results, DomainHealthCheck.JsonOptions));
+                Console.WriteLine(JsonSerializer.Serialize(results, JsonOptions.Default));
             } else {
                 foreach (var r in results) {
                     var records = r.Records.Select(rec => {

--- a/DomainDetective.CLI/Commands/SearchDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/SearchDomainCommand.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using DomainDetective.Helpers;
 
 namespace DomainDetective.CLI;
 
@@ -91,7 +92,7 @@ internal sealed class SearchDomainCommand : AsyncCommand<SearchDomainSettings>
                 {
                     list.Add(r);
                 }
-                var json = JsonSerializer.Serialize(list, new JsonSerializerOptions { WriteIndented = true });
+                var json = JsonSerializer.Serialize(list, JsonOptions.Default);
                 Console.WriteLine(json);
                 break;
             }

--- a/DomainDetective.Tests/GlobalUsings.cs
+++ b/DomainDetective.Tests/GlobalUsings.cs
@@ -1,2 +1,3 @@
 global using Xunit;
 global using DomainDetective;
+global using DomainDetective.Helpers;

--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -3,6 +3,7 @@ using DomainDetective;
 using System.Net;
 using System.Threading;
 using System.Linq;
+using DomainDetective.Helpers;
 namespace DomainDetective.Tests {
     public class TestDnsPropagation {
         [Fact]
@@ -278,7 +279,7 @@ namespace DomainDetective.Tests {
             Assert.Equal("Kabul", entry.Location!.Value.ToName());
 
             var details = DnsPropagationAnalysis.GetComparisonDetails(results);
-            var json = System.Text.Json.JsonSerializer.Serialize(details, DomainHealthCheck.JsonOptions);
+            var json = System.Text.Json.JsonSerializer.Serialize(details, JsonOptions.Default);
             Assert.Contains("Afghanistan", json);
             Assert.Contains("Kabul", json);
         }

--- a/DomainDetective.Tests/TestJsonOptions.cs
+++ b/DomainDetective.Tests/TestJsonOptions.cs
@@ -1,0 +1,14 @@
+using System.Text.Json;
+
+namespace DomainDetective.Tests;
+
+public class TestJsonOptions
+{
+    [Fact]
+    public void DefaultMatchesHealthCheck()
+    {
+        Assert.Same(JsonOptions.Default, DomainHealthCheck.JsonOptions);
+        Assert.True(JsonOptions.Default.WriteIndented);
+        Assert.Contains(JsonOptions.Default.Converters, c => c is IPAddressJsonConverter);
+    }
+}

--- a/DomainDetective.Tests/TestJsonSerialization.cs
+++ b/DomainDetective.Tests/TestJsonSerialization.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DomainDetective.Helpers;
 
 namespace DomainDetective.Tests {
     public class TestJsonSerialization {
@@ -6,7 +7,7 @@ namespace DomainDetective.Tests {
         public void HealthCheckSerializationConsistent() {
             var hc = new DomainHealthCheck();
             var json1 = hc.ToJson();
-            var json2 = JsonSerializer.Serialize(hc, DomainHealthCheck.JsonOptions);
+            var json2 = JsonSerializer.Serialize(hc, JsonOptions.Default);
             Assert.Equal(json1, json2);
         }
 
@@ -14,8 +15,8 @@ namespace DomainDetective.Tests {
         public void SummarySerializationConsistent() {
             var hc = new DomainHealthCheck();
             var summary = hc.BuildSummary();
-            var json1 = JsonSerializer.Serialize(summary, DomainHealthCheck.JsonOptions);
-            var json2 = JsonSerializer.Serialize(summary, DomainHealthCheck.JsonOptions);
+            var json1 = JsonSerializer.Serialize(summary, JsonOptions.Default);
+            var json2 = JsonSerializer.Serialize(summary, JsonOptions.Default);
             Assert.Equal(json1, json2);
         }
     }

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Text.Json;
 using System.Text;
 using System.Net.Http;
+using DomainDetective.Helpers;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -569,7 +570,7 @@ namespace DomainDetective {
             Directory.CreateDirectory(SnapshotDirectory);
             var safe = domain.Replace(Path.DirectorySeparatorChar, '-').Replace(Path.AltDirectorySeparatorChar, '-');
             var file = Path.Combine(SnapshotDirectory, $"{safe}_{recordType}_{DateTime.UtcNow:yyyyMMddHHmmss}.json");
-            var json = JsonSerializer.Serialize(results, DomainHealthCheck.JsonOptions);
+            var json = JsonSerializer.Serialize(results, JsonOptions.Default);
             File.WriteAllText(file, json, Encoding.UTF8);
         }
 
@@ -593,7 +594,7 @@ namespace DomainDetective {
 
             var previousFile = files.OrderByDescending(f => f).First();
             var previousJson = File.ReadAllText(previousFile);
-            var previousResults = JsonSerializer.Deserialize<List<DnsPropagationResult>>(previousJson, DomainHealthCheck.JsonOptions) ?? new List<DnsPropagationResult>();
+            var previousResults = JsonSerializer.Deserialize<List<DnsPropagationResult>>(previousJson, JsonOptions.Default) ?? new List<DnsPropagationResult>();
 
             static string[] ToLines(IEnumerable<DnsPropagationResult> res) => res
                 .OrderBy(r => r.Server.IPAddress.ToString())

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -21,16 +21,7 @@ namespace DomainDetective {
         /// <summary>
         /// Serialization settings used when persisting analysis data.
         /// </summary>
-        public static readonly JsonSerializerOptions JsonOptions = new()
-        {
-            WriteIndented = true,
-            Converters =
-            {
-                new IPAddressJsonConverter(),
-                new CountryIdConverter(),
-                new LocationIdConverter()
-            }
-        };
+        public static readonly JsonSerializerOptions JsonOptions = Helpers.JsonOptions.Default;
 
         /// <summary>Factory used to obtain <see cref="HttpClient"/> instances.</summary>
         public IHttpClientFactory HttpClientFactory { get; set; } = new SharedHttpClient();

--- a/DomainDetective/Helpers/JsonOptions.cs
+++ b/DomainDetective/Helpers/JsonOptions.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+
+namespace DomainDetective.Helpers;
+
+public static class JsonOptions
+{
+    public static JsonSerializerOptions Default { get; } = new()
+    {
+        WriteIndented = true,
+        Converters =
+        {
+            new IPAddressJsonConverter(),
+            new CountryIdConverter(),
+            new LocationIdConverter()
+        }
+    };
+}

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using DomainDetective.Helpers;
 
 namespace DomainDetective;
 
@@ -70,7 +71,7 @@ public class ThreatIntelAnalysis
                 threatEntries = new[] { new { url = domainName } }
             }
         };
-        var json = JsonSerializer.Serialize(payload, DomainHealthCheck.JsonOptions);
+        var json = JsonSerializer.Serialize(payload, JsonOptions.Default);
         using var content = new StringContent(json, Encoding.UTF8, "application/json");
         using var resp = await _client.PostAsync(url, content, ct);
         return await ReadAsStringAsync(resp);


### PR DESCRIPTION
## Summary
- create `Helpers.JsonOptions` with default serializer settings
- reference new options in domain health checks and CLI
- adjust tests for new helper and add coverage for `JsonOptions`

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release --no-build` *(fails: Host not reachable and SPF checks)*

------
https://chatgpt.com/codex/tasks/task_e_687f6000aa7c832e9d9eab09cd894e63