### PR TITLE
docs(powerShell): 📝 expand alias table

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -279,6 +279,7 @@ Test-Rpki -DomainName "example.com"
 | `Test-DDDnsSecStatus`          | `Test-DnsSec`            | `VerifyDNSSEC`          |
 | `Test-DDDnsBlacklistRecord`    | `Test-DnsBlacklist`      | `VerifyDNSBL` |
 | `Test-DDDnsDomainBlacklist`    | `Test-DnsDomainBlacklist`| `CheckDNSBL`                     |
+| `Test-DDDnsOpenResolver`       | `Test-OpenResolver`      | `CheckOpenResolverHost`          |
 | `Test-DDDnsDanglingCname`      | `Test-DnsDanglingCname`  | `VerifyDanglingCname`   |
 | `Test-DDDnsPropagation`        | `Test-DnsPropagation`    | `DnsPropagationAnalysis.QueryAsync` |
 | `Test-DDDnsTtl`                | `Test-DnsTtl`            | `DnsTtlAnalysis.Analyze`          |
@@ -301,6 +302,11 @@ Test-Rpki -DomainName "example.com"
 | `Get-DDDomainWhois`            | `Get-DomainWhois`        | `CheckWHOIS`                               |
 | `Get-DDFlattenedSpfIp`         | `Get-DomainFlattenedSpfIp` | `GetFlattenedIpAddresses`               |
 | `Test-DDThreatIntel`           | `Test-DomainThreatIntel` | `VerifyThreatIntel`                        |
+| `Test-DDRdap`                  | `Test-Rdap`              | `QueryRDAP`                                |
+| `Test-DDRpki`                  | `Test-Rpki`              | `VerifyRPKI`                               |
+| `Get-DDRdapObject`             | `Get-RdapObject`         | `RdapClient.Query*Async`                   |
+| `Get-DDSearchEngineInfo`       | `Get-SearchEngineInfo`   | `SearchEngineAnalysis.Search*`             |
+| `Show-DDDomainReport`          | `Export-DomainReport`<br>`New-DomainReport`<br>`Generate-DomainReport` | `DomainSecurityReport.GenerateReport` |
 
 ## 🔐 TLS Cmdlets
 
@@ -324,6 +330,7 @@ Test-Rpki -DomainName "example.com"
 | `Clear-DDDnsblProviderList`  | `Clear-DnsblProvider` | `ClearDNSBL`              |
 | `Import-DDDnsblConfig`       | `Import-DnsblConfig` | `LoadDnsblConfig`          |
 | `Import-DDDmarcReport`       | `Import-DmarcReport` | `DmarcReportParser.ParseZip` |
+| `Import-DDDmarcForensic`     | `Import-DmarcForensic` | `DmarcForensicParser.ParseZip` |
 
 ### MTA-STS
 


### PR DESCRIPTION
## Summary
- enumerate DomainDetective.PowerShell `[Alias]` attributes and sync README alias tables
- record OpenResolver, RDAP, RPKI, RDAP object, search engine, domain report, and DMARC forensic cmdlets with their C# methods

## Testing
- `dotnet build`
- `dotnet test --no-build` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_6899d2ad75dc832ea48e65acaf24654d