### PR TITLE
Add port scan progress display

### DIFF
--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -154,6 +154,9 @@ internal static async Task RunChecks(string[] domains, HealthCheckType[]? checks
                         if (e.ProgressActivity == "PortScan" && e.ProgressTotalSteps.HasValue && e.ProgressCurrentSteps.HasValue) {
                             portTask ??= ctx.AddTask($"Port scan for {domain}", maxValue: e.ProgressTotalSteps.Value);
                             portTask.Value = e.ProgressCurrentSteps.Value;
+                            if (!string.IsNullOrEmpty(e.ProgressCurrentOperation)) {
+                                portTask.Description = $"Port {e.ProgressCurrentOperation}";
+                            }
                         } else if (e.ProgressActivity == "HealthCheck" && e.ProgressTotalSteps.HasValue && e.ProgressCurrentSteps.HasValue) {
                             hcTask ??= ctx.AddTask($"Health checks for {domain}", maxValue: e.ProgressTotalSteps.Value);
                             hcTask.Value = e.ProgressCurrentSteps.Value;

--- a/DomainDetective.Tests/TestInternalLoggerPowerShell.cs
+++ b/DomainDetective.Tests/TestInternalLoggerPowerShell.cs
@@ -20,5 +20,25 @@ namespace DomainDetective.Tests {
             Assert.Equal("2", records[1].FullyQualifiedErrorId);
             Assert.Equal("second", records[1].ErrorDetails.Message);
         }
+
+        [Fact]
+        public void ProgressActivityIdIncrements() {
+            var logger = new InternalLogger();
+            var progress = new List<ProgressRecord>();
+            var psLogger = new InternalLoggerPowerShell(logger, null, null, null, null, progress.Add);
+
+            logger.WriteProgress("PortScan", "80", 50, 1, 2);
+            logger.WriteProgress("PortScan", "80", 100, 2, 2);
+            logger.WriteProgress("PortScan", "443", 50, 1, 2);
+            logger.WriteProgress("PortScan", "443", 100, 2, 2);
+
+            Assert.Equal(4, progress.Count);
+            Assert.Equal(1, progress[0].ActivityId);
+            Assert.Equal(1, progress[1].ActivityId);
+            Assert.Equal(2, progress[2].ActivityId);
+            Assert.Equal(2, progress[3].ActivityId);
+            Assert.Equal(ProgressRecordType.Completed, progress[1].RecordType);
+            Assert.Equal(ProgressRecordType.Completed, progress[3].RecordType);
+        }
     }
 }

--- a/DomainDetective.Tests/TestPortScanProgressCounts.cs
+++ b/DomainDetective.Tests/TestPortScanProgressCounts.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests;
+
+public class TestPortScanProgressCounts {
+    [Fact]
+    public async Task ReportsEventsPerPort() {
+        var tcpListener = new TcpListener(IPAddress.Loopback, 0);
+        tcpListener.Start();
+        var tcpPort = ((IPEndPoint)tcpListener.LocalEndpoint).Port;
+        var tcpAccept = tcpListener.AcceptTcpClientAsync();
+
+        using var udpServer = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        var udpPort = ((IPEndPoint)udpServer.Client.LocalEndPoint!).Port;
+        var udpTask = Task.Run(async () => {
+            var r = await udpServer.ReceiveAsync();
+            await udpServer.SendAsync(r.Buffer, r.Buffer.Length, r.RemoteEndPoint);
+        });
+
+        var events = new List<LogEventArgs>();
+        var logger = new InternalLogger();
+        logger.OnProgressMessage += (_, e) => events.Add(e);
+
+        var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromMilliseconds(200) };
+        await analysis.Scan("127.0.0.1", new[] { tcpPort, udpPort }, logger);
+        using var _ = await tcpAccept;
+
+        tcpListener.Stop();
+        await udpTask;
+
+        var portEvents = events.Where(e => e.ProgressActivity == "PortScan").ToList();
+        Assert.Equal(2, portEvents.Count);
+        Assert.Equal(100, portEvents.Last().ProgressPercentage);
+    }
+}


### PR DESCRIPTION
## Summary
- show port number in CLI progress view
- test progress id increment logic
- verify progress events fire per port

## Testing
- `dotnet test` *(fails: Hosts not reachable)*
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688283541e64832ea10f489b9e796334