### PR TITLE
feat(cert): add HTTP certificate narrative and positive advice

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -27,7 +27,7 @@ internal static class Program {
         // If arguments start with options (e.g., --domain), assume the 'wizard' command implicitly
         if (args.Length == 0) {
             args = new[] { "wizard", "--interactive", "--simple-ui", "--pause-exit" };
-        } else if (args.Length > 0 && args[0].StartsWith("-")) {
+        } else if (args.Length > 0 && args[0].StartsWith("-") && args[0] != "--help" && args[0] != "-h") {
             var list = new List<string> { "wizard" };
             list.AddRange(args);
             args = list.ToArray();
@@ -36,6 +36,7 @@ internal static class Program {
         var app = new CommandApp();
         app.Configure(config => {
             config.SetApplicationName("DomainDetective");
+            config.AddExample(new[] { "check", "example.com" });
             config.AddCommand<WizardScanCommand>("WizardScan")
                 .WithDescription("Run the Hacker Wizard (parallel, animated)")
                 .WithExample(new[] { "WizardScan", "--domain", "example.com", "--full", "--matrix" })

--- a/DomainDetective.Example/ExampleCertificateHTTP.cs
+++ b/DomainDetective.Example/ExampleCertificateHTTP.cs
@@ -1,4 +1,5 @@
 using DomainDetective;
+using DomainDetective.Narratives;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,5 +36,13 @@ public static partial class Program {
         Console.WriteLine($"Expired       : {analysis.IsExpired}");
         Console.WriteLine($"Days left     : {analysis.DaysToExpire}");
         Console.WriteLine($"Days valid    : {analysis.DaysValid}");
+    }
+
+    /// <summary>Builds a narrative and lists positive certificate advice.</summary>
+    public static async Task ExampleCertificateNarrative() {
+        var analysis = await CertificateAnalysis.CheckWebsiteCertificate("https://google.com");
+        var sections = CertificateHttpNarrative.Build(analysis, analysis.Assessments);
+        Helpers.ShowPropertiesTable("Certificate Highlights", sections.Highlights);
+        Helpers.ShowPropertiesTable("Certificate Positives", sections.Positives);
     }
 }

--- a/DomainDetective.Tests/TestCertificateHttpNarrative.cs
+++ b/DomainDetective.Tests/TestCertificateHttpNarrative.cs
@@ -24,6 +24,8 @@ public class TestCertificateHttpNarrative {
             Code = CertificateHttpCodes.ContentTypeValid,
             Message = "Content type ok"
         });
+        Assert.NotNull(analysis.Assessments);
+        Assert.Equal(2, analysis.Assessments.Count);
         var sections = CertificateHttpNarrative.Build(analysis, analysis.Assessments);
         Assert.Contains(sections.Highlights, h => h.Contains("chain is valid"));
         Assert.Contains(sections.Highlights, h => h.Contains("expires in"));
@@ -39,5 +41,52 @@ public class TestCertificateHttpNarrative {
         var positives = RecommendationEngine.FromPositives(assessments);
         Assert.Contains(positives, p => p.Code == CertificateHttpCodes.ChainValid);
         Assert.Contains(positives, p => p.Code == CertificateHttpCodes.ContentTypeValid);
+    }
+
+    [Fact]
+    public void HighlightsExpiredAndInvalidCertificates() {
+        var analysis = new CertificateAnalysis {
+            Subject = "expired.example",
+            Url = "https://expired.example",
+            IsReachable = true,
+            IsValid = false,
+            DaysToExpire = -1
+        };
+
+        typeof(CertificateAnalysis).GetProperty("IsExpired")!.SetValue(analysis, true);
+
+        var sections = CertificateHttpNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("invalid"));
+        Assert.Contains(sections.Highlights, h => h.Contains("expired"));
+    }
+
+    [Fact]
+    public void HandlesNullCertificateAndEmptyAssessments() {
+        var analysis = new CertificateAnalysis {
+            Subject = "nocert.example",
+            Url = "https://nocert.example",
+            IsReachable = true,
+            IsValid = true,
+            Certificate = null
+        };
+
+        var sections = CertificateHttpNarrative.Build(analysis, new List<Assessment>());
+        Assert.Empty(sections.Details);
+        Assert.Empty(sections.Positives);
+        Assert.Empty(sections.Remediations);
+    }
+
+    [Fact]
+    public void SplitsLargeAssessmentCollections() {
+        var analysis = new CertificateAnalysis { Subject = "big.example" };
+        for (var i = 0; i < 100; i++) {
+            analysis.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = CertificateHttpCodes.ChainValid, Message = "ok" });
+            analysis.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Error, Code = CertificateHttpCodes.FetchFailed, Message = "bad" });
+        }
+
+        var sections = CertificateHttpNarrative.Build(analysis, analysis.Assessments);
+        Assert.Equal(200, analysis.Assessments.Count);
+        Assert.Equal(1, sections.Positives.Count);
+        Assert.Equal(1, sections.Remediations.Count);
     }
 }

--- a/DomainDetective.Tests/TestCertificateHttpNarrative.cs
+++ b/DomainDetective.Tests/TestCertificateHttpNarrative.cs
@@ -1,0 +1,43 @@
+using DomainDetective.Narratives;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestCertificateHttpNarrative {
+    [Fact]
+    public void BuildsNarrativeWithHighlightsAndPositives() {
+        var analysis = new CertificateAnalysis {
+            Subject = "example.com",
+            Url = "https://example.com",
+            IsReachable = true,
+            IsValid = true,
+            DaysToExpire = 30
+        };
+        analysis.Assessments.Add(new Assessment {
+            Severity = AssessmentSeverity.Info,
+            Code = CertificateHttpCodes.ChainValid,
+            Message = "Chain valid"
+        });
+        analysis.Assessments.Add(new Assessment {
+            Severity = AssessmentSeverity.Info,
+            Code = CertificateHttpCodes.ContentTypeValid,
+            Message = "Content type ok"
+        });
+        var sections = CertificateHttpNarrative.Build(analysis, analysis.Assessments);
+        Assert.Contains(sections.Highlights, h => h.Contains("chain is valid"));
+        Assert.Contains(sections.Highlights, h => h.Contains("expires in"));
+        Assert.NotEmpty(sections.Positives);
+    }
+
+    [Fact]
+    public void ProvidesPositiveAdvice() {
+        var assessments = new List<Assessment> {
+            new() { Severity = AssessmentSeverity.Info, Code = CertificateHttpCodes.ChainValid, Message = "Chain valid" },
+            new() { Severity = AssessmentSeverity.Info, Code = CertificateHttpCodes.ContentTypeValid, Message = "Content type ok" }
+        };
+        var positives = RecommendationEngine.FromPositives(assessments);
+        Assert.Contains(positives, p => p.Code == CertificateHttpCodes.ChainValid);
+        Assert.Contains(positives, p => p.Code == CertificateHttpCodes.ContentTypeValid);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/CertificateHttpCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/CertificateHttpCodes.cs
@@ -3,5 +3,7 @@ namespace DomainDetective;
 internal static class CertificateHttpCodes {
     public const string FetchFailed = "CERTHTTP.Fetch.Failed";
     public const string ConnectFailed = "CERTHTTP.Connect.Failed";
+    public const string ChainValid = "CERTHTTP.Chain.Valid";
+    public const string ContentTypeValid = "CERTHTTP.ContentType.Valid";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/CertificateHttpRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/CertificateHttpRecommendations.cs
@@ -26,6 +26,30 @@ internal sealed class CertificateHttpRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Retry with curl -v --tlsv1.2 and verify successful HTTP 200 over TLS."
         };
+
+        // Positive signals (informational)
+        map[CertificateHttpCodes.ChainValid] = new RecommendationAdvice {
+            Code = CertificateHttpCodes.ChainValid,
+            Title = "Certificate chain valid",
+            Why = "A complete, trusted certificate chain allows clients to verify server identity.",
+            How = "Continue monitoring certificate expiration and intermediate CA trust.",
+            Domain = RecommendationDomain.Tls,
+            Tags = new [] { "tls", "certificate" },
+            Impact = "Users see no trust warnings when connecting over HTTPS.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Run openssl s_client -showcerts and confirm the chain verifies without errors."
+        };
+        map[CertificateHttpCodes.ContentTypeValid] = new RecommendationAdvice {
+            Code = CertificateHttpCodes.ContentTypeValid,
+            Title = "Serves certificate with correct content type",
+            Why = "Proper Content-Type headers ensure automated tools parse certificate responses reliably.",
+            How = "Keep the endpoint configured to return application/pem-certificate-chain or application/x-pem-file.",
+            Domain = RecommendationDomain.Tls,
+            Tags = new [] { "tls", "https", "content-type" },
+            Impact = "Clients can download certificates programmatically without additional handling.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Fetch the certificate URL and inspect the Content-Type header."
+        };
     }
 }
 

--- a/DomainDetective/Narratives/CertificateHttpNarrative.cs
+++ b/DomainDetective/Narratives/CertificateHttpNarrative.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -20,7 +21,7 @@ public static class CertificateHttpNarrative {
     }
 
     public static Sections Build(CertificateAnalysis analysis, IEnumerable<Assessment>? assessments = null) {
-        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject;
         var title = $"HTTPS Certificate — {subj}";
         var subtitle = "TLS Certificate Assessment";
         var category = "Web Security";
@@ -62,7 +63,9 @@ public static class CertificateHttpNarrative {
             if (assessments != null) {
                 AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
             }
-        } catch { }
+        } catch (Exception ex) {
+            System.Diagnostics.Debug.WriteLine(ex);
+        }
 
         return new Sections {
             Title = title,

--- a/DomainDetective/Narratives/CertificateHttpNarrative.cs
+++ b/DomainDetective/Narratives/CertificateHttpNarrative.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace DomainDetective.Narratives;
 
@@ -20,30 +19,32 @@ public static class CertificateHttpNarrative {
         public List<string> Remediations { get; init; } = new();
     }
 
-    public static Sections Build(CertificateAnalysis analysis, IEnumerable<Assessment>? assessments = null) {
-        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject;
-        var title = $"HTTPS Certificate — {subj}";
-        var subtitle = "TLS Certificate Assessment";
-        var category = "Web Security";
-        var keywords = $"TLS, certificate, DomainDetective, {subj}";
-        var creator = "DomainDetective";
+    /// <summary>Builds narrative sections for HTTP certificate analysis.</summary>
+    public static Sections Build(CertificateAnalysis? analysis, IEnumerable<Assessment>? assessments = null) {
         var intro = "Retrieves the TLS certificate over HTTPS and evaluates chain trust and expiry.";
         var why = "Trusted certificates with reasonable lifetimes prevent browser warnings and ensure secure connections.";
-
-        var hi = new List<string>();
-        var det = new List<string>();
-        var positives = new List<string>();
-        var remediations = new List<string>();
 
         if (analysis == null) {
             return new Sections {
                 Introduction = intro,
                 WhyItMatters = why,
                 Highlights = new List<string> { "No certificate data available." },
-                Details = det,
+                Details = new List<string>(),
                 References = DefaultRefs()
             };
         }
+
+        var subj = string.IsNullOrWhiteSpace(analysis.Subject) ? "(domain)" : analysis.Subject;
+        var title = $"HTTPS Certificate — {subj}";
+        const string subtitle = "TLS Certificate Assessment";
+        const string category = "Web Security";
+        var keywords = $"TLS, certificate, DomainDetective, {subj}";
+        const string creator = "DomainDetective";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
 
         hi.Add(analysis.IsReachable
             ? $"Successfully retrieved certificate from {analysis.Url ?? subj}."

--- a/DomainDetective/Narratives/CertificateHttpNarrative.cs
+++ b/DomainDetective/Narratives/CertificateHttpNarrative.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class CertificateHttpNarrative {
+    public sealed class Sections {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(CertificateAnalysis analysis, IEnumerable<Assessment>? assessments = null) {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"HTTPS Certificate — {subj}";
+        var subtitle = "TLS Certificate Assessment";
+        var category = "Web Security";
+        var keywords = $"TLS, certificate, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Retrieves the TLS certificate over HTTPS and evaluates chain trust and expiry.";
+        var why = "Trusted certificates with reasonable lifetimes prevent browser warnings and ensure secure connections.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null) {
+            return new Sections {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No certificate data available." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        hi.Add(analysis.IsReachable
+            ? $"Successfully retrieved certificate from {analysis.Url ?? subj}."
+            : $"Failed to retrieve certificate from {analysis.Url ?? subj}.");
+        hi.Add(analysis.IsValid ? "Certificate chain is valid." : "Certificate chain is invalid.");
+        hi.Add(analysis.IsExpired ? "Certificate has expired." : $"Certificate expires in {analysis.DaysToExpire} days.");
+
+        if (analysis.Certificate != null) {
+            det.Add($"Subject: {analysis.Certificate.Subject}");
+            det.Add($"Issuer: {analysis.Certificate.Issuer}");
+            det.Add($"NotAfter: {analysis.Certificate.NotAfter:u}");
+        }
+
+        var refs = DefaultRefs();
+
+        try {
+            if (assessments != null) {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        } catch { }
+
+        return new Sections {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new() {
+        "https://datatracker.ietf.org/doc/html/rfc5280",
+        "https://letsencrypt.org/docs/"
+    };
+}


### PR DESCRIPTION
## Summary
- build HTTP certificate narrative with highlights, expiry and chain status
- register success codes for valid chains and correct content types
- showcase narrative usage in example and add unit tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --no-build --filter TestCertificateHttpNarrative`
- `dotnet test -c Release` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68b95f344278832ebffa8de6dff491ab