### PR TITLE
docs: update message header example

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -7,7 +7,7 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Analyze headers from a file.</summary>
-    ///   <code>Get-Content './headers.txt' -Raw | Test-MessageHeader</code>
+    ///   <code>Get-Content './headers.txt' -Raw | Get-EmailHeaderInfo</code>
     /// </example>
 [Cmdlet(VerbsCommon.Get, "DDEmailMessageHeaderInfo")]
 [Alias("Get-EmailHeaderInfo")]


### PR DESCRIPTION
## Summary
- replace obsolete Test-MessageHeader with Get-EmailHeaderInfo in message header cmdlet example

## Testing
- `dotnet build --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_689a05bfb514832e81320dca3af228e6