### PR TITLE
feat(bimi): add BIMI narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseBIMI.cs
+++ b/DomainDetective.Example/ExampleAnalyseBIMI.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseBIMI() {
+        var healthCheck = new DomainHealthCheck();
+        await healthCheck.Verify("github.com", [HealthCheckType.BIMI]);
+        var narrative = BimiNarrative.Build(healthCheck.BimiAnalysis);
+        Helpers.ShowPropertiesTable("BIMI narrative for github.com", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestBimiAnalysis.Narrative.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.Narrative.cs
@@ -1,0 +1,62 @@
+using DnsClientX;
+using DomainDetective.Tests.Fixtures;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace DomainDetective.Tests {
+    public partial class TestBimiAnalysis {
+    [Fact]
+    public async Task BimiNarrativeAndRecommendations() {
+        using var vmc = CreateTrustedVmc(out var root);
+        using var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+        store.Open(OpenFlags.ReadWrite);
+        store.Add(root);
+        using var cert = CreateSelfSigned();
+        var server = new TcpListenerFixture((l, t) => RunServer(l, cert, path =>
+            path.EndsWith(".svg")
+                ? ("image/svg+xml", Encoding.UTF8.GetBytes("<svg width='64' height='64' viewBox='0 0 64 64'></svg>"))
+                : ("application/pkix-cert", vmc.Export(X509ContentType.Cert)), t));
+        await server.InitializeAsync();
+        var prefix = $"https://localhost:{server.Port}/";
+        try {
+            var record = $"v=BIMI1; l={prefix}logo.svg; a={prefix}vmc.cer";
+            var answers = new List<DnsAnswer> { new() { DataRaw = record, Type = DnsRecordType.TXT } };
+            var analysis = new BimiAnalysis();
+            await analysis.AnalyzeBimiRecords(answers, new InternalLogger());
+
+            var codes = analysis.Recommendations.Select(r => r.Code).ToList();
+            Assert.Contains(BimiCodes.SvgValid, codes);
+            Assert.Contains(BimiCodes.VmcVerified, codes);
+
+            var narrative = DomainDetective.Narratives.BimiNarrative.Build(analysis);
+            Assert.Contains(narrative.Highlights, h => h.Contains("BIMI record is published"));
+            Assert.Contains(narrative.Highlights, h => h.Contains("SVG"));
+            Assert.Contains(narrative.Highlights, h => h.Contains("certificate"));
+        } finally {
+            await server.DisposeAsync();
+            store.Remove(root);
+            store.Close();
+        }
+    }
+
+    private static X509Certificate2 CreateTrustedVmc(out X509Certificate2 root) {
+        using var rootKey = RSA.Create(2048);
+        var rootReq = new CertificateRequest("CN=RootCA", rootKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        rootReq.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
+        rootReq.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(rootReq.PublicKey, false));
+        var rootCert = rootReq.CreateSelfSigned(DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddYears(1));
+        root = new X509Certificate2(rootCert.Export(X509ContentType.Pfx));
+
+        using var leafKey = RSA.Create(2048);
+        var leafReq = new CertificateRequest("CN=example", leafKey, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        leafReq.CertificateExtensions.Add(new X509Extension("1.3.6.1.5.5.7.1.12", Encoding.ASCII.GetBytes("image/svg+xml"), false));
+        var serial = new byte[8];
+        RandomNumberGenerator.Fill(serial);
+        var leafCert = leafReq.Create(root, DateTimeOffset.UtcNow.AddDays(-1), DateTimeOffset.UtcNow.AddDays(30), serial);
+        return new X509Certificate2(leafCert.Export(X509ContentType.Pfx));
+    }
+}
+}

--- a/DomainDetective.Tests/TestBimiAnalysis.cs
+++ b/DomainDetective.Tests/TestBimiAnalysis.cs
@@ -12,7 +12,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace DomainDetective.Tests {
-    public class TestBimiAnalysis {
+    public partial class TestBimiAnalysis {
         [Fact]
         public async Task ParseBimiRecord() {
             using var cert = CreateSelfSigned();

--- a/DomainDetective/Diagnostics/Codes/BimiCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/BimiCodes.cs
@@ -10,6 +10,9 @@ internal static class BimiCodes {
     public const string SvgMissingAttributes = "BIMI.SVG.MissingAttributes";
     public const string SvgWrongDimensions = "BIMI.SVG.WrongDimensions";
     public const string SvgWrongViewBox = "BIMI.SVG.WrongViewBox";
+    public const string SvgValid = "BIMI.SVG.Valid";
+    public const string VmcVerified = "BIMI.VMC.Verified";
     public const string MissingRecord = "BIMI.Record.Missing";
     public const string StartsInvalid = "BIMI.Record.StartsInvalid";
+    public const string RecordPresent = "BIMI.Record.Present";
 }

--- a/DomainDetective/Diagnostics/Recommendations/BimiRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/BimiRecommendations.cs
@@ -106,5 +106,31 @@ internal sealed class BimiRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Validate width == height and viewBox square."
         };
+
+        map[BimiCodes.SvgValid] = new RecommendationAdvice {
+            Code = BimiCodes.SvgValid,
+            Title = "BIMI SVG valid",
+            Why = "A compliant SVG indicator allows inboxes to display your brand logo.",
+            How = "Maintain SVG within BIMI size and dimension requirements.",
+            Links = new [] { "https://bimigroup.org/" },
+            Domain = RecommendationDomain.Branding,
+            Tags = new [] { "bimi", "svg" },
+            Impact = "Logo eligible for display.",
+            Effort = RecommendationEffort.Low,
+            Verify = "SVG passes BIMI validation checks."
+        };
+
+        map[BimiCodes.VmcVerified] = new RecommendationAdvice {
+            Code = BimiCodes.VmcVerified,
+            Title = "BIMI certificate verified",
+            Why = "A verified VMC proves logo ownership and is trusted by receivers.",
+            How = "Keep the certificate renewed and monitor expiry dates.",
+            Links = new [] { "https://bimigroup.org/" },
+            Domain = RecommendationDomain.Branding,
+            Tags = new [] { "bimi", "vmc" },
+            Impact = "Logo can display in supporting inboxes.",
+            Effort = RecommendationEffort.Medium,
+            Verify = "VMC chain builds to a trusted root."
+        };
     }
 }

--- a/DomainDetective/Narratives/BimiNarrative.cs
+++ b/DomainDetective/Narratives/BimiNarrative.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class BimiNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(BimiAnalysis bimi)
+    {
+        var subj = string.IsNullOrWhiteSpace(bimi?.Subject) ? "(domain)" : bimi.Subject;
+        var title = $"BIMI Report — {subj}";
+        var subtitle = "BIMI Assessment";
+        var category = "Email Branding";
+        var keywords = $"BIMI, email, branding, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Brand Indicators for Message Identification (BIMI) lets a domain publish a logo that supporting mail clients can display.";
+        var why = "A valid BIMI record with a compliant SVG and a verified certificate builds trust and strengthens brand recognition.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        hi.Add(bimi.BimiRecordExists
+            ? "BIMI record is published and begins with v=BIMI1."
+            : "No BIMI record is published.");
+
+        if (bimi.SvgFetched)
+        {
+            hi.Add(bimi.SvgValid
+                ? "BIMI SVG passed validation checks."
+                : $"BIMI SVG failed validation: {bimi.SvgInvalidReason ?? "unknown reason"}.");
+        }
+
+        if (bimi.ValidVmc)
+        {
+            hi.Add(bimi.VmcSignedByKnownRoot
+                ? "BIMI certificate is valid and trusted."
+                : "BIMI certificate present but not issued by a trusted authority.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(bimi.Location))
+        {
+            det.Add($"Indicator location: {bimi.Location}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(bimi.Authority))
+        {
+            det.Add($"Certificate location: {bimi.Authority}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(bimi.FailureReason))
+        {
+            det.Add($"Failure reason: {bimi.FailureReason}");
+        }
+
+        var refs = bimi.RfcReferences?.Select(r => string.IsNullOrWhiteSpace(r.Url) ? r.Reference : r.Url).ToList()
+                   ?? new List<string> { "https://bimigroup.org/" };
+
+        try
+        {
+            var assessments = (IEnumerable<Assessment>)(bimi.Assessments ?? new List<Assessment>());
+            var groups = RecommendationEngine.GroupByCode(assessments);
+            foreach (var g in groups)
+            {
+                var msg = string.IsNullOrWhiteSpace(g.Advice?.Title)
+                    ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
+                    : g.Advice.Title;
+                if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
+                    positives.Add(msg);
+                }
+                else
+                {
+                    remediations.Add(msg);
+                }
+            }
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+        };
+    }
+}

--- a/DomainDetective/Protocols/BimiAnalysis.cs
+++ b/DomainDetective/Protocols/BimiAnalysis.cs
@@ -107,6 +107,7 @@ public partial class BimiAnalysis : IHasAssessments {
                 logger?.WriteWarningCode(BimiCodes.MissingRecord, "No BIMI record found.");
                 return;
             }
+            logger?.WriteInformationCode(BimiCodes.RecordPresent, "BIMI record present");
 
             BimiRecord = string.Join(" ", recordList.Select(r => r.Data));
             logger.WriteVerbose($"Analyzing BIMI record {BimiRecord}");
@@ -126,6 +127,9 @@ public partial class BimiAnalysis : IHasAssessments {
                     if (svg != null) {
                         SvgFetched = true;
                         SvgValid = ValidateSvg(svg, size, logger);
+                        if (SvgValid) {
+                            logger?.WriteInformationCode(BimiCodes.SvgValid, "BIMI SVG valid");
+                        }
                         logger?.WriteVerbose("Successfully downloaded BIMI indicator from {0}", Location);
                     } else {
                         logger?.WriteWarningCode(BimiCodes.DownloadFailed, "Failed to download BIMI indicator from {0}", Location);
@@ -141,6 +145,9 @@ public partial class BimiAnalysis : IHasAssessments {
                 }
 
                 (ValidVmc, VmcSignedByKnownRoot, VmcContainsLogo) = await DownloadAndValidateVmc(Authority, logger, cancellationToken);
+                if (ValidVmc && VmcSignedByKnownRoot) {
+                    logger?.WriteInformationCode(BimiCodes.VmcVerified, "BIMI certificate valid and trusted");
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- add BIMI narrative builder highlighting record, SVG, and certificate
- add success recommendations for valid BIMI SVG and verified certificate
- include BIMI narrative example and tests

## Testing
- `dotnet build --no-restore`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --logger "console;verbosity=minimal"` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68b958ac317c832eb9a79984e5de5cd4