### PR TITLE
Add Codecov config

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -57,6 +57,8 @@ jobs:
 
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+              if: always()
+              continue-on-error: true
               with:
                   files: '**/coverage.cobertura.xml'
                   fail_ci_if_error: false
@@ -99,6 +101,8 @@ jobs:
 
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+              if: always()
+              continue-on-error: true
               with:
                   files: '**/coverage.cobertura.xml'
                   fail_ci_if_error: false
@@ -142,6 +146,8 @@ jobs:
 
             - name: Upload coverage to Codecov
               uses: codecov/codecov-action@v3
+              if: always()
+              continue-on-error: true
               with:
                   files: '**/coverage.cobertura.xml'
                   fail_ci_if_error: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Summary
- add Codecov YAML to mark coverage checks as informational only

## Testing
- `dotnet build DomainDetective.sln --configuration Release --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity normal --logger trx` *(fails: 8 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688080a98c34832e8eb0ef6f624fe5f3