### PR TITLE
Ensure VerifyPlainHttp retains explicit port

### DIFF
--- a/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
+++ b/DomainDetective.Tests/TestPlainHttpHealthCheck.cs
@@ -58,6 +58,14 @@ namespace DomainDetective.Tests {
                 await healthCheck.VerifyPlainHttp(domain));
         }
 
+        [Fact]
+        public async Task VerifyPlainHttpUsesExplicitPort() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.HttpAnalysis.Timeout = TimeSpan.FromMilliseconds(500);
+            await healthCheck.VerifyPlainHttp("example.com:8080");
+            Assert.Equal("http://example.com:8080/", healthCheck.HttpAnalysis.VisitedUrls[0]);
+        }
+
         private static int GetFreePort() {
             return PortHelper.GetFreePort();
         }

--- a/DomainDetective/DomainHealthCheck.Verification.Http.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Http.cs
@@ -24,8 +24,14 @@ namespace DomainDetective {
                 throw new ArgumentNullException(nameof(domainName));
             }
             domainName = ValidateHostName(domainName);
-            UpdateIsPublicSuffix(domainName);
-            await HttpAnalysis.AnalyzeUrl($"http://{domainName}", false, _logger, cancellationToken: cancellationToken);
+            if (!Uri.TryCreate($"http://{domainName}", UriKind.Absolute, out var uri)) {
+                throw new ArgumentException($"Invalid host name '{domainName}'.", nameof(domainName));
+            }
+
+            var host = ValidateHostName(uri.Host);
+            var hostWithPort = uri.IsDefaultPort ? host : $"{host}:{uri.Port}";
+            UpdateIsPublicSuffix(host);
+            await HttpAnalysis.AnalyzeUrl($"http://{hostWithPort}", false, _logger, cancellationToken: cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Summary
- keep explicit port when verifying plain HTTP
- test plain HTTP with example.com port

## Testing
- `dotnet test DomainDetective.sln -c Release` *(fails: `Assert.Contains() Failure: Item not found in collection`)*

------
https://chatgpt.com/codex/tasks/task_e_688396217858832e9f0e5e09269ba829