### PR TITLE
feat: add robots.txt narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseROBOTS.cs
+++ b/DomainDetective.Example/ExampleAnalyseROBOTS.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using DomainDetective.Narratives;
 
 namespace DomainDetective.Example;
 
@@ -18,5 +19,8 @@ public static partial class Program
                 Console.WriteLine($"{kvp.Key}: {string.Join(", ", kvp.Value)}");
             }
         }
+        var narrative = RobotsTxtNarrative.Build(healthCheck.RobotsTxtAnalysis, healthCheck.RobotsTxtAnalysis.Assessments);
+        Console.WriteLine(narrative.Title);
+        foreach (var h in narrative.Highlights) Console.WriteLine(" - " + h);
     }
 }

--- a/DomainDetective.Tests/TestRobotsTxtNarrative.cs
+++ b/DomainDetective.Tests/TestRobotsTxtNarrative.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using Xunit;
+using Xunit.Sdk;
+
+namespace DomainDetective.Tests;
+
+[Collection("HttpListener")]
+public class TestRobotsTxtNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithHighlightsAndPositives()
+    {
+        using var listener = StartListener(out var prefix);
+        var content = "User-agent: *\nDisallow: /private\nSitemap: https://example.com/sitemap.xml";
+        var serverTask = Task.Run(async () =>
+        {
+            try
+            {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "text/plain";
+                var buffer = Encoding.UTF8.GetBytes(content);
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+            catch (HttpListenerException)
+            {
+            }
+        });
+
+        try
+        {
+            var healthCheck = new DomainHealthCheck();
+            await healthCheck.Verify(prefix.Replace("http://", string.Empty).TrimEnd('/'), new[] { HealthCheckType.ROBOTS });
+            var sections = RobotsTxtNarrative.Build(healthCheck.RobotsTxtAnalysis, healthCheck.RobotsTxtAnalysis.Assessments);
+            Assert.Contains(sections.Highlights, h => h.Contains("robots.txt"));
+            Assert.Contains(sections.Highlights, h => h.Contains("Disallow"));
+            Assert.Contains(sections.Highlights, h => h.Contains("Sitemaps referenced"));
+            Assert.NotEmpty(sections.Positives);
+        }
+        finally
+        {
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
+    private static int GetFreePort() => PortHelper.GetFreePort();
+
+    private static HttpListener StartListener(out string prefix)
+    {
+        Skip.If(!HttpListener.IsSupported, "HttpListener not supported");
+
+        while (true)
+        {
+            var port = GetFreePort();
+            prefix = $"http://127.0.0.1:{port}/";
+            var l = new HttpListener();
+            l.Prefixes.Add(prefix);
+            try
+            {
+                l.Start();
+                PortHelper.ReleasePort(port);
+                return l;
+            }
+            catch (HttpListenerException)
+            {
+                l.Close();
+                PortHelper.ReleasePort(port);
+            }
+        }
+    }
+}
+

--- a/DomainDetective.Tests/TestRobotsTxtRecommendations.cs
+++ b/DomainDetective.Tests/TestRobotsTxtRecommendations.cs
@@ -1,0 +1,19 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestRobotsTxtRecommendations
+{
+    [Fact]
+    public void RegistersPositiveCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new RobotsTxtRecommendations().Register(map);
+        Assert.Contains(RobotsTxtCodes.Available, map.Keys);
+        Assert.Contains(RobotsTxtCodes.DisallowPresent, map.Keys);
+        Assert.Contains(RobotsTxtCodes.SitemapPresent, map.Keys);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/RobotsTxtCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/RobotsTxtCodes.cs
@@ -5,5 +5,8 @@ internal static class RobotsTxtCodes {
     public const string FallbackHttp = "ROBOTS.FallbackHttp";
     public const string AiBotDirectivesPresent = "ROBOTS.AiBot.Directives";
     public const string DownloadFailed = "ROBOTS.Download.Failed";
+    public const string Available = "ROBOTS.Available";
+    public const string DisallowPresent = "ROBOTS.Disallow.Present";
+    public const string SitemapPresent = "ROBOTS.Sitemap.Present";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/RobotsTxtRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/RobotsTxtRecommendations.cs
@@ -48,6 +48,39 @@ internal sealed class RobotsTxtRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "robots.txt fetch returns 200 over HTTPS."
         };
+        map[RobotsTxtCodes.Available] = new RecommendationAdvice {
+            Code = RobotsTxtCodes.Available,
+            Title = "robots.txt accessible over HTTPS",
+            Why = "Serving robots.txt over HTTPS ensures policies are retrieved securely.",
+            How = "Maintain robots.txt at https://<domain>/robots.txt and enforce HTTPS redirects.",
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "robots", "https" },
+            Impact = "Crawlers reliably obtain crawl policy.",
+            Effort = RecommendationEffort.Low,
+            Verify = "GET https://<domain>/robots.txt returns 200."
+        };
+        map[RobotsTxtCodes.DisallowPresent] = new RecommendationAdvice {
+            Code = RobotsTxtCodes.DisallowPresent,
+            Title = "Disallow rules defined",
+            Why = "Disallow directives restrict crawler access to sensitive paths.",
+            How = "Review and update Disallow entries as site structure changes.",
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "robots", "disallow" },
+            Impact = "Helps protect areas from unwanted crawling.",
+            Effort = RecommendationEffort.Low,
+            Verify = "robots.txt contains Disallow directives."
+        };
+        map[RobotsTxtCodes.SitemapPresent] = new RecommendationAdvice {
+            Code = RobotsTxtCodes.SitemapPresent,
+            Title = "Sitemap referenced in robots.txt",
+            Why = "Listing sitemaps aids crawlers in discovering site content.",
+            How = "Ensure sitemap URLs are accurate and reachable.",
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "robots", "sitemap" },
+            Impact = "Improves crawler coverage of valid URLs.",
+            Effort = RecommendationEffort.Low,
+            Verify = "robots.txt contains a Sitemap directive pointing to an existing sitemap."
+        };
     }
 }
 

--- a/DomainDetective/Narratives/RobotsTxtNarrative.cs
+++ b/DomainDetective/Narratives/RobotsTxtNarrative.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class RobotsTxtNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(RobotsTxtAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Domain) ? "(domain)" : analysis.Domain;
+        var title = $"robots.txt Report — {subj}";
+        var subtitle = "robots.txt Assessment";
+        var category = "Web Crawling";
+        var keywords = $"robots.txt, crawl, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "robots.txt guides crawlers on which paths to access.";
+        var why = "Clear directives and sitemap references protect sensitive areas and improve indexing.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || !analysis.RecordPresent)
+        {
+            hi.Add("robots.txt not found.");
+            return new Sections
+            {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        hi.Add(analysis.FallbackUsed
+            ? "robots.txt served over HTTP."
+            : "robots.txt available over HTTPS.");
+
+        var robots = analysis.Robots;
+        if (robots != null)
+        {
+            var disallows = robots.Groups
+                .SelectMany(g => g.Directives)
+                .Where(d => d.Type == RobotsDirectiveType.Disallow)
+                .Select(d => d.Value)
+                .ToList();
+            if (disallows.Count > 0)
+            {
+                hi.Add($"Disallow rules: {disallows.Count}.");
+                det.AddRange(disallows.Select(d => $"Disallow: {d}"));
+            }
+
+            if (robots.Sitemaps.Count > 0)
+            {
+                hi.Add($"Sitemaps referenced: {robots.Sitemaps.Count}.");
+                det.AddRange(robots.Sitemaps.Select(s => $"Sitemap: {s}"));
+            }
+        }
+
+        var refs = DefaultRefs();
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://developers.google.com/search/docs/crawling-indexing/robots/intro",
+        "https://www.robotstxt.org/robotstxt.html"
+    };
+}
+

--- a/DomainDetective/Protocols/RobotsTxtAnalysis.cs
+++ b/DomainDetective/Protocols/RobotsTxtAnalysis.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -123,6 +124,16 @@ public class RobotsTxtAnalysis : IHasAssessments
                     Message = "robots.txt retrieved over HTTP (no HTTPS)"
                 });
             }
+            else
+            {
+                Assessments.Add(new Assessment {
+                    Severity = AssessmentSeverity.Info,
+                    Category = "Robots",
+                    Target = Domain,
+                    Code = RobotsTxtCodes.Available,
+                    Message = "robots.txt available over HTTPS"
+                });
+            }
             if (HasAiBotRules)
             {
                 Assessments.Add(new Assessment {
@@ -131,6 +142,26 @@ public class RobotsTxtAnalysis : IHasAssessments
                     Target = Domain,
                     Code = RobotsTxtCodes.AiBotDirectivesPresent,
                     Message = "AI bot directives present in robots.txt"
+                });
+            }
+            if (Robots?.Groups.Any(g => g.Directives.Any(d => d.Type == RobotsDirectiveType.Disallow)) == true)
+            {
+                Assessments.Add(new Assessment {
+                    Severity = AssessmentSeverity.Info,
+                    Category = "Robots",
+                    Target = Domain,
+                    Code = RobotsTxtCodes.DisallowPresent,
+                    Message = "robots.txt defines disallow rules"
+                });
+            }
+            if (Robots?.Sitemaps.Count > 0)
+            {
+                Assessments.Add(new Assessment {
+                    Severity = AssessmentSeverity.Info,
+                    Category = "Robots",
+                    Target = Domain,
+                    Code = RobotsTxtCodes.SitemapPresent,
+                    Message = "robots.txt references sitemap"
                 });
             }
         }


### PR DESCRIPTION
## Summary
- add narrative summarizing robots.txt availability, disallow directives, and sitemap references
- register success recommendation codes for well-configured robots.txt files
- provide example usage and unit tests for narrative and recommendations

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`
- `dotnet test` *(fails: Assert.Contains() Failure: Sub-string not found in DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68b964794684832e816e886eec3c5148