### PR TITLE
fix: restore example scripts and update cmdlet aliases

### DIFF
--- a/Module/Examples/Example.FlattenSpfIps.ps1
+++ b/Module/Examples/Example.FlattenSpfIps.ps1
@@ -2,6 +2,6 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$result = Test-SpfRecord -DomainName 'github.com' -Verbose
+$result = Test-EmailSpf -DomainName 'github.com' -Verbose
 $ips = $result.GetFlattenedIpAddresses('github.com')
 $ips

--- a/Module/Examples/Example.TestBimiRecord.ps1
+++ b/Module/Examples/Example.TestBimiRecord.ps1
@@ -2,8 +2,8 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Results = Test-BimiRecord -DomainName 'evotec.pl' -Verbose
+$Results = Test-EmailBimi -DomainName 'evotec.pl' -Verbose
 $Results | Format-Table
 
-$Example = Test-BimiRecord -DomainName 'example.com'
+$Example = Test-EmailBimi -DomainName 'example.com'
 $Example | Format-Table

--- a/Module/Examples/Example.TestDane.ps1
+++ b/Module/Examples/Example.TestDane.ps1
@@ -2,9 +2,9 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Results = Test-DaneRecord -DomainName 'evotec.pl' -Verbose
+$Results = Test-TlsDane -DomainName 'evotec.pl' -Verbose
 $Results | Format-List
 
-$Results = Test-DaneRecord -DomainName 'ietf.org' -Verbose
+$Results = Test-TlsDane -DomainName 'ietf.org' -Verbose
 $Results | Format-List
 

--- a/Module/Examples/Example.TestDkim.ps1
+++ b/Module/Examples/Example.TestDkim.ps1
@@ -2,6 +2,6 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Results = Test-DkimRecord -DomainName 'evotec.pl' -Verbose -Selectors "selector1", "selector2"
+$Results = Test-EmailDkim -DomainName 'evotec.pl' -Verbose -Selectors "selector1", "selector2"
 $Results | Format-Table
 $Results | Format-List

--- a/Module/Examples/Example.TestDmarcRecord.ps1
+++ b/Module/Examples/Example.TestDmarcRecord.ps1
@@ -2,10 +2,11 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Dmarc = Test-DmarcRecord -DomainName 'evotec.pl' -Verbose
+$Dmarc = Test-EmailDmarc -DomainName 'evotec.pl' -Verbose
 $Dmarc | Format-Table
 $Dmarc | Format-List
 
-$Example = Test-DmarcRecord -DomainName 'example.com'
+
+$Example = Test-EmailDmarc -DomainName 'example.com'
 $Example | Format-Table
 $Example | Format-List

--- a/Module/Examples/Example.TestMailLatency.ps1
+++ b/Module/Examples/Example.TestMailLatency.ps1
@@ -2,5 +2,5 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Result = Test-MailLatency -HostName 'mail.example.com' -Port 25 -Verbose
+$Result = Test-EmailLatency -HostName 'mail.example.com' -Port 25 -Verbose
 $Result | Format-Table

--- a/Module/Examples/Example.TestOpenRelay.ps1
+++ b/Module/Examples/Example.TestOpenRelay.ps1
@@ -2,11 +2,11 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Gmail = Test-OpenRelay -HostName 'gmail-smtp-in.l.google.com' -Port 25 -Verbose
+$Gmail = Test-EmailOpenRelay -HostName 'gmail-smtp-in.l.google.com' -Port 25 -Verbose
 $Gmail | Format-Table
 
-$Example = Test-OpenRelay -HostName 'mail.example.com' -Port 25 -Verbose
+$Example = Test-EmailOpenRelay -HostName 'mail.example.com' -Port 25 -Verbose
 $Example | Format-Table
 
-$Example = Test-OpenRelay -HostName 'mail.example.com'
+$Example = Test-EmailOpenRelay -HostName 'mail.example.com'
 $Example | Format-Table

--- a/Module/Examples/Example.TestSmtpTls.ps1
+++ b/Module/Examples/Example.TestSmtpTls.ps1
@@ -2,8 +2,8 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Gmail = Test-SmtpTls -HostName 'gmail.com' -Port 25 -Verbose
+$Gmail = Test-EmailSmtpTls -HostName 'gmail.com' -Port 25 -Verbose
 $Gmail | Format-Table
 
-$Example = Test-SmtpTls -HostName 'mail.example.com' -ShowChain -Verbose
+$Example = Test-EmailSmtpTls -HostName 'mail.example.com' -ShowChain -Verbose
 $Example | Format-List

--- a/Module/Examples/Example.TestSpf.ps1
+++ b/Module/Examples/Example.TestSpf.ps1
@@ -2,17 +2,17 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Results = Test-SpfRecord -DomainName 'google.com' -Verbose
+$Results = Test-EmailSpf -DomainName 'google.com' -Verbose
 $Results | Format-Table
 
-$ResultsMicrosoft = Test-SpfRecord -DomainName 'microsoft.com' -Verbose
+$ResultsMicrosoft = Test-EmailSpf -DomainName 'microsoft.com' -Verbose
 $ResultsMicrosoft | Format-Table
 $ResultsMicrosoft | Format-List
 
-$ResultsEvotec = Test-SpfRecord -DomainName 'evotec.pl' -Verbose
+$ResultsEvotec = Test-EmailSpf -DomainName 'evotec.pl' -Verbose
 $ResultsEvotec | Format-Table
 $ResultsEvotec | Format-List
 
-$ResultsIdn = Test-SpfRecord -DomainName 'xn--bcher-kva.ch' -Verbose
+$ResultsIdn = Test-EmailSpf -DomainName 'xn--bcher-kva.ch' -Verbose
 $ResultsIdn | Format-Table
 $ResultsIdn | Format-List

--- a/Module/Examples/Example.TestStartTls.ps1
+++ b/Module/Examples/Example.TestStartTls.ps1
@@ -2,15 +2,15 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$Gmail = Test-StartTls -DomainName 'gmail.com' -Verbose
+$Gmail = Test-EmailStartTls -DomainName 'gmail.com' -Verbose
 $Gmail | Format-Table
 
-$Evotec = Test-StartTls -DomainName 'evotec.pl' -Port 25
+$Evotec = Test-EmailStartTls -DomainName 'evotec.pl' -Port 25
 $Evotec | Format-Table
 
-$Example = Test-StartTls -DomainName 'example.com' -DnsEndpoint System -Port 587
+$Example = Test-EmailStartTls -DomainName 'example.com' -DnsEndpoint System -Port 587
 $Example | Format-Table
 
 # Test a single host on a custom port
-$HostTls = Test-StartTls -DomainName 'example.com' -Port 2525
+$HostTls = Test-EmailStartTls -DomainName 'example.com' -Port 2525
 $HostTls | Format-Table

--- a/Module/Examples/Example.TestTlsRptRecord.ps1
+++ b/Module/Examples/Example.TestTlsRptRecord.ps1
@@ -2,10 +2,10 @@
 
 Import-Module $PSScriptRoot\..\DomainDetective.psd1 -Force
 
-$TlsRpt = Test-TlsRptRecord -DomainName 'evotec.pl' -Verbose
+$TlsRpt = Test-EmailTlsRpt -DomainName 'evotec.pl' -Verbose
 $TlsRpt | Format-Table
 $TlsRpt | Format-List
 
-$Example = Test-TlsRptRecord -DomainName 'example.com'
+$Example = Test-EmailTlsRpt -DomainName 'example.com'
 $Example | Format-Table
 $Example | Format-List


### PR DESCRIPTION
## Summary
- restore original example filenames and update cmdlet calls to current aliases like Test-EmailDkim and Test-EmailSpf

## Testing
- `dotnet build`
- `pwsh Module/Examples/Example.FlattenSpfIps.ps1`
- `pwsh Module/Examples/Example.TestBimiRecord.ps1`
- `pwsh Module/Examples/Example.TestDkim.ps1`
- `pwsh Module/Examples/Example.TestDmarcRecord.ps1`
- `pwsh Module/Examples/Example.TestMailLatency.ps1`
- `pwsh Module/Examples/Example.TestOpenRelay.ps1` *(network unreachable)*
- `pwsh Module/Examples/Example.TestSmtpTls.ps1` *(network unreachable)*
- `pwsh Module/Examples/Example.TestSpf.ps1`
- `pwsh Module/Examples/Example.TestStartTls.ps1`
- `pwsh Module/Examples/Example.TestTlsRptRecord.ps1`
- `pwsh Module/Examples/Example.TestDane.ps1`


------
https://chatgpt.com/codex/tasks/task_e_6899bde74084832e84653af94a7a4dae