### PR TITLE
Fix logger deduplication causing test flakiness

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysis.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysis.cs
@@ -298,5 +298,23 @@ namespace DomainDetective.Tests {
             Assert.Contains("h=sha1:sha256", result.DeprecatedTags);
             Assert.Contains(warnings, w => w.FullMessage.Contains("deprecated"));
         }
+
+        [Fact]
+        public async Task LogsWarningsAcrossInstances() {
+            const string record = "v=DKIM1; g=*; k=rsa; p=QUJD";
+
+            var logger = new InternalLogger();
+            var warnings = new List<LogEventArgs>();
+            logger.OnWarningMessage += (_, e) => warnings.Add(e);
+
+            var first = new DomainHealthCheck(internalLogger: logger);
+            await first.CheckDKIM(record);
+
+            var second = new DomainHealthCheck(internalLogger: logger);
+            await second.CheckDKIM(record);
+
+            var count = warnings.Count(w => w.FullMessage.Contains("deprecated"));
+            Assert.Equal(2, count);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -387,6 +387,7 @@ namespace DomainDetective {
             if (internalLogger != null) {
                 _logger = internalLogger;
             }
+            _logger.ClearLoggedMessages();
             DnsEndpoint = dnsEndpoint;
             DnsSelectionStrategy = DnsSelectionStrategy.First;
 

--- a/DomainDetective/Logger/InternalLogger.cs
+++ b/DomainDetective/Logger/InternalLogger.cs
@@ -83,6 +83,15 @@ namespace DomainDetective {
             IsVerbose = isVerbose;
         }
 
+        /// <summary>
+        /// Clears cached messages to allow duplicates to be logged again.
+        /// </summary>
+        public void ClearLoggedMessages() {
+            lock (_lock) {
+                _loggedMessages.Clear();
+            }
+        }
+
         public void WriteProgress(string activity, string currentOperation, double percentCompleted, int? currentSteps = null, int? totalSteps = null) {
             lock (_lock) {
                 var roundedPercent = (int)Math.Round(percentCompleted);


### PR DESCRIPTION
## Summary
- clear InternalLogger message cache for each new DomainHealthCheck
- expose `ClearLoggedMessages` on `InternalLogger`
- add regression test to ensure warnings are not deduplicated across instances

## Testing
- `dotnet build --no-restore`
- `dotnet test DomainDetective.Tests --filter "DetectsDeprecatedTags|LogsWarningsAcrossInstances" --no-build`

------
https://chatgpt.com/codex/tasks/task_e_688751bbc71c832e8344d5f9614cc148