### PR TITLE
Add Autodiscover HttpListener tests

### DIFF
--- a/DomainDetective.Tests/TestAutodiscoverHttpListener.cs
+++ b/DomainDetective.Tests/TestAutodiscoverHttpListener.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Threading;
+using DomainDetective;
+using Xunit.Sdk;
+
+namespace DomainDetective.Tests;
+
+[Collection("HttpListener")]
+public class TestAutodiscoverHttpListener {
+    private sealed class RewriteHandler : DelegatingHandler {
+        public RewriteHandler(HttpMessageHandler inner) : base(inner) { }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) {
+            var uri = request.RequestUri!;
+            var builder = new UriBuilder(uri) {
+                Scheme = "http",
+                Port = uri.Port
+            };
+            request.RequestUri = builder.Uri;
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    [Fact]
+    public async Task FirstUrlSucceeds() {
+        if (!HttpListener.IsSupported) {
+            throw SkipException.ForSkip("HttpListener not supported");
+        }
+        using var listener = new HttpListener();
+        var port = PortHelper.GetFreePort();
+        var prefix = $"http://*:{port}/autodiscover/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        PortHelper.ReleasePort(port);
+        var serverTask = Task.Run(async () => {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 200;
+            var buffer = Encoding.UTF8.GetBytes("<Autodiscover></Autodiscover>");
+            await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+            ctx.Response.Close();
+        });
+
+        try {
+            var analysis = new AutodiscoverHttpAnalysis {
+                HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler())
+            };
+            await analysis.Analyze($"localhost:{port}", new InternalLogger());
+            Assert.Single(analysis.Endpoints);
+            var result = analysis.Endpoints[0];
+            Assert.Equal(AutodiscoverMethod.AutodiscoverSubdomainHttps, result.Method);
+            Assert.Equal(200, result.StatusCode);
+            Assert.True(result.XmlValid);
+            Assert.Equal($"https://autodiscover.localhost:{port}/autodiscover/autodiscover.xml", result.Url);
+        } finally {
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
+    [Fact]
+    public async Task RedirectIsFollowed() {
+        if (!HttpListener.IsSupported) {
+            throw SkipException.ForSkip("HttpListener not supported");
+        }
+        using var listener = new HttpListener();
+        var port = PortHelper.GetFreePort();
+        var prefix = $"http://*:{port}/autodiscover/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        PortHelper.ReleasePort(port);
+        var serverTask = Task.Run(async () => {
+            var ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 302;
+            ctx.Response.RedirectLocation = $"https://localhost:{port}/autodiscover/autodiscover.xml";
+            ctx.Response.Close();
+            ctx = await listener.GetContextAsync();
+            ctx.Response.StatusCode = 200;
+            var buffer = Encoding.UTF8.GetBytes("<Autodiscover></Autodiscover>");
+            await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+            ctx.Response.Close();
+        });
+
+        try {
+            var analysis = new AutodiscoverHttpAnalysis {
+                HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler())
+            };
+            await analysis.Analyze($"localhost:{port}", new InternalLogger());
+            Assert.Single(analysis.Endpoints);
+            var result = analysis.Endpoints[0];
+            Assert.Equal(2, result.RedirectChain?.Count);
+            Assert.Equal(200, result.StatusCode);
+            Assert.True(result.XmlValid);
+        } finally {
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
+    [Fact]
+    public async Task AllEndpointsFailWhenNoServer() {
+        var port = PortHelper.GetFreePort();
+        PortHelper.ReleasePort(port);
+        var analysis = new AutodiscoverHttpAnalysis {
+            HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler())
+        };
+        await analysis.Analyze($"localhost:{port}", new InternalLogger());
+        Assert.Equal(4, analysis.Endpoints.Count);
+        Assert.Equal(
+            new[] {
+                AutodiscoverMethod.AutodiscoverSubdomainHttps,
+                AutodiscoverMethod.RootDomainHttps,
+                AutodiscoverMethod.HttpRedirect,
+                AutodiscoverMethod.HttpRedirect
+            },
+            analysis.Endpoints.Select(e => e.Method).ToArray());
+        Assert.All(analysis.Endpoints, e => Assert.Equal(0, e.StatusCode));
+    }
+}

--- a/DomainDetective.Tests/TestAutodiscoverHttpListener.cs
+++ b/DomainDetective.Tests/TestAutodiscoverHttpListener.cs
@@ -21,8 +21,10 @@ public class TestAutodiscoverHttpListener {
             var uri = request.RequestUri!;
             var builder = new UriBuilder(uri) {
                 Scheme = "http",
+                Host = "localhost",
                 Port = uri.Port
             };
+            request.Headers.Host = "localhost";
             request.RequestUri = builder.Uri;
             return base.SendAsync(request, cancellationToken);
         }
@@ -35,7 +37,7 @@ public class TestAutodiscoverHttpListener {
         }
         using var listener = new HttpListener();
         var port = PortHelper.GetFreePort();
-        var prefix = $"http://*:{port}/autodiscover/";
+        var prefix = $"http://localhost:{port}/autodiscover/";
         listener.Prefixes.Add(prefix);
         listener.Start();
         PortHelper.ReleasePort(port);
@@ -49,7 +51,7 @@ public class TestAutodiscoverHttpListener {
 
         try {
             var analysis = new AutodiscoverHttpAnalysis {
-                HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler())
+                HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler { AllowAutoRedirect = false })
             };
             await analysis.Analyze($"localhost:{port}", new InternalLogger());
             Assert.Single(analysis.Endpoints);
@@ -71,7 +73,7 @@ public class TestAutodiscoverHttpListener {
         }
         using var listener = new HttpListener();
         var port = PortHelper.GetFreePort();
-        var prefix = $"http://*:{port}/autodiscover/";
+        var prefix = $"http://localhost:{port}/autodiscover/";
         listener.Prefixes.Add(prefix);
         listener.Start();
         PortHelper.ReleasePort(port);
@@ -89,7 +91,7 @@ public class TestAutodiscoverHttpListener {
 
         try {
             var analysis = new AutodiscoverHttpAnalysis {
-                HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler())
+                HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler { AllowAutoRedirect = false })
             };
             await analysis.Analyze($"localhost:{port}", new InternalLogger());
             Assert.Single(analysis.Endpoints);
@@ -108,7 +110,7 @@ public class TestAutodiscoverHttpListener {
         var port = PortHelper.GetFreePort();
         PortHelper.ReleasePort(port);
         var analysis = new AutodiscoverHttpAnalysis {
-            HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler())
+            HttpHandlerFactory = () => new RewriteHandler(new HttpClientHandler { AllowAutoRedirect = false })
         };
         await analysis.Analyze($"localhost:{port}", new InternalLogger());
         Assert.Equal(4, analysis.Endpoints.Count);


### PR DESCRIPTION
## Summary
- add AutodiscoverHttpListener tests using `HttpListener`

## Testing
- `dotnet test --verbosity minimal --filter FullyQualifiedName~TestAutodiscoverHttpListener` *(fails: Assert.Single() Failure)*

------
https://chatgpt.com/codex/tasks/task_e_688241d4655c832eb00dff2262d30797