### PR TITLE
feat(whois): expose days until expiration

### DIFF
--- a/DomainDetective.Tests/TestWhoisAnalysis.cs
+++ b/DomainDetective.Tests/TestWhoisAnalysis.cs
@@ -609,5 +609,50 @@ namespace DomainDetective.Tests {
             Assert.Contains($"127.0.0.1:{port}", eventArgs!.FullMessage);
             Assert.Contains("example.sample", eventArgs.FullMessage);
         }
+
+        [Fact]
+        public void CalculatesDaysUntilExpirationForFutureDates() {
+            var whois = new WhoisAnalysis {
+                ExpiryDate = DateTime.UtcNow.AddDays(60).ToString("o")
+            };
+            var method = typeof(WhoisAnalysis).GetMethod(
+                "UpdateExpiryFlags",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            method!.Invoke(whois, null);
+
+            Assert.Equal(60, whois.DaysUntilExpiration);
+            Assert.False(whois.ExpiresSoon);
+            Assert.False(whois.IsExpired);
+        }
+
+        [Fact]
+        public void CalculatesDaysUntilExpirationForNearFutureDates() {
+            var whois = new WhoisAnalysis {
+                ExpiryDate = DateTime.UtcNow.AddDays(5).ToString("o")
+            };
+            var method = typeof(WhoisAnalysis).GetMethod(
+                "UpdateExpiryFlags",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            method!.Invoke(whois, null);
+
+            Assert.Equal(5, whois.DaysUntilExpiration);
+            Assert.True(whois.ExpiresSoon);
+            Assert.False(whois.IsExpired);
+        }
+
+        [Fact]
+        public void CalculatesDaysUntilExpirationForPastDates() {
+            var whois = new WhoisAnalysis {
+                ExpiryDate = DateTime.UtcNow.AddDays(-3).AddHours(12).ToString("o")
+            };
+            var method = typeof(WhoisAnalysis).GetMethod(
+                "UpdateExpiryFlags",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            method!.Invoke(whois, null);
+
+            Assert.Equal(-3, whois.DaysUntilExpiration);
+            Assert.False(whois.ExpiresSoon);
+            Assert.True(whois.IsExpired);
+        }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -245,6 +245,7 @@ namespace DomainDetective {
                 DnsSecKeyExpiresSoon = DnsSecAnalysis?.KeyExpiresSoon ?? false,
                 IsPublicSuffix = IsPublicSuffix,
                 ExpiryDate = WhoisAnalysis.ExpiryDate,
+                DaysUntilExpiration = WhoisAnalysis.DaysUntilExpiration,
                 ExpiresSoon = WhoisAnalysis.ExpiresSoon,
                 IsExpired = WhoisAnalysis.IsExpired,
                 RegistrarLocked = WhoisAnalysis.RegistrarLocked,

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -16,7 +16,7 @@ namespace DomainDetective {
     ///   var health = new DomainHealthCheck();
     ///   await health.Verify("example.com");
     ///   var summary = health.BuildSummary();
-    ///   Console.WriteLine(summary.ExpiryDate);
+    ///   Console.WriteLine($"Expires on {summary.ExpiryDate} in {summary.DaysUntilExpiration} days");
     ///   </code>
     /// </example>
     public class DomainSummary {
@@ -59,6 +59,9 @@ namespace DomainDetective {
 
         /// <summary>Expiration date reported by WHOIS.</summary>
         public string ExpiryDate { get; init; }
+
+        /// <summary>Number of days until expiration; negative when already expired.</summary>
+        public int? DaysUntilExpiration { get; init; }
 
         /// <summary>True when the domain expires soon.</summary>
         public bool ExpiresSoon { get; init; }


### PR DESCRIPTION
## Summary
- compute days until WHOIS expiry alongside `ExpiresSoon`
- expose numeric expiry countdown in `DomainSummary`
- add tests for past, near, and future expiration dates

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68acbf469724832e9b577e9cf58531bc