### PR TITLE
feat(whois): add dynamic WHOIS server lookup

### DIFF
--- a/DomainDetective.Tests/TestWhoisDynamicLookup.cs
+++ b/DomainDetective.Tests/TestWhoisDynamicLookup.cs
@@ -1,0 +1,29 @@
+namespace DomainDetective.Tests {
+    using System.Collections.Generic;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public class TestWhoisDynamicLookup {
+        [Fact]
+        public async Task UnmappedTldFallsBackToIanaLookup() {
+            var whois = new WhoisAnalysis {
+                IanaQueryOverride = _ => Task.FromResult("% IANA WHOIS server\r\nwhois: whois.test.net\r\n")
+            };
+
+            var method = typeof(WhoisAnalysis).GetMethod("GetWhoisServer", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(method);
+            var task = (Task<string?>)method!.Invoke(whois, new object[] { "example.unknownxtld", CancellationToken.None })!;
+            var server = await task;
+            Assert.Equal("whois.test.net", server);
+
+            var dictField = typeof(WhoisAnalysis).GetField("WhoisServers", BindingFlags.NonPublic | BindingFlags.Instance);
+            var lockField = typeof(WhoisAnalysis).GetField("_whoisServersLock", BindingFlags.NonPublic | BindingFlags.Instance);
+            var dict = (Dictionary<string, string>)dictField!.GetValue(whois)!;
+            var lockObj = lockField!.GetValue(whois)!;
+            lock (lockObj) {
+                Assert.Equal("whois.test.net", dict["unknownxtld"]);
+            }
+        }
+    }
+}

--- a/DomainDetective/Protocols/WhoisAnalysis.cs
+++ b/DomainDetective/Protocols/WhoisAnalysis.cs
@@ -405,7 +405,7 @@ public class WhoisAnalysis {
 
     public WhoisAnalysis() { }
 
-    private string GetWhoisServer(string domain) {
+    private async Task<string?> GetWhoisServer(string domain, CancellationToken ct) {
         var domainParts = domain.Split('.');
         var tld = string.Join(".", domainParts.Skip(1));
         TLD = tld;
@@ -419,8 +419,43 @@ public class WhoisAnalysis {
         tld = domainParts.Last();
         TLD = tld;
         lock (_whoisServersLock) {
-            return WhoisServers.TryGetValue(tld, out var server) ? server : null;
+            if (WhoisServers.TryGetValue(tld, out var server)) {
+                return server;
+            }
         }
+
+        var dnsServer = $"{tld}.whois-servers.net";
+        try {
+            await Dns.GetHostEntryAsync(dnsServer).ConfigureAwait(false);
+            lock (_whoisServersLock) {
+                WhoisServers[tld] = dnsServer;
+            }
+            return dnsServer;
+        } catch (SocketException) {
+        }
+
+        try {
+            string response;
+            if (IanaQueryOverride != null) {
+                response = await IanaQueryOverride(tld).ConfigureAwait(false);
+            } else {
+                response = await SharedHttpClient.GetStringWithRetryAsync(
+                    $"https://www.iana.org/whois?q={tld}",
+                    ct).ConfigureAwait(false);
+            }
+            var match = Regex.Match(response, @"whois:\s*(\S+)", RegexOptions.IgnoreCase);
+            if (match.Success) {
+                var server = match.Groups[1].Value.Trim();
+                lock (_whoisServersLock) {
+                    WhoisServers[tld] = server;
+                }
+                return server;
+            }
+        } catch (Exception ex) when (ex is HttpRequestException || ex is IOException) {
+            _logger.WriteDebug(ex.Message);
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -431,7 +466,7 @@ public class WhoisAnalysis {
         if (string.IsNullOrWhiteSpace(domain) || !domain.Contains('.')) {
             throw new UnsupportedTldException(domain, domain);
         }
-        var whoisServer = GetWhoisServer(domain);
+        var whoisServer = await GetWhoisServer(domain, cancellationToken);
         if (whoisServer == null) {
             throw new UnsupportedTldException(domain, TLD);
         }


### PR DESCRIPTION
## Summary
- add dynamic WHOIS server discovery with DNS and IANA fallbacks
- cache discovered WHOIS servers for future queries
- test unmapped TLD handling through IANA lookup

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68ac57345f24832ea8611c9c6dc79ce6