### PR TITLE
refactor(dmarc): enhance parser validation metrics

### DIFF
--- a/DomainDetective/DmarcAggregateReport.cs
+++ b/DomainDetective/DmarcAggregateReport.cs
@@ -9,4 +9,10 @@ public sealed class DmarcAggregateReport {
 
     /// <summary>Individual aggregate records contained in the report.</summary>
     public List<DmarcAggregateRecord> Records { get; } = new();
+
+    /// <summary>Schema validation messages encountered during parsing.</summary>
+    public List<string> ValidationMessages { get; } = new();
+
+    /// <summary>Total number of parsed records.</summary>
+    public int RecordCount => Records.Count;
 }

--- a/DomainDetective/DmarcPolicyPublished.cs
+++ b/DomainDetective/DmarcPolicyPublished.cs
@@ -26,7 +26,7 @@ public sealed class DmarcPolicyPublished {
     /// <summary>Failure reporting option.</summary>
     public string? Fo { get; set; }
 
-    /// <summary>Policy for non-existent subdomains.</summary>
+    /// <summary>Policy for non-existent subdomains (DMARC v2).</summary>
     public string? Np { get; set; }
 
     /// <summary>Any additional policy extensions.</summary>


### PR DESCRIPTION
## Summary
- document np field for DMARC v2
- improve namespace error and reset stream before schema selection
- track validation messages and record counts in parsed reports
- extend DMARC parser tests for metrics and error message

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "FullyQualifiedName~TestDmarcReportParser" --logger "console;verbosity=normal"`
- `dotnet test DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj --no-build --filter "FullyQualifiedName~DomainDetective.CLI.Tests" --logger "console;verbosity=normal"`


------
https://chatgpt.com/codex/tasks/task_e_68a9fe525b10832ebd75d4b7773f56fb