### PR TITLE
Add BIMI SVG validation enhancements

### DIFF
--- a/DomainDetective.Tests/Data/bimi-missing-attrs.svg
+++ b/DomainDetective.Tests/Data/bimi-missing-attrs.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/DomainDetective.Tests/Data/bimi-valid.svg
+++ b/DomainDetective.Tests/Data/bimi-valid.svg
@@ -1,0 +1,1 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg"></svg>

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -122,6 +122,12 @@
         <None Include="Data/rdap/ip/192.0.2.1.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+        <None Include="Data/bimi-valid.svg">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
+        <None Include="Data/bimi-missing-attrs.svg">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </None>
     </ItemGroup>
 
 </Project>

--- a/DomainDetective/DomainHealthCheck.Verification.Bimi.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Bimi.cs
@@ -11,7 +11,8 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="bimiRecord">BIMI record text.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
-        public async Task CheckBIMI(string bimiRecord, CancellationToken cancellationToken = default) {
+        public async Task CheckBIMI(string bimiRecord, bool skipIndicatorDownload = false, CancellationToken cancellationToken = default) {
+            BimiAnalysis.SkipIndicatorDownload = skipIndicatorDownload;
             await BimiAnalysis.AnalyzeBimiRecords(new List<DnsAnswer> {
                 new DnsAnswer {
                     DataRaw = bimiRecord,
@@ -25,13 +26,13 @@ namespace DomainDetective {
         /// </summary>
         /// <param name="domainName">Domain to verify.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
-        public async Task VerifyBIMI(string domainName, CancellationToken cancellationToken = default) {
+        public async Task VerifyBIMI(string domainName, bool skipIndicatorDownload = false, CancellationToken cancellationToken = default) {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
-            BimiAnalysis = new BimiAnalysis();
+            BimiAnalysis = new BimiAnalysis { SkipIndicatorDownload = skipIndicatorDownload };
             var bimi = await DnsConfiguration.QueryDNS($"default._bimi.{domainName}", DnsRecordType.TXT, cancellationToken: cancellationToken);
             await BimiAnalysis.AnalyzeBimiRecords(bimi, _logger, cancellationToken: cancellationToken);
         }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -117,7 +117,7 @@ namespace DomainDetective {
                 [HealthCheckType.DNSBL] = () => VerifyDNSBL(domainName, cancellationToken),
                 [HealthCheckType.MTASTS] = () => VerifyMTASTS(domainName, cancellationToken),
                 [HealthCheckType.TLSRPT] = () => VerifyTLSRPT(domainName, cancellationToken),
-                [HealthCheckType.BIMI] = () => VerifyBIMI(domainName, cancellationToken),
+                [HealthCheckType.BIMI] = () => VerifyBIMI(domainName, cancellationToken: cancellationToken),
                 [HealthCheckType.AUTODISCOVER] = () => VerifyAutodiscover(domainName, cancellationToken),
                 [HealthCheckType.CERT] = () => VerifyWebsiteCertificate(domainName, cancellationToken: cancellationToken),
                 [HealthCheckType.SECURITYTXT] = () => VerifySecurityTxtAsync(domainName, cancellationToken),

--- a/DomainDetective/Protocols/BimiAnalysis.Parse.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.Parse.cs
@@ -21,6 +21,7 @@ namespace DomainDetective {
             SvgSizeValid = false;
             DimensionsValid = false;
             ViewBoxValid = false;
+            SvgAttributesPresent = false;
             ValidVmc = false;
             VmcSignedByKnownRoot = false;
             VmcContainsLogo = false;


### PR DESCRIPTION
## Summary
- check for required SVG attributes
- allow skipping BIMI image download
- support skip option in health check methods
- add test SVG files and unit tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --verbosity minimal` *(fails: Hosts not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_688283713274832e98cfd34ef581078f