### PR TITLE
Improve RDAP error reporting

### DIFF
--- a/DomainDetective.Tests/TestRdapAnalysis.cs
+++ b/DomainDetective.Tests/TestRdapAnalysis.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace DomainDetective.Tests {
@@ -62,10 +63,14 @@ namespace DomainDetective.Tests {
             logger.OnErrorMessage += (_, e) => error = e;
 
             var analysis = new RdapAnalysis {
+#if NET6_0_OR_GREATER
                 QueryOverride = _ => throw new HttpRequestException(
                     "NotFound",
                     null,
                     HttpStatusCode.NotFound),
+#else
+                QueryOverride = _ => throw new HttpRequestException("404"),
+#endif
                 RdapClient = new RdapClient("http://localhost")
             };
 
@@ -85,10 +90,14 @@ namespace DomainDetective.Tests {
             logger.OnErrorMessage += (_, e) => error = e;
 
             var analysis = new RdapAnalysis {
+#if NET6_0_OR_GREATER
                 QueryOverride = _ => throw new HttpRequestException(
                     "ServerError",
                     null,
                     HttpStatusCode.InternalServerError),
+#else
+                QueryOverride = _ => throw new HttpRequestException("500"),
+#endif
                 RdapClient = new RdapClient("http://localhost")
             };
 

--- a/DomainDetective.Tests/TestRdapAnalysis.cs
+++ b/DomainDetective.Tests/TestRdapAnalysis.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Net;
+using System.Text;
 using System.Threading.Tasks;
+using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestRdapAnalysis {
@@ -50,6 +53,72 @@ namespace DomainDetective.Tests {
             await analysis2.Analyze("example.net", new InternalLogger());
 
             Assert.Equal(2, hitCount);
+        }
+
+        [Fact]
+        public async Task NotFoundResponseLogged() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
+            using var listener = new HttpListener();
+            var port = PortHelper.GetFreePort();
+            var prefix = $"http://localhost:{port}/domain/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            PortHelper.ReleasePort(port);
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 404;
+                ctx.Response.Close();
+            });
+
+            var logger = new InternalLogger();
+            LogEventArgs? error = null;
+            logger.OnErrorMessage += (_, e) => error = e;
+
+            try {
+                var analysis = new RdapAnalysis { RdapClient = new RdapClient($"http://localhost:{port}") };
+                await analysis.Analyze("example.com", logger);
+                Assert.Null(analysis.DomainData);
+                Assert.NotNull(error);
+                Assert.Contains("404", error!.FullMessage);
+                Assert.Contains($"http://localhost:{port}/domain/example.com", error.FullMessage);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
+        public async Task ServerErrorThrowsAndLogs() {
+            if (!HttpListener.IsSupported) {
+                throw SkipException.ForSkip("HttpListener not supported");
+            }
+            using var listener = new HttpListener();
+            var port = PortHelper.GetFreePort();
+            var prefix = $"http://localhost:{port}/domain/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            PortHelper.ReleasePort(port);
+            var serverTask = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 500;
+                ctx.Response.Close();
+            });
+
+            var logger = new InternalLogger();
+            LogEventArgs? error = null;
+            logger.OnErrorMessage += (_, e) => error = e;
+            try {
+                var analysis = new RdapAnalysis { RdapClient = new RdapClient($"http://localhost:{port}") };
+                await Assert.ThrowsAsync<HttpRequestException>(() => analysis.Analyze("example.com", logger));
+                Assert.NotNull(error);
+                Assert.Contains("500", error!.FullMessage);
+                Assert.Contains($"http://localhost:{port}/domain/example.com", error.FullMessage);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
         }
     }
 }

--- a/DomainDetective.Tests/TestRdapAnalysis.cs
+++ b/DomainDetective.Tests/TestRdapAnalysis.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
-using Xunit.Sdk;
 
 namespace DomainDetective.Tests {
     public class TestRdapAnalysis {
         [Fact]
         public async Task ParsesRdapResponse() {
+            RdapAnalysis.ClearCache();
             const string json = "{\"ldhName\":\"example.com\",\"status\":[\"active\"],\"nameservers\":[{\"ldhName\":\"ns1.example.net\"},{\"ldhName\":\"ns2.example.net\"}],\"events\":[{\"eventAction\":\"registration\",\"eventDate\":\"2000-01-01T00:00:00Z\"},{\"eventAction\":\"expiration\",\"eventDate\":\"2030-01-01T00:00:00Z\"}],\"entities\":[{\"handle\":\"123\",\"roles\":[\"registrar\"],\"vcardArray\":[\"vcard\",[[\"fn\",{},\"text\",\"Registrar Inc\"]]]}]}";
             var analysis = new RdapAnalysis { QueryOverride = _ => Task.FromResult(json) };
             await analysis.Analyze("example.com", new InternalLogger());
@@ -57,6 +56,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task NotFoundResponseLogged() {
+            RdapAnalysis.ClearCache();
             var logger = new InternalLogger();
             LogEventArgs? error = null;
             logger.OnErrorMessage += (_, e) => error = e;
@@ -79,6 +79,7 @@ namespace DomainDetective.Tests {
 
         [Fact]
         public async Task ServerErrorThrowsAndLogs() {
+            RdapAnalysis.ClearCache();
             var logger = new InternalLogger();
             LogEventArgs? error = null;
             logger.OnErrorMessage += (_, e) => error = e;


### PR DESCRIPTION
## Summary
- include status code and URI when RDAP analysis fails
- allow tests to swap in a custom `RdapClient`
- test non-200 RDAP responses

## Testing
- `dotnet test` *(fails: Host not reachable, Exceeds lookups should be true)*

------
https://chatgpt.com/codex/tasks/task_e_688396576630832ead1fb44e94c12d75