### PR TITLE
Fix DKIM analysis when selectors absent

### DIFF
--- a/DomainDetective.Tests/TestDKIMAnalysisNoTxt.cs
+++ b/DomainDetective.Tests/TestDKIMAnalysisNoTxt.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DnsClientX;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDkimAnalysisNoTxt {
+    [Fact]
+    public async Task DkimRecordExistsFalseWhenOnlySoaReturned() {
+        var answers = new List<DnsAnswer> {
+            new() { DataRaw = "ns.example.com hostmaster.example.com 1 7200 3600 1209600 3600", Type = DnsRecordType.SOA }
+        };
+        var analysis = new DkimAnalysis();
+        await analysis.AnalyzeDkimRecords("selector", answers, new InternalLogger());
+        var result = analysis.AnalysisResults["selector"];
+        Assert.False(result.DkimRecordExists);
+        Assert.Null(result.DkimRecord);
+    }
+
+    [Fact]
+    public async Task AdspRecordIgnoredWhenOnlySoaReturned() {
+        var answers = new List<DnsAnswer> {
+            new() { DataRaw = "ns.example.com hostmaster.example.com 1 7200 3600 1209600 3600", Type = DnsRecordType.SOA }
+        };
+        var logger = new InternalLogger();
+        var warnings = new List<LogEventArgs>();
+        logger.OnWarningMessage += (_, e) => warnings.Add(e);
+        var analysis = new DkimAnalysis();
+        await analysis.AnalyzeAdspRecord(answers, logger);
+        Assert.False(analysis.AdspRecordExists);
+        Assert.Null(analysis.AdspRecord);
+        Assert.Empty(warnings);
+    }
+}

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -47,7 +47,9 @@ namespace DomainDetective {
         public async Task AnalyzeDkimRecords(string selector, IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             await Task.Yield(); // To avoid warning about lack of 'await'
 
-            var dkimRecordList = dnsResults?.ToList() ?? new List<DnsAnswer>();
+            var dkimRecordList = dnsResults?
+                .Where(r => r.Type == DnsRecordType.TXT)
+                .ToList() ?? new List<DnsAnswer>();
             var recordExists = dkimRecordList.Any(r =>
                 (r.DataStringsEscaped?.Any(s => !string.IsNullOrWhiteSpace(s)) ?? false) ||
                 !string.IsNullOrWhiteSpace(r.Data));
@@ -224,7 +226,9 @@ namespace DomainDetective {
                 return;
             }
 
-            var records = dnsResults.ToList();
+            var records = dnsResults
+                .Where(r => r.Type == DnsRecordType.TXT)
+                .ToList();
             AdspRecordExists = records.Any();
             if (!AdspRecordExists) {
                 return;


### PR DESCRIPTION
## Summary
- ignore non-TXT DNS answers when analyzing DKIM and ADSP records
- add regression tests for non-TXT responses and absence of TXT records

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`
- `Invoke-Pester Module/Tests/DkimRecord.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68a4c52a3b28832eae50435b5c3d2acb