### PR TITLE
Add FilterServers helper to DnsServerQuery

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
+++ b/DomainDetective.PowerShell/CmdletTestDnsPropagation.cs
@@ -111,7 +111,8 @@ namespace DomainDetective.PowerShell {
                 }
                 servers = _analysis.SelectServers(dict);
             } else {
-                servers = _analysis.FilterServers(Country, Location, Take);
+                var query = DnsServerQuery.Create().FilterServers(Country, Location, Take);
+                servers = _analysis.FilterServers(query);
             }
             var serverList = servers.ToList();
             var progress = new Progress<double>(p => {

--- a/DomainDetective.Tests/TestDnsServerQuery.cs
+++ b/DomainDetective.Tests/TestDnsServerQuery.cs
@@ -55,5 +55,20 @@ namespace DomainDetective.Tests {
             LocationIdExtensions.TryParse("Kabul", out var kab);
             Assert.All(servers, s => Assert.Equal(kab, s.Location));
         }
+
+        [Fact]
+        public void FilterServersAppliesAllFilters() {
+            var analysis = new DnsPropagationAnalysis();
+            analysis.LoadBuiltinServers();
+            CountryIdExtensions.TryParse("Afghanistan", out var af);
+            LocationIdExtensions.TryParse("Kabul", out var kab);
+            var query = DnsServerQuery.Create().FilterServers(af, kab, 1);
+            var servers = analysis.FilterServers(query).ToList();
+            Assert.Single(servers);
+            Assert.All(servers, s => {
+                Assert.Equal(af, s.Country);
+                Assert.Equal(kab, s.Location);
+            });
+        }
     }
 }

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -8,45 +8,66 @@ namespace DomainDetective {
         /// <summary>Selected location.</summary>
         public LocationId? Location { get; private set; }
         /// <summary>Number of servers to take.</summary>
-    public int? TakeCount { get; private set; }
+        public int? TakeCount { get; private set; }
 
-    /// <summary>Creates a new query instance.</summary>
-    public static DnsServerQuery Create() => new();
+        /// <summary>Creates a new query instance.</summary>
+        public static DnsServerQuery Create() => new();
 
-    /// <summary>Filters by country name.</summary>
-    public DnsServerQuery FromCountry(string name) {
-        if (!string.IsNullOrWhiteSpace(name) &&
-            CountryIdExtensions.TryParse(name.Trim().ToUpperInvariant(), out var id)) {
+        /// <summary>Filters by country name.</summary>
+        public DnsServerQuery FromCountry(string name) {
+            if (!string.IsNullOrWhiteSpace(name) &&
+                CountryIdExtensions.TryParse(name.Trim().ToUpperInvariant(), out var id)) {
+                Country = id;
+            }
+            return this;
+        }
+
+        /// <summary>Filters by country enum.</summary>
+        public DnsServerQuery FromCountry(CountryId id) {
             Country = id;
+            return this;
         }
-        return this;
-    }
 
-    /// <summary>Filters by country enum.</summary>
-    public DnsServerQuery FromCountry(CountryId id) {
-        Country = id;
-        return this;
-    }
+        /// <summary>Filters by location name.</summary>
+        public DnsServerQuery FromLocation(string name) {
+            if (!string.IsNullOrWhiteSpace(name) &&
+                LocationIdExtensions.TryParse(name.Trim().ToUpperInvariant(), out var id)) {
+                Location = id;
+            }
+            return this;
+        }
 
-    /// <summary>Filters by location name.</summary>
-    public DnsServerQuery FromLocation(string name) {
-        if (!string.IsNullOrWhiteSpace(name) &&
-            LocationIdExtensions.TryParse(name.Trim().ToUpperInvariant(), out var id)) {
+        /// <summary>Filters by location enum.</summary>
+        public DnsServerQuery FromLocation(LocationId id) {
             Location = id;
+            return this;
         }
-        return this;
-    }
 
-    /// <summary>Filters by location enum.</summary>
-    public DnsServerQuery FromLocation(LocationId id) {
-        Location = id;
-        return this;
-    }
+        /// <summary>Limits the number of servers returned.</summary>
+        public DnsServerQuery Take(int count) {
+            TakeCount = count > 0 ? count : null;
+            return this;
+        }
 
-    /// <summary>Limits the number of servers returned.</summary>
-    public DnsServerQuery Take(int count) {
-        TakeCount = count > 0 ? count : null;
-        return this;
-    }
+        /// <summary>
+        /// Applies all filters in a single call.
+        /// </summary>
+        /// <param name="country">Country filter.</param>
+        /// <param name="location">Location filter.</param>
+        /// <param name="take">Number of servers to take.</param>
+        /// <returns>The current <see cref="DnsServerQuery"/> instance.</returns>
+        public DnsServerQuery FilterServers(CountryId? country, LocationId? location, int? take) {
+            if (country.HasValue) {
+                Country = country.Value;
+            }
+            if (location.HasValue) {
+                Location = location.Value;
+            }
+            if (take.HasValue) {
+                TakeCount = take.Value > 0 ? take.Value : null;
+            }
+
+            return this;
+        }
     }
 }

--- a/DomainDetective/DnsServerQuery.cs
+++ b/DomainDetective/DnsServerQuery.cs
@@ -60,12 +60,12 @@ namespace DomainDetective {
             if (country.HasValue) {
                 Country = country.Value;
             }
+
             if (location.HasValue) {
                 Location = location.Value;
             }
-            if (take.HasValue) {
-                TakeCount = take.Value > 0 ? take.Value : null;
-            }
+
+            TakeCount = take;
 
             return this;
         }


### PR DESCRIPTION
## Summary
- add `FilterServers` to `DnsServerQuery` for combined filtering
- update `CmdletTestDnsPropagation` to build queries with new helper
- restore original query builder tests and add a dedicated test for the new method

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: selector1 key not present, DNS queries unavailable, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687f60163af8832e9318da1e09ec5b6f