### PR TITLE
test: 🧪 check UDP availability when reserving ports

### DIFF
--- a/DomainDetective.Tests/PortHelper.cs
+++ b/DomainDetective.Tests/PortHelper.cs
@@ -28,7 +28,18 @@ internal static class PortHelper {
                 var listener = new TcpListener(IPAddress.Loopback, 0);
                 listener.Start();
                 var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+                var udp = new Socket(AddressFamily.InterNetwork, SocketType.Dgram, ProtocolType.Udp);
+                try {
+                    udp.Bind(new IPEndPoint(IPAddress.Loopback, port));
+                } catch (SocketException) {
+                    listener.Stop();
+                    udp.Dispose();
+                    continue;
+                }
+
                 listener.Stop();
+                udp.Dispose();
 
                 if (!UsedPorts.Add(port)) {
                     continue;


### PR DESCRIPTION
## Summary
- ensure PortHelper only reserves ports available for both TCP and UDP to avoid conflicts
- restore SNMP UDP banner test to use PortHelper for safe port reservation

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --configuration Release --framework net8.0 --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68ad635fa130832eb5c7e18b8a886de9