### PR TITLE
Fix cancellation token handling

### DIFF
--- a/DomainDetective/DomainHealthCheck.Verification.Dane.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Dane.cs
@@ -13,11 +13,12 @@ namespace DomainDetective {
         /// <param name="daneRecord">TLSA record text.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         public async Task CheckDANE(string daneRecord, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
             await DaneAnalysis.AnalyzeDANERecords(new List<DnsAnswer> {
                 new DnsAnswer {
                     DataRaw = daneRecord
                 }
-            }, _logger);
+            }, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -26,10 +27,11 @@ namespace DomainDetective {
         /// <param name="daneRecords">Collection of TLSA record texts.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
         public async Task CheckDANE(IEnumerable<string> daneRecords, CancellationToken cancellationToken = default) {
+            cancellationToken.ThrowIfCancellationRequested();
             var answers = daneRecords.Select(record => new DnsAnswer {
                 DataRaw = record
             }).ToList();
-            await DaneAnalysis.AnalyzeDANERecords(answers, _logger);
+            await DaneAnalysis.AnalyzeDANERecords(answers, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -65,7 +67,8 @@ namespace DomainDetective {
             }
 
             if (allDaneRecords.Count > 0) {
-                await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger);
+                cancellationToken.ThrowIfCancellationRequested();
+                await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger, cancellationToken);
             } else {
                 _logger.WriteWarning("No DANE records found.");
             }
@@ -98,7 +101,8 @@ namespace DomainDetective {
             }
 
             if (allDaneRecords.Count > 0) {
-                await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger);
+                cancellationToken.ThrowIfCancellationRequested();
+                await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger, cancellationToken);
             } else {
                 _logger.WriteWarning("No DANE records found.");
             }
@@ -172,7 +176,8 @@ namespace DomainDetective {
 
             }
             if (allDaneRecords.Count > 0) {
-                await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger);
+                cancellationToken.ThrowIfCancellationRequested();
+                await DaneAnalysis.AnalyzeDANERecords(allDaneRecords, _logger, cancellationToken);
             } else {
                 _logger.WriteWarning("No DANE records found.");
             }

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -2,6 +2,7 @@ using DnsClientX;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace DomainDetective {
@@ -33,8 +34,10 @@ namespace DomainDetective {
         }
 
 
-        public async Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        public async Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger, CancellationToken cancellationToken = default) {
             Reset();
+
+            cancellationToken.ThrowIfCancellationRequested();
 
             if (dnsResults == null) {
                 logger?.WriteVerbose("DNS query returned no results.");
@@ -52,6 +55,7 @@ namespace DomainDetective {
             NumberOfRecords = daneRecordList.Count;
 
             foreach (var record in daneRecordList) {
+                cancellationToken.ThrowIfCancellationRequested();
                 var analysis = new DANERecordAnalysis();
                 analysis.DomainName = record.Name;
                 analysis.DANERecord = record.Data;
@@ -163,6 +167,7 @@ namespace DomainDetective {
                 AnalysisResults.Add(analysis);
             }
 
+            cancellationToken.ThrowIfCancellationRequested();
             HasInvalidRecords = AnalysisResults.Any(x => !x.ValidDANERecord);
         }
 


### PR DESCRIPTION
## Summary
- propagate cancellation token in DANE health checks
- pass token to `AnalyzeDANERecords`
- update unit tests and add cancellation tests

## Testing
- `dotnet build -c Release`
- `dotnet test -c Release --filter "FullyQualifiedName~TestDANEnalysis.CheckDaneHonorsCancellation"`
- `dotnet test -c Release --filter "FullyQualifiedName~TestDANEnalysis.VerifyDaneHonorsCancellation"`


------
https://chatgpt.com/codex/tasks/task_e_688392d60880832eb250d25a6f50f689