### PR TITLE
Fix SMB port scan timeout

### DIFF
--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -153,7 +153,7 @@ namespace DomainDetective.Tests {
             var accept = listener.AcceptTcpClientAsync();
             try {
                 PortScanProfileDefinition.OverrideProfilePorts(PortScanProfile.SMB, new[] { port });
-                var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+                var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromSeconds(1) };
                 await analysis.Scan("127.0.0.1", PortScanProfile.SMB, new InternalLogger());
                 using var _ = await accept;
                 Assert.True(analysis.Results[port].TcpOpen);


### PR DESCRIPTION
## Summary
- increase timeout for SMB profile port scan test

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release -f net8.0` *(fails: Hosts not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_688081a40a10832e95ad3e68c2103ca8