### PR TITLE
Add advanced HTML report base

### DIFF
--- a/DomainDetective.Reports.Html.Advanced/AdvancedReportBase.cs
+++ b/DomainDetective.Reports.Html.Advanced/AdvancedReportBase.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using HtmlForgeX;
+
+namespace DomainDetective.Reports.Html.Advanced;
+
+/// <summary>
+/// Provides base functionality for advanced HTML reports.
+/// Handles standard layout and progress log rendering.
+/// </summary>
+public abstract class AdvancedReportBase {
+    private readonly List<LogEventArgs> _progressLog = new();
+
+    /// <summary>
+    /// Collected progress log entries.
+    /// </summary>
+    protected IReadOnlyList<LogEventArgs> ProgressLog => _progressLog;
+
+    /// <summary>
+    /// Associated health check instance.
+    /// </summary>
+    protected DomainHealthCheck HealthCheck { get; }
+
+    /// <summary>
+    /// Domain name used for the report.
+    /// </summary>
+    protected string Domain { get; }
+
+    protected AdvancedReportBase(DomainHealthCheck healthCheck, string domain, IEnumerable<LogEventArgs>? progressLog = null) {
+        HealthCheck = healthCheck;
+        Domain = domain;
+        if (progressLog != null) {
+            _progressLog.AddRange(progressLog);
+        }
+    }
+
+    /// <summary>
+    /// Adds a progress log entry to the report.
+    /// </summary>
+    protected void AddProgressLog(LogEventArgs entry) {
+        _progressLog.Add(entry);
+    }
+
+    /// <summary>
+    /// Creates a new HTML document with common settings.
+    /// </summary>
+    protected static Document CreateDocument(string title) {
+        return new Document {
+            Head = {
+                Title = title,
+                Author = "DomainDetective",
+            },
+            LibraryMode = LibraryMode.Online,
+            ThemeMode = ThemeMode.Light
+        };
+    }
+
+    /// <summary>
+    /// Renders collected progress log entries as a list.
+    /// </summary>
+    protected void RenderProgressLog(TablerPage page) {
+        if (_progressLog.Count == 0) {
+            return;
+        }
+
+        page.Divider("Scan Progress");
+        page.Row(row => {
+            row.Column(TablerColumnNumber.Twelve, col => {
+                col.Card(card => {
+                    card.Header(h => h.Title("Progress Log"));
+                    card.Body(body => {
+                        body.AddList(list => {
+                            list.WithItems(items => {
+                                foreach (var entry in _progressLog) {
+                                    var text = entry.FullMessage;
+                                    if (entry.ProgressPercentage.HasValue) {
+                                        text += $" ({entry.ProgressPercentage.Value}%)";
+                                    }
+                                    items.Item(text);
+                                }
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}

--- a/DomainDetective.Reports.Html.Advanced/DomainDetective.Reports.Html.Advanced.csproj
+++ b/DomainDetective.Reports.Html.Advanced/DomainDetective.Reports.Html.Advanced.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
+    <ProjectReference Include="..\DomainDetective.Reports\DomainDetective.Reports.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="HtmlForgeX" Version="0.2.0" />
+  </ItemGroup>
+</Project>

--- a/DomainDetective.Reports.Html.Advanced/README.md
+++ b/DomainDetective.Reports.Html.Advanced/README.md
@@ -1,0 +1,13 @@
+# DomainDetective Advanced HTML Reports
+
+This project extends the basic HTML reporting by providing a common base for advanced layouts.
+
+## Usage
+
+```csharp
+var healthCheck = new DomainHealthCheck();
+var report = new CustomReport(healthCheck, "example.com");
+report.Generate("report.html");
+```
+
+The `CustomReport` type derives from `AdvancedReportBase` and can use `RenderProgressLog` to include scan progress in the output.

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -36,6 +36,7 @@
         <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
         <ProjectReference Include="..\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj" />
         <ProjectReference Include="..\DomainDetective.Reports\DomainDetective.Reports.csproj" />
+        <ProjectReference Include="..\DomainDetective.Reports.Html.Advanced\DomainDetective.Reports.Html.Advanced.csproj" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">

--- a/DomainDetective.Tests/TestAdvancedReportBase.cs
+++ b/DomainDetective.Tests/TestAdvancedReportBase.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using DomainDetective.Reports.Html.Advanced;
+
+namespace DomainDetective.Tests;
+
+public class TestAdvancedReportBase {
+    private class DummyReport : AdvancedReportBase {
+        public DummyReport(DomainHealthCheck hc) : base(hc, "example.com") { }
+        public IReadOnlyList<LogEventArgs> Logs => ProgressLog;
+    }
+
+    [Fact]
+    public void AddsLogEntry() {
+        var report = new DummyReport(new DomainHealthCheck());
+        var entry = new LogEventArgs("Activity", "Step", 1, 2, 50);
+        var method = report.GetType().GetMethod("AddProgressLog", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!;
+        method.Invoke(report, new object[] { entry });
+        Assert.Single(report.Logs);
+        Assert.Equal("Step", report.Logs[0].ProgressCurrentOperation);
+    }
+}

--- a/DomainDetective.sln
+++ b/DomainDetective.sln
@@ -31,6 +31,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.Reports.Off
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.Reports.Pdf", "DomainDetective.Reports.Pdf\DomainDetective.Reports.Pdf.csproj", "{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DomainDetective.Reports.Html.Advanced", "DomainDetective.Reports.Html.Advanced\DomainDetective.Reports.Html.Advanced.csproj", "{4DAA655D-005E-407E-BC71-890416D8EA65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -170,10 +172,22 @@ Global
 		{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x64.ActiveCfg = Release|Any CPU
-		{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x64.Build.0 = Release|Any CPU
-		{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x86.ActiveCfg = Release|Any CPU
-		{F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
+                {F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x64.Build.0 = Release|Any CPU
+                {F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x86.ActiveCfg = Release|Any CPU
+                {F1E2D3C4-B5A6-9870-4321-FEDCBA098765}.Release|x86.Build.0 = Release|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Debug|x64.ActiveCfg = Debug|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Debug|x64.Build.0 = Debug|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Debug|x86.ActiveCfg = Debug|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Debug|x86.Build.0 = Debug|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Release|Any CPU.Build.0 = Release|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Release|x64.ActiveCfg = Release|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Release|x64.Build.0 = Release|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Release|x86.ActiveCfg = Release|Any CPU
+                {4DAA655D-005E-407E-BC71-890416D8EA65}.Release|x86.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- introduce `DomainDetective.Reports.Html.Advanced` project
- implement `AdvancedReportBase` for common layout and progress logs
- wire new project into solution and unit tests

## Testing
- `dotnet test --no-build` *(fails: ParseUnicodeDomain)*

------
https://chatgpt.com/codex/tasks/task_e_688b4596183c832ea7890bc4c9e65e77