### PR TITLE
feat(caa): add narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseCAA.cs
+++ b/DomainDetective.Example/ExampleAnalyseCAA.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using DomainDetective.Narratives;
 
 namespace DomainDetective.Example;
 
@@ -34,6 +36,9 @@ public static partial class Program {
         Helpers.ShowPropertiesTable(analysisOf: "CAA Example by String", objs: healthCheck.CAAAnalysis);
 
         Helpers.ShowPropertiesTable(analysisOf: "CAA Example by String", objs: healthCheck.CAAAnalysis.AnalysisResults);
+        var narrative = CaaNarrative.Build(healthCheck.CAAAnalysis);
+        Console.WriteLine(narrative.Title);
+        foreach (var h in narrative.Highlights) Console.WriteLine(" - " + h);
     }
 
     public static async Task ExampleAnalyseByDomainCAA() {

--- a/DomainDetective.Tests/TestCaaNarrative.cs
+++ b/DomainDetective.Tests/TestCaaNarrative.cs
@@ -1,0 +1,31 @@
+using DomainDetective;
+using DomainDetective.Narratives;
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestCaaNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeAndPositives()
+    {
+        var records = new List<string>
+        {
+            "0 issue \"letsencrypt.org\"",
+            "0 issuewild \"letsencrypt.org\"",
+            "0 iodef \"mailto:security@example.com\""
+        };
+        var hc = new DomainHealthCheck { Verbose = false };
+        await hc.CheckCAA(records);
+        var sections = CaaNarrative.Build(hc.CAAAnalysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("letsencrypt.org"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Wildcard", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(sections.Highlights, h => h.Contains("security@example.com"));
+        var positives = RecommendationEngine.FromPositives(hc.CAAAnalysis.Assessments);
+        Assert.Contains(positives, p => p.Code == CaaCodes.RecordPresent);
+        Assert.Contains(positives, p => p.Code == CaaCodes.IodefPresent);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/CaaCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/CaaCodes.cs
@@ -4,5 +4,7 @@ internal static class CaaCodes {
     public const string ReservedFlagBits = "CAA.Flag.ReservedBits";
     public const string UnknownCriticalTag = "CAA.Tag.Unknown.Critical";
     public const string DuplicateIssuers = "CAA.Issuer.Duplicate";
+    public const string RecordPresent = "CAA.Record.Present";
+    public const string IodefPresent = "CAA.Iodef.Present";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/CaaRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/CaaRecommendations.cs
@@ -42,5 +42,31 @@ internal sealed class CaaRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "List unique issuers; remove duplicates."
         };
+
+        map[CaaCodes.RecordPresent] = new RecommendationAdvice {
+            Code = CaaCodes.RecordPresent,
+            Title = "CAA record present",
+            Why = "Restricts certificate issuance to specified authorities.",
+            How = "Maintain the authorized CA list to match organizational requirements.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc8659" },
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "caa", "tls" },
+            Impact = "Reduces risk of unauthorized certificates.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Query CAA records and confirm expected issuers."
+        };
+
+        map[CaaCodes.IodefPresent] = new RecommendationAdvice {
+            Code = CaaCodes.IodefPresent,
+            Title = "CAA reporting endpoint present",
+            Why = "Enables CAs to report unauthorized certificate requests.",
+            How = "Monitor the listed contact address or URL for CAA violation reports.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc8659" },
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "caa", "reporting" },
+            Impact = "Provides visibility into certificate issuance attempts.",
+            Effort = RecommendationEffort.Low,
+            Verify = "CAA record includes an iodef tag with a reachable URI."
+        };
     }
 }

--- a/DomainDetective/Narratives/CaaNarrative.cs
+++ b/DomainDetective/Narratives/CaaNarrative.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class CaaNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(CAAAnalysis caa)
+    {
+        var subj = string.IsNullOrWhiteSpace(caa?.Subject) ? "(domain)" : caa.Subject;
+        var title = $"CAA Report — {subj}";
+        var subtitle = "CAA Assessment";
+        var category = "TLS Security";
+        var keywords = $"CAA, tls, certificate, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Certificate Authority Authorization (CAA) records specify which certificate authorities may issue certificates and where to report policy violations.";
+        var why = "CAA reduces the risk of unauthorized certificates by limiting trusted issuers and providing contacts for violation reporting.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        hi.Add(caa.AnalysisResults.Count > 0 ? "CAA record is published." : "No CAA record is published.");
+        if (caa.CanIssueCertificatesForDomain.Any())
+            hi.Add($"Authorized CAs: {string.Join(", ", caa.CanIssueCertificatesForDomain)}");
+        if (caa.CanIssueWildcardCertificatesForDomain.Any())
+            hi.Add($"Wildcard CAs: {string.Join(", ", caa.CanIssueWildcardCertificatesForDomain)}");
+        if (caa.ReportViolationEmail.Any())
+            hi.Add($"Report tags: {string.Join(", ", caa.ReportViolationEmail)}");
+
+        det.Add($"Valid records: {caa.ValidRecords}");
+        det.Add($"Invalid records: {caa.InvalidRecords}");
+
+        var refs = new List<string>
+        {
+            "https://www.rfc-editor.org/rfc/rfc8659"
+        };
+
+        try
+        {
+            AssessmentSplit.SplitTitles(caa.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -312,6 +312,14 @@ As an illustration, a CAA record that is set on example.com is also applicable t
             CanIssueWildcardCertificatesForDomain = wildcardIssuers.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
             CanIssueMail = mailIssuers.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
             ReportViolationEmail = emails.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+
+            if (Valid && AnalysisResults.Count > 0) {
+                logger?.WriteInformationCode(CaaCodes.RecordPresent, $"CAA record present with {AnalysisResults.Count} record(s)");
+            }
+
+            if (ReportViolationEmail.Count > 0) {
+                logger?.WriteInformationCode(CaaCodes.IodefPresent, $"CAA reporting endpoint(s) configured: {ReportViolationEmail.Count}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- implement CAA narrative summarising authorized issuers, wildcard flags, and report endpoints
- log and map positive CAA recommendations for valid records and iodef tags
- add example and tests covering narrative sections and positive signals

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test --no-build` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b95f3029e8832e8d26141dcd1da9d5