### PR TITLE
ci(github): 🧪 add test verbosity controls

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -17,6 +17,8 @@ on:
 env:
     DOTNET_VERSION: '8.x'
     BUILD_CONFIGURATION: 'Release'
+    TEST_VERBOSITY: minimal # set to 'detailed' to restore full test output
+    SUMMARIZE_FAILURES: true # set to 'false' to disable summarizing failing tests
 
 jobs:
     test-windows:
@@ -39,7 +41,41 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -83,7 +119,41 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
 
             - name: Upload test results
               uses: actions/upload-artifact@v4
@@ -128,7 +198,41 @@ jobs:
               run: dotnet build DomainDetective.sln --configuration ${{ env.BUILD_CONFIGURATION }} --no-restore
 
             - name: Run tests
-              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity normal --logger trx --collect:"XPlat Code Coverage"
+              run: dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net8.0 --no-build --verbosity ${{ env.TEST_VERBOSITY }} --logger "console;verbosity=${{ env.TEST_VERBOSITY }}" --logger trx --collect:"XPlat Code Coverage"
+
+            - name: Summarize failing tests
+              if: failure() && env.SUMMARIZE_FAILURES == 'true'
+              shell: pwsh
+              run: |
+                  $trxFiles = Get-ChildItem -Recurse -Filter *.trx
+                  if ($trxFiles.Count -eq 0) {
+                    Write-Host "No TRX files found for failure analysis"
+                    exit 0
+                  }
+
+                  Write-Host "=== Failed Tests Summary ==="
+                  $failureCount = 0
+
+                  $trxFiles | ForEach-Object {
+                    try {
+                      Select-Xml -Path $_.FullName -XPath "//UnitTestResult[@outcome='Failed']" |
+                        ForEach-Object {
+                          $name = $_.Node.testName
+                          $msg = $_.Node.Output.ErrorInfo.Message ?? "No error message available"
+                          Write-Host "❌ $name"
+                          Write-Host "   $msg"
+                          $failureCount++
+                        }
+                    } catch {
+                      Write-Host "Warning: Could not parse TRX file $($_.Name): $($_.Exception.Message)"
+                    }
+                  }
+
+                  if ($failureCount -eq 0) {
+                    Write-Host "No failed tests found in TRX files"
+                  } else {
+                    Write-Host "=== Total failed tests: $failureCount ==="
+                  }
 
             - name: Upload test results
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add TEST_VERBOSITY and SUMMARIZE_FAILURES variables for .NET tests
- summarize failing tests and include console logger for clearer output

## Testing
- `dotnet build DomainDetective.sln --configuration Release`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration Release --framework net8.0`


------
https://chatgpt.com/codex/tasks/task_e_68a345ce6938832eb9426869d10e4c62