### PR TITLE
Handle canceled trust anchor downloads

### DIFF
--- a/DomainDetective.Tests/TestDnssecCacheCleanup.cs
+++ b/DomainDetective.Tests/TestDnssecCacheCleanup.cs
@@ -1,0 +1,22 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestDnssecCacheCleanup {
+        [Fact]
+        public async Task DeletesCacheFileOnCancel() {
+            string cacheDir = Path.Combine(Path.GetTempPath(), "DomainDetective");
+            string cacheFile = Path.Combine(cacheDir, "root-anchors.xml");
+            if (File.Exists(cacheFile)) {
+                File.Delete(cacheFile);
+            }
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => DnsSecAnalysis.DownloadTrustAnchors(null, cts.Token));
+            Assert.False(File.Exists(cacheFile));
+        }
+    }
+}

--- a/DomainDetective/DomainHealthCheck.Verification.DnsRecords.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.DnsRecords.cs
@@ -23,7 +23,7 @@ namespace DomainDetective {
                 return;
             }
             DnsSecAnalysis = new DnsSecAnalysis();
-            await DnsSecAnalysis.Analyze(domainName, _logger, DnsConfiguration);
+            await DnsSecAnalysis.Analyze(domainName, _logger, DnsConfiguration, cancellationToken);
         }
 
 


### PR DESCRIPTION
## Summary
- track trust anchor cache file creation in DNSSEC analysis
- clean up the cache file if downloading is canceled
- pass cancellation token from health check DNSSEC verification
- test that cancelled downloads remove the temporary file

## Testing
- `dotnet test` *(fails: Should exceed DNS lookups due to many includes)*

------
https://chatgpt.com/codex/tasks/task_e_68839618e464832e883141df885bf3c0