### PR TITLE
Add port overload for VerifySMTPTLS

### DIFF
--- a/DomainDetective.Tests/TestVerifySmtpTls.cs
+++ b/DomainDetective.Tests/TestVerifySmtpTls.cs
@@ -1,0 +1,37 @@
+using DnsClientX;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestVerifySmtpTls {
+        private static DomainHealthCheck CreateHealthCheck() {
+            var hc = new DomainHealthCheck();
+            hc.DnsConfiguration = new DnsConfiguration {
+                QueryDnsOverride = (name, type) => {
+                    if (type == DnsRecordType.MX) {
+                        return Task.FromResult(new[] { new DnsAnswer { DataRaw = "0 localhost" } });
+                    }
+                    return Task.FromResult(Array.Empty<DnsAnswer>());
+                }
+            };
+            return hc;
+        }
+
+        [Fact]
+        public async Task DefaultPortIs25() {
+            var hc = CreateHealthCheck();
+            await hc.VerifySMTPTLS("example.com");
+            Assert.Contains("localhost:25", hc.SmtpTlsAnalysis.ServerResults.Keys);
+        }
+
+        [Fact]
+        public async Task CustomPortRespected() {
+            var port = PortHelper.GetFreePort();
+            var hc = CreateHealthCheck();
+            await hc.VerifySMTPTLS("example.com", port);
+            Assert.Contains($"localhost:{port}", hc.SmtpTlsAnalysis.ServerResults.Keys);
+            PortHelper.ReleasePort(port);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
@@ -24,16 +24,23 @@ namespace DomainDetective {
         /// <summary>
         /// Checks all MX hosts for SMTP TLS configuration.
         /// </summary>
-        public async Task VerifySMTPTLS(string domainName, CancellationToken cancellationToken = default) {
+        public async Task VerifySMTPTLS(string domainName, int port, CancellationToken cancellationToken = default) {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
+            ValidatePort(port);
             var mxRecordsForTls = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.MX, cancellationToken: cancellationToken);
             var tlsHosts = CertificateAnalysis.ExtractMxHosts(mxRecordsForTls);
-            await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, 25, _logger, cancellationToken);
+            await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, port, _logger, cancellationToken);
         }
+
+        /// <summary>
+        /// Checks all MX hosts for SMTP TLS configuration using the default port.
+        /// </summary>
+        public Task VerifySMTPTLS(string domainName, CancellationToken cancellationToken = default)
+            => VerifySMTPTLS(domainName, 25, cancellationToken);
 
         /// <summary>
         /// Checks all MX hosts for IMAP TLS configuration.

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -125,7 +125,7 @@ namespace DomainDetective {
                 [HealthCheckType.OPENRELAY] = () => VerifyOpenRelay(domainName, 25, cancellationToken),
                 [HealthCheckType.OPENRESOLVER] = () => VerifyOpenResolver(domainName, cancellationToken),
                 [HealthCheckType.STARTTLS] = () => VerifySTARTTLS(domainName, 25, cancellationToken),
-                [HealthCheckType.SMTPTLS] = () => VerifySMTPTLS(domainName, cancellationToken),
+                [HealthCheckType.SMTPTLS] = () => VerifySMTPTLS(domainName, 25, cancellationToken),
                 [HealthCheckType.IMAPTLS] = () => VerifyIMAPTLS(domainName, cancellationToken),
                 [HealthCheckType.POP3TLS] = () => VerifyPOP3TLS(domainName, cancellationToken),
                 [HealthCheckType.SMTPBANNER] = () => VerifySMTPBanner(domainName, 25, cancellationToken),


### PR DESCRIPTION
## Summary
- overload `VerifySMTPTLS` to accept port
- keep default 25 via helper overload
- ensure `Verify` uses the new overload
- add unit tests for the default and custom port behaviour

## Testing
- `dotnet test` *(fails: Host not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_6882839ee824832eabc5255d7d4ba3d3