### PR TITLE
Fix MTA‑STS override validation

### DIFF
--- a/DomainDetective.Tests/TestMtaStsPolicyUrlOverride.cs
+++ b/DomainDetective.Tests/TestMtaStsPolicyUrlOverride.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace DomainDetective.Tests {
+    public class TestMtaStsPolicyUrlOverride {
+        [Fact]
+        public void AcceptsAbsoluteUri() {
+            var hc = new DomainHealthCheck();
+            const string url = "https://example.com/policy.txt";
+            hc.MtaStsPolicyUrlOverride = url;
+            Assert.Equal(url, hc.MtaStsPolicyUrlOverride);
+        }
+
+        [Fact]
+        public void ThrowsOnRelativeUri() {
+            var hc = new DomainHealthCheck();
+            Assert.Throws<ArgumentException>(() => hc.MtaStsPolicyUrlOverride = "policy.txt");
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -39,7 +39,20 @@ namespace DomainDetective {
 
         /// <summary>Optional override for the MTA-STS policy URL.</summary>
         /// <value>A URL to use instead of querying DNS.</value>
-        public string MtaStsPolicyUrlOverride { get; set; }
+        public string? MtaStsPolicyUrlOverride {
+            get => _mtaStsPolicyUrlOverride;
+            set {
+                if (value is null) {
+                    _mtaStsPolicyUrlOverride = null;
+                } else if (!Uri.TryCreate(value, UriKind.Absolute, out _)) {
+                    throw new ArgumentException("Value must be an absolute URI", nameof(value));
+                } else {
+                    _mtaStsPolicyUrlOverride = value;
+                }
+            }
+        }
+
+        private string? _mtaStsPolicyUrlOverride;
 
         /// <summary>API key for Google Safe Browsing.</summary>
         public string? GoogleSafeBrowsingApiKey { get; set; }


### PR DESCRIPTION
## Summary
- ensure DomainHealthCheck only accepts absolute URIs for the MTASTS policy override
- throw `ArgumentException` when an invalid URI is assigned
- test MTA‑STS override URI validation

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release` *(fails: Host not reachable)*
- `dotnet build DomainDetective.sln --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_688392cd8fb0832e93b7483b76390329