### PR TITLE
Add SPF tree flattening

### DIFF
--- a/DomainDetective.Example/ExampleFlattenSpfTree.cs
+++ b/DomainDetective.Example/ExampleFlattenSpfTree.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Example showing how to render the flattened SPF tree.
+    /// </summary>
+    public static async Task ExampleFlattenSpfTree() {
+        var healthCheck = new DomainHealthCheck();
+        await healthCheck.Verify("github.com", [HealthCheckType.SPF]);
+        var tree = await healthCheck.SpfAnalysis.GetFlattenedSpfTree();
+        Helpers.ShowPropertiesTable("Flattened SPF tree for github.com", tree, unicode: true);
+    }
+}

--- a/DomainDetective.Reports.Html/BasicDomainReport.cs
+++ b/DomainDetective.Reports.Html/BasicDomainReport.cs
@@ -94,6 +94,16 @@ public class BasicDomainReport {
                                     grid.AddItem("DNSSEC", hasDsRecords ? "✅ DS Records found" : "⚠️ No DS Records");
                                 }
                             });
+
+                            if (_healthCheck.SpfAnalysis?.SpfRecordExists == true) {
+                                var tree = _healthCheck.SpfAnalysis.GetFlattenedSpfTree().GetAwaiter().GetResult();
+                                body.DataGrid(tg => {
+                                    tg.AddItem("Flattened SPF", string.Join("\n", tree));
+                                    foreach (var warn in _healthCheck.SpfAnalysis.Warnings) {
+                                        tg.AddItem("Warning", warn);
+                                    }
+                                });
+                            }
                         });
                     });
                 });

--- a/DomainDetective.Reports.Html/DomainSecurityReport.cs
+++ b/DomainDetective.Reports.Html/DomainSecurityReport.cs
@@ -236,16 +236,26 @@ public class DomainSecurityReport {
                     card.Body(body => {
                         body.DataGrid(grid => {
                             grid.AddItem("SPF Record", _healthCheck.SpfAnalysis?.SpfRecordExists == true ? "Found" : "Not found");
-                            grid.AddItem("SPF Valid", 
+                            grid.AddItem("SPF Valid",
                                 _healthCheck.SpfAnalysis?.StartsCorrectly == true ? "Yes" : "No");
-                            
+
                             grid.AddItem("DMARC Policy", _healthCheck.DmarcAnalysis?.Policy ?? "Not found");
                             grid.AddItem("DMARC Valid",
                                 _healthCheck.DmarcAnalysis?.DmarcRecordExists == true ? "Yes" : "No");
-                            
-                            grid.AddItem("DKIM Valid", 
+
+                            grid.AddItem("DKIM Valid",
                                 _healthCheck.DKIMAnalysis?.AnalysisResults?.Count > 0 ? "Yes" : "No");
                         });
+
+                        if (_healthCheck.SpfAnalysis?.SpfRecordExists == true) {
+                            var tree = _healthCheck.SpfAnalysis.GetFlattenedSpfTree().GetAwaiter().GetResult();
+                            body.DataGrid(tg => {
+                                tg.AddItem("Flattened SPF", string.Join("\n", tree));
+                                foreach (var warn in _healthCheck.SpfAnalysis.Warnings) {
+                                    tg.AddItem("Warning", warn);
+                                }
+                            });
+                        }
                     });
                 });
             });


### PR DESCRIPTION
## Summary
- extend `SpfAnalysis` with a method returning an indented SPF tree
- show flattened SPF tree and warnings in `BasicDomainReport`
- expose example demonstrating flattened SPF tree
- add unit tests for SPF tree flattening

## Testing
- `dotnet build`
- `dotnet test` *(fails: DNS queries unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_688d069e465c832e918ce675c90f092d