### PR TITLE
docs(powershell): update examples to current aliases

### DIFF
--- a/DomainDetective.PowerShell/CmdletGetFlattenedSpfIp.cs
+++ b/DomainDetective.PowerShell/CmdletGetFlattenedSpfIp.cs
@@ -9,7 +9,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Use the <c>TestSpfRecord</c> parameter to supply an SPF record during tests.</para>
     /// <example>
     ///   <summary>Get flattened SPF IPs.</summary>
-    ///   <code>Get-FlattenedSpfIp -DomainName example.com</code>
+    ///   <code>Get-DomainFlattenedSpfIp -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsCommon.Get, "DDFlattenedSpfIp", DefaultParameterSetName = "ServerName")]
 [Alias("Get-DomainFlattenedSpfIp")]

--- a/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
+++ b/DomainDetective.PowerShell/CmdletGetWhoisInfo.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Get WHOIS details.</summary>
-    ///   <code>Get-WhoisInfo -DomainName example.com</code>
+    ///   <code>Get-DomainWhois -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsCommon.Get, "DDDomainWhois", DefaultParameterSetName = "ServerName")]
 [Alias("Get-DomainWhois")]

--- a/DomainDetective.PowerShell/CmdletTestArc.cs
+++ b/DomainDetective.PowerShell/CmdletTestArc.cs
@@ -8,11 +8,11 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Analyze ARC headers from a file.</summary>
-    ///   <code>Test-Arc -File './headers.txt'</code>
+    ///   <code>Test-EmailArc -File './headers.txt'</code>
     /// </example>
     /// <example>
     ///   <summary>Analyze ARC headers from pipeline input.</summary>
-    ///   <code>Get-Content './headers.txt' -Raw | Test-Arc</code>
+    ///   <code>Get-Content './headers.txt' -Raw | Test-EmailArc</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailArcRecord", DefaultParameterSetName = "Text")]
 [Alias("Test-EmailArc")]

--- a/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestBimiRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check BIMI configuration.</summary>
-    ///   <code>Test-BimiRecord -DomainName example.com</code>
+    ///   <code>Test-EmailBimi -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailBimiRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailBimi")]

--- a/DomainDetective.PowerShell/CmdletTestBlackList.cs
+++ b/DomainDetective.PowerShell/CmdletTestBlackList.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check a single host.</summary>
-    ///   <code>Test-DomainBlacklist -NameOrIpAddress example.com</code>
+    ///   <code>Test-DnsDomainBlacklist -NameOrIpAddress example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsDomainBlacklist", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsDomainBlacklist")]

--- a/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestCaaRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check CAA entries.</summary>
-    ///   <code>Test-CaaRecord -DomainName example.com</code>
+    ///   <code>Test-DnsCaa -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsCaaRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsCaa")]

--- a/DomainDetective.PowerShell/CmdletTestContactRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestContactRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Get contact details.</summary>
-    ///   <code>Test-ContactRecord -DomainName example.com</code>
+    ///   <code>Test-DomainContact -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDomainContactRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DomainContact")]

--- a/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDNSBLRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>List DNSBL records.</summary>
-    ///   <code>Test-DNSBLRecord -NameOrIpAddress example.com</code>
+    ///   <code>Test-DnsBlacklist -NameOrIpAddress example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsBlacklistRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsBlacklist")]

--- a/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDaneRecord.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check DANE records.</summary>
-    ///   <code>Test-DaneRecord -DomainName example.com</code>
+    ///   <code>Test-TlsDane -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDTlsDaneRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-TlsDane")]

--- a/DomainDetective.PowerShell/CmdletTestDanglingCname.cs
+++ b/DomainDetective.PowerShell/CmdletTestDanglingCname.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Detect unclaimed CNAMEs.</summary>
-    ///   <code>Test-DanglingCname -DomainName example.com</code>
+    ///   <code>Test-DnsDanglingCname -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsDanglingCname", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsDanglingCname")]

--- a/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDkimRecord.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Verify DKIM selectors.</summary>
-    ///   <code>Test-DkimRecord -DomainName example.com -Selectors selector1</code>
+    ///   <code>Test-EmailDkim -DomainName example.com -Selectors selector1</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailDkimRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailDkim")]

--- a/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestDmarcRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check DMARC settings.</summary>
-    ///   <code>Test-DmarcRecord -DomainName example.com</code>
+    ///   <code>Test-EmailDmarc -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailDmarcRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailDmarc")]

--- a/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
+++ b/DomainDetective.PowerShell/CmdletTestEdnsSupport.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell;
 /// <para>Part of the DomainDetective project.</para>
 /// <example>
 ///   <summary>Check EDNS support.</summary>
-///   <code>Test-EdnsSupport -DomainName example.com</code>
+///   <code>Test-DnsEdnsSupport -DomainName example.com</code>
 /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEdnsSupport", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsEdnsSupport")]

--- a/DomainDetective.PowerShell/CmdletTestFCrDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestFCrDns.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell;
 /// <summary>Validates forward-confirmed reverse DNS for MX hosts.</summary>
 /// <example>
 ///   <summary>Check FCrDNS configuration.</summary>
-///   <code>Test-FCrDns -DomainName example.com</code>
+///   <code>Test-DnsFcrDns -DomainName example.com</code>
 /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsForwardReverse", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsFcrDns")]

--- a/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
+++ b/DomainDetective.PowerShell/CmdletTestIPNeighbor.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check IP neighbors.</summary>
-    ///   <code>Test-IPNeighbor -DomainName example.com</code>
+    ///   <code>Test-NetworkIpNeighbor -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDIpNeighbor", DefaultParameterSetName = "ServerName")]
 [Alias("Test-NetworkIpNeighbor")]

--- a/DomainDetective.PowerShell/CmdletTestMailLatency.cs
+++ b/DomainDetective.PowerShell/CmdletTestMailLatency.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check mail latency for a server.</summary>
-    ///   <code>Test-MailLatency -HostName mail.example.com -Port 25</code>
+    ///   <code>Test-EmailLatency -HostName mail.example.com -Port 25</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDMailLatency", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailLatency")]

--- a/DomainDetective.PowerShell/CmdletTestNsRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestNsRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Query name servers.</summary>
-    ///   <code>Test-NsRecord -DomainName example.com</code>
+    ///   <code>Test-DnsNs -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsNsRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsNs")]

--- a/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
+++ b/DomainDetective.PowerShell/CmdletTestOpenRelay.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <example>
     ///   <summary>Test a mail server.</summary>
     /// <para>Part of the DomainDetective project.</para>
-    ///   <code>Test-OpenRelay -HostName mail.example.com -Port 25</code>
+    ///   <code>Test-EmailOpenRelay -HostName mail.example.com -Port 25</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailOpenRelay", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailOpenRelay")]

--- a/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
+++ b/DomainDetective.PowerShell/CmdletTestPortAvailability.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check ports on a server.</summary>
-    ///   <code>Test-PortAvailability -HostName mail.example.com -Ports 25,443</code>
+    ///   <code>Test-NetworkPortAvailability -HostName mail.example.com -Ports 25,443</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDPortAvailability", DefaultParameterSetName = "ServerName")]
 [Alias("Test-NetworkPortAvailability")]

--- a/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
+++ b/DomainDetective.PowerShell/CmdletTestSecurityTXT.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Get security contacts.</summary>
-    ///   <code>Test-SecurityTXT -DomainName example.com</code>
+    ///   <code>Test-DomainSecurityTxt -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDomainSecurityTxt", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DomainSecurityTxt")]

--- a/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmimeaRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check SMIMEA record.</summary>
-    ///   <code>Test-SmimeaRecord -EmailAddress user@example.com</code>
+    ///   <code>Test-DnsSmimea -EmailAddress user@example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDSmimeaRecord", DefaultParameterSetName = "Email")]
 [Alias("Test-DnsSmimea")]

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Test mail server TLS.</summary>
-    ///   <code>Test-SmtpTls -HostName mail.example.com -Port 587</code>
+    ///   <code>Test-EmailSmtpTls -HostName mail.example.com -Port 587</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailSmtpTls", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailSmtpTls")]

--- a/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSoaRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Query SOA information.</summary>
-    ///   <code>Test-SoaRecord -DomainName example.com</code>
+    ///   <code>Test-DnsSoa -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsSoaRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsSoa")]

--- a/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestSpfRecord.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check SPF configuration.</summary>
-    ///   <code>Test-SpfRecord -DomainName example.com</code>
+    ///   <code>Test-EmailSpf -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailSpfRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailSpf")]

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Verify STARTTLS.</summary>
-    ///   <code>Test-StartTls -DomainName example.com -Port 587</code>
+    ///   <code>Test-EmailStartTls -DomainName example.com -Port 587</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailStartTls", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailStartTls")]

--- a/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
+++ b/DomainDetective.PowerShell/CmdletTestThreatIntel.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell;
 /// <para>Part of the DomainDetective project.</para>
 /// <example>
 ///   <summary>Check reputation listings.</summary>
-///   <code>Test-ThreatIntel -NameOrIpAddress example.com</code>
+///   <code>Test-DomainThreatIntel -NameOrIpAddress example.com</code>
 /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDThreatIntel")]
 [Alias("Test-DomainThreatIntel")]

--- a/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
+++ b/DomainDetective.PowerShell/CmdletTestTlsRptRecord.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check TLS report policy.</summary>
-    ///   <code>Test-TlsRptRecord -DomainName example.com</code>
+    ///   <code>Test-EmailTlsRpt -DomainName example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailTlsRptRecord", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailTlsRpt")]

--- a/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
+++ b/DomainDetective.PowerShell/CmdletTestWebsiteCertificate.cs
@@ -6,7 +6,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Check HTTPS certificate.</summary>
-    ///   <code>Test-WebsiteCertificate -Url https://example.com</code>
+    ///   <code>Test-DomainCertificate -Url https://example.com</code>
     /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDomainCertificate", DefaultParameterSetName = "Url")]
 [Alias("Test-DomainCertificate")]

--- a/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
+++ b/DomainDetective.PowerShell/CmdletTestWildcardDns.cs
@@ -8,7 +8,7 @@ namespace DomainDetective.PowerShell;
 /// <para>Part of the DomainDetective project.</para>
 /// <example>
 ///   <summary>Check for wildcard DNS.</summary>
-///   <code>Test-WildcardDns -DomainName example.com</code>
+///   <code>Test-DnsWildcard -DomainName example.com</code>
 /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDDnsWildcard", DefaultParameterSetName = "ServerName")]
 [Alias("Test-DnsWildcard")]


### PR DESCRIPTION
## Summary
- align PowerShell cmdlet examples with their declared aliases
- refresh outdated names in XML documentation blocks

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6899bdf1f00c832e8d4270b22494505c