### PR TITLE
Replace check option dictionary with Enum parsing

### DIFF
--- a/DomainDetective.CLI/Commands/CheckDomainCommand.cs
+++ b/DomainDetective.CLI/Commands/CheckDomainCommand.cs
@@ -46,7 +46,7 @@ internal sealed class CheckDomainCommand : AsyncCommand<CheckDomainSettings> {
 
         var selected = new List<HealthCheckType>();
         foreach (var check in settings.Checks.SelectMany(c => c.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))) {
-            if (CommandUtilities.Options.TryGetValue(check.ToLowerInvariant(), out var type)) {
+            if (Enum.TryParse<HealthCheckType>(check, true, out var type)) {
                 selected.Add(type);
             }
         }


### PR DESCRIPTION
## Summary
- remove `CommandUtilities.Options` dictionary
- parse check names using `Enum.TryParse`
- update wizard to list enum names

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_687ff9221c88832ea4a95d92b6f09d62