### PR TITLE
Add NotificationSenderFactory

### DIFF
--- a/DomainDetective.Example/ExampleNotificationFactory.cs
+++ b/DomainDetective.Example/ExampleNotificationFactory.cs
@@ -1,0 +1,23 @@
+using DomainDetective.Monitoring;
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Example demonstrating NotificationSenderFactory.
+    /// </summary>
+    public static async Task ExampleNotificationFactory() {
+        var webhook = NotificationSenderFactory.CreateWebhook("https://example.com/hook");
+        var email = NotificationSenderFactory.CreateEmail("smtp.example.com", 25, false, "from@example.com", "to@example.com");
+        var custom = NotificationSenderFactory.CreateCustom((m, _) => {
+            Console.WriteLine(m);
+            return Task.CompletedTask;
+        });
+
+        await webhook.SendAsync("Webhook message");
+        await email.SendAsync("Email message");
+        await custom.SendAsync("Custom message");
+    }
+}

--- a/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
+++ b/DomainDetective.PowerShell/CmdletStartDnsPropagationMonitor.cs
@@ -101,7 +101,7 @@ namespace DomainDetective.PowerShell {
                 }
             }
             if (!string.IsNullOrWhiteSpace(WebhookUrl)) {
-                _monitor.Notifier = new WebhookNotificationSender(WebhookUrl);
+                _monitor.Notifier = NotificationSenderFactory.CreateWebhook(WebhookUrl);
             }
             _monitor.Start();
             WriteObject(_monitor);

--- a/DomainDetective.Tests/TestBgpPrefixMonitor.cs
+++ b/DomainDetective.Tests/TestBgpPrefixMonitor.cs
@@ -55,4 +55,18 @@ public class TestBgpPrefixMonitor
             Assert.Null(timerField.GetValue(monitor));
         }
     }
+
+    [Fact]
+    public void FactoryMethodsSetNotifier()
+    {
+        var monitor = new BgpPrefixMonitor { Domain = "example.com" };
+        monitor.UseWebhook("https://example.com");
+        Assert.IsType<WebhookNotificationSender>(monitor.Notifier);
+
+        monitor.UseEmail("smtp", 25, false, "from@e.com", "to@e.com");
+        Assert.IsType<EmailNotificationSender>(monitor.Notifier);
+
+        monitor.UseCustom((_, _) => Task.CompletedTask);
+        Assert.IsType<DelegateNotificationSender>(monitor.Notifier);
+    }
 }

--- a/DomainDetective.Tests/TestDnsPropagationMonitorFactory.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitorFactory.cs
@@ -1,0 +1,20 @@
+using DomainDetective.Monitoring;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsPropagationMonitorFactory {
+    [Fact]
+    public void FactoryMethodsSetNotifier() {
+        var monitor = new DnsPropagationMonitor { Domain = "example.com" };
+        monitor.UseWebhook("https://example.com");
+        Assert.IsType<WebhookNotificationSender>(monitor.Notifier);
+
+        monitor.UseEmail("smtp", 25, false, "from@e.com", "to@e.com");
+        Assert.IsType<EmailNotificationSender>(monitor.Notifier);
+
+        monitor.UseCustom((_, _) => Task.CompletedTask);
+        Assert.IsType<DelegateNotificationSender>(monitor.Notifier);
+    }
+}

--- a/DomainDetective.Tests/TestNotificationSenderFactory.cs
+++ b/DomainDetective.Tests/TestNotificationSenderFactory.cs
@@ -26,4 +26,11 @@ public class TestNotificationSenderFactory
         Assert.Equal("user", email.Username);
         Assert.Equal("pass", email.Password);
     }
+
+    [Fact]
+    public void CreatesCustomSender()
+    {
+        var sender = NotificationSenderFactory.CreateCustom((_, _) => Task.CompletedTask);
+        Assert.IsType<DelegateNotificationSender>(sender);
+    }
 }

--- a/DomainDetective.Tests/TestNotificationSenderFactory.cs
+++ b/DomainDetective.Tests/TestNotificationSenderFactory.cs
@@ -1,0 +1,29 @@
+using DomainDetective.Monitoring;
+
+namespace DomainDetective.Tests;
+
+public class TestNotificationSenderFactory
+{
+    [Fact]
+    public void CreatesWebhookSender()
+    {
+        var url = "https://example.com/hook";
+        var sender = NotificationSenderFactory.CreateWebhook(url);
+        var webhook = Assert.IsType<WebhookNotificationSender>(sender);
+        Assert.Equal(url, webhook.Url);
+    }
+
+    [Fact]
+    public void CreatesEmailSender()
+    {
+        var sender = NotificationSenderFactory.CreateEmail("smtp.local", 25, false, "from@example.com", "to@example.com", "user", "pass");
+        var email = Assert.IsType<EmailNotificationSender>(sender);
+        Assert.Equal("smtp.local", email.SmtpHost);
+        Assert.Equal(25, email.Port);
+        Assert.False(email.UseSsl);
+        Assert.Equal("from@example.com", email.From);
+        Assert.Equal("to@example.com", email.To);
+        Assert.Equal("user", email.Username);
+        Assert.Equal("pass", email.Password);
+    }
+}

--- a/DomainDetective/Monitoring/BgpPrefixMonitor.cs
+++ b/DomainDetective/Monitoring/BgpPrefixMonitor.cs
@@ -29,6 +29,24 @@ public class BgpPrefixMonitor
     /// <summary>Notification sender.</summary>
     public INotificationSender? Notifier { get; set; }
 
+    /// <summary>Configure a webhook notification.</summary>
+    public void UseWebhook(string url)
+    {
+        Notifier = NotificationSenderFactory.CreateWebhook(url);
+    }
+
+    /// <summary>Configure an email notification.</summary>
+    public void UseEmail(string smtpHost, int port, bool useSsl, string from, string to, string? username = null, string? password = null)
+    {
+        Notifier = NotificationSenderFactory.CreateEmail(smtpHost, port, useSsl, from, to, username, password);
+    }
+
+    /// <summary>Configure a custom notification handler.</summary>
+    public void UseCustom(Func<string, CancellationToken, Task> handler)
+    {
+        Notifier = NotificationSenderFactory.CreateCustom(handler);
+    }
+
     /// <summary>Override prefix query for testing.</summary>
     public Func<CancellationToken, Task<Dictionary<string, int>>>? QueryOverride { private get; set; }
 

--- a/DomainDetective/Monitoring/DelegateNotificationSender.cs
+++ b/DomainDetective/Monitoring/DelegateNotificationSender.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Monitoring;
+
+internal sealed class DelegateNotificationSender : INotificationSender {
+    private readonly Func<string, CancellationToken, Task> _handler;
+
+    public DelegateNotificationSender(Func<string, CancellationToken, Task> handler) {
+        _handler = handler ?? throw new ArgumentNullException(nameof(handler));
+    }
+
+    public Task SendAsync(string message, CancellationToken ct = default) {
+        return _handler(message, ct);
+    }
+}

--- a/DomainDetective/Monitoring/DnsPropagationMonitor.cs
+++ b/DomainDetective/Monitoring/DnsPropagationMonitor.cs
@@ -26,6 +26,24 @@ namespace DomainDetective.Monitoring {
         /// <summary>Notification sender.</summary>
         public INotificationSender? Notifier { get; set; }
 
+        /// <summary>Configure a webhook notification.</summary>
+        public void UseWebhook(string url)
+        {
+            Notifier = NotificationSenderFactory.CreateWebhook(url);
+        }
+
+        /// <summary>Configure an email notification.</summary>
+        public void UseEmail(string smtpHost, int port, bool useSsl, string from, string to, string? username = null, string? password = null)
+        {
+            Notifier = NotificationSenderFactory.CreateEmail(smtpHost, port, useSsl, from, to, username, password);
+        }
+
+        /// <summary>Configure a custom notification handler.</summary>
+        public void UseCustom(Func<string, CancellationToken, Task> handler)
+        {
+            Notifier = NotificationSenderFactory.CreateCustom(handler);
+        }
+
         /// <summary>Override query for testing.</summary>
         public Func<IEnumerable<PublicDnsEntry>, CancellationToken, Task<List<DnsPropagationResult>>>? QueryOverride { private get; set; }
 

--- a/DomainDetective/Monitoring/NotificationSenderFactory.cs
+++ b/DomainDetective/Monitoring/NotificationSenderFactory.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace DomainDetective.Monitoring;
 
@@ -17,6 +19,20 @@ public static class NotificationSenderFactory
         }
 
         return new WebhookNotificationSender(url);
+    }
+
+    /// <summary>
+    /// Creates a notification sender using a custom delegate.
+    /// </summary>
+    /// <param name="handler">Delegate invoked to deliver the message.</param>
+    public static INotificationSender CreateCustom(Func<string, CancellationToken, Task> handler)
+    {
+        if (handler == null)
+        {
+            throw new ArgumentNullException(nameof(handler));
+        }
+
+        return new DelegateNotificationSender(handler);
     }
 
     /// <summary>

--- a/DomainDetective/Monitoring/NotificationSenderFactory.cs
+++ b/DomainDetective/Monitoring/NotificationSenderFactory.cs
@@ -1,0 +1,60 @@
+using System;
+
+namespace DomainDetective.Monitoring;
+
+/// <summary>Creates configured notification senders.</summary>
+public static class NotificationSenderFactory
+{
+    /// <summary>
+    /// Creates a webhook notification sender.
+    /// </summary>
+    /// <param name="url">Webhook URL.</param>
+    public static INotificationSender CreateWebhook(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            throw new ArgumentException("URL cannot be null or empty", nameof(url));
+        }
+
+        return new WebhookNotificationSender(url);
+    }
+
+    /// <summary>
+    /// Creates an email notification sender.
+    /// </summary>
+    /// <param name="smtpHost">SMTP server host.</param>
+    /// <param name="port">SMTP server port.</param>
+    /// <param name="useSsl">Whether to use SSL.</param>
+    /// <param name="from">Sender email address.</param>
+    /// <param name="to">Recipient email address.</param>
+    /// <param name="username">SMTP username.</param>
+    /// <param name="password">SMTP password.</param>
+    public static INotificationSender CreateEmail(string smtpHost, int port, bool useSsl, string from, string to, string? username = null, string? password = null)
+    {
+        if (string.IsNullOrWhiteSpace(smtpHost))
+        {
+            throw new ArgumentException("SMTP host cannot be null or empty", nameof(smtpHost));
+        }
+
+        if (string.IsNullOrWhiteSpace(from))
+        {
+            throw new ArgumentException("Sender address cannot be null or empty", nameof(from));
+        }
+
+        if (string.IsNullOrWhiteSpace(to))
+        {
+            throw new ArgumentException("Recipient address cannot be null or empty", nameof(to));
+        }
+
+        return new EmailNotificationSender
+        {
+            SmtpHost = smtpHost,
+            Port = port,
+            UseSsl = useSsl,
+            From = from,
+            To = to,
+            Username = username,
+            Password = password
+        };
+    }
+}

--- a/Module/Examples/Example.SendNotifications.ps1
+++ b/Module/Examples/Example.SendNotifications.ps1
@@ -1,0 +1,12 @@
+# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$monitor = Start-DnsPropagationMonitor -DomainName 'example.com' -RecordType A
+$monitor.UseWebhook('https://example.com/hook')
+$monitor.UseEmail('smtp.example.com', 25, $false, 'from@example.com', 'to@example.com')
+
+# Run a single check
+$monitor.RunAsync().Wait()
+
+$monitor.Stop()


### PR DESCRIPTION
## Summary
- add `NotificationSenderFactory` for creating webhook or email senders
- use factory in `CmdletStartDnsPropagationMonitor`
- test the new factory and webhook assignment in cmdlet

## Testing
- `dotnet test DomainDetective.sln --verbosity minimal` *(fails: Host not reachable and other network issues)*

------
https://chatgpt.com/codex/tasks/task_e_687ff8eb72f4832e9331b216e21cfa30