### PR TITLE
Fix SNMP probe reliability

### DIFF
--- a/DomainDetective/Protocols/SnmpAnalysis.cs
+++ b/DomainDetective/Protocols/SnmpAnalysis.cs
@@ -55,11 +55,12 @@ public class SnmpAnalysis
             using var udp = new UdpClient();
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             cts.CancelAfter(timeout);
+            udp.Connect(host, port);
 #if NET8_0_OR_GREATER
-            await udp.SendAsync(Probe, host, port, cts.Token);
+            await udp.SendAsync(Probe, cts.Token);
             var result = await udp.ReceiveAsync(cts.Token);
 #else
-            await udp.SendAsync(Probe, Probe.Length, host, port).WaitWithCancellation(cts.Token);
+            await udp.SendAsync(Probe, Probe.Length).WaitWithCancellation(cts.Token);
             var result = await udp.ReceiveAsync().WaitWithCancellation(cts.Token);
 #endif
             return result.Buffer.Length > 0;


### PR DESCRIPTION
## Summary
- connect UDP socket before sending SNMP probe

## Testing
- `dotnet test --filter "FullyQualifiedName=DomainDetective.Tests.TestPortScanAnalysis.DetectsSnmpUdpBanner" -v n`
- `dotnet test` *(fails: KeyNotFoundException, Should exceed DNS lookups, Exceeds lookups should be true, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688792156098832e86f1790ecb7a7781