### PR TITLE
Add autodiscover HTTP checks

### DIFF
--- a/DomainDetective.Tests/TestAutodiscoverHttpAnalysis.cs
+++ b/DomainDetective.Tests/TestAutodiscoverHttpAnalysis.cs
@@ -1,5 +1,8 @@
 using DomainDetective;
 using RichardSzalay.MockHttp;
+using System;
+using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests;

--- a/DomainDetective.Tests/TestAutodiscoverHttpAnalysis.cs
+++ b/DomainDetective.Tests/TestAutodiscoverHttpAnalysis.cs
@@ -1,0 +1,48 @@
+using DomainDetective;
+using RichardSzalay.MockHttp;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestAutodiscoverHttpAnalysis {
+    [Fact]
+    public async Task FollowsRedirectAndParsesXml() {
+        var mock = new MockHttpMessageHandler();
+        mock.When("https://autodiscover.example.com/autodiscover/autodiscover.xml")
+            .Respond(req => {
+                var resp = new HttpResponseMessage(System.Net.HttpStatusCode.Moved);
+                resp.Headers.Location = new Uri("https://example.com/autodiscover/autodiscover.xml");
+                return resp;
+            });
+        mock.When("https://example.com/autodiscover/autodiscover.xml")
+            .Respond("application/xml", "<Autodiscover></Autodiscover>");
+
+        var analysis = new AutodiscoverHttpAnalysis { HttpHandlerFactory = () => mock };
+        await analysis.Analyze("example.com", new InternalLogger());
+
+        Assert.Single(analysis.Endpoints);
+        var result = analysis.Endpoints[0];
+        Assert.Equal(AutodiscoverMethod.AutodiscoverSubdomainHttps, result.Method);
+        Assert.Equal(200, result.StatusCode);
+        Assert.True(result.XmlValid);
+        Assert.Contains("https://example.com/autodiscover/autodiscover.xml", result.RedirectChain);
+    }
+
+    [Fact]
+    public async Task FallsBackToHttpWhenHttpsFails() {
+        var mock = new MockHttpMessageHandler();
+        mock.When("https://autodiscover.example.com/autodiscover/autodiscover.xml")
+            .Respond(System.Net.HttpStatusCode.NotFound);
+        mock.When("https://example.com/autodiscover/autodiscover.xml")
+            .Respond(System.Net.HttpStatusCode.NotFound);
+        mock.When("http://autodiscover.example.com/autodiscover/autodiscover.xml")
+            .Respond("application/xml", "<Autodiscover></Autodiscover>");
+
+        var analysis = new AutodiscoverHttpAnalysis { HttpHandlerFactory = () => mock };
+        await analysis.Analyze("example.com", new InternalLogger());
+
+        Assert.Equal(3, analysis.Endpoints.Count);
+        Assert.Equal(AutodiscoverMethod.HttpRedirect, analysis.Endpoints[2].Method);
+        Assert.True(analysis.Endpoints[2].XmlValid);
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.Autodiscover.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Autodiscover.cs
@@ -12,6 +12,8 @@ namespace DomainDetective {
             domainName = NormalizeDomain(domainName);
             AutodiscoverAnalysis = new AutodiscoverAnalysis();
             await AutodiscoverAnalysis.Analyze(domainName, DnsConfiguration, _logger, cancellationToken);
+            AutodiscoverHttpAnalysis = new AutodiscoverHttpAnalysis();
+            await AutodiscoverHttpAnalysis.Analyze(domainName, _logger, cancellationToken);
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -361,6 +361,7 @@ namespace DomainDetective {
             filtered.TLSRPTAnalysis = active.Contains(HealthCheckType.TLSRPT) ? CloneAnalysis(TLSRPTAnalysis) : null;
             filtered.BimiAnalysis = active.Contains(HealthCheckType.BIMI) ? CloneAnalysis(BimiAnalysis) : null;
             filtered.AutodiscoverAnalysis = active.Contains(HealthCheckType.AUTODISCOVER) ? CloneAnalysis(AutodiscoverAnalysis) : null;
+            filtered.AutodiscoverHttpAnalysis = active.Contains(HealthCheckType.AUTODISCOVER) ? CloneAnalysis(AutodiscoverHttpAnalysis) : null;
             filtered.CertificateAnalysis = active.Contains(HealthCheckType.CERT) ? CloneAnalysis(CertificateAnalysis) : null;
             filtered.SecurityTXTAnalysis = active.Contains(HealthCheckType.SECURITYTXT) ? CloneAnalysis(SecurityTXTAnalysis) : null;
             filtered.SOAAnalysis = active.Contains(HealthCheckType.SOA) ? CloneAnalysis(SOAAnalysis) : null;

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -239,6 +239,12 @@ namespace DomainDetective {
         public AutodiscoverAnalysis AutodiscoverAnalysis { get; private set; } = new AutodiscoverAnalysis();
 
         /// <summary>
+        /// Gets the Autodiscover HTTP analysis.
+        /// </summary>
+        /// <value>Results of Autodiscover endpoint checks.</value>
+        public AutodiscoverHttpAnalysis AutodiscoverHttpAnalysis { get; private set; } = new AutodiscoverHttpAnalysis();
+
+        /// <summary>
         /// Gets the HTTP analysis.
         /// </summary>
         /// <value>HTTP endpoint validation results.</value>

--- a/DomainDetective/Protocols/AutodiscoverHttpAnalysis.cs
+++ b/DomainDetective/Protocols/AutodiscoverHttpAnalysis.cs
@@ -5,7 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 
-namespace DomainDetective;
+namespace DomainDetective {
 
 /// <summary>
 /// Performs Autodiscover endpoint checks over HTTP/HTTPS.
@@ -113,4 +113,5 @@ public class AutodiscoverHttpAnalysis {
             XmlValid = valid
         };
     }
+}
 }

--- a/DomainDetective/Protocols/AutodiscoverHttpAnalysis.cs
+++ b/DomainDetective/Protocols/AutodiscoverHttpAnalysis.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Performs Autodiscover endpoint checks over HTTP/HTTPS.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class AutodiscoverHttpAnalysis {
+    /// <summary>HTTP request timeout.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+    /// <summary>Maximum redirects to follow.</summary>
+    public int MaxRedirects { get; set; } = 5;
+
+    private readonly List<AutodiscoverEndpointResult> _endpoints = new();
+    /// <summary>Results of attempted endpoints.</summary>
+    public IReadOnlyList<AutodiscoverEndpointResult> Endpoints => _endpoints;
+
+    /// <summary>Factory for creating custom HTTP handlers.</summary>
+    internal Func<HttpMessageHandler>? HttpHandlerFactory { get; set; }
+
+    /// <summary>
+    /// Checks common Autodiscover URLs in sequence.
+    /// </summary>
+    /// <param name="domain">Domain to test.</param>
+    /// <param name="logger">Logger for debug output.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task Analyze(string domain, InternalLogger logger, CancellationToken cancellationToken = default) {
+        if (string.IsNullOrWhiteSpace(domain)) {
+            throw new ArgumentNullException(nameof(domain));
+        }
+
+        _endpoints.Clear();
+        var attempts = new[] {
+            (Url: $"https://autodiscover.{domain}/autodiscover/autodiscover.xml", Method: AutodiscoverMethod.AutodiscoverSubdomainHttps),
+            (Url: $"https://{domain}/autodiscover/autodiscover.xml", Method: AutodiscoverMethod.RootDomainHttps),
+            (Url: $"http://autodiscover.{domain}/autodiscover/autodiscover.xml", Method: AutodiscoverMethod.HttpRedirect),
+            (Url: $"http://{domain}/autodiscover/autodiscover.xml", Method: AutodiscoverMethod.HttpRedirect)
+        };
+
+        foreach (var attempt in attempts) {
+            var result = await CheckEndpoint(attempt.Url, attempt.Method, logger, cancellationToken);
+            _endpoints.Add(result);
+            if (result.XmlValid) {
+                break;
+            }
+        }
+    }
+
+    private (HttpClient client, bool dispose) CreateClient() {
+        if (HttpHandlerFactory != null) {
+            var handler = HttpHandlerFactory();
+            var client = new HttpClient(handler, disposeHandler: true) { Timeout = Timeout };
+            return (client, true);
+        }
+        var h = new HttpClientHandler { AllowAutoRedirect = false };
+        var c = new HttpClient(h, disposeHandler: true) { Timeout = Timeout };
+        return (c, true);
+    }
+
+    private static bool ValidateXml(string content) {
+        try {
+            var doc = XDocument.Parse(content);
+            return string.Equals(doc.Root?.Name.LocalName, "Autodiscover", StringComparison.OrdinalIgnoreCase);
+        } catch {
+            return false;
+        }
+    }
+
+    private async Task<AutodiscoverEndpointResult> CheckEndpoint(string url, AutodiscoverMethod method, InternalLogger logger, CancellationToken cancellationToken) {
+        var redirects = new List<string>();
+        int status = 0;
+        bool valid = false;
+        var tuple = CreateClient();
+        var client = tuple.client;
+        try {
+            var current = new Uri(url);
+            while (true) {
+                redirects.Add(current.AbsoluteUri);
+                using var response = await client.GetAsync(current, cancellationToken);
+                status = (int)response.StatusCode;
+                if ((int)response.StatusCode >= 300 && (int)response.StatusCode < 400 && response.Headers.Location != null) {
+                    if (redirects.Count > MaxRedirects) {
+                        throw new InvalidOperationException($"Maximum number of redirects ({MaxRedirects}) exceeded.");
+                    }
+                    current = response.Headers.Location.IsAbsoluteUri ? response.Headers.Location : new Uri(current, response.Headers.Location);
+                    continue;
+                }
+                if (response.IsSuccessStatusCode) {
+                    var body = await response.Content.ReadAsStringAsync();
+                    valid = ValidateXml(body);
+                }
+                break;
+            }
+        } catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or InvalidOperationException) {
+            logger?.WriteError("Autodiscover HTTP check failed for {0}: {1}", url, ex.Message);
+        } finally {
+            if (tuple.dispose) {
+                client.Dispose();
+            }
+        }
+
+        return new AutodiscoverEndpointResult {
+            Method = method,
+            Url = url,
+            StatusCode = status,
+            RedirectChain = redirects,
+            XmlValid = valid
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- implement `AutodiscoverHttpAnalysis` for sequential endpoint checks
- invoke HTTP analysis from `VerifyAutodiscover`
- clone HTTP results in health check filtering
- expose analysis via new property
- test autodiscover HTTP logic

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build` *(fails: Host not reachable, DNS queries unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688221247eb8832eba0f104c7cd62088