### PR TITLE
Add threat intel narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleThreatIntelNarrative.cs
+++ b/DomainDetective.Example/ExampleThreatIntelNarrative.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example {
+    public static partial class Program {
+        /// <summary>
+        /// Demonstrates building a narrative from threat intelligence analysis.
+        /// </summary>
+        public static async Task ExampleThreatIntelNarrative() {
+            var analysis = new ThreatIntelAnalysis { EnableUrlHaus = false };
+            await analysis.Analyze("example.com", null, null, null, new InternalLogger());
+            var sections = ThreatIntelNarrative.Build(analysis);
+            Helpers.ShowPropertiesTable("Threat Intel Narrative", sections);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestThreatIntelNarrative.cs
+++ b/DomainDetective.Tests/TestThreatIntelNarrative.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestThreatIntelNarrative {
+        [Fact]
+        public async Task BuildsNarrativeWithPositives() {
+            var analysis = new ThreatIntelAnalysis {
+                EnableUrlHaus = false,
+                GoogleSafeBrowsingOverride = _ => Task.FromResult("{}"),
+                PhishTankOverride = _ => Task.FromResult("{\"results\":{\"valid\":\"true\",\"in_database\":\"false\"}}"),
+                VirusTotalObjectOverride = _ => Task.FromResult<VirusTotalObject?>(new VirusTotalObject {
+                    Attributes = new VirusTotalAttributes {
+                        LastAnalysisStats = new VirusTotalStats { Malicious = 0 },
+                        Reputation = 0
+                    }
+                })
+            };
+            await analysis.Analyze("example.com", "g", "p", "v", new InternalLogger());
+            var sections = ThreatIntelNarrative.Build(analysis);
+            Assert.Contains(sections.Highlights, h => h.Contains("Google Safe Browsing"));
+            Assert.Contains(sections.Positives, p => p.Contains("No threats"));
+        }
+    }
+}

--- a/DomainDetective.Tests/TestThreatIntelRecommendations.cs
+++ b/DomainDetective.Tests/TestThreatIntelRecommendations.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestThreatIntelRecommendations {
+        [Fact]
+        public async Task EmitsPositiveRecommendations() {
+            var analysis = new ThreatIntelAnalysis {
+                EnableUrlHaus = false,
+                GoogleSafeBrowsingOverride = _ => Task.FromResult("{}"),
+                PhishTankOverride = _ => Task.FromResult("{\"results\":{\"valid\":\"true\",\"in_database\":\"false\"}}"),
+                VirusTotalObjectOverride = _ => Task.FromResult<VirusTotalObject?>(new VirusTotalObject {
+                    Attributes = new VirusTotalAttributes {
+                        LastAnalysisStats = new VirusTotalStats { Malicious = 0 },
+                        Reputation = 0
+                    }
+                })
+            };
+            await analysis.Analyze("example.com", "g", "p", "v", new InternalLogger());
+            var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+            Assert.Contains(positives, p => p.Code == ThreatIntelCodes.NoListings);
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/ThreatIntelCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/ThreatIntelCodes.cs
@@ -8,4 +8,5 @@ internal static class ThreatIntelCodes {
     public const string AbuseIpdbQueryFailed = "THREAT.AbuseIPDB.QueryFailed";
     public const string UrlHausQueryFailed = "THREAT.UrlHaus.QueryFailed";
     public const string OpenPhishQueryFailed = "THREAT.OpenPhish.QueryFailed";
+    public const string NoListings = "THREAT.Success.NoListings";
 }

--- a/DomainDetective/Diagnostics/Recommendations/ThreatIntelRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/ThreatIntelRecommendations.cs
@@ -13,6 +13,14 @@ internal sealed class ThreatIntelRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.ThreatIntel,
             Tags = new [] { "reputation" }
         };
+        map[ThreatIntelCodes.NoListings] = new RecommendationAdvice {
+            Code = ThreatIntelCodes.NoListings,
+            Title = "No threats detected",
+            Why = "None of the checked feeds list the domain or IP, indicating a clean reputation.",
+            How = "Maintain security hygiene and monitor feeds regularly to keep the reputation clean.",
+            Domain = RecommendationDomain.ThreatIntel,
+            Tags = new [] { "reputation" }
+        };
     }
 }
 

--- a/DomainDetective/Narratives/ThreatIntelNarrative.cs
+++ b/DomainDetective/Narratives/ThreatIntelNarrative.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class ThreatIntelNarrative {
+    public sealed class Sections {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(ThreatIntelAnalysis ti) {
+        var subj = string.IsNullOrWhiteSpace(ti?.Subject) ? "(domain)" : ti.Subject;
+        var title = $"Threat Intelligence Report — {subj}";
+        var subtitle = "Threat Intelligence";
+        var category = "Security";
+        var keywords = $"threat intelligence, malware, reputation, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Threat intelligence services identify malicious domains and IPs across global feeds.";
+        var why = "Monitoring these feeds helps detect compromises early and protect users.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (ti?.Listings != null) {
+            foreach (var f in ti.Listings) {
+                hi.Add($"{Label(f.Source)}: {(f.IsListed ? "listed" : "not listed")}");
+            }
+        }
+
+        if (ti?.RiskScore != null) {
+            hi.Add($"Reputation score: {ti.RiskScore}");
+        }
+
+        if (ti?.CompositeScore != null) {
+            det.Add($"Composite score: {ti.CompositeScore}/100");
+        }
+
+        if (!string.IsNullOrWhiteSpace(ti?.Severity)) {
+            det.Add($"Severity: {ti.Severity}");
+        }
+
+        if (ti?.Confidence != null) {
+            det.Add($"Confidence: {ti.Confidence:P0}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(ti?.FailureReason)) {
+            det.Add($"Failure reason: {ti.FailureReason}");
+        }
+
+        var refs = new List<string> {
+            "https://developers.google.com/safe-browsing/",
+            "https://phishtank.com/",
+            "https://www.virustotal.com/"
+        };
+
+        try {
+            AssessmentSplit.SplitTitles(ti?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        } catch {
+        }
+
+        return new Sections {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static string Label(ThreatIntelSource source) {
+        return source switch {
+            ThreatIntelSource.GoogleSafeBrowsing => "Google Safe Browsing",
+            ThreatIntelSource.PhishTank => "PhishTank",
+            ThreatIntelSource.VirusTotal => "VirusTotal",
+            ThreatIntelSource.UrlHaus => "URLHaus",
+            ThreatIntelSource.OpenPhish => "OpenPhish",
+            _ => source.ToString()
+        };
+    }
+}

--- a/DomainDetective/Protocols/ThreatIntelAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatIntelAnalysis.cs
@@ -326,6 +326,9 @@ public class ThreatIntelAnalysis : IHasAssessments
 
         // Compute composite score and confidence
         ComputeComposite(domainName, googleListed, phishListed, vtListed, urlHausListed, openPhishListed, RiskScore);
+        if (!googleListed && !phishListed && !vtListed && !urlHausListed && !openPhishListed && (!RiskScore.HasValue || RiskScore.Value <= 0)) {
+            logger?.WriteInformationCode(ThreatIntelCodes.NoListings, "No threat intelligence listings for {0}", domainName);
+        }
     }
 
     public List<Assessment> Assessments { get; } = new();


### PR DESCRIPTION
## Summary
- add ThreatIntel narrative summarizing feed listings and reputation scores
- report clean results with a new NoListings code and recommendation
- include example usage and unit tests for narrative and positive recommendations

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68b979f81068832e8508bc8db227cbb4