### PR TITLE
Ensure cache directory creation

### DIFF
--- a/DomainDetective.Tests/TestDnsSnapshotDirectoryCreation.cs
+++ b/DomainDetective.Tests/TestDnsSnapshotDirectoryCreation.cs
@@ -1,0 +1,31 @@
+using DnsClientX;
+using DomainDetective;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnsSnapshotDirectoryCreation {
+        [Fact]
+        public void CreatesDirectoryWhenSavingSnapshot() {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            var analysis = new DnsPropagationAnalysis { SnapshotDirectory = dir };
+            var results = new List<DnsPropagationResult> {
+                new() {
+                    Server = new PublicDnsEntry { IPAddress = IPAddress.Parse("1.1.1.1"), Enabled = true },
+                    RecordType = DnsRecordType.A,
+                    Records = new[] { "1.2.3.4" },
+                    Success = true
+                }
+            };
+
+            analysis.SaveSnapshot("example.com", DnsRecordType.A, results);
+
+            var files = Directory.GetFiles(dir);
+            Assert.Single(files);
+            Directory.Delete(dir, true);
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -69,9 +69,17 @@ namespace DomainDetective {
                     var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
                     _cacheDirectory = Path.Combine(home, ".domain-detective");
                 }
+                if (!Directory.Exists(_cacheDirectory)) {
+                    Directory.CreateDirectory(_cacheDirectory);
+                }
                 return _cacheDirectory;
             }
-            set => _cacheDirectory = value;
+            set {
+                _cacheDirectory = value;
+                if (!string.IsNullOrEmpty(_cacheDirectory) && !Directory.Exists(_cacheDirectory)) {
+                    Directory.CreateDirectory(_cacheDirectory);
+                }
+            }
         }
 
         private string? _cacheDirectory;


### PR DESCRIPTION
## Summary
- ensure `CacheDirectory` creates missing folder
- test DNS snapshot directory creation

## Testing
- `dotnet test DomainDetective.sln` *(fails: DNS queries unavailable etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68832d220d0c832ea2bbb4947ca1bf45