### PR TITLE
Ensure case-insensitive CompareResults

### DIFF
--- a/DomainDetective.Tests/TestDnsPropagation.cs
+++ b/DomainDetective.Tests/TestDnsPropagation.cs
@@ -107,6 +107,8 @@ namespace DomainDetective.Tests {
             Assert.Single(groups);
             Assert.Equal(2, groups.First().Value.Count);
             Assert.Equal(IPAddress.Parse("2001:db8::1").ToString(), groups.Keys.First());
+            Assert.True(groups.ContainsKey("2001:DB8::1"));
+            Assert.Equal(2, groups["2001:DB8::1"].Count);
         }
 
         [Fact]
@@ -130,6 +132,8 @@ namespace DomainDetective.Tests {
             Assert.Single(groups);
             Assert.Equal(2, groups.First().Value.Count);
             Assert.Equal("2001:db8::1", groups.Keys.First());
+            Assert.True(groups.ContainsKey("2001:DB8::1"));
+            Assert.Equal(2, groups["2001:DB8::1"].Count);
         }
 
         [Fact]
@@ -254,6 +258,8 @@ namespace DomainDetective.Tests {
             Assert.Single(groups);
             Assert.Equal(2, groups.First().Value.Count);
             Assert.Equal(IPAddress.Parse("fe80::1%2").ToString(), groups.Keys.First());
+            Assert.True(groups.ContainsKey("FE80::1%2"));
+            Assert.Equal(2, groups["FE80::1%2"].Count);
         }
 
         [Fact]

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -512,7 +512,7 @@ namespace DomainDetective {
         /// their country and location.
         /// </returns>
         public static Dictionary<string, List<DnsComparisonEntry>> CompareResults(IEnumerable<DnsPropagationResult> results) {
-            var comparison = new Dictionary<string, List<DnsComparisonEntry>>();
+            var comparison = new Dictionary<string, List<DnsComparisonEntry>>(StringComparer.OrdinalIgnoreCase);
             foreach (var res in results.Where(r => r.Success && r.Records != null)) {
                 var normalizedRecords = res.Records
                     .Select(r =>


### PR DESCRIPTION
## Summary
- initialize DNS comparison dictionary with `StringComparer.OrdinalIgnoreCase`
- check case-insensitive lookup in canonicalization tests

## Testing
- `dotnet test` *(fails: Host not reachable, exceeds lookups)*

------
https://chatgpt.com/codex/tasks/task_e_68814aa577c0832e8e341463cda4c440