### PR TITLE
feat(tls): add HTTPS TLS narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleTlsNarrative.cs
+++ b/DomainDetective.Example/ExampleTlsNarrative.cs
@@ -8,7 +8,7 @@ public static class ExampleTlsNarrative
 {
     public static async Task Run()
     {
-        var analysis = new TlsAnalysis { Subject = "example.com" };
+        using var analysis = new TlsAnalysis { Subject = "example.com" };
         var logger = new InternalLogger();
         await analysis.AnalyzeServer("example.com", 443, logger);
         var sections = TlsNarrative.Build(analysis);

--- a/DomainDetective.Example/ExampleTlsNarrative.cs
+++ b/DomainDetective.Example/ExampleTlsNarrative.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static class ExampleTlsNarrative
+{
+    public static async Task Run()
+    {
+        var analysis = new TlsAnalysis { Subject = "example.com" };
+        var logger = new InternalLogger();
+        await analysis.AnalyzeServer("example.com", 443, logger);
+        var sections = TlsNarrative.Build(analysis);
+        Console.WriteLine(sections.Title);
+    }
+}
+

--- a/DomainDetective.Tests/TestTlsNarrative.cs
+++ b/DomainDetective.Tests/TestTlsNarrative.cs
@@ -1,0 +1,29 @@
+using DomainDetective.Narratives;
+using System.Security.Authentication;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestTlsNarrative
+{
+    [Fact]
+    public void BuildsNarrativeWithPositives()
+    {
+        var analysis = new TlsAnalysis { Subject = "example.com" };
+        analysis.ServerResults["www.example.com:443"] = new TlsProbe.Result
+        {
+            Protocol = SslProtocols.Tls13,
+            CipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+            CertificateValid = true,
+            HostnameMatch = true
+        };
+        analysis.Assessments.Add(new Assessment { Code = TlsCodes.StrongProtocol, Severity = AssessmentSeverity.Info, Message = "Strong protocol" });
+        analysis.Assessments.Add(new Assessment { Code = TlsCodes.PfsCipher, Severity = AssessmentSeverity.Info, Message = "Forward secrecy" });
+
+        var sections = TlsNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("TLS"));
+        Assert.Contains("Modern TLS protocol negotiated", sections.Positives);
+        Assert.Contains("Forward secrecy cipher suite negotiated", sections.Positives);
+    }
+}
+

--- a/DomainDetective.Tests/TestTlsNarrative.cs
+++ b/DomainDetective.Tests/TestTlsNarrative.cs
@@ -12,7 +12,11 @@ public class TestTlsNarrative
         var analysis = new TlsAnalysis { Subject = "example.com" };
         analysis.ServerResults["www.example.com:443"] = new TlsProbe.Result
         {
+#if NET8_0_OR_GREATER
             Protocol = SslProtocols.Tls13,
+#else
+            Protocol = SslProtocols.Tls12,
+#endif
             CipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             CertificateValid = true,
             HostnameMatch = true

--- a/DomainDetective.Tests/TestTlsNarrative.cs
+++ b/DomainDetective.Tests/TestTlsNarrative.cs
@@ -9,7 +9,7 @@ public class TestTlsNarrative
     [Fact]
     public void BuildsNarrativeWithPositives()
     {
-        var analysis = new TlsAnalysis { Subject = "example.com" };
+        using var analysis = new TlsAnalysis { Subject = "example.com" };
         analysis.ServerResults["www.example.com:443"] = new TlsProbe.Result
         {
 #if NET8_0_OR_GREATER

--- a/DomainDetective.Tests/TestTlsRecommendations.cs
+++ b/DomainDetective.Tests/TestTlsRecommendations.cs
@@ -1,0 +1,18 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestTlsRecommendations
+{
+    [Fact]
+    public void RegistersPositiveCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new TlsRecommendations().Register(map);
+        Assert.Contains(TlsCodes.StrongProtocol, map.Keys);
+        Assert.Contains(TlsCodes.PfsCipher, map.Keys);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/TlsCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/TlsCodes.cs
@@ -9,4 +9,6 @@ internal static class TlsCodes {
     public const string WeakKeyExchange = "TLS.Kex.Weak";
     public const string OcspStaplingPresent = "TLS.OCSP.StaplingPresent";
     public const string OcspStaplingMissing = "TLS.OCSP.StaplingMissing";
+    public const string StrongProtocol = "TLS.Protocol.Strong";
+    public const string PfsCipher = "TLS.Cipher.ForwardSecrecy";
 }

--- a/DomainDetective/Diagnostics/Recommendations/TlsRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/TlsRecommendations.cs
@@ -107,5 +107,31 @@ internal sealed class TlsRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Probe with an OCSP-aware client (openssl s_client -status) and confirm stapled response present."
         };
+
+        map[TlsCodes.StrongProtocol] = new RecommendationAdvice {
+            Code = TlsCodes.StrongProtocol,
+            Title = "Modern TLS protocol negotiated",
+            Why = "Using TLS 1.2 or 1.3 provides strong encryption and broad client compatibility.",
+            How = "Keep TLS 1.2/1.3 enabled and disable older protocols when possible.",
+            Links = new [] { "https://datatracker.ietf.org/doc/rfc8996/" },
+            Domain = RecommendationDomain.Tls,
+            Tags = new [] { "tls", "protocol" },
+            Impact = "Reduces exposure to known protocol attacks and meets industry requirements.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Handshake should negotiate TLS 1.2 or TLS 1.3."
+        };
+
+        map[TlsCodes.PfsCipher] = new RecommendationAdvice {
+            Code = TlsCodes.PfsCipher,
+            Title = "Forward secrecy cipher suite negotiated",
+            Why = "Perfect forward secrecy prevents compromise of past sessions if keys are exposed.",
+            How = "Prefer ECDHE/DHE-based cipher suites such as TLS_AES_* or TLS_CHACHA20_POLY1305_*.",
+            Links = new [] { "https://en.wikipedia.org/wiki/Perfect_forward_secrecy" },
+            Domain = RecommendationDomain.Tls,
+            Tags = new [] { "tls", "pfs", "cipher" },
+            Impact = "Protects historical traffic even if long-term keys are compromised.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Confirm handshake negotiates an ECDHE or DHE cipher suite."
+        };
     }
 }

--- a/DomainDetective/Narratives/TlsNarrative.cs
+++ b/DomainDetective/Narratives/TlsNarrative.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class TlsNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(TlsAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(host)" : analysis.Subject!;
+        var title = $"TLS Report — {subj}";
+        var subtitle = "HTTPS TLS Assessment";
+        var category = "Web Security";
+        var keywords = $"TLS, HTTPS, security, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "TLS secures HTTPS connections and verifies server identity.";
+        var why = "Modern protocols and ciphers protect confidentiality and integrity.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis != null)
+        {
+            foreach (var kv in analysis.ServerResults)
+            {
+                var r = kv.Value;
+                var cipher = string.IsNullOrWhiteSpace(r.CipherSuite) ? r.KeyExchangeAlgorithm : r.CipherSuite;
+                var certStatus = r.CertificateValid && r.ChainValid && r.HostnameMatch ? "valid certificate" : "certificate issues";
+                hi.Add($"{kv.Key} negotiated {r.Protocol} ({cipher}) — {certStatus}.");
+                if (!string.IsNullOrWhiteSpace(r.CertificateSubject) || !string.IsNullOrWhiteSpace(r.CertificateIssuer))
+                {
+                    det.Add($"{kv.Key} certificate: {r.CertificateSubject} issued by {r.CertificateIssuer}");
+                }
+            }
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        else
+        {
+            hi.Add("No TLS data available.");
+        }
+
+        var refs = new List<string>
+        {
+            "https://datatracker.ietf.org/doc/rfc8446/",
+            "https://ssl-config.mozilla.org/"
+        };
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct().ToList(),
+            Remediations = remediations.Distinct().ToList()
+        };
+    }
+}
+

--- a/DomainDetective/Protocols/TlsAnalysis.cs
+++ b/DomainDetective/Protocols/TlsAnalysis.cs
@@ -17,20 +17,29 @@ public class TlsAnalysis : IHasAssessments
     public List<Assessment> Assessments { get; } = new();
     public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
+    private static bool IsStrongProtocol(SslProtocols protocol)
+    {
+#if NET8_0_OR_GREATER
+        return protocol == SslProtocols.Tls12 || protocol == SslProtocols.Tls13;
+#else
+        return protocol == SslProtocols.Tls12;
+#endif
+    }
+
     public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
     {
         using var collector = AssessmentCollector.ForAnalysis(logger, this, category: "TLS", target: $"{host}:{port}");
         var result = await TlsProbe.ProbeAsync(host, port, cancellationToken);
         ServerResults[$"{host}:{port}"] = result;
-        if (result.Protocol == SslProtocols.Tls13 || result.Protocol == SslProtocols.Tls12)
+        if (IsStrongProtocol(result.Protocol))
         {
             logger?.WriteInformationCode(TlsCodes.StrongProtocol, "Strong TLS protocol negotiated on {0}:{1} - {2}", host, port, result.Protocol);
         }
         var suite = result.CipherSuite ?? string.Empty;
         if (!string.IsNullOrEmpty(suite))
         {
-            var up = suite.ToUpperInvariant();
-            if (up.Contains("ECDHE", StringComparison.Ordinal) || up.Contains("DHE", StringComparison.Ordinal))
+            if (suite.IndexOf("ECDHE", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                suite.IndexOf("DHE", StringComparison.OrdinalIgnoreCase) >= 0)
             {
                 logger?.WriteInformationCode(TlsCodes.PfsCipher, "Forward secrecy cipher negotiated on {0}:{1} - {2}", host, port, suite);
             }

--- a/DomainDetective/Protocols/TlsAnalysis.cs
+++ b/DomainDetective/Protocols/TlsAnalysis.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Provides TLS metadata for HTTPS endpoints.
+/// </summary>
+public class TlsAnalysis : IHasAssessments
+{
+    public string? Subject { get; set; }
+    public Dictionary<string, TlsProbe.Result> ServerResults { get; } = new();
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+    public List<Assessment> Assessments { get; } = new();
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
+
+    public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        using var collector = AssessmentCollector.ForAnalysis(logger, this, category: "TLS", target: $"{host}:{port}");
+        var result = await TlsProbe.ProbeAsync(host, port, cancellationToken);
+        ServerResults[$"{host}:{port}"] = result;
+        if (result.Protocol == SslProtocols.Tls13 || result.Protocol == SslProtocols.Tls12)
+        {
+            logger?.WriteInformationCode(TlsCodes.StrongProtocol, "Strong TLS protocol negotiated on {0}:{1} - {2}", host, port, result.Protocol);
+        }
+        var suite = result.CipherSuite ?? string.Empty;
+        if (!string.IsNullOrEmpty(suite))
+        {
+            var up = suite.ToUpperInvariant();
+            if (up.Contains("ECDHE", StringComparison.Ordinal) || up.Contains("DHE", StringComparison.Ordinal))
+            {
+                logger?.WriteInformationCode(TlsCodes.PfsCipher, "Forward secrecy cipher negotiated on {0}:{1} - {2}", host, port, suite);
+            }
+        }
+    }
+
+    public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
+    {
+        foreach (var host in hosts)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await AnalyzeServer(host, port, logger, cancellationToken);
+        }
+    }
+}
+

--- a/DomainDetective/Protocols/TlsAnalysis.cs
+++ b/DomainDetective/Protocols/TlsAnalysis.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Security.Authentication;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,11 +10,12 @@ namespace DomainDetective;
 /// <summary>
 /// Provides TLS metadata for HTTPS endpoints.
 /// </summary>
-public class TlsAnalysis : IHasAssessments
+public class TlsAnalysis : IHasAssessments, IDisposable
 {
     public string? Subject { get; set; }
     public Dictionary<string, TlsProbe.Result> ServerResults { get; } = new();
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+    public int MaxConcurrency { get; set; } = Environment.ProcessorCount;
     public List<Assessment> Assessments { get; } = new();
     public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
@@ -29,7 +31,7 @@ public class TlsAnalysis : IHasAssessments
     public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
     {
         using var collector = AssessmentCollector.ForAnalysis(logger, this, category: "TLS", target: $"{host}:{port}");
-        var result = await TlsProbe.ProbeAsync(host, port, cancellationToken);
+        var result = await TlsProbe.ProbeAsync(host, port, Timeout, cancellationToken);
         ServerResults[$"{host}:{port}"] = result;
         if (IsStrongProtocol(result.Protocol))
         {
@@ -48,10 +50,27 @@ public class TlsAnalysis : IHasAssessments
 
     public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
     {
-        foreach (var host in hosts)
+        using var gate = new SemaphoreSlim(Math.Max(1, MaxConcurrency));
+        var tasks = hosts.Select(async host =>
         {
-            cancellationToken.ThrowIfCancellationRequested();
-            await AnalyzeServer(host, port, logger, cancellationToken);
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await AnalyzeServer(host, port, logger, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                gate.Release();
+            }
+        });
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+    }
+
+    public void Dispose()
+    {
+        foreach (var r in ServerResults.Values)
+        {
+            r.Dispose();
         }
     }
 }

--- a/DomainDetective/Protocols/TlsProbe.cs
+++ b/DomainDetective/Protocols/TlsProbe.cs
@@ -24,6 +24,7 @@ public static class TlsProbe
         public bool HostnameMatch { get; set; }
         public bool ChainValid => ChainErrors.Count == 0;
         public List<X509ChainStatusFlags> ChainErrors { get; } = new();
+        public List<X509Certificate2> Chain { get; } = new();
         public X509Certificate2? Certificate { get; set; }
         public string? CertificateSubject { get; set; }
         public string? CertificateIssuer { get; set; }
@@ -46,8 +47,13 @@ public static class TlsProbe
             result.CertificateValid = errors == SslPolicyErrors.None;
             result.HostnameMatch = (errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
             result.ChainErrors.Clear();
+            result.Chain.Clear();
             if (chain != null)
             {
+                foreach (var element in chain.ChainElements)
+                {
+                    result.Chain.Add(new X509Certificate2(element.Certificate.Export(X509ContentType.Cert)));
+                }
                 foreach (var s in chain.ChainStatus) result.ChainErrors.Add(s.Status);
             }
             if (certificate is X509Certificate2 cert)

--- a/DomainDetective/Protocols/TlsProbe.cs
+++ b/DomainDetective/Protocols/TlsProbe.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Security.Authentication;
+#if NET5_0_OR_GREATER
+using System.Security.Cryptography;
+#endif
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,7 +18,9 @@ namespace DomainDetective;
 /// <para>Shared by analyses that need basic TLS metadata without duplicating logic.</para>
 public static class TlsProbe
 {
-    public sealed class Result
+    private const string SubjectAlternativeNameOid = "2.5.29.17";
+
+    public sealed class Result : IDisposable
     {
         public SslProtocols Protocol { get; set; }
         public string? CipherSuite { get; set; }
@@ -31,16 +36,34 @@ public static class TlsProbe
         public DateTime? NotBefore { get; set; }
         public DateTime? NotAfter { get; set; }
         public List<string> DnsNames { get; } = new();
+
+        public void Dispose()
+        {
+            Certificate?.Dispose();
+            foreach (var cert in Chain)
+            {
+                cert.Dispose();
+            }
+        }
     }
 
-    public static async Task<Result> ProbeAsync(string host, int port = 443, CancellationToken token = default)
+    public static Task<Result> ProbeAsync(string host, int port = 443, CancellationToken token = default)
+        => ProbeAsync(host, port, null, token);
+
+    public static async Task<Result> ProbeAsync(string host, int port, TimeSpan? timeout, CancellationToken token)
     {
         var result = new Result();
         using var client = new TcpClient();
+        using var timeoutCts = timeout.HasValue ? CancellationTokenSource.CreateLinkedTokenSource(token) : null;
+        if (timeout.HasValue)
+        {
+            timeoutCts!.CancelAfter(timeout.Value);
+        }
+        var ct = timeoutCts?.Token ?? token;
 #if NET6_0_OR_GREATER
-        await client.ConnectAsync(host, port, token);
+        await client.ConnectAsync(host, port, ct);
 #else
-        await client.ConnectAsync(host, port).WaitWithCancellation(token);
+        await client.ConnectAsync(host, port).WaitWithCancellation(ct);
 #endif
         using var ssl = new SslStream(client.GetStream(), false, (sender, certificate, chain, errors) =>
         {
@@ -65,10 +88,20 @@ public static class TlsProbe
                 result.NotAfter = result.Certificate.NotAfter;
                 try
                 {
-                    var san = result.Certificate.Extensions["2.5.29.17"]; // subjectAltName
+#if NET5_0_OR_GREATER
+                    var san = result.Certificate.Extensions[SubjectAlternativeNameOid];
                     if (san != null)
                     {
-                        // very lightweight parse for DNS names
+                        var sanExt = new X509SubjectAlternativeNameExtension(san.RawData, san.Critical);
+                        foreach (var name in sanExt.EnumerateDnsNames())
+                        {
+                            if (!string.IsNullOrWhiteSpace(name)) result.DnsNames.Add(name);
+                        }
+                    }
+#else
+                    var san = result.Certificate.Extensions[SubjectAlternativeNameOid];
+                    if (san != null)
+                    {
                         var raw = san.Format(false);
                         foreach (var part in raw.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
                         {
@@ -81,6 +114,7 @@ public static class TlsProbe
                             }
                         }
                     }
+#endif
                 }
                 catch { }
             }
@@ -89,9 +123,9 @@ public static class TlsProbe
         try
         {
 #if NET8_0_OR_GREATER
-            await ssl.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13 | SslProtocols.Tls12, false);
+            await ssl.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13 | SslProtocols.Tls12, false).WaitWithCancellation(ct);
 #else
-            await ssl.AuthenticateAsClientAsync(host);
+            await ssl.AuthenticateAsClientAsync(host).WaitWithCancellation(ct);
 #endif
 #if NET6_0_OR_GREATER
             result.CipherSuite = ssl.NegotiatedCipherSuite.ToString();


### PR DESCRIPTION
## Summary
- add TlsAnalysis and narrative for HTTPS endpoints
- capture certificate chains and flag strong protocols and forward-secrecy ciphers
- register success recommendations and example usage

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b979f2c3ac832eb214d983472483bb