### PR TITLE
Improve validation messages

### DIFF
--- a/DomainDetective.Tests/TestIdnValidation.cs
+++ b/DomainDetective.Tests/TestIdnValidation.cs
@@ -32,7 +32,28 @@ public class TestIdnValidation
         var method = typeof(DomainHealthCheck)
             .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
         var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { "example.123" }));
-        Assert.IsType<ArgumentException>(ex.InnerException);
+        var inner = Assert.IsType<ArgumentException>(ex.InnerException);
+        Assert.Contains("example.123", inner.Message);
+    }
+
+    [Fact]
+    public void ValidateHostNameRejectsPath()
+    {
+        var method = typeof(DomainHealthCheck)
+            .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { "example.com/path" }));
+        var inner = Assert.IsType<ArgumentException>(ex.InnerException);
+        Assert.Contains("example.com/path", inner.Message);
+    }
+
+    [Fact]
+    public void ValidateHostNameRejectsBadPort()
+    {
+        var method = typeof(DomainHealthCheck)
+            .GetMethod("ValidateHostName", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var ex = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, new object[] { "example.com:65536" }));
+        var inner = Assert.IsType<ArgumentException>(ex.InnerException);
+        Assert.Contains("65536", inner.Message);
     }
 
     [Fact]

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -287,7 +287,7 @@ namespace DomainDetective {
                 try {
                     hostName = DomainHelper.ValidateIdn(hostName);
                 } catch (ArgumentException) {
-                    throw new ArgumentException("Invalid host name.", nameof(domainName));
+                    throw new ArgumentException($"Invalid host name '{trimmed}'.", nameof(domainName));
                 }
 
                 var rebuilt = portIndex > 0 && trimmed.IndexOf(':') == portIndex
@@ -295,13 +295,13 @@ namespace DomainDetective {
                     : hostName;
 
                 if (!Uri.TryCreate($"http://{rebuilt}", UriKind.Absolute, out uri)) {
-                    throw new ArgumentException("Invalid host name.", nameof(domainName));
+                    throw new ArgumentException($"Invalid host name '{trimmed}'.", nameof(domainName));
                 }
             }
 
             if (!string.IsNullOrEmpty(uri.PathAndQuery) && uri.PathAndQuery != "/" ||
                 !string.IsNullOrEmpty(uri.Fragment)) {
-                throw new ArgumentException("Invalid host name.", nameof(domainName));
+                throw new ArgumentException($"Invalid host name '{trimmed}'.", nameof(domainName));
             }
 
             var host = uri.IdnHost;
@@ -310,14 +310,14 @@ namespace DomainDetective {
                 if (labels.Length == 0 ||
                     !Helpers.DomainHelper.IsValidTld(labels[labels.Length - 1])) {
                     throw new ArgumentException(
-                        "Invalid host name.",
+                        $"Invalid host name '{trimmed}'.",
                         nameof(domainName));
                 }
             }
 
             if (!uri.IsDefaultPort) {
                 if (uri.Port <= 0 || uri.Port > 65535) {
-                    throw new ArgumentException("Invalid port.", nameof(domainName));
+                    throw new ArgumentException($"Invalid port '{uri.Port}'.", nameof(domainName));
                 }
                 return $"{NormalizeDomain(host)}:{uri.Port}";
             }


### PR DESCRIPTION
## Summary
- include offending values in `ValidateHostName` exceptions
- verify new messages with tests

## Testing
- `dotnet test` *(fails: Host not reachable)*

------
https://chatgpt.com/codex/tasks/task_e_68832d37e7a0832e9cb8e7705916b7b4