### PR TITLE
Refactor BIMI http client usage

### DIFF
--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -181,21 +181,19 @@ public class BimiAnalysis {
             _client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
         }
 
-        private HttpClient GetClient(out bool dispose)
+        private (HttpClient client, bool dispose) GetOrCreateClient()
         {
             if (HttpHandlerFactory != null)
             {
-                dispose = true;
-                return new HttpClient(HttpHandlerFactory(), disposeHandler: true);
+                return (new HttpClient(HttpHandlerFactory(), disposeHandler: true), true);
             }
 
-            dispose = false;
-            return _client;
+            return (_client, false);
         }
 
         private async Task<(string? content, int size)> DownloadIndicator(string url, InternalLogger logger, CancellationToken cancellationToken) {
             try {
-                var client = GetClient(out var dispose);
+                var (client, dispose) = GetOrCreateClient();
                 try {
                     using var response = await client.GetAsync(url, cancellationToken);
                 if (!response.IsSuccessStatusCode) {
@@ -236,7 +234,7 @@ public class BimiAnalysis {
 
         private async Task<(bool valid, bool signedByKnownRoot, bool hasLogo)> DownloadAndValidateVmc(string url, InternalLogger logger, CancellationToken cancellationToken) {
             try {
-                var client = GetClient(out var dispose);
+                var (client, dispose) = GetOrCreateClient();
                 try {
                     using var response = await client.GetAsync(url, cancellationToken);
                 if (!response.IsSuccessStatusCode) {


### PR DESCRIPTION
## Summary
- centralize HttpClient creation via `GetOrCreateClient`
- reuse new method in BIMI download helpers
- run BIMI test suite

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter Bimi --verbosity normal`
- `dotnet build DomainDetective.sln -c Release --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687ff9032cd4832e8d07773929ae4b79