### PR TITLE
Fix exception message for unknown health check type

### DIFF
--- a/DomainDetective.Tests/TestUnknownHealthCheckType.cs
+++ b/DomainDetective.Tests/TestUnknownHealthCheckType.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.Tests {
             var healthCheck = new DomainHealthCheck();
             var ex = await Assert.ThrowsAsync<NotSupportedException>(async () =>
                 await healthCheck.Verify("example.com", new[] { (HealthCheckType)999 }));
-            Assert.Contains("999", ex.Message);
+            Assert.Equal("Health check type not implemented: 999", ex.Message);
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -164,7 +164,7 @@ namespace DomainDetective {
                     await action();
                 } else {
                     _logger.WriteError("Unknown health check type: {0}", healthCheckType);
-                    throw new NotSupportedException($"Health check type not implemented: {healthCheckType}");
+                    throw new NotSupportedException($"Health check type not implemented: {(int)healthCheckType}");
                 }
 
                 processedChecks++;


### PR DESCRIPTION
## Summary
- show numeric value of unknown HealthCheckType in exception message
- verify exception message content with a unit test

## Testing
- `dotnet build --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter FullyQualifiedName~TestUnknownHealthCheckType --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_688392c488cc832eb042d3c417ab718b