### PR TITLE
Add RDAP narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleRdapNarrative.cs
+++ b/DomainDetective.Example/ExampleRdapNarrative.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building an RDAP narrative for a domain.
+    /// </summary>
+    public static async Task ExampleRdapNarrative()
+    {
+        var healthCheck = new DomainHealthCheck();
+        await healthCheck.QueryRDAP("example.com");
+        var narrative = RdapNarrative.Build(healthCheck.RdapAnalysis);
+        Helpers.ShowPropertiesTable("RDAP Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestRdapNarrative.cs
+++ b/DomainDetective.Tests/TestRdapNarrative.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Tests;
+
+public class TestRdapNarrative
+{
+    [Fact]
+    public async Task RdapNarrativeSummarizesFields()
+    {
+        RdapAnalysis.ClearCache();
+        const string json = "{\"ldhName\":\"example.com\",\"status\":[\"active\"],\"nameservers\":[{\"ldhName\":\"ns1.example.net\"},{\"ldhName\":\"ns2.example.net\"}],\"events\":[{\"eventAction\":\"registration\",\"eventDate\":\"2000-01-01T00:00:00Z\"},{\"eventAction\":\"expiration\",\"eventDate\":\"2030-01-01T00:00:00Z\"}],\"entities\":[{\"handle\":\"123\",\"roles\":[\"registrar\"],\"vcardArray\":[\"vcard\",[[\"fn\",{},\"text\",\"Registrar Inc\"],[\"email\",{},\"text\",\"admin@example.com\"]]]}]}";
+        var analysis = new RdapAnalysis { QueryOverride = _ => Task.FromResult(json) };
+        await analysis.Analyze("example.com", new InternalLogger());
+        var sections = RdapNarrative.Build(analysis);
+        Assert.Contains("Registered on 2000-01-01T00:00:00Z", sections.Highlights);
+        Assert.Contains("Expires on 2030-01-01T00:00:00Z", sections.Highlights);
+        Assert.Contains("Registrar: Registrar Inc", sections.Highlights);
+        var codes = analysis.Assessments.Select(a => a.Code).ToList();
+        Assert.Contains(RdapCodes.ContactValid, codes);
+        Assert.Contains(RdapCodes.ExpiryFuture, codes);
+    }
+}

--- a/DomainDetective.Tests/TestRdapRecommendations.cs
+++ b/DomainDetective.Tests/TestRdapRecommendations.cs
@@ -1,0 +1,17 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+
+namespace DomainDetective.Tests;
+
+public class TestRdapRecommendations
+{
+    [Fact]
+    public void RegistersSuccessCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new RdapRecommendations().Register(map);
+        Assert.Contains(RdapCodes.ContactValid, map.Keys);
+        Assert.Equal("RDAP contact details available", map[RdapCodes.ContactValid].Title);
+        Assert.Contains(RdapCodes.ExpiryFuture, map.Keys);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/RdapCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/RdapCodes.cs
@@ -5,5 +5,7 @@ internal static class RdapCodes {
     public const string NotFound = "RDAP.NotFound";
     public const string StatusHold = "RDAP.Status.Hold";
     public const string ExpirySoon = "RDAP.Expiry.Soon";
+    public const string ExpiryFuture = "RDAP.Expiry.Future";
+    public const string ContactValid = "RDAP.Contact.Valid";
     public const string ParseAnomaly = "RDAP.Parse.Anomaly";
 }

--- a/DomainDetective/Diagnostics/Recommendations/RdapRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/RdapRecommendations.cs
@@ -37,6 +37,17 @@ internal sealed class RdapRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "RDAP expiration event updated to a future date."
         };
+        map[RdapCodes.ExpiryFuture] = new RecommendationAdvice {
+            Code = RdapCodes.ExpiryFuture,
+            Title = "Domain not near RDAP expiry",
+            Why = "A future expiration date indicates the domain is under current control.",
+            How = "Monitor renewal reminders so the domain stays registered well before expiry.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "rdap", "expiry" },
+            Impact = "Low risk of unexpected domain lapse.",
+            Effort = RecommendationEffort.Low,
+            Verify = "RDAP expiration date remains well into the future."
+        };
         map[RdapCodes.ParseAnomaly] = new RecommendationAdvice {
             Code = RdapCodes.ParseAnomaly,
             Title = "RDAP parse anomaly",
@@ -58,6 +69,17 @@ internal sealed class RdapRecommendations : IRecommendationProvider {
             Impact = "Uncertain registration status.",
             Effort = RecommendationEffort.Low,
             Verify = "RDAP request succeeds with status 200 and valid JSON."
+        };
+        map[RdapCodes.ContactValid] = new RecommendationAdvice {
+            Code = RdapCodes.ContactValid,
+            Title = "RDAP contact details available",
+            Why = "Published contact information helps reach the domain owner for operational or abuse issues.",
+            How = "Ensure registrar and registry contact fields remain accurate and complete.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "rdap", "contact" },
+            Impact = "Improves accountability and facilitates communication.",
+            Effort = RecommendationEffort.Low,
+            Verify = "RDAP entities include reachable email or telephone data."
         };
     }
 }

--- a/DomainDetective/Narratives/RdapNarrative.cs
+++ b/DomainDetective/Narratives/RdapNarrative.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+public static class RdapNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(RdapAnalysis rdap)
+    {
+        var subj = string.IsNullOrWhiteSpace(rdap?.DomainName) ? "(domain)" : rdap.DomainName;
+        var title = $"RDAP Report — {subj}";
+        var subtitle = "RDAP Registration";
+        var category = "Domain Registration";
+        var keywords = $"RDAP, domain, registration, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Registration Data Access Protocol (RDAP) provides standardized domain registration information.";
+        var why = "RDAP reveals ownership, registrar, and lifecycle dates that help assess domain control.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (!string.IsNullOrWhiteSpace(rdap.CreationDate))
+            hi.Add($"Registered on {rdap.CreationDate}");
+        if (!string.IsNullOrWhiteSpace(rdap.ExpiryDate))
+            hi.Add($"Expires on {rdap.ExpiryDate}");
+        hi.Add(!string.IsNullOrWhiteSpace(rdap.Registrar) ? $"Registrar: {rdap.Registrar}" : "Registrar unknown");
+
+        if (!string.IsNullOrWhiteSpace(rdap.RegistrarId))
+            det.Add($"Registrar ID: {rdap.RegistrarId}");
+        if (rdap.NameServers != null && rdap.NameServers.Count > 0)
+            det.Add($"Name servers: {string.Join(", ", rdap.NameServers)}");
+        if (rdap.Status != null && rdap.Status.Count > 0)
+            det.Add($"Status: {string.Join(", ", rdap.Status)}");
+
+        var refs = new List<string>
+        {
+            "https://datatracker.ietf.org/doc/html/rfc9082"
+        };
+
+        try
+        {
+            AssessmentSplit.SplitTitles(rdap.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        catch (Exception)
+        {
+            // best effort
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/RdapAnalysis.cs
+++ b/DomainDetective/Protocols/RdapAnalysis.cs
@@ -185,6 +185,7 @@ public class RdapAnalysis : IHasAssessments
 
         if (DomainData.Entities != null)
         {
+            var hasContact = false;
             foreach (var ent in DomainData.Entities)
             {
                 if (ent.Roles.Any(r => string.Equals(r, "registrar", StringComparison.OrdinalIgnoreCase)))
@@ -202,6 +203,26 @@ public class RdapAnalysis : IHasAssessments
                         }
                     }
                 }
+                if (!hasContact && ent.VcardArray.HasValue && ent.VcardArray.Value.ValueKind == JsonValueKind.Array && ent.VcardArray.Value.GetArrayLength() > 1)
+                {
+                    foreach (var card in ent.VcardArray.Value[1].EnumerateArray())
+                    {
+                        if (card.GetArrayLength() > 3)
+                        {
+                            var t = card[0].GetString();
+                            if ((t == "email" || t == "tel") && !string.IsNullOrWhiteSpace(card[3].GetString()))
+                            {
+                                hasContact = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if (hasContact)
+            {
+                using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "RDAP", target: DomainName) : null;
+                logger?.WriteInformationCode(RdapCodes.ContactValid, "RDAP contact data present");
             }
         }
 
@@ -226,6 +247,11 @@ public class RdapAnalysis : IHasAssessments
                 {
                     using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "RDAP", target: DomainName) : null;
                     logger?.WriteWarningCode(RdapCodes.ExpirySoon, "Domain expires in {0} days (on {1:u})", Math.Ceiling(delta.TotalDays), exp);
+                }
+                else if (delta > TimeSpan.FromDays(30))
+                {
+                    using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "RDAP", target: DomainName) : null;
+                    logger?.WriteInformationCode(RdapCodes.ExpiryFuture, "Domain expires in {0} days (on {1:u})", Math.Ceiling(delta.TotalDays), exp);
                 }
             }
             else


### PR DESCRIPTION
## Summary
- extend RDAP codes and recommendations with positive signals for contact data and long-term expiration
- log new RDAP success codes and expose narrative summarizing registration details
- include example usage plus tests for narrative and recommendations

## Testing
- `dotnet build DomainDetective.sln -v minimal`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -v minimal --filter Rdap`

------
https://chatgpt.com/codex/tasks/task_e_68b964598870832ea7e4783a13aa8ea3