### PR TITLE
Parse Received headers into structured hops

### DIFF
--- a/DomainDetective.Tests/TestMessageHeaderAnalysis.cs
+++ b/DomainDetective.Tests/TestMessageHeaderAnalysis.cs
@@ -12,7 +12,15 @@ namespace DomainDetective.Tests {
             Assert.Equal("recipient@example.com", analysis.To);
             Assert.Equal("Test Message", analysis.Subject);
             Assert.NotNull(analysis.Date);
-            Assert.Equal(2, analysis.ReceivedChain.Count);
+            Assert.Equal(2, analysis.ReceivedHops.Count);
+            var hop = analysis.ReceivedHops[0];
+            Assert.Equal("mail1.example.com", hop.FromHost);
+            Assert.Equal("192.0.2.1", hop.FromIp);
+            Assert.Equal("mx.example.net", hop.ByHost);
+            Assert.Equal("ESMTP", hop.With);
+            Assert.Equal("abc123", hop.Id);
+            Assert.Equal("<recipient@example.com>", hop.For);
+            Assert.NotNull(hop.Timestamp);
             Assert.Equal("pass", analysis.DkimResult);
             Assert.Equal("pass", analysis.SpfResult);
             Assert.Equal("pass", analysis.DmarcResult);

--- a/DomainDetective.Tests/TestMessageHeaderDkimValidator.cs
+++ b/DomainDetective.Tests/TestMessageHeaderDkimValidator.cs
@@ -9,7 +9,7 @@ namespace DomainDetective.Tests {
             analysis.Parse(raw, new InternalLogger());
 
             Assert.Equal("someuser@dkimvalidator.com", analysis.Headers["Delivered-To"]);
-            Assert.Single(analysis.ReceivedChain);
+            Assert.Single(analysis.ReceivedHops);
             Assert.Contains("v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com; s=selector1; t=1615567890; h=from:to:subject:date:message-id:mime-version:content-type; bh=abc123; b=ZGVmNDU2", analysis.Headers["DKIM-Signature"]);
             Assert.Contains("dkim=pass", analysis.Headers["Authentication-Results"]);
             Assert.Contains(MessageHeaderIssue.MissingArc, analysis.Issues);

--- a/DomainDetective.Tests/TestMessageHeaderMalformed.cs
+++ b/DomainDetective.Tests/TestMessageHeaderMalformed.cs
@@ -12,7 +12,7 @@ namespace DomainDetective.Tests {
             Assert.Equal("recipient@example.com", analysis.To);
             Assert.Equal("Malformed Message", analysis.Subject);
             Assert.NotNull(analysis.Date);
-            Assert.Single(analysis.ReceivedChain);
+            Assert.Single(analysis.ReceivedHops);
             Assert.Equal("pass", analysis.DkimResult);
             Assert.Equal("pass", analysis.SpfResult);
             Assert.Equal("pass", analysis.DmarcResult);

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -18,8 +18,8 @@ namespace DomainDetective {
         public Dictionary<string, string> Headers { get; } = new(StringComparer.OrdinalIgnoreCase);
         /// <summary>Duplicate header values keyed by header name.</summary>
         public Dictionary<string, List<string>> DuplicateHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
-        /// <summary>List of <c>Received</c> header values in order.</summary>
-        public List<string> ReceivedChain { get; } = new();
+        /// <summary>List of parsed <c>Received</c> header hops in order.</summary>
+        public List<ReceivedHop> ReceivedHops { get; } = new();
         /// <summary>Total message transit time across all hops.</summary>
         public TimeSpan? TotalTransitTime { get; private set; }
         /// <summary>Value of the <c>From</c> header.</summary>
@@ -55,7 +55,7 @@ namespace DomainDetective {
             RawHeaders = rawHeaders;
             Headers.Clear();
             DuplicateHeaders.Clear();
-            ReceivedChain.Clear();
+            ReceivedHops.Clear();
             SpamHeaders.Clear();
             Issues.Clear();
             TotalTransitTime = null;
@@ -132,7 +132,7 @@ namespace DomainDetective {
 
             switch (lower) {
                 case "received":
-                    ReceivedChain.Add(value);
+                    ReceivedHops.Add(ReceivedHop.Parse(value));
                     break;
                 case "from":
                     From = value;
@@ -247,14 +247,9 @@ namespace DomainDetective {
 
         private void ComputeTransitTime() {
             var times = new List<DateTimeOffset>();
-            foreach (var received in ReceivedChain) {
-                var idx = received.LastIndexOf(';');
-                if (idx < 0) {
-                    continue;
-                }
-                var datePart = received.Substring(idx + 1).Trim();
-                if (DateUtils.TryParse(datePart, out var dt)) {
-                    times.Add(dt);
+            foreach (var hop in ReceivedHops) {
+                if (hop.Timestamp.HasValue) {
+                    times.Add(hop.Timestamp.Value);
                 }
             }
             if (times.Count >= 2) {

--- a/DomainDetective/Protocols/ReceivedHop.cs
+++ b/DomainDetective/Protocols/ReceivedHop.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Text.RegularExpressions;
+using MimeKit.Utils;
+
+namespace DomainDetective;
+
+/// <summary>Represents a parsed <c>Received</c> header hop.</summary>
+public class ReceivedHop {
+    /// <summary>Host specified in the <c>from</c> clause.</summary>
+    public string? FromHost { get; set; }
+    /// <summary>IP address specified in the <c>from</c> clause.</summary>
+    public string? FromIp { get; set; }
+    /// <summary>Host specified in the <c>by</c> clause.</summary>
+    public string? ByHost { get; set; }
+    /// <summary>IP address specified in the <c>by</c> clause.</summary>
+    public string? ByIp { get; set; }
+    /// <summary>Protocol specified in the <c>with</c> clause.</summary>
+    public string? With { get; set; }
+    /// <summary>Identifier specified in the <c>id</c> clause.</summary>
+    public string? Id { get; set; }
+    /// <summary>Recipient specified in the <c>for</c> clause.</summary>
+    public string? For { get; set; }
+    /// <summary>Timestamp at the end of the header.</summary>
+    public DateTimeOffset? Timestamp { get; set; }
+    /// <summary>Raw header value.</summary>
+    public string Raw { get; set; } = string.Empty;
+
+    private static readonly Regex FoldingWhitespace = new("\r?\n[ \t]+", RegexOptions.Compiled);
+    private static readonly Regex LinearWhitespace = new("[ \t]+", RegexOptions.Compiled);
+    private static readonly Regex HeaderRegex = new(
+        @"^from\s+(?<fromHost>[^\s]+)(?:\s+\((?<fromDetails>.*?)\))?\s+by\s+(?<byHost>[^\s]+)(?:\s+\((?<byDetails>.*?)\))?(?:\s+with\s+(?<with>[^\s]+))?(?:\s+id\s+(?<id>[^\s]+))?(?:\s+for\s+(?<for>.+))?",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>Parses a <c>Received</c> header value into a <see cref="ReceivedHop"/>.</summary>
+    /// <param name="raw">Raw header value.</param>
+    /// <returns>Parsed <see cref="ReceivedHop"/>.</returns>
+    public static ReceivedHop Parse(string raw) {
+        var hop = new ReceivedHop { Raw = raw };
+        var noFold = FoldingWhitespace.Replace(raw, " ");
+        var normalized = LinearWhitespace.Replace(noFold, " ").Trim();
+
+        var idx = normalized.LastIndexOf(';');
+        var before = normalized;
+        if (idx >= 0) {
+            var datePart = normalized.Substring(idx + 1).Trim();
+            before = normalized.Substring(0, idx).Trim();
+            if (DateUtils.TryParse(datePart, out var dt)) {
+                hop.Timestamp = dt;
+            }
+        }
+
+        var match = HeaderRegex.Match(before);
+        if (match.Success) {
+            hop.FromHost = match.Groups["fromHost"].Value;
+            hop.ByHost = match.Groups["byHost"].Value;
+            if (match.Groups["with"].Success) {
+                hop.With = match.Groups["with"].Value;
+            }
+            if (match.Groups["id"].Success) {
+                hop.Id = match.Groups["id"].Value;
+            }
+            if (match.Groups["for"].Success) {
+                hop.For = match.Groups["for"].Value;
+            }
+
+            var fromDetails = match.Groups["fromDetails"].Value;
+            if (!string.IsNullOrEmpty(fromDetails)) {
+                var ipMatch = Regex.Match(fromDetails, @"\[(?<ip>[0-9A-Fa-f:.]+)\]");
+                if (ipMatch.Success) {
+                    hop.FromIp = ipMatch.Groups["ip"].Value;
+                }
+            }
+            var byDetails = match.Groups["byDetails"].Value;
+            if (!string.IsNullOrEmpty(byDetails)) {
+                var ipMatch = Regex.Match(byDetails, @"\[(?<ip>[0-9A-Fa-f:.]+)\]");
+                if (ipMatch.Success) {
+                    hop.ByIp = ipMatch.Groups["ip"].Value;
+                }
+            }
+        }
+
+        return hop;
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `ReceivedHop` model and parser for RFC 5321/822 Received headers
- switch `MessageHeaderAnalysis` to structured `ReceivedHops`
- extend message header tests to validate hop parsing

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68b75e7b0914832ea01b23a92ac728da