### PR TITLE
feat: add StartTLS narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleStartTlsNarrative.cs
+++ b/DomainDetective.Example/ExampleStartTlsNarrative.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a STARTTLS narrative.
+    /// </summary>
+    public static Task ExampleStartTlsNarrative()
+    {
+        var analysis = new STARTTLSAnalysis { Subject = "example.com" };
+        analysis.ServerDetails["smtp.example.com:25"] = new STARTTLSResult
+        {
+            Host = "smtp.example.com",
+            Port = 25,
+            StartTlsAdvertised = true,
+            TlsNegotiated = true,
+            TlsProtocol = "TLS1.2",
+            CipherAlgorithm = "AES",
+            CipherStrength = 256
+        };
+        analysis.Assessments.Add(new Assessment { Code = "STARTTLS.Session.Enforced", Severity = AssessmentSeverity.Info });
+        analysis.Assessments.Add(new Assessment { Code = "STARTTLS.Cipher.Modern", Severity = AssessmentSeverity.Info });
+        var narrative = StartTlsNarrative.Build(analysis);
+        Helpers.ShowPropertiesTable("STARTTLS Narrative", narrative);
+        return Task.CompletedTask;
+    }
+}

--- a/DomainDetective.Tests/TestStartTlsNarrative.cs
+++ b/DomainDetective.Tests/TestStartTlsNarrative.cs
@@ -1,0 +1,32 @@
+using DomainDetective.Narratives;
+using Xunit;
+using DomainDetective;
+
+namespace DomainDetective.Tests;
+
+public class TestStartTlsNarrative
+{
+    [Fact]
+    public void BuildsNarrativeWithPositives()
+    {
+        var analysis = new STARTTLSAnalysis { Subject = "example.com" };
+        analysis.ServerDetails["smtp.example.com:25"] = new STARTTLSResult
+        {
+            Host = "smtp.example.com",
+            Port = 25,
+            StartTlsAdvertised = true,
+            TlsNegotiated = true,
+            TlsProtocol = "TLS1.2",
+            CipherAlgorithm = "AES",
+            CipherStrength = 256
+        };
+        analysis.Assessments.Add(new Assessment { Code = StartTlsCodes.Enforced, Severity = AssessmentSeverity.Info, Message = "Enforced" });
+        analysis.Assessments.Add(new Assessment { Code = StartTlsCodes.ModernCipher, Severity = AssessmentSeverity.Info, Message = "Modern" });
+
+        var sections = StartTlsNarrative.Build(analysis);
+
+        Assert.Contains(sections.Highlights, h => h.Contains("advertises STARTTLS"));
+        Assert.Contains("STARTTLS enforced", sections.Positives);
+        Assert.Contains("Modern cipher suite negotiated", sections.Positives);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/StartTlsCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/StartTlsCodes.cs
@@ -5,5 +5,7 @@ internal static class StartTlsCodes {
     public const string EhloUnexpected = "STARTTLS.EHLO.Unexpected";
     public const string EhloMissingFinal250 = "STARTTLS.EHLO.MissingFinal250";
     public const string CheckFailed = "STARTTLS.Check.Failed";
+    public const string Enforced = "STARTTLS.Session.Enforced";
+    public const string ModernCipher = "STARTTLS.Cipher.Modern";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/StartTlsRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/StartTlsRecommendations.cs
@@ -46,5 +46,25 @@ internal sealed class StartTlsRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.Tls,
             Tags = new [] { "smtp", "starttls" }
         };
+
+        map[StartTlsCodes.Enforced] = new RecommendationAdvice {
+            Code = StartTlsCodes.Enforced,
+            Title = "STARTTLS enforced",
+            Why = "Servers requiring TLS upgrades prevent plaintext fallback.",
+            How = "Monitor for downgrade attempts and maintain strong TLS settings.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc3207" },
+            Domain = RecommendationDomain.Tls,
+            Tags = new [] { "smtp", "imap", "pop", "starttls" }
+        };
+
+        map[StartTlsCodes.ModernCipher] = new RecommendationAdvice {
+            Code = StartTlsCodes.ModernCipher,
+            Title = "Modern cipher suite negotiated",
+            Why = "Modern TLS ciphers protect against known weaknesses.",
+            How = "Keep TLS libraries and configuration up to date to retain strong cipher support.",
+            Links = new [] { "https://ssl-config.mozilla.org/" },
+            Domain = RecommendationDomain.Tls,
+            Tags = new [] { "starttls", "tls" }
+        };
     }
 }

--- a/DomainDetective/Narratives/StartTlsNarrative.cs
+++ b/DomainDetective/Narratives/StartTlsNarrative.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class StartTlsNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(STARTTLSAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"STARTTLS Report — {subj}";
+        var subtitle = "STARTTLS Assessment";
+        var category = "Email Security";
+        var keywords = $"STARTTLS, SMTP, IMAP, POP, security, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "STARTTLS upgrades plaintext mail protocols like SMTP, IMAP and POP to encrypted TLS sessions.";
+        var why = "Enforcing STARTTLS with modern ciphers prevents downgrade attacks and eavesdropping.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis != null && analysis.ServerDetails.Count > 0)
+        {
+            foreach (var kv in analysis.ServerDetails)
+            {
+                var r = kv.Value;
+                var proto = r.Port switch
+                {
+                    25 or 587 or 465 => "SMTP",
+                    143 or 993 => "IMAP",
+                    110 or 995 => "POP3",
+                    _ => "Server"
+                };
+                var status = r.StartTlsAdvertised ? "advertises STARTTLS" : "does not advertise STARTTLS";
+                var upgrade = r.TlsNegotiated ? $"upgraded to {r.TlsProtocol} ({r.CipherAlgorithm} {r.CipherStrength} bits)" : "no TLS negotiation";
+                var downgrade = r.DowngradeDetected ? " (downgrade suspected)" : string.Empty;
+                hi.Add($"{kv.Key} [{proto}] {status} and {upgrade}{downgrade}.");
+                det.Add($"{kv.Key} downgrade detected: {r.DowngradeDetected}");
+            }
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        else
+        {
+            hi.Add("No STARTTLS data available.");
+        }
+
+        var refs = new List<string>
+        {
+            "https://www.rfc-editor.org/rfc/rfc3207",
+            "https://www.rfc-editor.org/rfc/rfc2595",
+            "https://ssl-config.mozilla.org/"
+        };
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct().ToList(),
+            Remediations = remediations.Distinct().ToList()
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add StartTLS narrative highlighting SMTP/IMAP/POP upgrades
- include success recommendations for enforced STARTTLS and modern ciphers
- provide example and tests for narrative and positive advice

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b979fd4628832eb3ff1b21be5229ff