### PR TITLE
Fix DMARC RUF size warning test

### DIFF
--- a/DomainDetective/Settings.cs
+++ b/DomainDetective/Settings.cs
@@ -5,7 +5,7 @@ namespace DomainDetective {
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
     public class Settings {
-        protected static InternalLogger _logger = new InternalLogger();
+        protected InternalLogger _logger = new InternalLogger();
 
         /// <summary>
         /// Gets or sets a value indicating whether error messages are written.


### PR DESCRIPTION
## Summary
- avoid static logger in `Settings` to prevent concurrency issues

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: DNS queries unavailable)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter "FullyQualifiedName~RufSizeWarningWhenTooLarge" --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68875193b65c832ea88e580b4f76077a