### PR TITLE
Add protocol detail to certificate monitor

### DIFF
--- a/DomainDetective.Tests/TestCertificateMonitor.cs
+++ b/DomainDetective.Tests/TestCertificateMonitor.cs
@@ -15,6 +15,10 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, monitor.Results.Count);
             Assert.True(monitor.ValidCount >= 1);
             Assert.True(monitor.FailedCount >= 1);
+
+            var reachable = monitor.Results.Find(r => r.Analysis.IsReachable);
+            Assert.NotNull(reachable);
+            Assert.Equal(reachable!.Analysis.TlsProtocol, reachable.Protocol);
         }
 
         [Fact]

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Authentication;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,6 +30,8 @@ namespace DomainDetective {
             public bool Expired { get; init; }
             /// <summary>Whether the certificate chain contained all intermediates.</summary>
             public bool ChainComplete { get; init; }
+            /// <summary>The negotiated TLS protocol.</summary>
+            public SslProtocols Protocol { get; init; }
             /// <summary>Captured analysis details.</summary>
             public CertificateAnalysis Analysis { get; init; }
         }
@@ -133,7 +136,10 @@ namespace DomainDetective {
                 if (showProgress) {
                     logger.WriteProgress("CertificateMonitor", host, processed * 100d / list.Count, processed, list.Count);
                 }
-                var analysis = new CertificateAnalysis();
+                var analysis = new CertificateAnalysis
+                {
+                    CaptureTlsDetails = true
+                };
                 await analysis.AnalyzeUrl(host, port, logger, cancellationToken);
                 var entry = new Entry {
                     Host = host,
@@ -141,6 +147,7 @@ namespace DomainDetective {
                     Valid = analysis.IsValid,
                     Expired = analysis.IsExpired,
                     ChainComplete = analysis.Chain.Count > 1 && analysis.IsValid,
+                    Protocol = analysis.TlsProtocol,
                     Analysis = analysis
                 };
                 Results.Add(entry);


### PR DESCRIPTION
## Summary
- track the negotiated TLS protocol in `CertificateMonitor.Entry`
- capture TLS details during monitor analysis
- assert protocol data in certificate monitor tests

## Testing
- `dotnet test` *(fails: `$XunitDynamicSkip$Hosts not reachable`, `DNS queries unavailable`)*

------
https://chatgpt.com/codex/tasks/task_e_6883965109bc832e8b10d3e68a175393