### PR TITLE
Fix UDP port binding in test

### DIFF
--- a/DomainDetective.Tests/PortHelper.cs
+++ b/DomainDetective.Tests/PortHelper.cs
@@ -20,4 +20,10 @@ internal static class PortHelper {
             return port;
         }
     }
+
+    public static void ReservePort(int port) {
+        lock (PortLock) {
+            UsedPorts.Add(port);
+        }
+    }
 }

--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -209,6 +209,7 @@ namespace DomainDetective.Tests {
         public async Task DetectsSnmpUdpBanner() {
             using var udp = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
             var port = ((IPEndPoint)udp.Client.LocalEndPoint!).Port;
+            PortHelper.ReservePort(port);
             var task = Task.Run(async () => {
                 var r = await udp.ReceiveAsync();
                 await udp.SendAsync(new byte[] { 1 }, 1, r.RemoteEndPoint);


### PR DESCRIPTION
## Summary
- use OS-assigned port in `DetectsSnmpUdpBanner`

## Testing
- `dotnet test --verbosity normal` *(fails: Host not reachable, DNS unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68808af78d40832e8fdd5933815eb020