### PR TITLE
Rename TaskExtensions to CancellationExtensions

### DIFF
--- a/DomainDetective/CancellationExtensions.cs
+++ b/DomainDetective/CancellationExtensions.cs
@@ -6,7 +6,7 @@ namespace DomainDetective {
     /// <summary>
     /// Provides helper methods for working with tasks and cancellation tokens.
     /// </summary>
-    internal static class TaskExtensions {
+    internal static class CancellationExtensions {
         /// <summary>
         /// Waits for the task to complete while observing a cancellation token.
         /// </summary>


### PR DESCRIPTION
## Summary
- rename `TaskExtensions.cs` to `CancellationExtensions.cs`
- update class name

## Testing
- `dotnet test`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687ff8e2f7bc832ea0d05ff113cf6033