### PR TITLE
Implement cross-process port reservation

### DIFF
--- a/DomainDetective.Tests/PortHelper.cs
+++ b/DomainDetective.Tests/PortHelper.cs
@@ -2,22 +2,48 @@ namespace DomainDetective.Tests;
 
 using System.Net;
 using System.Net.Sockets;
+using System.Collections.Generic;
+using System.Threading;
 
 internal static class PortHelper {
     private static readonly object PortLock = new();
     private static readonly HashSet<int> UsedPorts = new();
+    private static readonly Dictionary<int, Mutex> Mutexes = new();
 
     public static int GetFreePort() {
         lock (PortLock) {
-            int port;
-            do {
+            while (true) {
                 var listener = new TcpListener(IPAddress.Loopback, 0);
                 listener.Start();
-                port = ((IPEndPoint)listener.LocalEndpoint).Port;
+                var port = ((IPEndPoint)listener.LocalEndpoint).Port;
                 listener.Stop();
-            } while (!UsedPorts.Add(port));
 
-            return port;
+                if (!UsedPorts.Add(port)) {
+                    continue;
+                }
+
+                var mutex = new Mutex(false, $"DomainDetective_{port}");
+                if (!mutex.WaitOne(0)) {
+                    mutex.Dispose();
+                    UsedPorts.Remove(port);
+                    continue;
+                }
+
+                Mutexes[port] = mutex;
+                return port;
+            }
+        }
+    }
+
+    public static void ReleasePort(int port) {
+        lock (PortLock) {
+            if (Mutexes.TryGetValue(port, out var mutex)) {
+                mutex.ReleaseMutex();
+                mutex.Dispose();
+                Mutexes.Remove(port);
+            }
+
+            UsedPorts.Remove(port);
         }
     }
 }

--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -92,6 +92,7 @@ namespace DomainDetective.Tests {
 
             Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
             Assert.False(analysis.SvgFetched);
+            PortHelper.ReleasePort(port);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCmdletNewDmarcRecord.cs
+++ b/DomainDetective.Tests/TestCmdletNewDmarcRecord.cs
@@ -15,9 +15,11 @@ public class TestCmdletNewDmarcRecord {
             throw SkipException.ForSkip("HttpListener not supported");
         }
         using var listener = new HttpListener();
-        var prefix = $"http://localhost:{PortHelper.GetFreePort()}/";
+        var port = PortHelper.GetFreePort();
+        var prefix = $"http://localhost:{port}/";
         listener.Prefixes.Add(prefix);
         listener.Start();
+        PortHelper.ReleasePort(port);
         string? body = null;
         var serverTask = Task.Run(async () => {
             var ctx = await listener.GetContextAsync();
@@ -55,9 +57,11 @@ public class TestCmdletNewDmarcRecord {
             throw SkipException.ForSkip("HttpListener not supported");
         }
         using var listener = new HttpListener();
-        var prefix = $"http://localhost:{PortHelper.GetFreePort()}/";
+        var port2 = PortHelper.GetFreePort();
+        var prefix = $"http://localhost:{port2}/";
         listener.Prefixes.Add(prefix);
         listener.Start();
+        PortHelper.ReleasePort(port2);
         var serverTask = Task.Run(async () => {
             var ctx = await listener.GetContextAsync();
             ctx.Response.StatusCode = 500;

--- a/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
+++ b/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
@@ -14,9 +14,11 @@ public class TestDirectoryExposureAnalysis
             throw SkipException.ForSkip("HttpListener not supported");
         }
         using var listener = new HttpListener();
-        var prefix = $"http://localhost:{GetFreePort()}/";
+        var port = GetFreePort();
+        var prefix = $"http://localhost:{port}/";
         listener.Prefixes.Add(prefix);
         listener.Start();
+        PortHelper.ReleasePort(port);
         var serverTask = Task.Run(async () =>
         {
             while (listener.IsListening)
@@ -55,9 +57,11 @@ public class TestDirectoryExposureAnalysis
             throw SkipException.ForSkip("HttpListener not supported");
         }
         using var listener = new HttpListener();
-        var prefix = $"http://localhost:{GetFreePort()}/";
+        var port2 = GetFreePort();
+        var prefix = $"http://localhost:{port2}/";
         listener.Prefixes.Add(prefix);
         listener.Start();
+        PortHelper.ReleasePort(port2);
         var serverTask = Task.Run(async () =>
         {
             var ctx = await listener.GetContextAsync();

--- a/DomainDetective.Tests/TestDuplicateHealthChecks.cs
+++ b/DomainDetective.Tests/TestDuplicateHealthChecks.cs
@@ -13,9 +13,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var pin = Convert.ToBase64String(Enumerable.Repeat((byte)5, 32).ToArray());
             var header = $"pin-sha256=\"{pin}\"; pin-sha256=\"{pin}\"; max-age=123";
             var count = 0;

--- a/DomainDetective.Tests/TestHPKPAnalysis.cs
+++ b/DomainDetective.Tests/TestHPKPAnalysis.cs
@@ -14,9 +14,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)1, 32).ToArray());
             var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)2, 32).ToArray());
             var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=1000";
@@ -50,9 +52,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var header = "pin-sha256=\"invalidbase64\"; max-age=1000";
             var task = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
@@ -77,9 +81,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)1, 32).ToArray());
             var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)2, 32).ToArray());
             var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=10; includeSubDomains";
@@ -107,9 +113,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var pin = Convert.ToBase64String(Enumerable.Repeat((byte)6, 32).ToArray());
             var header = $"pin-sha256=\"{pin}\"; max-age=100";
             var task = Task.Run(async () => {
@@ -137,9 +145,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)7, 32).ToArray());
             var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)8, 32).ToArray());
             var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=200";
@@ -168,9 +178,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var task = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -193,9 +205,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
 
             var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)9, 32).ToArray());
             var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)10, 32).ToArray());
@@ -234,9 +248,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
 
             int hitCount = 0;
             var task = Task.Run(async () => {

--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -13,9 +13,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)3, 32).ToArray());
             var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)4, 32).ToArray());
             var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=500";

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -16,9 +16,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -93,9 +95,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 404;
@@ -117,8 +121,10 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task UnreachableHostSetsIsReachableFalse() {
             var analysis = new HttpAnalysis();
-            var url = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var url = $"http://localhost:{port}/";
             await analysis.AnalyzeUrl(url, false, new InternalLogger());
+            PortHelper.ReleasePort(port);
             Assert.False(analysis.IsReachable);
             Assert.False(string.IsNullOrEmpty(analysis.FailureReason));
             Assert.Null(analysis.ProtocolVersion);
@@ -130,9 +136,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -166,14 +174,18 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener1 = new HttpListener();
-            var prefix1 = $"http://localhost:{GetFreePort()}/";
+            var port1 = GetFreePort();
+            var prefix1 = $"http://localhost:{port1}/";
             listener1.Prefixes.Add(prefix1);
             listener1.Start();
+            PortHelper.ReleasePort(port1);
 
             using var listener2 = new HttpListener();
-            var prefix2 = $"http://localhost:{GetFreePort()}/";
+            var port2 = GetFreePort();
+            var prefix2 = $"http://localhost:{port2}/";
             listener2.Prefixes.Add(prefix2);
             listener2.Start();
+            PortHelper.ReleasePort(port2);
 
             var task1 = Task.Run(async () => {
                 var ctx = await listener1.GetContextAsync();
@@ -208,9 +220,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -236,9 +250,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
 
             using var cts = new CancellationTokenSource();
             var serverTask = Task.Run(async () => {
@@ -274,14 +290,18 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener1 = new HttpListener();
-            var prefix1 = $"http://localhost:{GetFreePort()}/";
+            var port1 = GetFreePort();
+            var prefix1 = $"http://localhost:{port1}/";
             listener1.Prefixes.Add(prefix1);
             listener1.Start();
+            PortHelper.ReleasePort(port1);
 
             using var listener2 = new HttpListener();
-            var prefix2 = $"http://localhost:{GetFreePort()}/";
+            var port2 = GetFreePort();
+            var prefix2 = $"http://localhost:{port2}/";
             listener2.Prefixes.Add(prefix2);
             listener2.Start();
+            PortHelper.ReleasePort(port2);
 
             var task1 = Task.Run(async () => {
                 var ctx = await listener1.GetContextAsync();
@@ -315,9 +335,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var tcs = new TaskCompletionSource<object?>();
             var serverTask = Task.Run(async () => {
                 try {
@@ -348,9 +370,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -381,9 +405,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -409,9 +435,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -437,9 +465,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -463,9 +493,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -491,9 +523,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -519,9 +553,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -546,9 +582,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -576,9 +614,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -603,9 +643,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -634,9 +676,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -667,9 +711,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;
@@ -694,9 +740,11 @@ namespace DomainDetective.Tests {
                 throw SkipException.ForSkip("HttpListener not supported");
             }
             using var listener = new HttpListener();
-            var prefix = $"http://localhost:{GetFreePort()}/";
+            var port = GetFreePort();
+            var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;

--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -80,6 +80,7 @@ namespace DomainDetective.Tests {
             var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
 
             const string policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";
             var serverTask = Task.Run(async () => {
@@ -130,6 +131,7 @@ namespace DomainDetective.Tests {
             var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
 
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
@@ -282,7 +284,7 @@ namespace DomainDetective.Tests {
             var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
-
+            PortHelper.ReleasePort(port);
             const string policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";
             int hitCount = 0;
             var serverTask = Task.Run(async () => {
@@ -336,6 +338,7 @@ namespace DomainDetective.Tests {
             listener.Prefixes.Add(prefix);
             listener.Start();
 
+            PortHelper.ReleasePort(port);
             const string policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 1";
             int hitCount = 0;
             var serverTask = Task.Run(async () => {

--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -15,6 +15,7 @@ namespace DomainDetective.Tests {
             var prefix = $"http://localhost:{port}/";
             listener.Prefixes.Add(prefix);
             listener.Start();
+            PortHelper.ReleasePort(port);
             var serverTask = Task.Run(async () => {
                 var ctx = await listener.GetContextAsync();
                 ctx.Response.StatusCode = 200;

--- a/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityAnalysis.cs
@@ -33,6 +33,7 @@ namespace DomainDetective.Tests {
             await analysis.AnalyzeServer("127.0.0.1", port, new InternalLogger());
             var result = analysis.ServerResults[$"127.0.0.1:{port}"];
             Assert.False(result.Success);
+            PortHelper.ReleasePort(port);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestPortScanAnalysis.cs
+++ b/DomainDetective.Tests/TestPortScanAnalysis.cs
@@ -135,6 +135,7 @@ namespace DomainDetective.Tests {
             await analysis.Scan("127.0.0.1", new[] { port }, new InternalLogger());
             Assert.False(analysis.Results[port].TcpOpen);
             Assert.False(string.IsNullOrEmpty(analysis.Results[port].Error));
+            PortHelper.ReleasePort(port);
         }
 
         [Fact]
@@ -220,6 +221,7 @@ namespace DomainDetective.Tests {
             } finally {
                 udp.Close();
                 await task;
+                PortHelper.ReleasePort(port);
             }
         }
 


### PR DESCRIPTION
## Summary
- hold open cross-process ports in tests using named mutexes
- release reserved ports after starting listeners in network tests
- fix tests to reserve/release ports as needed

## Testing
- `dotnet test` *(fails: Hosts not reachable, KeyNotFoundException, etc.)*
- `dotnet build -c Debug`

------
https://chatgpt.com/codex/tasks/task_e_6881f56ec7c8832e9c5a54848c221863