### PR TITLE
Stabilize NTP analysis test timeout

### DIFF
--- a/DomainDetective.Tests/TestNtpAnalysis.cs
+++ b/DomainDetective.Tests/TestNtpAnalysis.cs
@@ -21,13 +21,12 @@ public class TestNtpAnalysis {
             await server.SendAsync(resp, resp.Length, r.RemoteEndPoint);
         });
         try {
-            var analysis = new NtpAnalysis { Timeout = System.TimeSpan.FromSeconds(1) };
+            var analysis = new NtpAnalysis { Timeout = System.TimeSpan.FromSeconds(5) };
             await analysis.AnalyzeServer("127.0.0.1", port, new InternalLogger());
             var result = analysis.ServerResults[$"127.0.0.1:{port}"];
             Assert.True(result.Success);
             Assert.Equal((byte)2, result.Stratum);
         } finally {
-            server.Close();
             await task;
         }
     }


### PR DESCRIPTION
## Summary
- increase NTP test timeout to 5 seconds and remove premature close
- await server task to prevent race when responding

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration Release --framework net8.0 --verbosity minimal --filter FullyQualifiedName=DomainDetective.Tests.TestNtpAnalysis.ParsesStratum`


------
https://chatgpt.com/codex/tasks/task_e_68ad5d9cbe20832eae63e0a95b5e375e