### PR TITLE
feat: add typosquatting narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleTyposquattingNarrative.cs
+++ b/DomainDetective.Example/ExampleTyposquattingNarrative.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using DnsClientX;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a typosquatting narrative.
+    /// </summary>
+    public static async Task ExampleTyposquattingNarrative()
+    {
+        var hc = new DomainHealthCheck();
+        hc.TyposquattingAnalysis.QueryDnsOverride = (name, type) =>
+        {
+            if (name == "examp1e.com" && type == DnsRecordType.A)
+            {
+                return Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1", Type = DnsRecordType.A } });
+            }
+            return Task.FromResult(System.Array.Empty<DnsAnswer>());
+        };
+        await hc.VerifyTyposquatting("example.com");
+        var narrative = TyposquattingNarrative.Build(hc.TyposquattingAnalysis);
+        Helpers.ShowPropertiesTable("Typosquatting Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestTyposquattingNarrative.cs
+++ b/DomainDetective.Tests/TestTyposquattingNarrative.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using DnsClientX;
+
+namespace DomainDetective.Tests;
+
+public class TestTyposquattingNarrative
+{
+    [Fact]
+    public async Task TyposquattingNarrativeHighlightsActiveAndDefensive()
+    {
+        var analysis = new TyposquattingAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (name, type) =>
+            {
+                if (name == "examp1e.com" && type == DnsRecordType.A)
+                {
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1", Type = DnsRecordType.A } });
+                }
+                return Task.FromResult(System.Array.Empty<DnsAnswer>());
+            }
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger());
+
+        var sections = TyposquattingNarrative.Build(analysis);
+        Assert.Contains("Active typosquat domains: examp1e.com", sections.Highlights);
+        Assert.Contains(sections.Details, d => d.StartsWith("Available for defensive registration:"));
+    }
+}

--- a/DomainDetective.Tests/TestTyposquattingRecommendations.cs
+++ b/DomainDetective.Tests/TestTyposquattingRecommendations.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using DnsClientX;
+
+namespace DomainDetective.Tests;
+
+public class TestTyposquattingRecommendations
+{
+    [Fact]
+    public async Task EmitsPositiveWhenNoActiveVariants()
+    {
+        var log = new InternalLogger();
+        var analysis = new TyposquattingAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (_, _) => Task.FromResult(System.Array.Empty<DnsAnswer>())
+        };
+
+        await analysis.Analyze("example.com", log);
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == TyposquattingCodes.VariantNone);
+    }
+
+    [Fact]
+    public async Task EmitsPositiveWhenDefensiveRegistered()
+    {
+        var log = new InternalLogger();
+        var analysis = new TyposquattingAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (name, type) =>
+            {
+                if (name == "examp1e.com" && type == DnsRecordType.A)
+                {
+                    return Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1", Type = DnsRecordType.A } });
+                }
+                return Task.FromResult(System.Array.Empty<DnsAnswer>());
+            }
+        };
+
+        await analysis.Analyze("example.com", log);
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == TyposquattingCodes.DefensiveRegistered);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/TyposquattingCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/TyposquattingCodes.cs
@@ -3,5 +3,7 @@ namespace DomainDetective;
 internal static class TyposquattingCodes {
     public const string ContainsHomoglyphs = "TYPOSQUAT.ContainsHomoglyphs";
     public const string VariantActive = "TYPOSQUAT.Variant.Active";
+    public const string VariantNone = "TYPOSQUAT.Variant.None";
+    public const string DefensiveRegistered = "TYPOSQUAT.Defensive.Registered";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/TyposquattingRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/TyposquattingRecommendations.cs
@@ -27,6 +27,30 @@ internal sealed class TyposquattingRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.High,
             Verify = "Confirm control or takedown of the variant domain."
         };
+
+        map[TyposquattingCodes.VariantNone] = new RecommendationAdvice {
+            Code = TyposquattingCodes.VariantNone,
+            Title = "No active typosquat variants detected",
+            Why = "No look-alike domains resolved in DNS during analysis.",
+            How = "Continue monitoring for new registrations and maintain defensive strategy.",
+            Domain = RecommendationDomain.Branding,
+            Tags = new [] { "typosquat" },
+            Impact = "Low current risk from typosquatting.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Run periodic scans for emerging variants."
+        };
+
+        map[TyposquattingCodes.DefensiveRegistered] = new RecommendationAdvice {
+            Code = TyposquattingCodes.DefensiveRegistered,
+            Title = "Defensive typosquat domains registered",
+            Why = "Registered variants reduce the chance of malicious use by third parties.",
+            How = "Maintain control and renew these domains as part of brand protection.",
+            Domain = RecommendationDomain.Branding,
+            Tags = new [] { "typosquat", "defensive" },
+            Impact = "Helps prevent brand abuse.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Ensure the domains remain under your ownership."
+        };
     }
 }
 

--- a/DomainDetective/Narratives/TyposquattingNarrative.cs
+++ b/DomainDetective/Narratives/TyposquattingNarrative.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class TyposquattingNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(TyposquattingAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"Typosquatting Report — {subj}";
+        var subtitle = "Typosquatting Assessment";
+        var category = "Brand Protection";
+        var keywords = $"typosquatting, brand, security, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Typosquatting involves registering look-alike domains to deceive users or capture traffic.";
+        var why = "Monitoring and defensively registering variants reduces impersonation risk.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var active = analysis?.ActiveDomains ?? new List<string>();
+        if (active.Count > 0)
+        {
+            hi.Add($"Active typosquat domains: {string.Join(", ", active)}");
+            det.AddRange(active.Select(d => $"Active: {d}"));
+        }
+        else
+        {
+            hi.Add("No active typosquat domains detected.");
+        }
+
+        var available = (analysis?.Variants ?? new List<string>())
+            .Except(active, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (available.Count > 0)
+        {
+            det.Add("Available for defensive registration: " + string.Join(", ", available));
+        }
+
+        var refs = new List<string>
+        {
+            "https://en.wikipedia.org/wiki/Typosquatting"
+        };
+
+        var positives = new List<string>();
+        var remediations = new List<string>();
+        try
+        {
+            var groups = RecommendationEngine.GroupByCode(analysis?.Assessments ?? new List<Assessment>());
+            foreach (var g in groups)
+            {
+                var msg = string.IsNullOrWhiteSpace(g.Advice?.Title)
+                    ? g.Instances.FirstOrDefault()?.Message ?? g.Code
+                    : g.Advice.Title;
+                if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
+                    positives.Add(msg);
+                }
+                else
+                {
+                    remediations.Add(msg);
+                }
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+        };
+    }
+}

--- a/DomainDetective/Protocols/TyposquattingAnalysis.cs
+++ b/DomainDetective/Protocols/TyposquattingAnalysis.cs
@@ -11,7 +11,7 @@ namespace DomainDetective;
 /// Generates common typosquatting variants and checks if they resolve.
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
-public class TyposquattingAnalysis
+public class TyposquattingAnalysis : IHasAssessments
 {
     private static readonly Dictionary<char, char[]> _homoglyphs = new()
     {
@@ -27,6 +27,9 @@ public class TyposquattingAnalysis
         ['e'] = new[] { '3' },
         ['3'] = new[] { 'e' }
     };
+
+    /// <summary>Domain under analysis.</summary>
+    public string? Subject { get; private set; }
 
     /// <summary>DNS configuration for lookups.</summary>
     public DnsConfiguration DnsConfiguration { get; set; } = new();
@@ -172,7 +175,9 @@ public class TyposquattingAnalysis
     /// </summary>
     public async Task Analyze(string domainName, InternalLogger logger, CancellationToken ct = default)
     {
+        Subject = domainName;
         var list = PublicSuffixList ?? new PublicSuffixList();
+        using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "TYPOSQUAT", target: domainName) : null;
         ContainsHomoglyphs = DetectHomoglyphs && StringAlgorithms.ContainsHomoglyphs(domainName);
         if (ContainsHomoglyphs)
         {
@@ -193,5 +198,17 @@ public class TyposquattingAnalysis
                 logger?.WriteWarningCode(TyposquattingCodes.VariantActive, "Potential typosquat detected: {0}", variant);
             }
         }
+
+        if (ActiveDomains.Count == 0)
+        {
+            logger?.WriteInformationCode(TyposquattingCodes.VariantNone, "No active typosquat variants detected");
+        }
+        else
+        {
+            logger?.WriteInformationCode(TyposquattingCodes.DefensiveRegistered, $"{ActiveDomains.Count} variant(s) resolve");
+        }
     }
+
+    public List<Assessment> Assessments { get; } = new();
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 }


### PR DESCRIPTION
## Summary
- add Typosquatting narrative outlining active variants and defensive registrations
- log positive typosquatting assessments and expose recommendations
- document narrative usage and cover with unit tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter "Typosquatting"`

------
https://chatgpt.com/codex/tasks/task_e_68b979e9176c832ea9c55508d82a6e28