### PR TITLE
feat: add directory exposure narrative and positive advice

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseDirectoryExposure.cs
+++ b/DomainDetective.Example/ExampleAnalyseDirectoryExposure.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>Demonstrates directory exposure analysis.</summary>
+    public static async Task ExampleAnalyseDirectoryExposure()
+    {
+        var healthCheck = new DomainHealthCheck { Verbose = false };
+        await healthCheck.Verify("example.com", new[] { HealthCheckType.DIRECTORYEXPOSURE });
+        Helpers.ShowPropertiesTable("Directory exposure for example.com", healthCheck.DirectoryExposureAnalysis);
+        if (healthCheck.DirectoryExposureAnalysis.ExposedPaths.Count > 0)
+        {
+            Console.WriteLine("Exposed paths:");
+            foreach (var path in healthCheck.DirectoryExposureAnalysis.ExposedPaths)
+            {
+                Console.WriteLine(path);
+            }
+        }
+    }
+}

--- a/DomainDetective.Tests/TestDirectoryExposureNarrative.cs
+++ b/DomainDetective.Tests/TestDirectoryExposureNarrative.cs
@@ -1,0 +1,79 @@
+using System.Net;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+[Collection("HttpListener")]
+public class TestDirectoryExposureNarrative
+{
+    [Fact]
+    public async Task NarrativeHighlightsExposedPaths()
+    {
+        Skip.If(!HttpListener.IsSupported, "HttpListener not supported");
+        using var listener = new HttpListener();
+        var port = PortHelper.GetFreePort();
+        var prefix = $"http://localhost:{port}/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        PortHelper.ReleasePort(port);
+        var serverTask = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                var ctx = await listener.GetContextAsync();
+                if (ctx.Request.Url.AbsolutePath.StartsWith("/.git"))
+                    ctx.Response.StatusCode = 200;
+                else
+                    ctx.Response.StatusCode = 404;
+                ctx.Response.Close();
+            }
+        });
+        try
+        {
+            var hc = new DomainHealthCheck();
+            await hc.VerifyDirectoryExposure(prefix.Replace("http://", string.Empty).TrimEnd('/'));
+            var sections = DirectoryExposureNarrative.Build(hc.DirectoryExposureAnalysis);
+            Assert.Contains(sections.Highlights, h => h.Contains(".git"));
+        }
+        finally
+        {
+            listener.Stop();
+            await Task.Delay(50);
+        }
+    }
+
+    [Fact]
+    public async Task NarrativeIncludesPositiveAdviceWhenBrowsingDisabled()
+    {
+        Skip.If(!HttpListener.IsSupported, "HttpListener not supported");
+        using var listener = new HttpListener();
+        var port = PortHelper.GetFreePort();
+        var prefix = $"http://localhost:{port}/";
+        listener.Prefixes.Add(prefix);
+        listener.Start();
+        PortHelper.ReleasePort(port);
+        var serverTask = Task.Run(async () =>
+        {
+            while (listener.IsListening)
+            {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.StatusCode = 404;
+                ctx.Response.Close();
+            }
+        });
+        try
+        {
+            var hc = new DomainHealthCheck();
+            await hc.VerifyDirectoryExposure(prefix.Replace("http://", string.Empty).TrimEnd('/'));
+            var sections = DirectoryExposureNarrative.Build(hc.DirectoryExposureAnalysis);
+            Assert.Contains(sections.Positives, p => p.Contains("Directory browsing disabled"));
+        }
+        finally
+        {
+            listener.Stop();
+            await Task.Delay(50);
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/DirectoryExposureCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/DirectoryExposureCodes.cs
@@ -7,5 +7,6 @@ internal static class DirectoryExposureCodes {
     public const string SourceMapExposed = "DIR.SourceMap.Exposed";
     public const string InfoSitemapPresent = "DIR.Info.SitemapPresent";
     public const string InfoSecurityTxtPresent = "DIR.Info.SecurityTxtPresent";
+    public const string DirectoryListingDisabled = "DIR.Success.DirectoryListingDisabled";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/DirectoryExposureRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/DirectoryExposureRecommendations.cs
@@ -59,6 +59,18 @@ internal sealed class DirectoryExposureRecommendations : IRecommendationProvider
             Verify = "Requests to *.map return 403/404 and are not deployed."
         };
 
+        map[DirectoryExposureCodes.DirectoryListingDisabled] = new RecommendationAdvice {
+            Code = DirectoryExposureCodes.DirectoryListingDisabled,
+            Title = "Directory browsing disabled",
+            Why = "Disabling directory listing prevents disclosure of file structure and sensitive files.",
+            How = "Keep directory indexes off and ensure new paths return 403/404 or custom pages.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "http", "hardening" },
+            Impact = "Reduces information disclosure exposure.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Request common directories and confirm 403/404 responses."
+        };
+
         // Informational presence signals (coded to appear in datasets consistently)
         map[DirectoryExposureCodes.InfoSitemapPresent] = new RecommendationAdvice {
             Code = DirectoryExposureCodes.InfoSitemapPresent,

--- a/DomainDetective/Narratives/DirectoryExposureNarrative.cs
+++ b/DomainDetective/Narratives/DirectoryExposureNarrative.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class DirectoryExposureNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(DirectoryExposureAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"Directory Listing Report — {subj}";
+        var subtitle = "Directory Exposure Assessment";
+        var category = "Web Security";
+        var keywords = $"directory listing, web, security, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Web servers may expose sensitive files when directory browsing is enabled.";
+        var why = "Disabling directory listing reduces information disclosure and mitigates abuse.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        if (analysis?.ExposedPaths != null && analysis.ExposedPaths.Count > 0)
+        {
+            hi.Add($"Exposed paths: {string.Join(", ", analysis.ExposedPaths)}");
+            det.AddRange(analysis.ExposedPaths.Select(p => $"Exposed: {p}"));
+        }
+        else
+        {
+            hi.Add("No exposed directories detected.");
+        }
+
+        var refs = new List<string> {
+            "https://owasp.org/www-project-top-ten/",
+            "https://developer.mozilla.org/docs/Web/Security/Directory_listing"
+        };
+
+        var positives = new List<string>();
+        var remediations = new List<string>();
+        try
+        {
+            var groups = RecommendationEngine.GroupByCode(analysis?.Assessments ?? new List<Assessment>());
+            foreach (var g in groups)
+            {
+                var msg = string.IsNullOrWhiteSpace(g.Advice?.Title)
+                    ? g.Instances.FirstOrDefault()?.Message ?? g.Code
+                    : g.Advice.Title;
+                if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
+                    positives.Add(msg);
+                }
+                else
+                {
+                    remediations.Add(msg);
+                }
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+        };
+    }
+}

--- a/DomainDetective/Protocols/DirectoryExposureAnalysis.cs
+++ b/DomainDetective/Protocols/DirectoryExposureAnalysis.cs
@@ -138,6 +138,11 @@ public class DirectoryExposureAnalysis : IHasAssessments
                 logger?.WriteDebug("Failed to query {0}: {1}", url, ex.Message);
             }
         }
+
+        if (ExposedPaths.Count == 0)
+        {
+            logger?.WriteInformationCode(DirectoryExposureCodes.DirectoryListingDisabled, "Directory browsing disabled for common paths");
+        }
     }
 
     public List<Assessment> Assessments { get; } = new();


### PR DESCRIPTION
## Summary
- add narrative summarizing directory exposure findings
- log and recommend success when directory browsing is disabled
- demonstrate directory exposure analysis and cover with tests

## Testing
- `dotnet test` *(fails: Assert.Contains() Failure in DomainDetective.CLI.Tests/TestCliHelp.cs)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b964688dc4832e93ceb8e045739b34