### PR TITLE
Refactor prefix parsing

### DIFF
--- a/DomainDetective.Tests/TestBgpPrefixMonitor.cs
+++ b/DomainDetective.Tests/TestBgpPrefixMonitor.cs
@@ -1,5 +1,7 @@
 using DomainDetective.Monitoring;
 using System.Collections.Generic;
+using System.Reflection;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,5 +56,19 @@ public class TestBgpPrefixMonitor
             monitor.Stop();
             Assert.Null(timerField.GetValue(monitor));
         }
+    }
+
+    [Fact]
+    public void ParsePrefixesParsesDocument()
+    {
+        var method = typeof(BgpPrefixMonitor).GetMethod(
+            "ParsePrefixes",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        using var doc = JsonDocument.Parse(
+            "{\"data\":{\"resource\":\"1.1.1.0/24\",\"asns\":[{\"asn\":65000}]}}"
+        );
+        var result = (Dictionary<string, int>)method.Invoke(null, new object?[] { doc })!;
+        Assert.Single(result);
+        Assert.Equal(65000, result["1.1.1.0/24"]);
     }
 }


### PR DESCRIPTION
## Summary
- extract BGP prefix parsing logic into `ParsePrefixes`
- adjust `QueryPrefixesAsync` to use the parser
- add test for `ParsePrefixes`

## Testing
- `dotnet build --no-restore`
- `dotnet test` *(fails: Host not reachable for some tests)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8f77228832e9c22808f78edac44