### PR TITLE
Fix DANE cmdlet cancellation handling

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -53,7 +53,7 @@ namespace DomainDetective.PowerShell {
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Querying DANE record for domain: {0}", DomainName);
             var ports = Ports != null && Ports.Length > 0 ? Ports : new[] { (int)ServiceType.SMTP };
-            await healthCheck.VerifyDANE(DomainName, ports, CancelToken);
+            await healthCheck.VerifyDANE(DomainName, ports, cancellationToken: CancelToken);
             WriteObject(healthCheck.DaneAnalysis);
         }
     }

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -5,7 +5,10 @@ Describe 'Test-DaneRecord cmdlet' {
             Import-Module "$using:PSScriptRoot/../DomainDetective.psd1" -Force
             Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose
         }
-        Start-Sleep -Milliseconds 20
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($job.State -eq 'NotStarted' -and $stopwatch.ElapsedMilliseconds -lt 1000) {
+            Start-Sleep -Milliseconds 10
+        }
         Stop-Job $job
         Wait-Job $job
         $job.ChildJobs[0].State | Should -Be 'Stopped'
@@ -16,7 +19,10 @@ Describe 'Test-DaneRecord cmdlet' {
         $ps = [powershell]::Create()
         $ps.AddScript("Import-Module '$PSScriptRoot/../DomainDetective.psd1' -Force; Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose") | Out-Null
         $handle = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 20
+        $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        while ($ps.InvocationStateInfo.State -eq 'NotStarted' -and $stopwatch.ElapsedMilliseconds -lt 1000) {
+            Start-Sleep -Milliseconds 10
+        }
         $ps.Stop()
         $null = $handle.AsyncWaitHandle.WaitOne()
         $ps.InvocationStateInfo.State | Should -Be 'Stopped'

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'Test-DaneRecord cmdlet' {
             Import-Module "$using:PSScriptRoot/../DomainDetective.psd1" -Force
             Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose
         }
-        Start-Sleep -Milliseconds 50
+        Start-Sleep -Milliseconds 20
         Stop-Job $job
         Wait-Job $job
         $job.ChildJobs[0].State | Should -Be 'Stopped'
@@ -16,7 +16,7 @@ Describe 'Test-DaneRecord cmdlet' {
         $ps = [powershell]::Create()
         $ps.AddScript("Import-Module '$PSScriptRoot/../DomainDetective.psd1' -Force; Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose") | Out-Null
         $handle = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 200
+        Start-Sleep -Milliseconds 20
         $ps.Stop()
         $null = $handle.AsyncWaitHandle.WaitOne()
         $ps.InvocationStateInfo.State | Should -Be 'Stopped'

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -10,4 +10,16 @@ Describe 'Test-DaneRecord cmdlet' {
         Wait-Job $job
         $job.ChildJobs[0].State | Should -Be 'Stopped'
     }
+
+    It 'cancels using PowerShell.Stop()' {
+        Import-Module "$PSScriptRoot/../DomainDetective.psd1" -Force
+        $ps = [powershell]::Create()
+        $ps.AddScript("Import-Module '$PSScriptRoot/../DomainDetective.psd1' -Force; Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose") | Out-Null
+        $handle = $ps.BeginInvoke()
+        Start-Sleep -Milliseconds 500
+        $ps.Stop()
+        $null = $handle.AsyncWaitHandle.WaitOne()
+        $ps.InvocationStateInfo.State | Should -Be 'Stopped'
+        $ps.Dispose()
+    }
 }

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Test-DaneRecord cmdlet' {
         $ps = [powershell]::Create()
         $ps.AddScript("Import-Module '$PSScriptRoot/../DomainDetective.psd1' -Force; Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose") | Out-Null
         $handle = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 20
+        Start-Sleep -Milliseconds 200
         $ps.Stop()
         $null = $handle.AsyncWaitHandle.WaitOne()
         $ps.InvocationStateInfo.State | Should -Be 'Stopped'

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -5,7 +5,7 @@ Describe 'Test-DaneRecord cmdlet' {
             Import-Module "$using:PSScriptRoot/../DomainDetective.psd1" -Force
             Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose
         }
-        Start-Sleep -Milliseconds 500
+        Start-Sleep -Milliseconds 50
         Stop-Job $job
         Wait-Job $job
         $job.ChildJobs[0].State | Should -Be 'Stopped'
@@ -16,7 +16,7 @@ Describe 'Test-DaneRecord cmdlet' {
         $ps = [powershell]::Create()
         $ps.AddScript("Import-Module '$PSScriptRoot/../DomainDetective.psd1' -Force; Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose") | Out-Null
         $handle = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 100
+        Start-Sleep -Milliseconds 20
         $ps.Stop()
         $null = $handle.AsyncWaitHandle.WaitOne()
         $ps.InvocationStateInfo.State | Should -Be 'Stopped'

--- a/Module/Tests/Dane.Tests.ps1
+++ b/Module/Tests/Dane.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Test-DaneRecord cmdlet' {
         $ps = [powershell]::Create()
         $ps.AddScript("Import-Module '$PSScriptRoot/../DomainDetective.psd1' -Force; Test-TlsDane -DomainName 'does-not-exist.invalid' -DnsEndpoint System -Verbose") | Out-Null
         $handle = $ps.BeginInvoke()
-        Start-Sleep -Milliseconds 500
+        Start-Sleep -Milliseconds 100
         $ps.Stop()
         $null = $handle.AsyncWaitHandle.WaitOne()
         $ps.InvocationStateInfo.State | Should -Be 'Stopped'


### PR DESCRIPTION
## Summary
- ensure `CancelToken` is passed to `VerifyDANE`
- add PowerShell test verifying cancellation via `PowerShell.Stop()`

## Testing
- `dotnet test DomainDetective.sln -c Release -p:TargetFramework=net8.0`
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path Module/Tests/Dane.Tests.ps1 -Output Detailed"` *(fails: Invoke-Pester not available)*

------
https://chatgpt.com/codex/tasks/task_e_688392bf1f04832e84dac2343a4ed25e