### PR TITLE
Fix tests to use free ports

### DIFF
--- a/DomainDetective.Tests/TestBgpPrefixMonitor.cs
+++ b/DomainDetective.Tests/TestBgpPrefixMonitor.cs
@@ -79,8 +79,10 @@ public class TestBgpPrefixMonitor
         monitor.UseWebhook("https://example.com");
         Assert.IsType<WebhookNotificationSender>(monitor.Notifier);
 
-        monitor.UseEmail("smtp", 25, false, "from@e.com", "to@e.com");
+        var port = PortHelper.GetFreePort();
+        monitor.UseEmail("smtp", port, false, "from@e.com", "to@e.com");
         Assert.IsType<EmailNotificationSender>(monitor.Notifier);
+        PortHelper.ReleasePort(port);
 
         monitor.UseCustom((_, _) => Task.CompletedTask);
         Assert.IsType<DelegateNotificationSender>(monitor.Notifier);

--- a/DomainDetective.Tests/TestDnsPropagationMonitorFactory.cs
+++ b/DomainDetective.Tests/TestDnsPropagationMonitorFactory.cs
@@ -11,8 +11,10 @@ public class TestDnsPropagationMonitorFactory {
         monitor.UseWebhook("https://example.com");
         Assert.IsType<WebhookNotificationSender>(monitor.Notifier);
 
-        monitor.UseEmail("smtp", 25, false, "from@e.com", "to@e.com");
+        var port = PortHelper.GetFreePort();
+        monitor.UseEmail("smtp", port, false, "from@e.com", "to@e.com");
         Assert.IsType<EmailNotificationSender>(monitor.Notifier);
+        PortHelper.ReleasePort(port);
 
         monitor.UseCustom((_, _) => Task.CompletedTask);
         Assert.IsType<DelegateNotificationSender>(monitor.Notifier);

--- a/DomainDetective.Tests/TestIdnValidation.cs
+++ b/DomainDetective.Tests/TestIdnValidation.cs
@@ -20,8 +20,10 @@ public class TestIdnValidation
     {
         var method = typeof(DomainHealthCheck)
             .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (string)method.Invoke(null, new object[] { "bücher.de:25" })!;
-        Assert.Equal("xn--bcher-kva.de:25", result);
+        var port = PortHelper.GetFreePort();
+        var result = (string)method.Invoke(null, new object[] { $"bücher.de:{port}" })!;
+        Assert.Equal($"xn--bcher-kva.de:{port}", result);
+        PortHelper.ReleasePort(port);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMailLatencyAnalysis.cs
+++ b/DomainDetective.Tests/TestMailLatencyAnalysis.cs
@@ -41,8 +41,10 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task RecordsConnectTimeout() {
             var analysis = new MailLatencyAnalysis { Timeout = TimeSpan.FromMilliseconds(300) };
-            await analysis.AnalyzeServer("203.0.113.1", 25, new InternalLogger());
-            var result = analysis.ServerResults["203.0.113.1:25"];
+            var port = PortHelper.GetFreePort();
+            await analysis.AnalyzeServer("203.0.113.1", port, new InternalLogger());
+            var result = analysis.ServerResults[$"203.0.113.1:{port}"];
+            PortHelper.ReleasePort(port);
             Assert.False(result.ConnectSuccess);
         }
     }

--- a/DomainDetective.Tests/TestMailTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestMailTlsAnalysis.cs
@@ -91,8 +91,10 @@ public class TestMailTlsAnalysis
     public async Task ConnectionTimeoutReturnsDefault()
     {
         var analysis = new IMAPTLSAnalysis { Timeout = TimeSpan.FromMilliseconds(300) };
-        await analysis.AnalyzeServer("203.0.113.1", 143, new InternalLogger());
-        var result = analysis.ServerResults["203.0.113.1:143"];
+        var port = PortHelper.GetFreePort();
+        await analysis.AnalyzeServer("203.0.113.1", port, new InternalLogger());
+        var result = analysis.ServerResults[$"203.0.113.1:{port}"];
+        PortHelper.ReleasePort(port);
         Assert.False(result.StartTlsAdvertised);
         Assert.Null(result.Certificate);
     }

--- a/DomainDetective.Tests/TestNotificationSenderFactory.cs
+++ b/DomainDetective.Tests/TestNotificationSenderFactory.cs
@@ -16,15 +16,17 @@ public class TestNotificationSenderFactory
     [Fact]
     public void CreatesEmailSender()
     {
-        var sender = NotificationSenderFactory.CreateEmail("smtp.local", 25, false, "from@example.com", "to@example.com", "user", "pass");
+        var port = PortHelper.GetFreePort();
+        var sender = NotificationSenderFactory.CreateEmail("smtp.local", port, false, "from@example.com", "to@example.com", "user", "pass");
         var email = Assert.IsType<EmailNotificationSender>(sender);
         Assert.Equal("smtp.local", email.SmtpHost);
-        Assert.Equal(25, email.Port);
+        Assert.Equal(port, email.Port);
         Assert.False(email.UseSsl);
         Assert.Equal("from@example.com", email.From);
         Assert.Equal("to@example.com", email.To);
         Assert.Equal("user", email.Username);
         Assert.Equal("pass", email.Password);
+        PortHelper.ReleasePort(port);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestOpenResolverAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenResolverAnalysis.cs
@@ -4,23 +4,31 @@ public class TestOpenResolverAnalysis {
     [Fact]
     public async Task DetectsRecursionAllowed() {
         var analysis = new OpenResolverAnalysis { RecursionTestOverride = (_, _) => Task.FromResult(true) };
-        await analysis.AnalyzeServer("server", 53, new InternalLogger());
-        Assert.True(analysis.ServerResults["server:53"]);
+        var port = PortHelper.GetFreePort();
+        await analysis.AnalyzeServer("server", port, new InternalLogger());
+        Assert.True(analysis.ServerResults[$"server:{port}"]);
+        PortHelper.ReleasePort(port);
     }
 
     [Fact]
     public async Task DetectsRecursionDisabled() {
         var analysis = new OpenResolverAnalysis { RecursionTestOverride = (_, _) => Task.FromResult(false) };
-        await analysis.AnalyzeServer("server", 53, new InternalLogger());
-        Assert.False(analysis.ServerResults["server:53"]);
+        var port = PortHelper.GetFreePort();
+        await analysis.AnalyzeServer("server", port, new InternalLogger());
+        Assert.False(analysis.ServerResults[$"server:{port}"]);
+        PortHelper.ReleasePort(port);
     }
 
     [Fact]
     public async Task ResultsResetBetweenRuns() {
         var analysis = new OpenResolverAnalysis { RecursionTestOverride = (_, _) => Task.FromResult(true) };
-        await analysis.AnalyzeServer("a", 53, new InternalLogger());
-        await analysis.AnalyzeServer("b", 53, new InternalLogger());
-        Assert.False(analysis.ServerResults.ContainsKey("a:53"));
-        Assert.True(analysis.ServerResults["b:53"]);
+        var portA = PortHelper.GetFreePort();
+        await analysis.AnalyzeServer("a", portA, new InternalLogger());
+        var portB = PortHelper.GetFreePort();
+        await analysis.AnalyzeServer("b", portB, new InternalLogger());
+        Assert.False(analysis.ServerResults.ContainsKey($"a:{portA}"));
+        Assert.True(analysis.ServerResults[$"b:{portB}"]);
+        PortHelper.ReleasePort(portA);
+        PortHelper.ReleasePort(portB);
     }
 }

--- a/DomainDetective.Tests/TestVerifyMethods.cs
+++ b/DomainDetective.Tests/TestVerifyMethods.cs
@@ -17,9 +17,14 @@ namespace DomainDetective.Tests {
             var hc = new DomainHealthCheck();
             var method = typeof(DomainHealthCheck).GetMethod(methodName)!;
             var parameters = method.GetParameters();
-            object[] args = parameters.Length == 2
-                ? new object[] { "com", default(System.Threading.CancellationToken) }
-                : new object[] { "com", 25, default(System.Threading.CancellationToken) };
+            object[] args;
+            if (parameters.Length == 2) {
+                args = new object[] { "com", default(System.Threading.CancellationToken) };
+            } else {
+                var port = PortHelper.GetFreePort();
+                args = new object[] { "com", port, default(System.Threading.CancellationToken) };
+                PortHelper.ReleasePort(port);
+            }
             var task = (Task)method.Invoke(hc, args)!;
             await task;
             Assert.True(hc.IsPublicSuffix);

--- a/Module/Tests/SmtpTls.Tests.ps1
+++ b/Module/Tests/SmtpTls.Tests.ps1
@@ -1,7 +1,11 @@
 Describe 'Test-EmailSmtpTls cmdlet' {
     It 'returns SMTPTLSAnalysis object' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
-        $result = Test-EmailSmtpTls -HostName 'localhost' -Port 25 -ErrorAction SilentlyContinue
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        $port = $listener.LocalEndpoint.Port
+        $listener.Stop()
+        $result = Test-EmailSmtpTls -HostName 'localhost' -Port $port -ErrorAction SilentlyContinue
         $result | Should -BeOfType 'DomainDetective.SMTPTLSAnalysis'
     }
 }


### PR DESCRIPTION
## Summary
- replace hardcoded port numbers with free port helper or ephemeral listeners
- use dynamic ports in PowerShell SmtpTls test

## Testing
- `dotnet test` *(fails: Produces 8 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6882295dc16c832ea639573bc5e1b027