### PR TITLE
Add DNSSEC key expiry checks

### DIFF
--- a/DomainDetective.Tests/TestDnssecAnchorExpiry.cs
+++ b/DomainDetective.Tests/TestDnssecAnchorExpiry.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnssecAnchorExpiry {
+        [Fact]
+        public async Task DetectsAnchorExpiry() {
+            string cacheDir = Path.Combine(Path.GetTempPath(), "DomainDetective");
+            string cacheFile = Path.Combine(cacheDir, "root-anchors.xml");
+            Directory.CreateDirectory(cacheDir);
+
+            DateTimeOffset expiry = DateTimeOffset.UtcNow.AddDays(10);
+            string xml = $"<TrustAnchor><Zone>.</Zone><KeyDigest validFrom=\"2020-01-01T00:00:00+00:00\" validUntil=\"{expiry:yyyy-MM-ddTHH:mm:sszzz}\"><KeyTag>12345</KeyTag><Algorithm>8</Algorithm><DigestType>2</DigestType><Digest>ABC</Digest></KeyDigest></TrustAnchor>";
+            File.WriteAllText(cacheFile, xml);
+            File.SetLastWriteTimeUtc(cacheFile, DateTime.UtcNow);
+
+            try {
+                var result = await DomainDetective.DnsSecAnalysis.DownloadTrustAnchors();
+                Assert.NotNull(result.expiration);
+                Assert.True(result.expiration.Value - DateTimeOffset.UtcNow < TimeSpan.FromDays(30));
+            } finally {
+                File.Delete(cacheFile);
+            }
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDomainSummary.cs
+++ b/DomainDetective.Tests/TestDomainSummary.cs
@@ -22,10 +22,16 @@ namespace DomainDetective.Tests {
                 System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
             )!;
             prop.SetValue(healthCheck.DnsSecAnalysis, true);
+            var warnProp = typeof(DnsSecAnalysis).GetProperty(
+                "KeyExpiresSoon",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public
+            )!;
+            warnProp.SetValue(healthCheck.DnsSecAnalysis, true);
 
             var summary = healthCheck.BuildSummary();
 
             Assert.True(summary.DnsSecValid);
+            Assert.True(summary.DnsSecKeyExpiresSoon);
 
         }
 

--- a/DomainDetective.Tests/TestDownloadTrustAnchors.cs
+++ b/DomainDetective.Tests/TestDownloadTrustAnchors.cs
@@ -8,8 +8,8 @@ namespace DomainDetective.Tests {
     public class TestDownloadTrustAnchors {
         [Fact]
         public async Task FetchesAnchors() {
-            var anchors = await DnsSecAnalysis.DownloadTrustAnchors();
-            Assert.NotEmpty(anchors);
+            var result = await DnsSecAnalysis.DownloadTrustAnchors();
+            Assert.NotEmpty(result.anchors);
         }
 
         [Fact]
@@ -21,8 +21,8 @@ namespace DomainDetective.Tests {
             File.SetLastWriteTimeUtc(cacheFile, DateTime.UtcNow);
 
             try {
-                var anchors = await DnsSecAnalysis.DownloadTrustAnchors();
-                Assert.Empty(anchors);
+                var result = await DnsSecAnalysis.DownloadTrustAnchors();
+                Assert.Empty(result.anchors);
             } finally {
                 File.Delete(cacheFile);
             }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -232,6 +232,7 @@ namespace DomainDetective {
                 DkimValid = dkimValid,
                 HasMxRecord = MXAnalysis?.MxRecordExists ?? false,
                 DnsSecValid = DnsSecAnalysis?.ChainValid ?? false,
+                DnsSecKeyExpiresSoon = DnsSecAnalysis?.KeyExpiresSoon ?? false,
                 IsPublicSuffix = IsPublicSuffix,
                 ExpiryDate = WhoisAnalysis.ExpiryDate,
                 ExpiresSoon = WhoisAnalysis.ExpiresSoon,

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -47,6 +47,9 @@ namespace DomainDetective {
         /// <summary>True when DNSSEC validation succeeded.</summary>
         public bool DnsSecValid { get; init; }
 
+        /// <summary>True when DNSSEC keys expire soon.</summary>
+        public bool DnsSecKeyExpiresSoon { get; init; }
+
         /// <summary>
         /// Indicates whether the analyzed domain is itself a public suffix as
         /// defined by <see href="https://datatracker.ietf.org/doc/html/rfc8499"/>


### PR DESCRIPTION
## Summary
- track DNSSEC warnings for upcoming expirations
- surface key expiry info in summaries
- update trust anchor parsing to read expiration
- warn when trust anchor or signatures expire soon
- test trust anchor expiry detection

## Testing
- `dotnet build`
- `dotnet test` *(fails: Should exceed DNS lookups due to many includes, The given key 'selector1' was not present, Exceeds lookups should be true, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688283598edc832e88b0f3e354658976