### PR TITLE
feat(openrelay): add narrative and secure relay checks

### DIFF
--- a/DomainDetective.Example/ExampleOpenRelayNarrative.cs
+++ b/DomainDetective.Example/ExampleOpenRelayNarrative.cs
@@ -16,7 +16,7 @@ public static partial class Program
         {
             Status = OpenRelayStatus.Denied
         };
-        var narrative = OpenRelayNarrative.Build(analysis);
+        var narrative = OpenRelayNarrative.Build(analysis, new InternalLogger());
         Helpers.ShowPropertiesTable("Open Relay Narrative", narrative);
         return Task.CompletedTask;
     }

--- a/DomainDetective.Example/ExampleOpenRelayNarrative.cs
+++ b/DomainDetective.Example/ExampleOpenRelayNarrative.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building an Open Relay narrative from analysis results.
+    /// </summary>
+    public static Task ExampleOpenRelayNarrative()
+    {
+        var analysis = new OpenRelayAnalysis();
+        analysis.ServerResults["smtp.example.com:25"] = new OpenRelayAnalysis.OpenRelayResult
+        {
+            Status = OpenRelayStatus.Denied
+        };
+        var narrative = OpenRelayNarrative.Build(analysis);
+        Helpers.ShowPropertiesTable("Open Relay Narrative", narrative);
+        return Task.CompletedTask;
+    }
+}

--- a/DomainDetective.Tests/TestOpenRelayAnalysis.cs
+++ b/DomainDetective.Tests/TestOpenRelayAnalysis.cs
@@ -172,6 +172,73 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task AnalyzeServersClearsPreviousResults() {
+            var listener1 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener1.Start();
+            var port1 = ((System.Net.IPEndPoint)listener1.LocalEndpoint).Port;
+            var serverTask1 = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener1.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220-test");
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-hello");
+                await writer.WriteLineAsync("250 hello");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-OK");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-OK");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            var analysis = new OpenRelayAnalysis();
+            try {
+                await analysis.AnalyzeServer("localhost", port1, new InternalLogger());
+                Assert.Single(analysis.ServerResults);
+            } finally {
+                listener1.Stop();
+                await serverTask1;
+            }
+
+            var listener2 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener2.Start();
+            var port2 = ((System.Net.IPEndPoint)listener2.LocalEndpoint).Port;
+            var serverTask2 = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener2.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220-test");
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-hello");
+                await writer.WriteLineAsync("250 hello");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-OK");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("550 relay denied");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                await analysis.AnalyzeServers(new[] { "localhost" }, new[] { port2 }, new InternalLogger());
+                Assert.Single(analysis.ServerResults);
+                Assert.False(analysis.ServerResults.ContainsKey($"localhost:{port1}"));
+                Assert.Equal(OpenRelayStatus.Denied, analysis.ServerResults[$"localhost:{port2}"].Status);
+            } finally {
+                listener2.Stop();
+                await serverTask2;
+            }
+        }
+
+        [Fact]
         public async Task AnalyzeServersMultiplePorts() {
             var listener1 = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
             listener1.Start();

--- a/DomainDetective.Tests/TestOpenRelayNarrative.cs
+++ b/DomainDetective.Tests/TestOpenRelayNarrative.cs
@@ -41,7 +41,7 @@ public class TestOpenRelayNarrative
             var logger = new InternalLogger();
             var analysis = new OpenRelayAnalysis();
             await analysis.AnalyzeServer("localhost", port, logger);
-            var narrative = OpenRelayNarrative.Build(analysis);
+            var narrative = OpenRelayNarrative.Build(analysis, logger);
             Assert.Contains("No servers allowed unauthenticated relay.", narrative.Highlights);
             var positives = RecommendationEngine.FromPositives(analysis.Assessments);
             Assert.Contains(positives, p => p.Code == OpenRelayCodes.Denied);

--- a/DomainDetective.Tests/TestOpenRelayNarrative.cs
+++ b/DomainDetective.Tests/TestOpenRelayNarrative.cs
@@ -1,0 +1,55 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestOpenRelayNarrative
+{
+    [Fact]
+    public async Task OpenRelayNarrativeShowsDeniedAndPositive()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var serverTask = Task.Run(async () =>
+        {
+            using var client = await listener.AcceptTcpClientAsync();
+            using var stream = client.GetStream();
+            using var reader = new StreamReader(stream);
+            using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220-test");
+            await writer.WriteLineAsync("220 local ESMTP");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("250-hello");
+            await writer.WriteLineAsync("250 hello");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("250-OK");
+            await writer.WriteLineAsync("250 OK");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("550 relay denied");
+            await reader.ReadLineAsync();
+            await writer.WriteLineAsync("221 bye");
+        });
+
+        try
+        {
+            var logger = new InternalLogger();
+            var analysis = new OpenRelayAnalysis();
+            await analysis.AnalyzeServer("localhost", port, logger);
+            var narrative = OpenRelayNarrative.Build(analysis);
+            Assert.Contains("No servers allowed unauthenticated relay.", narrative.Highlights);
+            var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+            Assert.Contains(positives, p => p.Code == OpenRelayCodes.Denied);
+        }
+        finally
+        {
+            listener.Stop();
+            await serverTask;
+        }
+    }
+}

--- a/DomainDetective.Tests/TestOpenRelayRecommendations.cs
+++ b/DomainDetective.Tests/TestOpenRelayRecommendations.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestOpenRelayRecommendations
+{
+    [Fact]
+    public void RegistersSuccessCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new OpenRelayRecommendations().Register(map);
+        Assert.Contains(OpenRelayCodes.Denied, map.Keys);
+        Assert.Contains(OpenRelayCodes.ConnectionFailed, map.Keys);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/OpenRelayCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/OpenRelayCodes.cs
@@ -3,4 +3,6 @@ namespace DomainDetective;
 internal static class OpenRelayCodes {
     public const string CheckFailed = "OPENRELAY.Check.Failed";
     public const string AllowsRelay = "OPENRELAY.AllowsRelay";
+    public const string Denied = "OPENRELAY.Denied";
+    public const string ConnectionFailed = "OPENRELAY.ConnectionFailed";
 }

--- a/DomainDetective/Diagnostics/Recommendations/OpenRelayRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/OpenRelayRecommendations.cs
@@ -26,6 +26,28 @@ internal sealed class OpenRelayRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Re-run the relay test; expect explicit denial codes for unauthenticated relay attempts."
         };
+        map[OpenRelayCodes.Denied] = new RecommendationAdvice {
+            Code = OpenRelayCodes.Denied,
+            Title = "SMTP relay attempt denied",
+            Why = "Server refused unauthenticated mail, preventing abuse.",
+            How = "No action needed; maintain current restrictions.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "smtp", "relay" },
+            Impact = "Blocks unauthorized use of your mail server.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Unauthenticated RCPT TO returns 550/551/554 or similar."
+        };
+        map[OpenRelayCodes.ConnectionFailed] = new RecommendationAdvice {
+            Code = OpenRelayCodes.ConnectionFailed,
+            Title = "SMTP relay connection failed",
+            Why = "Server did not accept connection or relay, indicating no open relay.",
+            How = "No action required.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "smtp", "relay" },
+            Impact = "Prevents unauthorized relaying from your infrastructure.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Unauthenticated connection attempts are refused or time out."
+        };
     }
 }
 

--- a/DomainDetective/Narratives/OpenRelayNarrative.cs
+++ b/DomainDetective/Narratives/OpenRelayNarrative.cs
@@ -23,7 +23,7 @@ public static class OpenRelayNarrative
         public List<string> Remediations { get; init; } = new();
     }
 
-    public static Sections Build(OpenRelayAnalysis analysis)
+    public static Sections Build(OpenRelayAnalysis analysis, InternalLogger? logger = null)
     {
         var title = "Open Relay Report";
         var subtitle = "SMTP Relay Assessment";
@@ -70,7 +70,10 @@ public static class OpenRelayNarrative
         {
             AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
         }
-        catch { }
+        catch (Exception ex)
+        {
+            logger?.WriteWarning($"Failed to split assessments: {ex.Message}");
+        }
 
         return new Sections
         {

--- a/DomainDetective/Narratives/OpenRelayNarrative.cs
+++ b/DomainDetective/Narratives/OpenRelayNarrative.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class OpenRelayNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(OpenRelayAnalysis analysis)
+    {
+        var title = "Open Relay Report";
+        var subtitle = "SMTP Relay Assessment";
+        var category = "Email Security";
+        var keywords = "SMTP relay, email, security, DomainDetective";
+        var creator = "DomainDetective";
+        var intro = "Open relay testing probes SMTP servers to see if they permit unauthenticated third-party mail.";
+        var why = "Open relays are abused to send spam and malware. Denying unauthenticated relay protects infrastructure and reputation.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        var results = analysis?.ServerResults ?? new Dictionary<string, OpenRelayAnalysis.OpenRelayResult>();
+        var total = results.Count;
+        var allows = results.Count(r => r.Value?.Status == OpenRelayStatus.AllowsRelay);
+        var denied = results.Count(r => r.Value?.Status == OpenRelayStatus.Denied);
+        var failed = results.Count(r => r.Value?.Status == OpenRelayStatus.ConnectionFailed);
+
+        if (total > 0)
+            hi.Add($"Servers tested: {total}");
+        if (allows > 0)
+            hi.Add($"{allows} server(s) allowed unauthenticated relay.");
+        else
+            hi.Add("No servers allowed unauthenticated relay.");
+
+        if (denied > 0)
+            hi.Add($"{denied} server(s) denied relay.");
+        if (failed > 0)
+            hi.Add($"{failed} server(s) failed to connect.");
+
+        foreach (var kv in results)
+        {
+            det.Add($"{kv.Key}: {kv.Value.Status}");
+        }
+
+        var refs = new List<string>
+        {
+            "https://datatracker.ietf.org/doc/html/rfc5321"
+        };
+
+        try
+        {
+            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -37,6 +37,8 @@ namespace DomainDetective {
             ServerResults[$"{host}:{port}"] = result;
             if (result.Status == OpenRelayStatus.AllowsRelay) {
                 logger?.WriteErrorCode(OpenRelayCodes.AllowsRelay, "Server {0}:{1} allows unauthenticated relay", host, port);
+            } else if (result.Status == OpenRelayStatus.Denied) {
+                logger?.WriteInformationCode(OpenRelayCodes.Denied, "Server {0}:{1} denied unauthenticated relay", host, port);
             }
         }
 
@@ -53,6 +55,8 @@ namespace DomainDetective {
                     ServerResults[$"{host}:{port}"] = result;
                     if (result.Status == OpenRelayStatus.AllowsRelay) {
                         logger?.WriteErrorCode(OpenRelayCodes.AllowsRelay, "Server {0}:{1} allows unauthenticated relay", host, port);
+                    } else if (result.Status == OpenRelayStatus.Denied) {
+                        logger?.WriteInformationCode(OpenRelayCodes.Denied, "Server {0}:{1} denied unauthenticated relay", host, port);
                     }
                 }
             }
@@ -108,7 +112,7 @@ namespace DomainDetective {
             } catch (OperationCanceledException) {
                 throw;
             } catch (Exception ex) {
-                logger?.WriteErrorCode(OpenRelayCodes.CheckFailed, "Open relay check failed for {0}:{1} - {2}", host, port, ex.Message);
+                logger?.WriteInformationCode(OpenRelayCodes.ConnectionFailed, "Open relay connection failed for {0}:{1} - {2}", host, port, ex.Message);
                 SocketError? errorCode = (ex as SocketException)?.SocketErrorCode;
                 return new OpenRelayResult { Status = OpenRelayStatus.ConnectionFailed, SocketErrorCode = errorCode };
             }

--- a/DomainDetective/Protocols/OpenRelayAnalysis.cs
+++ b/DomainDetective/Protocols/OpenRelayAnalysis.cs
@@ -103,7 +103,7 @@ namespace DomainDetective {
 
                 int mailCode = ParseStatusCode(mailResp);
                 int rcptCode = ParseStatusCode(rcptResp);
-                var status = mailCode >= 200 && mailCode < 300 && rcptCode >= 200 && rcptCode < 300 && mailCode != 550 && mailCode != 551 && rcptCode != 550 && rcptCode != 551
+                var status = mailCode >= 200 && mailCode < 300 && rcptCode >= 200 && rcptCode < 300
                     ? OpenRelayStatus.AllowsRelay
                     : OpenRelayStatus.Denied;
                 return new OpenRelayResult { Status = status };


### PR DESCRIPTION
## Summary
- add OpenRelayNarrative summarizing SMTP relay testing
- provide positive recommendations for denied or unreachable relays
- cover narrative with example and tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter "OpenRelayNarrative|OpenRelayRecommendations"`


------
https://chatgpt.com/codex/tasks/task_e_68b964812560832e95162e578e23fc4d