### PR TITLE
feat: support streams and DMARC v2 policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -374,3 +374,5 @@ packages-microsoft-prod.deb
 CLAUDE.md
 .claude/*
 DEMO/*
+DomainDetective.Tests/Reports/*.gz
+DomainDetective.Tests/Reports/*.zip

--- a/DomainDetective.Example/ExampleParseDmarcReport.cs
+++ b/DomainDetective.Example/ExampleParseDmarcReport.cs
@@ -7,8 +7,8 @@ public static partial class Program {
     /// Example parsing a DMARC aggregate report and summarizing failures.
     /// </summary>
     public static void ExampleParseDmarcReport() {
-        var records = DmarcReportParser.ParseZip("aggregate.zip");
-        var summaries = records.SummarizeFailuresByIp().ToList();
+        var report = DmarcReportParser.Parse("aggregate.zip");
+        var summaries = report.Records.SummarizeFailuresByIp().ToList();
         Helpers.ShowPropertiesTable("DMARC failures by IP", summaries);
     }
 }

--- a/DomainDetective.PowerShell/CmdletImportDmarcReport.cs
+++ b/DomainDetective.PowerShell/CmdletImportDmarcReport.cs
@@ -20,7 +20,8 @@ namespace DomainDetective.PowerShell {
         /// Parses the DMARC report archive and outputs each summary.
         /// </summary>
         protected override void ProcessRecord() {
-            foreach (var summary in DmarcReportParser.ParseZip(Path)) {
+            var report = DmarcReportParser.Parse(Path);
+            foreach (var summary in report.Records) {
                 WriteObject(summary);
             }
         }

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -127,4 +127,8 @@
         </None>
     </ItemGroup>
 
+    <ItemGroup>
+        <None Include="Reports/*" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/DomainDetective.Tests/Reports/sample_v1.xml
+++ b/DomainDetective.Tests/Reports/sample_v1.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feedback xmlns="http://dmarc.org/dmarc-xml/0.1">
+  <policy_published>
+    <domain>example.com</domain>
+    <adkim>r</adkim>
+    <aspf>r</aspf>
+    <p>none</p>
+    <sp>reject</sp>
+    <pct>100</pct>
+  </policy_published>
+  <record>
+    <identifiers>
+      <header_from>example.com</header_from>
+    </identifiers>
+    <row>
+      <source_ip>1.2.3.4</source_ip>
+      <count>1</count>
+      <policy_evaluated>
+        <dkim>pass</dkim>
+        <spf>pass</spf>
+        <disposition>none</disposition>
+      </policy_evaluated>
+    </row>
+  </record>
+</feedback>

--- a/DomainDetective.Tests/Reports/sample_v2.xml
+++ b/DomainDetective.Tests/Reports/sample_v2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feedback xmlns="http://dmarc.org/dmarc-xml/2.0">
+  <policy_published>
+    <domain>example.net</domain>
+    <adkim>s</adkim>
+    <aspf>s</aspf>
+    <p>quarantine</p>
+    <sp>reject</sp>
+    <pct>50</pct>
+    <np>reject</np>
+    <fo>1</fo>
+  </policy_published>
+  <record>
+    <identifiers>
+      <header_from>example.net</header_from>
+    </identifiers>
+    <row>
+      <source_ip>5.6.7.8</source_ip>
+      <count>2</count>
+      <policy_evaluated>
+        <dkim>pass</dkim>
+        <spf>pass</spf>
+        <disposition>none</disposition>
+      </policy_evaluated>
+    </row>
+  </record>
+</feedback>

--- a/DomainDetective.Tests/TestDmarcReportParser.cs
+++ b/DomainDetective.Tests/TestDmarcReportParser.cs
@@ -1,4 +1,5 @@
 using DomainDetective;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
@@ -16,19 +17,18 @@ public class TestDmarcReportParser {
     [Fact]
     public void ParseUnicodeDomain() {
         const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\"><record><identifiers><header_from>bücher.de</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><policy_evaluated><dkim>pass</dkim></policy_evaluated></row></record></feedback>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        var report = DmarcReportParser.Parse(tmp);
         File.Delete(tmp);
-        Assert.Single(records);
-        Assert.Equal("xn--bcher-kva.de", records[0].HeaderFrom);
-        Assert.Equal("1.2.3.4", records[0].SourceIp);
+        Assert.Single(report.Records);
+        Assert.Equal("xn--bcher-kva.de", report.Records[0].HeaderFrom);
+        Assert.Equal("1.2.3.4", report.Records[0].SourceIp);
     }
 
     [Fact]
@@ -37,16 +37,16 @@ public class TestDmarcReportParser {
             "<record><identifiers><header_from>example.com</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><count>2</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "<record><identifiers><header_from>example.org</header_from></identifiers><row><source_ip>5.6.7.8</source_ip><count>1</count><policy_evaluated><dkim>pass</dkim><spf>fail</spf><disposition>none</disposition></policy_evaluated></row></record>" +
             "</feedback>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        var report = DmarcReportParser.Parse(tmp);
         File.Delete(tmp);
+        var records = report.Records;
         var failures = records.GetFailureRecords().ToList();
         Assert.Single(failures);
         Assert.Equal("1.2.3.4", failures[0].SourceIp);
@@ -66,18 +66,17 @@ public class TestDmarcReportParser {
         const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\">" +
             "<record><identifiers><header_from>example.com</header_from></identifiers><row><source_ip>1.2.3.4</source_ip><count>-5</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "</feedback>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        var report = DmarcReportParser.Parse(tmp);
         File.Delete(tmp);
-        Assert.Single(records);
-        Assert.Equal(1, records[0].Count);
+        Assert.Single(report.Records);
+        Assert.Equal(1, report.Records[0].Count);
     }
 
     [Fact]
@@ -86,38 +85,35 @@ public class TestDmarcReportParser {
             "<record><identifiers><header_from>a.com</header_from></identifiers><row><source_ip>1.1.1.1</source_ip><count>2</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "<record><identifiers><header_from>b.com</header_from></identifiers><row><source_ip>1.1.1.1</source_ip><count>3</count><policy_evaluated><dkim>fail</dkim><spf>fail</spf><disposition>reject</disposition></policy_evaluated></row></record>" +
             "</feedback>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        var report = DmarcReportParser.Parse(tmp);
         File.Delete(tmp);
-        var summary = records.SummarizeFailuresByIp().Single();
+        var summary = report.Records.SummarizeFailuresByIp().Single();
         Assert.Equal("1.1.1.1", summary.SourceIp);
         Assert.Equal(5, summary.Count);
     }
 
     [Fact]
     public void ParseZipWithoutXmlEntryReturnsNoRecords() {
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             archive.CreateEntry("readme.txt");
         }
-        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        var report = DmarcReportParser.Parse(tmp);
         File.Delete(tmp);
-        Assert.Empty(records);
+        Assert.Empty(report.Records);
     }
 
     [Fact]
     public void InvalidXmlProducesValidationMessages() {
         const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\"><record><identifiers></identifiers><row><source_ip>1.2.3.4</source_ip><count>abc</count></row></record></feedback>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
@@ -125,56 +121,99 @@ public class TestDmarcReportParser {
             writer.Write(xml);
         }
         var errors = new List<string>();
-        var records = DmarcReportParser.ParseZip(tmp, errors).ToList();
+        var report = DmarcReportParser.Parse(tmp, errors);
         File.Delete(tmp);
         Assert.NotEmpty(errors);
-        Assert.Empty(records);
+        Assert.Empty(report.Records);
     }
 
     [Fact]
     public void InvalidXmlThrowsWhenNoCollector() {
         const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V1Ns + "\"><record><identifiers></identifiers><row><source_ip>1.2.3.4</source_ip><count>abc</count></row></record></feedback>"; 
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        Assert.Throws<XmlSchemaValidationException>(() => DmarcReportParser.ParseZip(tmp).ToList());
+        Assert.Throws<XmlSchemaValidationException>(() => DmarcReportParser.Parse(tmp));
         File.Delete(tmp);
     }
 
     [Fact]
     public void UnknownNamespaceThrows() {
         const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"http://example.com/unknown\"/>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        Assert.Throws<InvalidOperationException>(() => DmarcReportParser.ParseZip(tmp).ToList());
+        Assert.Throws<InvalidOperationException>(() => DmarcReportParser.Parse(tmp));
         File.Delete(tmp);
     }
 
     [Fact]
     public void ParseV2Namespace() {
         const string xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><feedback xmlns=\"" + V2Ns + "\"><record><identifiers><header_from>v2.com</header_from></identifiers><row><source_ip>8.8.8.8</source_ip><policy_evaluated><dkim>pass</dkim></policy_evaluated></row></record></feedback>";
-        var tmp = Path.GetTempFileName();
-        File.Delete(tmp);
+        var tmp = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
         using (var archive = ZipFile.Open(tmp, ZipArchiveMode.Create)) {
             var entry = archive.CreateEntry("report.xml");
             using var stream = entry.Open();
             using var writer = new StreamWriter(stream, Encoding.UTF8);
             writer.Write(xml);
         }
-        var records = DmarcReportParser.ParseZip(tmp).ToList();
+        var report = DmarcReportParser.Parse(tmp);
         File.Delete(tmp);
-        Assert.Single(records);
-        Assert.Equal("v2.com", records[0].HeaderFrom);
+        Assert.Single(report.Records);
+        Assert.Equal("v2.com", report.Records[0].HeaderFrom);
+    }
+
+    [Fact]
+    public void ParseSampleV1Reports() {
+        var baseDir = Path.Combine(AppContext.BaseDirectory, "Reports");
+        var xmlPath = Path.Combine(baseDir, "sample_v1.xml");
+        var xmlBytes = File.ReadAllBytes(xmlPath);
+
+        var gzPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".xml.gz");
+        using (var file = File.Create(gzPath))
+        using (var gz = new GZipStream(file, CompressionLevel.Optimal)) {
+            gz.Write(xmlBytes, 0, xmlBytes.Length);
+        }
+
+        var zipPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".zip");
+        using (var archive = ZipFile.Open(zipPath, ZipArchiveMode.Create)) {
+            var entry = archive.CreateEntry("sample_v1.xml");
+            using var entryStream = entry.Open();
+            entryStream.Write(xmlBytes, 0, xmlBytes.Length);
+        }
+
+        var xmlReport = DmarcReportParser.Parse(xmlPath);
+        var gzReport = DmarcReportParser.Parse(gzPath);
+        var zipReport = DmarcReportParser.Parse(zipPath);
+
+        Assert.Equal("example.com", xmlReport.PolicyPublished.Domain);
+        Assert.Equal(xmlReport.PolicyPublished.Domain, gzReport.PolicyPublished.Domain);
+        Assert.Equal(xmlReport.PolicyPublished.Domain, zipReport.PolicyPublished.Domain);
+
+        using (var stream = File.OpenRead(zipPath)) {
+            var streamReport = DmarcReportParser.Parse(stream, zipPath);
+            Assert.Equal("example.com", streamReport.PolicyPublished.Domain);
+        }
+
+        File.Delete(gzPath);
+        File.Delete(zipPath);
+    }
+
+    [Fact]
+    public void ParseSampleV2PolicyExtensions() {
+        var baseDir = Path.Combine(AppContext.BaseDirectory, "Reports");
+        var path = Path.Combine(baseDir, "sample_v2.xml");
+        var report = DmarcReportParser.Parse(path);
+        Assert.Equal("example.net", report.PolicyPublished.Domain);
+        Assert.Equal("reject", report.PolicyPublished.Np);
+        Assert.Equal("1", report.PolicyPublished.Fo);
     }
 }

--- a/DomainDetective/Definitions/DmarcAggregateReport_v1.xsd
+++ b/DomainDetective/Definitions/DmarcAggregateReport_v1.xsd
@@ -3,6 +3,13 @@
   <xs:element name="feedback">
     <xs:complexType>
       <xs:sequence>
+        <xs:element name="policy_published" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="record" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>

--- a/DomainDetective/Definitions/DmarcAggregateReport_v2.xsd
+++ b/DomainDetective/Definitions/DmarcAggregateReport_v2.xsd
@@ -3,6 +3,13 @@
   <xs:element name="feedback">
     <xs:complexType>
       <xs:sequence>
+        <xs:element name="policy_published" minOccurs="0">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax" />
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
         <xs:element name="record" minOccurs="0" maxOccurs="unbounded">
           <xs:complexType>
             <xs:sequence>

--- a/DomainDetective/DmarcAggregateReport.cs
+++ b/DomainDetective/DmarcAggregateReport.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace DomainDetective;
+
+/// <summary>Represents a DMARC aggregate feedback report.</summary>
+public sealed class DmarcAggregateReport {
+    /// <summary>Published policy of the report.</summary>
+    public DmarcPolicyPublished PolicyPublished { get; set; } = new();
+
+    /// <summary>Individual aggregate records contained in the report.</summary>
+    public List<DmarcAggregateRecord> Records { get; } = new();
+}

--- a/DomainDetective/DmarcPolicyPublished.cs
+++ b/DomainDetective/DmarcPolicyPublished.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective;
+
+/// <summary>Represents the published DMARC policy for a report.</summary>
+public sealed class DmarcPolicyPublished {
+    /// <summary>Domain the policy applies to.</summary>
+    public string Domain { get; set; } = string.Empty;
+
+    /// <summary>Alignment mode for DKIM.</summary>
+    public string? Adkim { get; set; }
+
+    /// <summary>Alignment mode for SPF.</summary>
+    public string? Aspf { get; set; }
+
+    /// <summary>Requested policy for the domain.</summary>
+    public string? P { get; set; }
+
+    /// <summary>Requested subdomain policy.</summary>
+    public string? Sp { get; set; }
+
+    /// <summary>Percentage of messages to which the policy is to be applied.</summary>
+    public string? Pct { get; set; }
+
+    /// <summary>Failure reporting option.</summary>
+    public string? Fo { get; set; }
+
+    /// <summary>Policy for non-existent subdomains.</summary>
+    public string? Np { get; set; }
+
+    /// <summary>Any additional policy extensions.</summary>
+    public Dictionary<string, string> Extensions { get; } = new(StringComparer.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
## Summary
- allow parsing DMARC reports from streams or .xml, .gz, and .zip paths
- capture v2 `policy_published` fields via new model types
- add regression samples for v1 and v2 aggregate reports
- generate gz/zip test archives at runtime instead of committing binaries

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a9d438acc4832eb7d3f82a4921ddb3