### PR TITLE
feat: add DMARC RUA schema validation

### DIFF
--- a/DomainDetective.Tests/TestDmarcReportParser.cs
+++ b/DomainDetective.Tests/TestDmarcReportParser.cs
@@ -1,4 +1,5 @@
 using DomainDetective;
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -8,9 +9,12 @@ using Xunit;
 namespace DomainDetective.Tests;
 
 public class TestDmarcReportParser {
+    private const string V1Ns = "http://dmarc.org/dmarc-xml/0.1";
+    private const string V2Ns = "http://dmarc.org/dmarc-xml/2.0";
+
     [Fact]
     public void ParseUnicodeDomain() {
-        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback><record><identifiers><header_from>bücher.de</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><policy_evaluated><dkim>pass</dkim></policy_evaluated></row></record></feedback>";
+        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\"><record><identifiers><header_from>bücher.de</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><policy_evaluated><dkim>pass</dkim></policy_evaluated></row></record></feedback>";
         var tmp = Path.GetTempFileName();
         File.Delete(tmp);
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
@@ -28,7 +32,7 @@ public class TestDmarcReportParser {
 
     [Fact]
     public void SummarizeFailures() {
-        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback>" +
+        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\">" +
             "<record><identifiers><header_from>example.com</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><count>2</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "<record><identifiers><header_from>example.org</header_from></identifiers><row><source_ip>5.6.7.8</source_ip><count>1</count><policy_evaluated><dkim>pass</dkim><spf>fail</spf><disposition>none</disposition></policy_evaluated></row></record>" +
             "</feedback>";
@@ -58,7 +62,7 @@ public class TestDmarcReportParser {
 
     [Fact]
     public void ParseNegativeCountDefaultsToOne() {
-        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback>" +
+        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\">" +
             "<record><identifiers><header_from>example.com</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><count>-5</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "</feedback>";
         var tmp = Path.GetTempFileName();
@@ -77,7 +81,7 @@ public class TestDmarcReportParser {
 
     [Fact]
     public void SummarizeByIpAggregatesCounts() {
-        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback>" +
+        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\">" +
             "<record><identifiers><header_from>a.com</header_from></identifiers><row><source_ip>1.1.1.1</source_ip><count>2</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "<record><identifiers><header_from>b.com</header_from></identifiers><row><source_ip>1.1.1.1</source_ip><count>3</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "</feedback>";
@@ -107,5 +111,39 @@ public class TestDmarcReportParser {
         File.Delete(tmp);
         Assert.Empty(records);
     }
-}
 
+    [Fact]
+    public void InvalidXmlProducesValidationMessages() {
+        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\"><record><identifiers></identifiers><row><source_ip>1.2.3.4</source_ip><count>abc</count></row></record></feedback>";
+        var tmp = Path.GetTempFileName();
+        File.Delete(tmp);
+        using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
+            var entry = archive.CreateEntry("report.xml");
+            using var stream = entry.Open();
+            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            writer.Write(xml);
+        }
+        var errors = new List<string>();
+        var records = DmarcReportParser.ParseZip(tmp, errors).ToList();
+        File.Delete(tmp);
+        Assert.NotEmpty(errors);
+        Assert.Empty(records);
+    }
+
+    [Fact]
+    public void ParseV2Namespace() {
+        const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V2Ns + "\"><record><identifiers><header_from>v2.com</header_from></identifiers><row><source_ip>8.8.8.8</source_ip><policy_evaluated><dkim>pass</dkim></policy_evaluated></row></record></feedback>";
+        var tmp = Path.GetTempFileName();
+        File.Delete(tmp);
+        using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
+            var entry = archive.CreateEntry("report.xml");
+            using var stream = entry.Open();
+            using var writer = new StreamWriter(stream, Encoding.UTF8);
+            writer.Write(xml);
+        }
+        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        File.Delete(tmp);
+        Assert.Single(records);
+        Assert.Equal("v2.com", records[0].HeaderFrom);
+    }
+}

--- a/DomainDetective/Definitions/DmarcAggregateReport_v1.xsd
+++ b/DomainDetective/Definitions/DmarcAggregateReport_v1.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://dmarc.org/dmarc-xml/0.1" elementFormDefault="qualified">
+  <xs:element name="feedback">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="record" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="identifiers">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="header_from" type="xs:string" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="row">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="source_ip" type="xs:string" />
+                    <xs:element name="count" type="xs:integer" minOccurs="0" />
+                    <xs:element name="policy_evaluated" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="dkim" type="xs:string" minOccurs="0" />
+                          <xs:element name="spf" type="xs:string" minOccurs="0" />
+                          <xs:element name="disposition" type="xs:string" minOccurs="0" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/DomainDetective/Definitions/DmarcAggregateReport_v2.xsd
+++ b/DomainDetective/Definitions/DmarcAggregateReport_v2.xsd
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://dmarc.org/dmarc-xml/2.0" elementFormDefault="qualified">
+  <xs:element name="feedback">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="record" minOccurs="0" maxOccurs="unbounded">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="identifiers">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="header_from" type="xs:string" />
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+              <xs:element name="row">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="source_ip" type="xs:string" />
+                    <xs:element name="count" type="xs:integer" minOccurs="0" />
+                    <xs:element name="policy_evaluated" minOccurs="0">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element name="dkim" type="xs:string" minOccurs="0" />
+                          <xs:element name="spf" type="xs:string" minOccurs="0" />
+                          <xs:element name="disposition" type="xs:string" minOccurs="0" />
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/DomainDetective/DmarcReportParser.cs
+++ b/DomainDetective/DmarcReportParser.cs
@@ -1,9 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Reflection;
+using System.Xml;
 using System.Xml.Linq;
+using System.Xml.Schema;
 using DomainDetective.Helpers;
 
 namespace DomainDetective;
@@ -12,7 +16,8 @@ namespace DomainDetective;
 public static class DmarcReportParser {
     /// <summary>Parses the specified zip file and returns individual report records.</summary>
     /// <param name="path">Path to the zipped XML feedback report.</param>
-    public static IEnumerable<DmarcAggregateRecord> ParseZip(string path) {
+    /// <param name="validationMessages">Optional list collecting schema validation errors.</param>
+    public static IEnumerable<DmarcAggregateRecord> ParseZip(string path, IList<string>? validationMessages = null) {
         using var archive = ZipFile.OpenRead(path);
         var entry = archive.Entries.FirstOrDefault(e => e.FullName.EndsWith(".xml", StringComparison.OrdinalIgnoreCase));
         if (entry == null) {
@@ -20,9 +25,34 @@ public static class DmarcReportParser {
         }
 
         using var stream = entry.Open();
-        XDocument doc = XDocument.Load(stream);
-        foreach (var record in doc.Descendants("record")) {
-            string rawDomain = record.Element("identifiers")?.Element("header_from")?.Value ?? string.Empty;
+        var assembly = typeof(DmarcReportParser).Assembly;
+        var schemas = new XmlSchemaSet();
+        using (var v1 = assembly.GetManifestResourceStream("DomainDetective.Definitions.DmarcAggregateReport_v1.xsd"))
+        using (var v2 = assembly.GetManifestResourceStream("DomainDetective.Definitions.DmarcAggregateReport_v2.xsd")) {
+            if (v1 != null) {
+                schemas.Add(null, XmlReader.Create(v1));
+            }
+            if (v2 != null) {
+                schemas.Add(null, XmlReader.Create(v2));
+            }
+        }
+
+        var settings = new XmlReaderSettings {
+            ValidationType = ValidationType.Schema,
+            Schemas = schemas
+        };
+        if (validationMessages != null) {
+            settings.ValidationEventHandler += (_, e) => validationMessages.Add(e.Message);
+        } else {
+            settings.ValidationEventHandler += (_, _) => { };
+        }
+
+        using var reader = XmlReader.Create(stream, settings);
+        XDocument doc = XDocument.Load(reader);
+        XNamespace ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+        foreach (var record in doc.Descendants(ns + "record")) {
+            string rawDomain = record.Element(ns + "identifiers")?
+                .Element(ns + "header_from")?.Value ?? string.Empty;
             if (string.IsNullOrEmpty(rawDomain)) {
                 continue;
             }
@@ -34,11 +64,12 @@ public static class DmarcReportParser {
                 continue;
             }
 
-            string sourceIp = record.Element("row")?.Element("source_ip")?.Value ?? string.Empty;
-            string dkim = record.Element("row")?.Element("policy_evaluated")?.Element("dkim")?.Value ?? string.Empty;
-            string spf = record.Element("row")?.Element("policy_evaluated")?.Element("spf")?.Value ?? string.Empty;
-            string disposition = record.Element("row")?.Element("policy_evaluated")?.Element("disposition")?.Value ?? string.Empty;
-            string countStr = record.Element("row")?.Element("count")?.Value ?? "1";
+            var row = record.Element(ns + "row");
+            string sourceIp = row?.Element(ns + "source_ip")?.Value ?? string.Empty;
+            string dkim = row?.Element(ns + "policy_evaluated")?.Element(ns + "dkim")?.Value ?? string.Empty;
+            string spf = row?.Element(ns + "policy_evaluated")?.Element(ns + "spf")?.Value ?? string.Empty;
+            string disposition = row?.Element(ns + "policy_evaluated")?.Element(ns + "disposition")?.Value ?? string.Empty;
+            string countStr = row?.Element(ns + "count")?.Value ?? "1";
             if (!int.TryParse(countStr, NumberStyles.Integer, CultureInfo.InvariantCulture, out int count) || count < 0) {
                 count = 1;
             }
@@ -65,4 +96,3 @@ public static class DmarcReportParser {
         }
     }
 }
-

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -46,4 +46,9 @@
         <ProjectReference Include="..\DomainDetective.Generators\DomainDetective.Generators.csproj"
             OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="Definitions\DmarcAggregateReport_v1.xsd" />
+        <EmbeddedResource Include="Definitions\DmarcAggregateReport_v2.xsd" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- embed DMARC RUA v1/v2 schema files
- validate DMARC aggregate reports using embedded schemas
- test DMARC schema validation for v1 and v2

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d4333250832ea03a1cd50317273d