### PR TITLE
Fix unknown HealthCheckType message

### DIFF
--- a/DomainDetective.Tests/TestUnknownHealthCheckType.cs
+++ b/DomainDetective.Tests/TestUnknownHealthCheckType.cs
@@ -6,8 +6,9 @@ namespace DomainDetective.Tests {
         [Fact]
         public async Task VerifyUnknownHealthCheckTypeThrows() {
             var healthCheck = new DomainHealthCheck();
-            await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            var ex = await Assert.ThrowsAsync<NotSupportedException>(async () =>
                 await healthCheck.Verify("example.com", new[] { (HealthCheckType)999 }));
+            Assert.Contains("999", ex.Message);
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -163,7 +163,7 @@ namespace DomainDetective {
                     await action();
                 } else {
                     _logger.WriteError("Unknown health check type: {0}", healthCheckType);
-                    throw new NotSupportedException("Health check type not implemented.");
+                    throw new NotSupportedException($"Health check type not implemented: {healthCheckType}");
                 }
 
                 processedChecks++;


### PR DESCRIPTION
## Summary
- include unknown `HealthCheckType` value in exception message
- verify exception message in `TestUnknownHealthCheckType`

## Testing
- `dotnet test --no-build --filter TestUnknownHealthCheckType`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_688283c86cd8832eb1a3bf3b5c688ba8