### PR TITLE
Add CacheDirectory validation

### DIFF
--- a/DomainDetective.Tests/TestPublicSuffixRefresh.cs
+++ b/DomainDetective.Tests/TestPublicSuffixRefresh.cs
@@ -39,5 +39,12 @@ namespace DomainDetective.Tests {
                 Directory.Delete(dir, true);
             }
         }
+
+        [Fact]
+        public async Task ThrowsIfCacheDirectoryEmpty() {
+            var hc = new DomainHealthCheck { CacheDirectory = string.Empty };
+            await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                await hc.RefreshPublicSuffixListAsync(force: true));
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -450,6 +450,10 @@ namespace DomainDetective {
         /// <param name="url">Optional URL to fetch the list from.</param>
         /// <param name="force">Ignore the cache and download fresh data.</param>
         public async Task RefreshPublicSuffixListAsync(string url = DefaultPublicSuffixListUrl, bool force = false) {
+            if (string.IsNullOrEmpty(CacheDirectory)) {
+                throw new InvalidOperationException("CacheDirectory cannot be null or empty.");
+            }
+
             Directory.CreateDirectory(CacheDirectory);
             var cacheFile = Path.Combine(CacheDirectory, "public_suffix_list.dat");
 


### PR DESCRIPTION
## Summary
- throw `InvalidOperationException` when `CacheDirectory` is empty
- test that `RefreshPublicSuffixListAsync` fails if no cache directory

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter TestPublicSuffixRefresh --verbosity minimal`
- `dotnet test --verbosity minimal` *(fails: Host not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68814abaf18c832e85609ea491862218