### PR TITLE
ci: skip psd1 commit for external PRs

### DIFF
--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -44,6 +44,7 @@ jobs:
               shell: pwsh
 
             - name: Commit refreshed PSD1
+              if: ${{ github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}


### PR DESCRIPTION
## Summary
- prevent manifest commit step from running in dependabot or fork pull requests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68ad530c0e4c832e9d3f2f1ef991d468