### PR TITLE
Add RADIUS port scan profile

### DIFF
--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -17,6 +17,7 @@ namespace DomainDetective.CLI;
 /// </summary>
 internal static class CommandUtilities {
     internal static readonly string[] CheckNames = Enum.GetNames<HealthCheckType>();
+    internal static readonly string[] PortProfileNames = Enum.GetNames<PortScanProfile>();
 
     [RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
     [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]

--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -23,7 +23,8 @@ internal static class Program {
             config.AddCommand<CheckDomainCommand>("check")
                 .WithDescription("Run domain health checks")
                 .WithExample(new[] { "check", "example.com", "--json" })
-                .WithExample(new[] { "check", "example.com", "--checks", "autodiscover" });
+                .WithExample(new[] { "check", "example.com", "--checks", "autodiscover" })
+                .WithExample(new[] { "check", "example.com", "--port-profiles", "radius" });
             config.AddCommand<AnalyzeMessageHeaderCommand>("AnalyzeMessageHeader")
                 .WithDescription("Analyze message header")
                 .WithExample(new[] { "AnalyzeMessageHeader", "--file", "./headers.txt", "--json" });

--- a/DomainDetective.Example/ExamplePortScan.cs
+++ b/DomainDetective.Example/ExamplePortScan.cs
@@ -11,7 +11,7 @@ public static partial class Program
     public static async Task ExamplePortScan()
     {
         var analysis = new PortScanAnalysis { Timeout = TimeSpan.FromSeconds(1) };
-        await analysis.Scan("scanme.nmap.org", new[] { 22, 80 }, new InternalLogger());
+        await analysis.Scan("scanme.nmap.org", PortScanProfileDefinition.PortScanProfile.RADIUS, new InternalLogger());
         Helpers.ShowPropertiesTable("Port Scan Results", analysis.Results);
     }
 }

--- a/DomainDetective.Tests/TestPortScanProfileDefinition.cs
+++ b/DomainDetective.Tests/TestPortScanProfileDefinition.cs
@@ -21,4 +21,12 @@ public class TestPortScanProfileDefinition
         Assert.Contains(9999, ntp);
         PortScanProfileDefinition.OverrideProfilePorts(PortScanProfileDefinition.PortScanProfile.NTP, new[] { 123 });
     }
+
+    [Fact]
+    public void IncludesRadiusPorts()
+    {
+        var ports = PortScanProfileDefinition.GetPorts(PortScanProfileDefinition.PortScanProfile.RADIUS);
+        Assert.Contains(1812, ports);
+        Assert.Contains(1813, ports);
+    }
 }

--- a/DomainDetective/Definitions/PortScanProfileDefinition.cs
+++ b/DomainDetective/Definitions/PortScanProfileDefinition.cs
@@ -16,7 +16,9 @@ public static class PortScanProfileDefinition
         /// <summary>Ports commonly used by SMB.</summary>
         SMB,
         /// <summary>Ports commonly used by NTP.</summary>
-        NTP
+        NTP,
+        /// <summary>Ports commonly used by RADIUS.</summary>
+        RADIUS
     }
 
     private const string PortsCsv = "80,631,161,137,123,445,138,1434,135,53,139,67,23,443,21,22,500,1900,68,520,25,514,4500,111,49152,162,69,5353,49154,3389,110,1701,999,998,996,997,49153,3283,1723,1433,8888,53,2083,49155,161,445,7777,7,8080,443,9090,587,873,3306,5432,9091,1900,464,139,631,49156,123,81,589,554,500,49157,2,5222,113,664,69,27017,587,110,8000,995,88,8080,139,161,995,23,8008,389,2082,3306,11211,110,389,591,1025,543,22,1194,139,520,873,4379,8089,49158,3306,110,1521,3268,631,6001,69,53,901,5672,25,8009,54321,3283,3311,49159,123,5000,49160";
@@ -27,6 +29,7 @@ public static class PortScanProfileDefinition
     {
         [PortScanProfile.SMB] = new[] { 445, 139 },
         [PortScanProfile.NTP] = new[] { 123 },
+        [PortScanProfile.RADIUS] = new[] { 1812, 1813 },
         [PortScanProfile.Default] = _topPorts
     };
 


### PR DESCRIPTION
## Summary
- extend `PortScanProfile` with RADIUS
- wire ports 1812/1813 for the new profile
- show RADIUS example in CLI help and example project
- expose port profile names for autocompletion
- test coverage for the new profile

## Testing
- `dotnet build DomainDetective.sln -c Release`
- `dotnet test DomainDetective.sln -c Release` *(fails: Host not reachable etc.)*
- `pwsh ./Module/DomainDetective.Tests.ps1`

------
https://chatgpt.com/codex/tasks/task_e_68828387a648832e91c2d74ae1d7e8b2