### PR TITLE
feat(ttl): add TTL narrative and success guidance

### DIFF
--- a/DomainDetective.Example/ExampleTtlNarrative.cs
+++ b/DomainDetective.Example/ExampleTtlNarrative.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a DNS TTL narrative.
+    /// </summary>
+    public static async Task ExampleTtlNarrative()
+    {
+        var hc = new DomainHealthCheck { Verbose = false };
+        await hc.Verify("evotec.pl", new[] { HealthCheckType.TTL });
+        var narrative = TtlNarrative.Build(hc.DnsTtlAnalysis, hc.DnsTtlAnalysis.Assessments);
+        Helpers.ShowPropertiesTable("TTL Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestTtlNarrative.cs
+++ b/DomainDetective.Tests/TestTtlNarrative.cs
@@ -1,0 +1,29 @@
+using DnsClientX;
+using DomainDetective.Narratives;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestTtlNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithPositives()
+    {
+        var analysis = new DnsTtlAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (_, type) =>
+            {
+                if (type == DnsRecordType.DS) return Task.FromResult(Array.Empty<DnsAnswer>());
+                return Task.FromResult(new[] { new DnsAnswer { TTL = 3600, Type = type } });
+            }
+        };
+        await analysis.Analyze("example.com", new InternalLogger());
+        var sections = TtlNarrative.Build(analysis, analysis.Assessments);
+        Assert.Contains(sections.Highlights, h => h.Contains("SOA TTL"));
+        Assert.Contains(sections.Positives, p => p.Contains("within recommended range"));
+        Assert.Contains(sections.Positives, p => p.Contains("aligned"));
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/TtlCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/TtlCodes.cs
@@ -9,5 +9,11 @@ internal static class TtlCodes {
     public const string NonUniformAcrossNS_AAAA = "DNS.TTL.AAAA.NonUniformAcrossNS";
     public const string NonUniformAcrossNS_NS = "DNS.TTL.NS.NonUniformAcrossNS";
     public const string NonUniformAcrossNS_CNAME = "DNS.TTL.CNAME.NonUniformAcrossNS";
+    public const string Optimal = "DNS.TTL.Success.Optimal";
+    public const string A_AAAA_Aligned = "DNS.TTL.Success.A_AAAA.Aligned";
+    public const string UniformAcrossNS_A = "DNS.TTL.Success.A.UniformAcrossNS";
+    public const string UniformAcrossNS_AAAA = "DNS.TTL.Success.AAAA.UniformAcrossNS";
+    public const string UniformAcrossNS_NS = "DNS.TTL.Success.NS.UniformAcrossNS";
+    public const string UniformAcrossNS_CNAME = "DNS.TTL.Success.CNAME.UniformAcrossNS";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/TtlRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/TtlRecommendations.cs
@@ -39,6 +39,57 @@ internal sealed class TtlRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.Infrastructure,
             Tags = new [] { "dns", "ttl" }
         };
+
+        map[TtlCodes.Optimal] = new RecommendationAdvice {
+            Code = TtlCodes.Optimal,
+            Title = "DNS TTLs within recommended range",
+            Why = "Balanced TTLs reduce lookup load while still allowing timely updates.",
+            How = "Maintain TTLs between 300 and 86400 seconds; use ≥3600s when DNSSEC is enabled.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ttl" }
+        };
+
+        map[TtlCodes.A_AAAA_Aligned] = new RecommendationAdvice {
+            Code = TtlCodes.A_AAAA_Aligned,
+            Title = "A and AAAA TTLs aligned",
+            Why = "Consistent IPv4 and IPv6 TTLs ensure uniform caching behavior across clients.",
+            How = "Keep A and AAAA records synchronized with matching TTL values.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ttl" }
+        };
+
+        map[TtlCodes.UniformAcrossNS_A] = new RecommendationAdvice {
+            Code = TtlCodes.UniformAcrossNS_A,
+            Title = "A TTL uniform across name servers",
+            Why = "Consistent TTLs simplify caching and diagnostics.",
+            How = "Ensure zone transfers propagate TTL updates to all authoritative servers.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ttl" }
+        };
+        map[TtlCodes.UniformAcrossNS_AAAA] = new RecommendationAdvice {
+            Code = TtlCodes.UniformAcrossNS_AAAA,
+            Title = "AAAA TTL uniform across name servers",
+            Why = "Consistent TTLs simplify caching and diagnostics.",
+            How = "Ensure zone transfers propagate TTL updates to all authoritative servers.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ttl" }
+        };
+        map[TtlCodes.UniformAcrossNS_NS] = new RecommendationAdvice {
+            Code = TtlCodes.UniformAcrossNS_NS,
+            Title = "NS TTL uniform across name servers",
+            Why = "Consistent TTLs simplify caching and diagnostics.",
+            How = "Ensure zone transfers propagate TTL updates to all authoritative servers.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ttl" }
+        };
+        map[TtlCodes.UniformAcrossNS_CNAME] = new RecommendationAdvice {
+            Code = TtlCodes.UniformAcrossNS_CNAME,
+            Title = "CNAME TTL uniform across name servers",
+            Why = "Consistent TTLs simplify caching and diagnostics.",
+            How = "Ensure zone transfers propagate TTL updates to all authoritative servers.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ttl" }
+        };
     }
 }
 

--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -223,28 +223,53 @@ namespace DomainDetective {
             NsUniformAcrossServers = IsUniform(ServerTtlNs);
             CnameUniformAcrossServers = IsUniform(ServerTtlCname);
 
-            if (!AUniformAcrossServers) logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_A, "A TTL differs across authoritative name servers");
-            if (!AaaaUniformAcrossServers) logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_AAAA, "AAAA TTL differs across authoritative name servers");
-            if (!NsUniformAcrossServers) logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_NS, "NS TTL differs across authoritative name servers");
-            if (!CnameUniformAcrossServers) logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_CNAME, "CNAME TTL differs across authoritative name servers");
+            if (!AUniformAcrossServers) {
+                logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_A, "A TTL differs across authoritative name servers");
+            } else {
+                logger?.WriteInformationCode(TtlCodes.UniformAcrossNS_A, "A TTL consistent across authoritative name servers.");
+            }
+            if (!AaaaUniformAcrossServers) {
+                logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_AAAA, "AAAA TTL differs across authoritative name servers");
+            } else {
+                logger?.WriteInformationCode(TtlCodes.UniformAcrossNS_AAAA, "AAAA TTL consistent across authoritative name servers.");
+            }
+            if (!NsUniformAcrossServers) {
+                logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_NS, "NS TTL differs across authoritative name servers");
+            } else {
+                logger?.WriteInformationCode(TtlCodes.UniformAcrossNS_NS, "NS TTL consistent across authoritative name servers.");
+            }
+            if (!CnameUniformAcrossServers) {
+                logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_CNAME, "CNAME TTL differs across authoritative name servers");
+            } else {
+                logger?.WriteInformationCode(TtlCodes.UniformAcrossNS_CNAME, "CNAME TTL consistent across authoritative name servers.");
+            }
         }
 
         private void Evaluate(string recordType, IEnumerable<int> ttls, int min, int max, bool dnssecSigned, InternalLogger logger) {
-            foreach (var ttl in ttls) {
+            var list = ttls?.ToArray() ?? Array.Empty<int>();
+            var allGood = true;
+            foreach (var ttl in list) {
                 if (dnssecSigned && ttl >= min && ttl < 3600) {
                     var msg = $"{recordType} TTL {ttl} is shorter than recommended 3600 seconds for DNSSEC-signed zones.";
                     _warnings.Add(msg);
                     logger?.WriteWarningCode(TtlCodes.TooShortForDnssec, msg);
+                    allGood = false;
                 }
                 if (ttl < min) {
                     var msg = $"{recordType} TTL {ttl} is shorter than recommended {min} seconds.";
                     _warnings.Add(msg);
                     logger?.WriteWarningCode(TtlCodes.TooShort, msg);
+                    allGood = false;
                 } else if (ttl > max) {
                     var msg = $"{recordType} TTL {ttl} exceeds recommended {max} seconds.";
                     _warnings.Add(msg);
                     logger?.WriteWarningCode(TtlCodes.TooLong, msg);
+                    allGood = false;
                 }
+            }
+
+            if (list.Any() && allGood) {
+                logger?.WriteInformationCode(TtlCodes.Optimal, $"{recordType} TTLs within recommended range.");
             }
 
             if ((recordType == "A" || recordType == "AAAA") && ATtls.Any() && AaaaTtls.Any()) {
@@ -255,6 +280,8 @@ namespace DomainDetective {
                     var msg = $"A and AAAA TTLs differ significantly: A {avgA} vs AAAA {avgAaaa} seconds.";
                     _warnings.Add(msg);
                     logger?.WriteWarningCode(TtlCodes.A_AAAA_Mismatch, msg);
+                } else if (ratio < 2) {
+                    logger?.WriteInformationCode(TtlCodes.A_AAAA_Aligned, "A and AAAA TTLs are aligned.");
                 }
             }
         }

--- a/DomainDetective/Narratives/TtlNarrative.cs
+++ b/DomainDetective/Narratives/TtlNarrative.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class TtlNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(DnsTtlAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"DNS TTL Report — {subj}";
+        var subtitle = "DNS TTL Assessment";
+        var category = "DNS";
+        var keywords = $"DNS, TTL, caching, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Time to Live (TTL) values control how long DNS data stays cached before revalidation.";
+        var why = "Appropriate TTLs balance caching efficiency with agility for updates; inconsistent values can cause cache churn or stale records.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No TTL data available." },
+                Details = det,
+                References = new List<string> { "https://www.rfc-editor.org/rfc/rfc1035" }
+            };
+        }
+
+        hi.Add($"SOA TTL: {analysis.SoaTtl}s.");
+        if (analysis.ATtls?.Count > 0)
+        {
+            hi.Add($"A TTLs min/max {analysis.ATtls.Min()}/{analysis.ATtls.Max()}s.");
+        }
+        if (analysis.AaaaTtls?.Count > 0)
+        {
+            hi.Add($"AAAA TTLs min/max {analysis.AaaaTtls.Min()}/{analysis.AaaaTtls.Max()}s.");
+        }
+        if (analysis.AUniformAcrossServers)
+        {
+            hi.Add("A TTLs uniform across name servers.");
+        }
+        else if (analysis.ServerTtlA.Count > 0)
+        {
+            hi.Add("A TTLs vary across name servers.");
+        }
+        if (analysis.AaaaUniformAcrossServers)
+        {
+            hi.Add("AAAA TTLs uniform across name servers.");
+        }
+        else if (analysis.ServerTtlAaaa.Count > 0)
+        {
+            hi.Add("AAAA TTLs vary across name servers.");
+        }
+        if (analysis.NsUniformAcrossServers)
+        {
+            hi.Add("NS TTLs uniform across name servers.");
+        }
+        else if (analysis.ServerTtlNs.Count > 0)
+        {
+            hi.Add("NS TTLs vary across name servers.");
+        }
+
+        if (analysis.Warnings != null && analysis.Warnings.Count > 0)
+        {
+            hi.AddRange(analysis.Warnings);
+        }
+        else
+        {
+            hi.Add("TTL values appear balanced for caching and agility.");
+        }
+
+        if (analysis.ATtls?.Count > 0)
+        {
+            det.Add($"A: {string.Join(", ", analysis.ATtls)}");
+        }
+        if (analysis.AaaaTtls?.Count > 0)
+        {
+            det.Add($"AAAA: {string.Join(", ", analysis.AaaaTtls)}");
+        }
+        if (analysis.MxTtls?.Count > 0)
+        {
+            det.Add($"MX: {string.Join(", ", analysis.MxTtls)}");
+        }
+        if (analysis.NsTtls?.Count > 0)
+        {
+            det.Add($"NS: {string.Join(", ", analysis.NsTtls)}");
+        }
+
+        var refs = new List<string> { "https://www.rfc-editor.org/rfc/rfc1035" };
+
+        try
+        {
+            var ass = assessments ?? analysis.Assessments;
+            if (ass != null)
+            {
+                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add success codes and recommendations for optimal DNS TTL strategies
- document TTL findings with new TTL narrative and example usage
- test TTL narrative to confirm positive advice generation

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b979ede3ec832eb6f4670a38e03a37