### PR TITLE
Add RDAP cache configuration to Test-Rdap cmdlet

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseRDAP.cs
+++ b/DomainDetective.Example/ExampleAnalyseRDAP.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Example;
@@ -8,6 +9,7 @@ public static partial class Program {
     /// </summary>
     public static async Task ExampleAnalyseRDAP() {
         var healthCheck = new DomainHealthCheck { Verbose = false };
+        healthCheck.RdapAnalysis.CacheDuration = TimeSpan.FromMinutes(10);
         await healthCheck.QueryRDAP("example.com");
         Helpers.ShowPropertiesTable("RDAP for example.com", healthCheck.RdapAnalysis);
     }

--- a/DomainDetective.PowerShell/CmdletTestRdap.cs
+++ b/DomainDetective.PowerShell/CmdletTestRdap.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -21,6 +22,10 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
+        /// <para>How long RDAP results are cached.</para>
+        [Parameter]
+        public TimeSpan CacheDuration = TimeSpan.FromHours(1);
+
         private InternalLogger _logger;
         private DomainHealthCheck _healthCheck;
 
@@ -30,6 +35,7 @@ namespace DomainDetective.PowerShell {
             var psLogger = new InternalLoggerPowerShell(_logger, WriteVerbose, WriteWarning, WriteDebug, WriteError, WriteProgress, WriteInformation);
             psLogger.ResetActivityIdCounter();
             _healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            _healthCheck.RdapAnalysis.CacheDuration = CacheDuration;
             return Task.CompletedTask;
         }
 

--- a/Module/Examples/Example.TestRdap.ps1
+++ b/Module/Examples/Example.TestRdap.ps1
@@ -1,0 +1,6 @@
+# Clear-Host
+
+Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
+
+$rdap = Test-Rdap -DomainName 'example.com' -CacheDuration '00:10:00'
+$rdap | Format-List

--- a/Module/Tests/Rdap.Tests.ps1
+++ b/Module/Tests/Rdap.Tests.ps1
@@ -1,0 +1,9 @@
+Describe 'Test-Rdap cmdlet' {
+    It 'exposes CacheDuration parameter' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        $command = Get-Command Test-Rdap
+        $command.Parameters.Keys | Should -Contain 'CacheDuration'
+        [DomainDetective.PowerShell.CmdletTestRdap]::new().CacheDuration |
+            Should -Be ([TimeSpan]::FromHours(1))
+    }
+}


### PR DESCRIPTION
## Summary
- expose `CacheDuration` parameter on Test-Rdap cmdlet
- configure RdapAnalysis cache duration during initialization
- demonstrate usage in new Example.TestRdap.ps1
- cover parameter with Pester tests

## Testing
- `dotnet test DomainDetective.sln` *(fails: 8 tests)*
- `pwsh Module/DomainDetective.Tests.ps1`
- `dotnet build DomainDetective.sln`


------
https://chatgpt.com/codex/tasks/task_e_68812424c908832eadaac9c4497ae660