### PR TITLE
Stabilize TimeoutSetsFailureReason test

### DIFF
--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -320,10 +320,14 @@ namespace DomainDetective.Tests {
             listener.Start();
             var tcs = new TaskCompletionSource<object?>();
             var serverTask = Task.Run(async () => {
-                var ctx = await listener.GetContextAsync();
-                await tcs.Task;
-                ctx.Response.StatusCode = 200;
-                ctx.Response.Close();
+                try {
+                    var ctx = await listener.GetContextAsync();
+                    await tcs.Task;
+                    ctx.Response.StatusCode = 200;
+                    ctx.Response.Close();
+                } catch (HttpListenerException) {
+                    // Ignore aborted requests when the client times out
+                }
             });
 
             try {


### PR DESCRIPTION
## Summary
- handle `HttpListenerException` in the `TimeoutSetsFailureReason` test

## Testing
- `dotnet test` *(fails: DNS queries unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_687f68f97ca4832e8c790eb6c8c76b8f