### PR TITLE
Serialize HTTP server tests

### DIFF
--- a/DomainDetective.CLI.Tests/HttpListenerCollection.cs
+++ b/DomainDetective.CLI.Tests/HttpListenerCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace DomainDetective.CLI.Tests;
+
+[CollectionDefinition("HttpListener", DisableParallelization = true)]
+public class HttpListenerCollection : ICollectionFixture<object>
+{
+}

--- a/DomainDetective.Tests/HttpListenerCollection.cs
+++ b/DomainDetective.Tests/HttpListenerCollection.cs
@@ -1,0 +1,8 @@
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+[CollectionDefinition("HttpListener", DisableParallelization = true)]
+public class HttpListenerCollection : ICollectionFixture<object>
+{
+}

--- a/DomainDetective.Tests/TestCmdletNewDmarcRecord.cs
+++ b/DomainDetective.Tests/TestCmdletNewDmarcRecord.cs
@@ -8,6 +8,7 @@ using Xunit.Sdk;
 
 namespace DomainDetective.Tests;
 
+[Collection("HttpListener")]
 public class TestCmdletNewDmarcRecord {
     [Fact]
     public async Task PublishesRecordSuccessfully() {

--- a/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
+++ b/DomainDetective.Tests/TestDirectoryExposureAnalysis.cs
@@ -4,6 +4,7 @@ using Xunit.Sdk;
 
 namespace DomainDetective.Tests;
 
+[Collection("HttpListener")]
 public class TestDirectoryExposureAnalysis
 {
     [Fact]

--- a/DomainDetective.Tests/TestDuplicateHealthChecks.cs
+++ b/DomainDetective.Tests/TestDuplicateHealthChecks.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestDuplicateHealthChecks {
         [Fact]
         public async Task DuplicatesExecuteOnce() {

--- a/DomainDetective.Tests/TestHPKPAnalysis.cs
+++ b/DomainDetective.Tests/TestHPKPAnalysis.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestHPKPAnalysis {
         [Fact]
         public async Task DetectsHeaderAndValidPins() {

--- a/DomainDetective.Tests/TestHPKPHealthCheck.cs
+++ b/DomainDetective.Tests/TestHPKPHealthCheck.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestHPKPHealthCheck {
         [Fact]
         public async Task VerifyViaHealthCheck() {

--- a/DomainDetective.Tests/TestHTTPAnalysis.cs
+++ b/DomainDetective.Tests/TestHTTPAnalysis.cs
@@ -9,6 +9,7 @@ using DomainDetective;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestHTTPAnalysis {
         [Fact]
         public async Task DetectStatusCodeAndHsts() {

--- a/DomainDetective.Tests/TestMTASTSAnalysis.cs
+++ b/DomainDetective.Tests/TestMTASTSAnalysis.cs
@@ -7,6 +7,7 @@ using Xunit;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestMTASTSAnalysis {
         [Fact]
         public void ParseValidPolicy() {

--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestPlainHttpHealthCheck {
         [Fact]
         public async Task VerifyPlainHttpDetectsStatusWithoutHsts() {

--- a/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
+++ b/DomainDetective.Tests/TestSecurityTXTAnalysis.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
     public class TestSecurityTXTAnalysis {
         [Fact]
         public async Task ValidSecurityTxtIsParsed() {


### PR DESCRIPTION
## Summary
- ensure tests that use `HttpListener` run serially by defining a shared xUnit collection
- mark each `HttpListener` test class in `DomainDetective.Tests`
- add the same collection definition to CLI tests

## Testing
- `dotnet build DomainDetective.sln -c Debug -f net8.0`
- `dotnet test DomainDetective.sln -c Debug -f net8.0 --no-build --verbosity quiet` *(fails: DomainDetective.Tests.TestCertificateHTTP.ValidCertificateProvidesExpirationInfo, TestCertificateHTTP.ValidHostSetsProtocolVersion, TestCertificateHTTP.CapturesCipherSuiteWhenEnabled, TestDkimAnalysis.TestDKIMByDomain, TestCertificateMonitor.ProducesSummaryCounts, TestSpfAnalysis.TestSpfOver255, TestAll.TestAllHealthChecks, TestSpfAnalysis.TestSpfNullsAndExceedDnsLookups)*

------
https://chatgpt.com/codex/tasks/task_e_68821e478704832eb8693712beb5aee1