### PR TITLE
fix: resolve initial compiler warnings

### DIFF
--- a/DomainDetective.Generators/DomainDetective.Generators.csproj
+++ b/DomainDetective.Generators/DomainDetective.Generators.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" PrivateAssets="all" />

--- a/DomainDetective/BlockListEntry.cs
+++ b/DomainDetective/BlockListEntry.cs
@@ -7,13 +7,13 @@ namespace DomainDetective;
 /// Entries are typically loaded from text files where each line contains a URL
 /// pointing to a list of blocked IP addresses.
 /// </remarks>
-public class BlockListEntry {
-    /// <summary>Gets or sets the list name.</summary>
-    public string Name { get; set; }
-    /// <summary>Gets or sets the source URL.</summary>
-    public string Url { get; set; }
-    /// <summary>Gets or sets whether the list is queried.</summary>
-    public bool Enabled { get; set; } = true;
-    /// <summary>Gets or sets optional descriptive text.</summary>
-    public string Comment { get; set; }
-}
+    public class BlockListEntry {
+        /// <summary>Gets or sets the list name.</summary>
+        public string Name { get; set; } = string.Empty;
+        /// <summary>Gets or sets the source URL.</summary>
+        public string Url { get; set; } = string.Empty;
+        /// <summary>Gets or sets whether the list is queried.</summary>
+        public bool Enabled { get; set; } = true;
+        /// <summary>Gets or sets optional descriptive text.</summary>
+        public string? Comment { get; set; }
+    }

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -33,7 +33,7 @@ namespace DomainDetective {
             /// <summary>The negotiated TLS protocol.</summary>
             public SslProtocols Protocol { get; init; }
             /// <summary>Captured analysis details.</summary>
-            public CertificateAnalysis Analysis { get; init; }
+            public CertificateAnalysis Analysis { get; init; } = null!;
         }
 
         private PeriodicTimer? _timer;

--- a/DomainDetective/Diagnostics/AssessmentSplit.cs
+++ b/DomainDetective/Diagnostics/AssessmentSplit.cs
@@ -17,9 +17,10 @@ public static class AssessmentSplit
         var grouped = RecommendationEngine.GroupByCode(assessments);
         foreach (var g in grouped)
         {
-            var title = string.IsNullOrWhiteSpace(g.Advice?.Title) ? (g.Instances.FirstOrDefault()?.Message ?? g.Code) : g.Advice.Title;
-            if (g.MaxSeverity == AssessmentSeverity.Info) positives.Add(title);
-            else remediations.Add(title);
+            var adviceTitle = g.Advice?.Title;
+            var title = string.IsNullOrWhiteSpace(adviceTitle) ? (g.Instances.FirstOrDefault()?.Message ?? g.Code ?? string.Empty) : adviceTitle;
+            if (g.MaxSeverity == AssessmentSeverity.Info) positives.Add(title ?? string.Empty);
+            else remediations.Add(title ?? string.Empty);
         }
         positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList();

--- a/DomainDetective/DmarcReportParser.cs
+++ b/DomainDetective/DmarcReportParser.cs
@@ -173,7 +173,7 @@ public static class DmarcReportParser {
     private static string ComputeReportingPolicy(string? fo)
     {
         if (string.IsNullOrWhiteSpace(fo)) return "any failure (default, fo=0)";
-        var tokens = fo.Split(new [] { ':', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+          var tokens = fo!.Split(new [] { ':', ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
         var parts = new List<string>();
         foreach (var t in tokens)
         {

--- a/DomainDetective/DnsPropagationAnalysis.cs
+++ b/DomainDetective/DnsPropagationAnalysis.cs
@@ -104,10 +104,10 @@ namespace DomainDetective {
                 var trimmed = new PublicDnsEntry {
                     Country = entry.Country,
                     IPAddress = ip,
-                    HostName = entry.HostName?.Trim(),
+                    HostName = entry.HostName?.Trim() ?? string.Empty,
                     Location = entry.Location,
                     ASN = entry.ASN,
-                    ASNName = entry.ASNName?.Trim(),
+                    ASNName = entry.ASNName?.Trim() ?? string.Empty,
                     Enabled = entry.Enabled
                 };
 
@@ -156,10 +156,10 @@ namespace DomainDetective {
                 var trimmed = new PublicDnsEntry {
                     Country = entry.Country,
                     IPAddress = ip,
-                    HostName = entry.HostName?.Trim(),
-                    Location = entry.Location,
-                    ASN = entry.ASN,
-                    ASNName = entry.ASNName?.Trim(),
+                  HostName = entry.HostName?.Trim() ?? string.Empty,
+                  Location = entry.Location,
+                  ASN = entry.ASN,
+                  ASNName = entry.ASNName?.Trim() ?? string.Empty,
                     Enabled = entry.Enabled
                 };
 

--- a/DomainDetective/DnsPropagationResult.cs
+++ b/DomainDetective/DnsPropagationResult.cs
@@ -12,17 +12,17 @@ namespace DomainDetective {
     /// </remarks>
     public class DnsPropagationResult {
         /// <summary>Gets the server that was queried.</summary>
-        public PublicDnsEntry Server { get; init; }
+        public PublicDnsEntry Server { get; init; } = null!;
         /// <summary>Gets the DNS record type that was queried.</summary>
         public DnsRecordType RecordType { get; init; }
         /// <summary>Gets the records returned by the server.</summary>
-        public IEnumerable<string> Records { get; init; }
+        public IEnumerable<string> Records { get; init; } = Array.Empty<string>();
         /// <summary>Gets the time the query took.</summary>
         public TimeSpan Duration { get; init; }
         /// <summary>Gets a value indicating whether the query succeeded.</summary>
         public bool Success { get; init; }
         /// <summary>Gets an error message if the query failed.</summary>
-        public string Error { get; init; }
+        public string Error { get; init; } = string.Empty;
 
         /// <summary>Gets geolocation information for returned IP addresses.</summary>
         public IReadOnlyDictionary<string, GeoLocationInfo>? Geo { get; init; }

--- a/DomainDetective/DnsResult.cs
+++ b/DomainDetective/DnsResult.cs
@@ -14,11 +14,11 @@ namespace DomainDetective {
     /// </remarks>
     public class DnsResult {
         /// <summary>Gets or sets the queried name.</summary>
-        public string Name { get; set; }
+        public string Name { get; set; } = string.Empty;
         /// <summary>Gets or sets the raw data returned.</summary>
-        public string[] Data { get; set; }
+        public string[] Data { get; set; } = Array.Empty<string>();
         /// <summary>Gets or sets the data joined into a single string.</summary>
-        public string DataJoined { get; set; }
+        public string DataJoined { get; set; } = string.Empty;
         /// <summary>Gets or sets the time to live value.</summary>
         public int Ttl { get; set; }
 

--- a/DomainDetective/DnsSecConverter.cs
+++ b/DomainDetective/DnsSecConverter.cs
@@ -133,16 +133,16 @@ namespace DomainDetective {
     /// </remarks>
     public class DnsSecInfo {
         /// <summary>Returned DS records.</summary>
-        public IReadOnlyList<DsRecordInfo> DsRecords { get; set; }
+        public IReadOnlyList<DsRecordInfo> DsRecords { get; set; } = Array.Empty<DsRecordInfo>();
 
         /// <summary>Returned DNSKEY records.</summary>
-        public IReadOnlyList<DnsKeyInfo> DnsKeys { get; set; }
+        public IReadOnlyList<DnsKeyInfo> DnsKeys { get; set; } = Array.Empty<DnsKeyInfo>();
 
         /// <summary>DNSSEC signature records.</summary>
-        public IReadOnlyList<string> Signatures { get; set; }
+        public IReadOnlyList<string> Signatures { get; set; } = Array.Empty<string>();
 
         /// <summary>Structured RRSIG records.</summary>
-        public IReadOnlyList<RrsigInfo> Rrsigs { get; set; }
+        public IReadOnlyList<RrsigInfo> Rrsigs { get; set; } = Array.Empty<RrsigInfo>();
 
         /// <summary>True when the DNSKEY query had the AD flag set.</summary>
         public bool AuthenticData { get; set; }
@@ -157,16 +157,16 @@ namespace DomainDetective {
         public bool ChainValid { get; set; }
 
         /// <summary>TTL values for each DS lookup in the validation chain.</summary>
-        public IReadOnlyList<int> DsTtls { get; set; }
+        public IReadOnlyList<int> DsTtls { get; set; } = Array.Empty<int>();
 
         /// <summary>Key tag for the root trust anchor.</summary>
         public int RootKeyTag { get; set; }
 
         /// <summary>Descriptions of any mismatches encountered.</summary>
-        public IReadOnlyList<string> MismatchSummary { get; set; }
+        public IReadOnlyList<string> MismatchSummary { get; set; } = Array.Empty<string>();
 
         /// <summary>Structured assessments gathered during DNSSEC validation.</summary>
-        public IReadOnlyList<Assessment> Assessments { get; set; }
+        public IReadOnlyList<Assessment> Assessments { get; set; } = Array.Empty<Assessment>();
     }
 
     /// <summary>
@@ -179,13 +179,13 @@ namespace DomainDetective {
         public int KeyTag { get; set; }
 
         /// <summary>Algorithm name.</summary>
-        public string Algorithm { get; set; }
+        public string Algorithm { get; set; } = string.Empty;
 
         /// <summary>Digest type identifier.</summary>
         public DnsDigestType DigestType { get; set; }
 
         /// <summary>Digest hex string.</summary>
-        public string Digest { get; set; }
+        public string Digest { get; set; } = string.Empty;
     }
 
     /// <summary>
@@ -203,10 +203,10 @@ namespace DomainDetective {
         public byte Protocol { get; set; }
 
         /// <summary>Algorithm name.</summary>
-        public string Algorithm { get; set; }
+        public string Algorithm { get; set; } = string.Empty;
 
         /// <summary>Base64 encoded public key.</summary>
-        public string PublicKey { get; set; }
+        public string PublicKey { get; set; } = string.Empty;
     }
 
     /// <summary>
@@ -221,7 +221,7 @@ namespace DomainDetective {
         public int KeyTag { get; set; }
 
         /// <summary>Algorithm name.</summary>
-        public string Algorithm { get; set; }
+        public string Algorithm { get; set; } = string.Empty;
 
         /// <summary>Signature inception time.</summary>
         public DateTimeOffset Inception { get; set; }

--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -41,7 +41,7 @@ namespace DomainDetective {
         public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
         /// <summary>Provides DNS query implementation details.</summary>
-        public DnsConfiguration DnsConfiguration { get; set; }
+        public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
 
         // Per-authoritative-server TTL uniformity results
         public Dictionary<string, int?> ServerTtlA { get; private set; } = new();
@@ -144,7 +144,7 @@ namespace DomainDetective {
         private async Task<int?> QueryTtlFromServer(System.Net.IPAddress ip, string name, ushort qtype, System.Threading.CancellationToken ct) {
             var q = BuildQuery(name, qtype);
             var buf = await QueryUdp(ip, q, ct);
-            return ParseFirstAnswerTtl(buf, qtype);
+            return buf != null ? ParseFirstAnswerTtl(buf, qtype) : null;
         }
 
         /// <summary>

--- a/DomainDetective/DnsblReplyCode.cs
+++ b/DomainDetective/DnsblReplyCode.cs
@@ -16,6 +16,6 @@ public class DnsblReplyCode {
         /// <summary>
         /// Human readable explanation of the reply code.
         /// </summary>
-        public string Meaning { get; set; }
+        public string Meaning { get; set; } = string.Empty;
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.cs
@@ -84,7 +84,14 @@ namespace DomainDetective {
         /// <param name="daneServiceType">DANE service types to inspect. When <c>null</c>, SMTP and HTTPS (port 443) are queried.</param>
         /// <param name="danePorts">Custom ports to check for DANE. Overrides <paramref name="daneServiceType"/> when provided.</param>
         /// <param name="cancellationToken">Token to cancel the operation.</param>
-        public async Task Verify(string domainName, HealthCheckType[] healthCheckTypes = null, string[] dkimSelectors = null, ServiceType[] daneServiceType = null, int[] danePorts = null, PortScanProfile[] portScanProfiles = null, CancellationToken cancellationToken = default) {
+        public async Task Verify(
+            string domainName,
+            HealthCheckType[]? healthCheckTypes = null,
+            string[]? dkimSelectors = null,
+            ServiceType[]? daneServiceType = null,
+            int[]? danePorts = null,
+            PortScanProfile[]? portScanProfiles = null,
+            CancellationToken cancellationToken = default) {
             if (string.IsNullOrWhiteSpace(domainName)) {
                 throw new ArgumentNullException(nameof(domainName));
             }
@@ -199,8 +206,7 @@ namespace DomainDetective {
             await DnsHealthAnalysis.Analyze(domainName, _logger, cancellationToken);
         }
 
-        /// Creates a high level summary of key analyses.
-        /// </summary>
+        /// <summary>Creates a high level summary of key analyses.</summary>
         /// <returns>A populated <see cref="DomainSummary"/>.</returns>
         public DomainSummary BuildSummary() {
             var spfValid = SpfAnalysis.SpfRecordExists && SpfAnalysis.StartsCorrectly &&
@@ -280,7 +286,7 @@ namespace DomainDetective {
         /// <para>A JSON representation of the current
         /// <see cref="DomainHealthCheck"/>.</para>
         /// </returns>
-        public string ToJson(JsonSerializerOptions options = null) {
+        public string ToJson(JsonSerializerOptions? options = null) {
             options ??= JsonOptions;
             if (UnicodeOutput && options.Converters.All(c => c is not IdnStringConverter)) {
                 var local = new JsonSerializerOptions(options);

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -278,8 +278,7 @@ namespace DomainDetective {
         /// <value>Information about unresolved CNAME targets.</value>
         public DanglingCnameAnalysis DanglingCnameAnalysis { get; private set; } = new DanglingCnameAnalysis();
 
-        /// Gets DNS TTL analysis.
-        /// </summary>
+        /// <summary>Gets DNS TTL analysis.</summary>
         /// <value>Information about record TTL values.</value>
         public DnsTtlAnalysis DnsTtlAnalysis { get; private set; } = new DnsTtlAnalysis();
 
@@ -362,7 +361,7 @@ namespace DomainDetective {
         /// <param name="internalLogger">
         /// <para>Optional logger for diagnostic output.</para>
         /// </param>
-        public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.System, InternalLogger internalLogger = null) {
+        public DomainHealthCheck(DnsEndpoint dnsEndpoint = DnsEndpoint.System, InternalLogger? internalLogger = null) {
 
             if (internalLogger != null) {
                 _logger = internalLogger;

--- a/DomainDetective/DomainSummary.cs
+++ b/DomainDetective/DomainSummary.cs
@@ -30,7 +30,7 @@ namespace DomainDetective {
         public bool HasDmarcRecord { get; init; }
 
         /// <summary>Policy configured in the DMARC record.</summary>
-        public string DmarcPolicy { get; init; }
+        public string DmarcPolicy { get; init; } = string.Empty;
 
         /// <summary>True when the DMARC record appears valid.</summary>
         public bool DmarcValid { get; init; }
@@ -53,12 +53,12 @@ namespace DomainDetective {
         /// <summary>
         /// Indicates whether the analyzed domain is itself a public suffix as
         /// defined by <see href="https://datatracker.ietf.org/doc/html/rfc8499"/>
-        /// RFC&nbsp;8499.
+        /// RFC&#160;8499.
         /// </summary>
         public bool IsPublicSuffix { get; init; }
 
         /// <summary>Expiration date reported by WHOIS.</summary>
-        public string ExpiryDate { get; init; }
+        public string ExpiryDate { get; init; } = string.Empty;
 
         /// <summary>Number of days until expiration; negative when already expired.</summary>
         public int? DaysUntilExpiration { get; init; }

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -75,7 +75,7 @@ namespace DomainDetective {
         /// <summary>Gets or sets a value indicating whether the entry is used during checks.</summary>
         public bool Enabled { get; set; } = true;
         /// <summary>Gets or sets optional descriptive text.</summary>
-        public string Comment { get; set; }
+        public string? Comment { get; set; }
         /// <summary>Gets or sets provider specific reply codes.</summary>
         public Dictionary<string, DnsblReplyCode> ReplyCodes { get; set; } = new(StringComparer.OrdinalIgnoreCase);
 
@@ -83,7 +83,7 @@ namespace DomainDetective {
         public int Port { get; set; } = 53;
 
         public DnsblEntry() { }
-        public DnsblEntry(string domain, bool enabled = true, string comment = null, int port = 53) {
+        public DnsblEntry(string domain, bool enabled = true, string? comment = null, int port = 53) {
             Domain = domain;
             Enabled = enabled;
             Comment = comment;
@@ -157,7 +157,7 @@ namespace DomainDetective {
         /// </value>
         internal List<DnsblEntry> DnsblEntries { get; } = new();
 
-        public DNSBLAnalysis(DnsConfiguration dnsConfiguration = null) {
+        public DNSBLAnalysis(DnsConfiguration? dnsConfiguration = null) {
             DnsConfiguration = dnsConfiguration ?? new DnsConfiguration();
             DnsblEntries.AddRange(_defaultEntries.Select(e => {
                 var entry = new DnsblEntry(e.Domain, e.Enabled, e.Comment, e.Port);
@@ -472,7 +472,7 @@ namespace DomainDetective {
             return ipAddress.ToPtrFormat();
         }
 
-        private async IAsyncEnumerable<DNSBLRecord> QueryDNSBL(IEnumerable<string> dnsblList, string ipAddressOrHostname, DnsblIpSource? ipSource = null, string sourceHost = null) {
+        private async IAsyncEnumerable<DNSBLRecord> QueryDNSBL(IEnumerable<string> dnsblList, string ipAddressOrHostname, DnsblIpSource? ipSource = null, string? sourceHost = null) {
             // Gracefully handle missing/empty provider lists to avoid crashes when configuration isn't loaded
             if (dnsblList == null)
                 yield break;
@@ -587,7 +587,7 @@ namespace DomainDetective {
         /// <param name="enabled">Whether the entry should be queried.</param>
         /// <param name="comment">Optional descriptive comment.</param>
         /// <param name="port">DNS port used when querying.</param>
-        public void AddDNSBL(string dnsbl, bool enabled = true, string comment = null, int port = 53) {
+        public void AddDNSBL(string dnsbl, bool enabled = true, string? comment = null, int port = 53) {
             if (string.IsNullOrWhiteSpace(dnsbl))
                 return;
 

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -93,7 +93,7 @@ namespace DomainDetective {
             _client.DefaultRequestHeaders.Add("Accept", "application/dns-json");
         }
 
-        public async Task Analyze(string domainName, InternalLogger logger, DnsConfiguration dnsConfiguration = null, CancellationToken ct = default) {
+        public async Task Analyze(string domainName, InternalLogger logger, DnsConfiguration? dnsConfiguration = null, CancellationToken ct = default) {
             using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "DNSSEC", target: domainName) : null;
             Subject = domainName;
             var client = _client;
@@ -651,7 +651,7 @@ namespace DomainDetective {
         /// <param name="logger">Optional logger for diagnostics.</param>
         /// <returns>List of DS record strings for the root zone.</returns>
         public static async Task<(IReadOnlyList<string> anchors, DateTimeOffset? expiration)> DownloadTrustAnchors(
-            InternalLogger logger = null,
+            InternalLogger? logger = null,
             CancellationToken cancellationToken = default) {
             const string url = "https://data.iana.org/root-anchors/root-anchors.xml";
             string cacheDir = Path.Combine(Path.GetTempPath(), "DomainDetective");

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -61,7 +61,7 @@ public class SecurityTXTAnalysis : IHasAssessments {
         /// <summary>
         /// Retrieves and parses the security.txt file for the given domain.
         /// </summary>
-        public async Task AnalyzeSecurityTxtRecord(string domainName, InternalLogger logger, string pgpPublicKey = null) {
+        public async Task AnalyzeSecurityTxtRecord(string domainName, InternalLogger logger, string? pgpPublicKey = null) {
             Logger = logger;
             using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "SECURITYTXT", target: domainName);
 


### PR DESCRIPTION
## Summary
- enable extended analyzer rules for source generators
- correct XML comments and adjust nullability across domain health components
- initialize various models to eliminate nullable warnings

## Testing
- `dotnet build`
- `dotnet test` *(fails: RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68b95e149c80832eaf57f814264a495b