### PR TITLE
Handle DANE cancellation

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -53,7 +53,7 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DANE record for domain: {0}", DomainName);
             var ports = Ports != null && Ports.Length > 0 ? Ports : new[] { (int)ServiceType.SMTP };
-            await healthCheck.VerifyDANE(DomainName, ports);
+            await healthCheck.VerifyDANE(DomainName, ports, CancelToken);
             WriteObject(healthCheck.DaneAnalysis);
         }
     }

--- a/DomainDetective.Tests/TestDnssecEcdsa.cs
+++ b/DomainDetective.Tests/TestDnssecEcdsa.cs
@@ -56,11 +56,25 @@ namespace DomainDetective.Tests {
             }
             if (signature[pos++] != 0x02) { throw new InvalidOperationException(); }
             int rLen = signature[pos++];
+            if (rLen >= 0x80) {
+                int lenBytes = rLen & 0x7F;
+                rLen = 0;
+                for (int i = 0; i < lenBytes; i++) {
+                    rLen = (rLen << 8) | signature[pos++];
+                }
+            }
             byte[] r = new byte[rLen];
             Buffer.BlockCopy(signature, pos, r, 0, rLen);
             pos += rLen;
             if (signature[pos++] != 0x02) { throw new InvalidOperationException(); }
             int sLen = signature[pos++];
+            if (sLen >= 0x80) {
+                int lenBytes = sLen & 0x7F;
+                sLen = 0;
+                for (int i = 0; i < lenBytes; i++) {
+                    sLen = (sLen << 8) | signature[pos++];
+                }
+            }
             byte[] s = new byte[sLen];
             Buffer.BlockCopy(signature, pos, s, 0, sLen);
 

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -1,0 +1,13 @@
+Describe 'Test-DaneRecord cmdlet' {
+    It 'cancels on Ctrl+C' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        $job = Start-Job -ScriptBlock {
+            Import-Module "$using:PSScriptRoot/../DomainDetective.psd1" -Force
+            Test-TlsDane -DomainName 'example.com' -DnsEndpoint System -Verbose
+        }
+        Start-Sleep -Milliseconds 500
+        Stop-Job $job
+        Wait-Job $job
+        $job.ChildJobs[0].State | Should -Be 'Stopped'
+    }
+}

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -3,7 +3,7 @@ Describe 'Test-DaneRecord cmdlet' {
         Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
         $job = Start-Job -ScriptBlock {
             Import-Module "$using:PSScriptRoot/../DomainDetective.psd1" -Force
-            Test-TlsDane -DomainName 'example.com' -DnsEndpoint System -Verbose
+            Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose
         }
         Start-Sleep -Milliseconds 500
         Stop-Job $job


### PR DESCRIPTION
## Summary
- respect cancellation token in `Test-DDTlsDaneRecord` cmdlet
- test that Ctrl+C stops `Test-TlsDane`

## Testing
- `dotnet build DomainDetective.sln -c Debug`
- `pwsh -NoLogo -Command ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_688283c2137c832e8952082891130a98