### PR TITLE
feat(smtp): add SMTP banner narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseSmtpBanner.cs
+++ b/DomainDetective.Example/ExampleAnalyseSmtpBanner.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Example analyzing SMTP banner for a server.
+    /// </summary>
+    public static async Task ExampleAnalyseSmtpBanner() {
+        var analysis = new SMTPBannerAnalysis { ExpectedHostname = "smtp.gmail.com" };
+        await analysis.AnalyzeServer("smtp.gmail.com", 25, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("smtp.gmail.com:25", out var result)) {
+            Helpers.ShowPropertiesTable("SMTP Banner", result);
+        }
+    }
+}
+

--- a/DomainDetective.Tests/TestSMTPBannerAnalysis.cs
+++ b/DomainDetective.Tests/TestSMTPBannerAnalysis.cs
@@ -178,5 +178,32 @@ namespace DomainDetective.Tests {
                 await serverTask;
             }
         }
+
+        [Fact]
+        public async Task GeneratesPositiveRecommendations() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 mail.example.com ESMTP Postfix TLS");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try {
+                var analysis = new SMTPBannerAnalysis { ExpectedHostname = "mail.example.com" };
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+                Assert.Contains(positives, p => p.Code == SmtpBannerCodes.HostnameMatch);
+                Assert.Contains(positives, p => p.Code == SmtpBannerCodes.TlsAdvertised);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
     }
 }

--- a/DomainDetective.Tests/TestSmtpBannerNarrative.cs
+++ b/DomainDetective.Tests/TestSmtpBannerNarrative.cs
@@ -1,0 +1,22 @@
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestSmtpBannerNarrative {
+        [Fact]
+        public void NarrativeSummarizesBanner() {
+            var analysis = new SMTPBannerAnalysis { Subject = "localhost:25", ExpectedHostname = "mail.example.com" };
+            analysis.ServerResults["localhost:25"] = new SMTPBannerAnalysis.BannerResult {
+                Banner = "220 mail.example.com ESMTP",
+                HostnameMatch = true,
+                TlsAdvertised = true
+            };
+
+            var sections = SmtpBannerNarrative.Build(analysis);
+            Assert.Contains("localhost:25 banner: 220 mail.example.com ESMTP", sections.Highlights);
+            Assert.Contains("Hostname matches expected mail.example.com.", sections.Highlights);
+            Assert.Contains("TLS advertised in banner.", sections.Highlights);
+        }
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/SmtpBannerCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SmtpBannerCodes.cs
@@ -8,4 +8,6 @@ internal static class SmtpBannerCodes {
     public const string Not220 = "SMTPBANNER.Greeting.Not220";
     public const string VersionLeaked = "SMTPBANNER.Banner.VersionLeaked";
     public const string UnexpectedSoftware = "SMTPBANNER.Software.Unexpected";
+    public const string HostnameMatch = "SMTPBANNER.Hostname.Match";
+    public const string TlsAdvertised = "SMTPBANNER.TLS.Advertised";
 }

--- a/DomainDetective/Diagnostics/Recommendations/SmtpBannerRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SmtpBannerRecommendations.cs
@@ -13,7 +13,7 @@ internal sealed class SmtpBannerRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.EmailAuth,
             Tags = new [] { "smtp", "banner" },
             Effort = RecommendationEffort.Low,
-            Verify = "Reconnect and ensure the greeting includes the correct hostname."
+            Verify = "Reconnect and ensure the greeting includes the correct hostname.",
         };
 
         map[SmtpBannerCodes.Not220] = new RecommendationAdvice {
@@ -25,7 +25,7 @@ internal sealed class SmtpBannerRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.EmailAuth,
             Tags = new [] { "smtp", "banner" },
             Effort = RecommendationEffort.Low,
-            Verify = "Reconnect and confirm a 220 greeting is sent."
+            Verify = "Reconnect and confirm a 220 greeting is sent.",
         };
 
         map[SmtpBannerCodes.VersionLeaked] = new RecommendationAdvice {
@@ -37,7 +37,7 @@ internal sealed class SmtpBannerRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.EmailAuth,
             Tags = new [] { "banner", "information-disclosure" },
             Effort = RecommendationEffort.Low,
-            Verify = "Reconnect and verify version tokens are no longer present."
+            Verify = "Reconnect and verify version tokens are no longer present.",
         };
 
         map[SmtpBannerCodes.UnexpectedSoftware] = new RecommendationAdvice {
@@ -49,7 +49,31 @@ internal sealed class SmtpBannerRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.EmailAuth,
             Tags = new [] { "smtp", "banner" },
             Effort = RecommendationEffort.Medium,
-            Verify = "Confirm banner matches the authorized MTA software."
+            Verify = "Confirm banner matches the authorized MTA software.",
+        };
+
+        map[SmtpBannerCodes.HostnameMatch] = new RecommendationAdvice {
+            Code = SmtpBannerCodes.HostnameMatch,
+            Title = "SMTP banner includes expected hostname",
+            Why = "Correct hostnames improve deliverability and simplify troubleshooting.",
+            How = "No action required; ensure deployments keep the banner aligned with the host.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc5321" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "smtp", "banner" },
+            Effort = RecommendationEffort.Low,
+            Verify = "Reconnect and confirm the hostname remains accurate.",
+        };
+
+        map[SmtpBannerCodes.TlsAdvertised] = new RecommendationAdvice {
+            Code = SmtpBannerCodes.TlsAdvertised,
+            Title = "SMTP banner advertises TLS",
+            Why = "Advertising TLS encourages clients to establish encrypted sessions.",
+            How = "No action required; maintain TLS support and advertisement.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc3207" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "smtp", "tls" },
+            Effort = RecommendationEffort.Low,
+            Verify = "Reconnect and verify TLS is still advertised.",
         };
     }
 }

--- a/DomainDetective/Narratives/SmtpBannerNarrative.cs
+++ b/DomainDetective/Narratives/SmtpBannerNarrative.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class SmtpBannerNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(SMTPBannerAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(host)" : analysis.Subject!;
+        var title = $"SMTP Banner Report — {subj}";
+        var subtitle = "SMTP Banner Assessment";
+        var category = "Email Security";
+        var keywords = $"SMTP, banner, email, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "SMTP servers greet clients with a 220 banner describing the host and capabilities.";
+        var why = "Accurate banners aid troubleshooting and security while TLS advertisement encourages encrypted connections.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || analysis.ServerResults.Count == 0)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No SMTP banner data available." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        foreach (var kv in analysis.ServerResults)
+        {
+            var r = kv.Value;
+            hi.Add($"{kv.Key} banner: {r?.Banner ?? "(none)"}");
+            if (!string.IsNullOrWhiteSpace(analysis.ExpectedHostname))
+            {
+                hi.Add(r?.HostnameMatch == true
+                    ? $"Hostname matches expected {analysis.ExpectedHostname}."
+                    : $"Hostname mismatch for expected {analysis.ExpectedHostname}.");
+            }
+            hi.Add(r?.TlsAdvertised == true ? "TLS advertised in banner." : "No TLS advertised in banner.");
+        }
+
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = DefaultRefs(),
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.rfc-editor.org/rfc/rfc5321"
+    };
+}
+

--- a/DomainDetective/Protocols/SMTPBannerAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPBannerAnalysis.cs
@@ -42,6 +42,8 @@ namespace DomainDetective {
             public bool Truncated { get; init; }
             /// <summary>Milliseconds between connect and first banner line.</summary>
             public int? ResponseTimeMs { get; init; }
+            /// <summary>True when banner mentions TLS capability.</summary>
+            public bool TlsAdvertised { get; init; }
         }
 
         private static readonly Regex _labelRegex = new(
@@ -167,6 +169,13 @@ namespace DomainDetective {
                 }
                 bool hostMatch = !string.IsNullOrWhiteSpace(ExpectedHostname) && banner?.IndexOf(ExpectedHostname, StringComparison.OrdinalIgnoreCase) >= 0;
                 bool softMatch = !string.IsNullOrWhiteSpace(ExpectedSoftware) && banner?.IndexOf(ExpectedSoftware, StringComparison.OrdinalIgnoreCase) >= 0;
+                bool tlsAdvertised = banner?.IndexOf("TLS", StringComparison.OrdinalIgnoreCase) >= 0;
+                if (hostMatch) {
+                    logger?.WriteInformationCode(SmtpBannerCodes.HostnameMatch, "Banner on {0}:{1} includes expected hostname '{2}'.", host, port, ExpectedHostname);
+                }
+                if (tlsAdvertised) {
+                    logger?.WriteInformationCode(SmtpBannerCodes.TlsAdvertised, "Banner on {0}:{1} advertises TLS support.", host, port);
+                }
                 if (!string.IsNullOrWhiteSpace(ExpectedSoftware) && banner != null && !softMatch) {
                     logger?.WriteWarningCode(SmtpBannerCodes.UnexpectedSoftware, "Banner software on {0}:{1} does not match expectation '{2}': {3}", host, port, ExpectedSoftware, banner);
                 }
@@ -187,7 +196,8 @@ namespace DomainDetective {
                     GreetingCode = code,
                     ServerDomain = domain,
                     Truncated = banner != null && banner.Length >= MaxBannerTextLength,
-                    ResponseTimeMs = (int)sw.ElapsedMilliseconds
+                    ResponseTimeMs = (int)sw.ElapsedMilliseconds,
+                    TlsAdvertised = tlsAdvertised
                 };
             } catch (TaskCanceledException ex) {
                 throw new OperationCanceledException(ex.Message, ex, cancellationToken);

--- a/DomainDetective/Views/Converters.SmtpBanner.cs
+++ b/DomainDetective/Views/Converters.SmtpBanner.cs
@@ -27,7 +27,8 @@ public static partial class Converters
                 GreetingCode = r?.GreetingCode,
                 ServerDomain = r?.ServerDomain,
                 Truncated = r?.Truncated ?? false,
-                ResponseTimeMs = r?.ResponseTimeMs
+                ResponseTimeMs = r?.ResponseTimeMs,
+                TlsAdvertised = r?.TlsAdvertised ?? false
             });
         }
         int hostMatch = 0;
@@ -88,4 +89,5 @@ public class SmtpBannerServerInfo
     public string ServerDomain { get; set; }
     public bool Truncated { get; set; }
     public int? ResponseTimeMs { get; set; }
+    public bool TlsAdvertised { get; set; }
 }


### PR DESCRIPTION
## Summary
- add `SmtpBannerNarrative` to describe banner text, hostname match, and TLS advertisement
- log positive hostname/TLS signals and map them to recommendations
- cover narrative and recommendation behavior with examples and tests

## Testing
- `dotnet test -c Release` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*


------
https://chatgpt.com/codex/tasks/task_e_68b96461f570832e8530e36ce78c1f56