### PR TITLE
feat: add Autodiscover narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseAutodiscover.cs
+++ b/DomainDetective.Example/ExampleAnalyseAutodiscover.cs
@@ -1,4 +1,7 @@
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using DomainDetective.Narratives;
 
 namespace DomainDetective.Example;
 
@@ -13,5 +16,11 @@ public static partial class Program {
         await healthCheck.VerifyAutodiscover("example.com");
         Helpers.ShowPropertiesTable("Autodiscover DNS", healthCheck.AutodiscoverAnalysis);
         Helpers.ShowPropertiesTable("Autodiscover Endpoints", healthCheck.AutodiscoverHttpAnalysis.Endpoints);
+        var narrative = AutodiscoverNarrative.Build(
+            healthCheck.AutodiscoverAnalysis,
+            healthCheck.AutodiscoverAnalysis.Assessments
+                .Concat(healthCheck.AutodiscoverHttpAnalysis.Assessments));
+        Console.WriteLine(narrative.Title);
+        foreach (var h in narrative.Highlights) Console.WriteLine(" - " + h);
     }
 }

--- a/DomainDetective.Tests/TestAutodiscoverNarrative.cs
+++ b/DomainDetective.Tests/TestAutodiscoverNarrative.cs
@@ -1,0 +1,41 @@
+using DnsClientX;
+using DomainDetective.Narratives;
+using DomainDetective.Recommendations;
+using RichardSzalay.MockHttp;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestAutodiscoverNarrative {
+    [Fact]
+    public async Task BuildsNarrativeWithHighlightsAndPositives() {
+        var answers = new List<DnsAnswer> {
+            new DnsAnswer { DataRaw = "0 0 443 autodiscover.example.com", Type = DnsRecordType.SRV }
+        };
+        var cnames = new List<DnsAnswer> {
+            new DnsAnswer { DataRaw = "mail.example.com", Type = DnsRecordType.CNAME }
+        };
+        var analysis = new AutodiscoverAnalysis();
+        analysis.QueryDnsOverride = (name, type) => {
+            if (type == DnsRecordType.SRV) return Task.FromResult(answers.ToArray());
+            if (type == DnsRecordType.CNAME) return Task.FromResult(cnames.ToArray());
+            return Task.FromResult(Array.Empty<DnsAnswer>());
+        };
+        await analysis.Analyze("example.com", new DnsConfiguration(), new InternalLogger());
+
+        var mock = new MockHttpMessageHandler();
+        mock.When("https://autodiscover.example.com/autodiscover/autodiscover.xml")
+            .Respond("application/xml", "<Autodiscover></Autodiscover>");
+        var http = new AutodiscoverHttpAnalysis { HttpHandlerFactory = () => mock };
+        await http.Analyze("example.com", new InternalLogger());
+        analysis.SetHttpEndpoints(http.Endpoints);
+
+        var sections = AutodiscoverNarrative.Build(analysis, analysis.Assessments.Concat(http.Assessments));
+        Assert.Contains(sections.Highlights, h => h.Contains("SRV"));
+        Assert.Contains(sections.Highlights, h => h.Contains("valid Autodiscover XML"));
+        Assert.NotEmpty(sections.Positives);
+    }
+}

--- a/DomainDetective.Tests/TestAutodiscoverRecommendations.cs
+++ b/DomainDetective.Tests/TestAutodiscoverRecommendations.cs
@@ -1,0 +1,17 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestAutodiscoverRecommendations {
+    [Fact]
+    public void RegistersPositiveCodes() {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new AutodiscoverRecommendations().Register(map);
+        Assert.Contains(AutodiscoverCodes.EndpointDiscovered, map.Keys);
+        Assert.Equal("Autodiscover endpoint discovered", map[AutodiscoverCodes.EndpointDiscovered].Title);
+        Assert.Contains(AutodiscoverCodes.XmlValid, map.Keys);
+        Assert.Contains(AutodiscoverCodes.JsonValid, map.Keys);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/AutodiscoverCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/AutodiscoverCodes.cs
@@ -9,4 +9,7 @@ internal static class AutodiscoverCodes {
     public const string BadAutoconfigTarget = "AUTODISC.Autoconfig.BadTarget";
     public const string BadAutodiscoverTarget = "AUTODISC.Autodiscover.BadTarget";
     public const string Office365FlowFailed = "AUTODISC.Office365.FlowFailed";
+    public const string EndpointDiscovered = "AUTODISC.Endpoint.Discovered";
+    public const string XmlValid = "AUTODISC.Xml.Valid";
+    public const string JsonValid = "AUTODISC.Json.Valid";
 }

--- a/DomainDetective/Diagnostics/Recommendations/AutodiscoverRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/AutodiscoverRecommendations.cs
@@ -81,7 +81,6 @@ internal sealed class AutodiscoverRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Target resolves and validates over HTTPS."
         };
-
         map[AutodiscoverCodes.Office365FlowFailed] = new RecommendationAdvice {
             Code = AutodiscoverCodes.Office365FlowFailed,
             Title = "Office 365 Autodiscover redirected but HTTP flow failed",
@@ -92,6 +91,39 @@ internal sealed class AutodiscoverRecommendations : IRecommendationProvider {
             Impact = "Outlook/clients may fail automatic configuration.",
             Effort = RecommendationEffort.Medium,
             Verify = "GET https://autodiscover.<domain>/autodiscover/autodiscover.xml follows redirects and returns Autodiscover XML (200)."
+        };
+        map[AutodiscoverCodes.EndpointDiscovered] = new RecommendationAdvice {
+            Code = AutodiscoverCodes.EndpointDiscovered,
+            Title = "Autodiscover endpoint discovered",
+            Why = "A responsive Autodiscover service allows clients to configure automatically.",
+            How = "Maintain DNS hints and HTTPS availability so clients continue to reach the service.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "autodiscover", "http" },
+            Impact = "Improves user experience through automatic setup.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Repeat Autodiscover check and confirm an endpoint responds successfully."
+        };
+        map[AutodiscoverCodes.XmlValid] = new RecommendationAdvice {
+            Code = AutodiscoverCodes.XmlValid,
+            Title = "Autodiscover XML response valid",
+            Why = "Valid XML ensures clients obtain configuration without errors.",
+            How = "Keep the Autodiscover implementation and TLS configuration up to date.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "autodiscover", "xml" },
+            Impact = "Clients can securely retrieve settings.",
+            Effort = RecommendationEffort.Low,
+            Verify = "GET/POST Autodiscover endpoint returns XML root <Autodiscover> with expected namespace."
+        };
+        map[AutodiscoverCodes.JsonValid] = new RecommendationAdvice {
+            Code = AutodiscoverCodes.JsonValid,
+            Title = "Autodiscover JSON discovery succeeded",
+            Why = "Outlook v2 JSON provided a valid Autodiscover endpoint.",
+            How = "Ensure the Microsoft discovery service remains reachable over HTTPS.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "autodiscover", "json" },
+            Impact = "Outlook clients have a fallback path for automatic configuration.",
+            Effort = RecommendationEffort.Low,
+            Verify = "https://autodiscover-s.outlook.com/autodiscover/autodiscover.json/v1.0/<domain>?Protocol=AutodiscoverV1 returns endpoint URL."
         };
     }
 }

--- a/DomainDetective/Narratives/AutodiscoverNarrative.cs
+++ b/DomainDetective/Narratives/AutodiscoverNarrative.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class AutodiscoverNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(AutodiscoverAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"Autodiscover Report — {subj}";
+        var subtitle = "Autodiscover Assessment";
+        var category = "Email Configuration";
+        var keywords = $"Autodiscover, email, configuration, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Autodiscover helps mail clients locate server settings automatically using DNS hints and a defined HTTP flow.";
+        var why = "Reliable Autodiscover records and endpoints reduce manual setup and support secure, automatic client configuration.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No Autodiscover data available." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        // DNS highlights
+        hi.Add(analysis.SrvRecordExists
+            ? $"_autodiscover._tcp SRV points to {analysis.SrvTarget}:{analysis.SrvPort}."
+            : "_autodiscover._tcp SRV record missing.");
+        hi.Add(analysis.AutodiscoverCnameExists
+            ? $"autodiscover.{subj} CNAME → {analysis.AutodiscoverTarget}."
+            : $"autodiscover.{subj} CNAME missing.");
+        hi.Add(analysis.AutoconfigCnameExists
+            ? $"autoconfig.{subj} CNAME → {analysis.AutoconfigTarget}."
+            : "autoconfig CNAME missing.");
+
+        // HTTP highlights
+        var endpoints = analysis.Endpoints ?? Array.Empty<AutodiscoverEndpointResult>();
+        var success = endpoints.FirstOrDefault(e => e.XmlValid || e.JsonValid);
+        if (success != null)
+        {
+            hi.Add(success.XmlValid
+                ? $"Endpoint {success.FinalHost ?? success.Url} returned valid Autodiscover XML."
+                : "Outlook JSON discovery returned an Autodiscover endpoint.");
+        }
+        else
+        {
+            hi.Add("No Autodiscover endpoint produced valid XML or JSON.");
+        }
+
+        // Endpoint details
+        foreach (var e in endpoints)
+        {
+            var line = $"{e.Method}: {e.StatusCode}";
+            if (e.XmlValid) line += " (valid XML)";
+            if (e.JsonValid) line += " (valid JSON)";
+            if (!string.IsNullOrWhiteSpace(e.FinalHost) && !string.Equals(e.FinalHost, new Uri(e.FinalUrl ?? e.Url ?? string.Empty).Host, StringComparison.OrdinalIgnoreCase))
+                line += $" → {e.FinalHost}";
+            det.Add(line);
+        }
+
+        var refs = DefaultRefs();
+
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://learn.microsoft.com/exchange/client-developer/exchange-web-services/autodiscover",
+        "https://learn.microsoft.com/outlook/troubleshoot/autodiscover/autodiscover-service-overview"
+    };
+}

--- a/DomainDetective/Protocols/AutodiscoverHttpAnalysis.cs
+++ b/DomainDetective/Protocols/AutodiscoverHttpAnalysis.cs
@@ -212,7 +212,7 @@ public class AutodiscoverHttpAnalysis : IHasAssessments {
             }
         }
 
-        return new AutodiscoverEndpointResult {
+        var result = new AutodiscoverEndpointResult {
             Method = method,
             Url = url,
             StatusCode = status,
@@ -228,6 +228,12 @@ public class AutodiscoverHttpAnalysis : IHasAssessments {
             JsonValid = false,
             JsonEndpointUrl = null
         };
+        if (valid) {
+            var host = result.FinalHost ?? result.FinalUrl ?? url;
+            logger?.WriteInformationCode(AutodiscoverCodes.XmlValid, "Autodiscover endpoint {0} returned valid XML", host);
+            logger?.WriteInformationCode(AutodiscoverCodes.EndpointDiscovered, "Autodiscover endpoint discovered at {0}", host);
+        }
+        return result;
     }
 
     private static string BuildAutodiscoverRequestXml(string email) {
@@ -322,7 +328,7 @@ public class AutodiscoverHttpAnalysis : IHasAssessments {
             if (tuple.dispose) client.Dispose();
         }
 
-        return new AutodiscoverEndpointResult {
+        var res = new AutodiscoverEndpointResult {
             Method = method,
             Url = url,
             StatusCode = status,
@@ -338,6 +344,11 @@ public class AutodiscoverHttpAnalysis : IHasAssessments {
             JsonValid = !string.IsNullOrWhiteSpace(jsonEndpoint),
             JsonEndpointUrl = jsonEndpoint
         };
+        if (res.JsonValid) {
+            logger?.WriteInformationCode(AutodiscoverCodes.JsonValid, "Autodiscover JSON discovery returned {0}", jsonEndpoint);
+            logger?.WriteInformationCode(AutodiscoverCodes.EndpointDiscovered, "Autodiscover endpoint discovered via JSON: {0}", jsonEndpoint);
+        }
+        return res;
     }
 
     public List<Assessment> Assessments { get; } = new();


### PR DESCRIPTION
## Summary
- narrate Autodiscover SRV/CNAME results and HTTP flow outcomes
- log and recommend successful Autodiscover XML/JSON responses
- sample usage and tests for Autodiscover narrative and recommendations

## Testing
- `dotnet test`
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b95896654c832e83e214d21ff5234b