### PR TITLE
Fix DNSBL address validation

### DIFF
--- a/DomainDetective.Tests/TestDNSBLArgument.cs
+++ b/DomainDetective.Tests/TestDNSBLArgument.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Tests {
+    public class TestDnsblArgument {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public async Task CheckDnsblThrowsIfAddressNullOrWhitespace(string? address) {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                await healthCheck.CheckDNSBL(address!));
+        }
+
+        [Theory]
+        [InlineData("invalid")]
+        [InlineData("256.256.256.256")]
+        public async Task CheckDnsblThrowsIfAddressInvalid(string address) {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await healthCheck.CheckDNSBL(address));
+        }
+
+        [Fact]
+        public async Task CheckDnsblArrayThrowsIfAddressInvalid() {
+            var healthCheck = new DomainHealthCheck();
+            await Assert.ThrowsAsync<ArgumentException>(async () =>
+                await healthCheck.CheckDNSBL(new[] { "127.0.0.1", "invalid" }));
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.Dnsbl.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Dnsbl.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Net;
 
 namespace DomainDetective {
     public partial class DomainHealthCheck {
@@ -28,6 +29,14 @@ namespace DomainDetective {
         /// <param name="ipAddress">IP address to query.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         public async Task CheckDNSBL(string ipAddress, CancellationToken cancellationToken = default) {
+            if (string.IsNullOrWhiteSpace(ipAddress)) {
+                throw new ArgumentNullException(nameof(ipAddress));
+            }
+
+            if (!IPAddress.TryParse(ipAddress, out _)) {
+                throw new ArgumentException("Invalid IP address", nameof(ipAddress));
+            }
+
             await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ipAddress, _logger)) {
                 cancellationToken.ThrowIfCancellationRequested();
                 // enumeration triggers processing
@@ -40,8 +49,16 @@ namespace DomainDetective {
         /// <param name="ipAddresses">IPs to query.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         public async Task CheckDNSBL(string[] ipAddresses, CancellationToken cancellationToken = default) {
+            if (ipAddresses == null) {
+                throw new ArgumentNullException(nameof(ipAddresses));
+            }
+
             foreach (var ip in ipAddresses) {
                 cancellationToken.ThrowIfCancellationRequested();
+                if (!IPAddress.TryParse(ip, out _)) {
+                    throw new ArgumentException("Invalid IP address", nameof(ipAddresses));
+                }
+
                 await foreach (var _ in DNSBLAnalysis.AnalyzeDNSBLRecords(ip, _logger)) {
                     cancellationToken.ThrowIfCancellationRequested();
                     // enumeration triggers processing


### PR DESCRIPTION
## Summary
- validate IP addresses before DNSBL checks
- handle invalid address arrays
- test DNSBL argument validation

## Testing
- `dotnet test` *(fails: Host not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68832d16df7c832eaed8b27eb2b3cb78