### PR TITLE
feat(spf): add positive SPF success codes

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseSPF.cs
+++ b/DomainDetective.Example/ExampleAnalyseSPF.cs
@@ -9,6 +9,8 @@ public static partial class Program {
         await healthCheck.Verify("github.com", [HealthCheckType.SPF]);
         //ShowProperties("Domain analysis of github.com", healthCheck.SpfAnalysis);
         Helpers.ShowPropertiesTable("Domain analysis of github.com", healthCheck.SpfAnalysis);
+        var positives = RecommendationEngine.FromPositives(healthCheck.SpfAnalysis.Assessments);
+        Helpers.ShowPropertiesTable("Positive SPF posture for github.com", positives);
 
         var healthCheck3 = new DomainHealthCheck();
         await healthCheck3.Verify("microsoft.com", [HealthCheckType.SPF]);
@@ -34,6 +36,8 @@ public static partial class Program {
         await healthCheck4.CheckSPF(spfRecord1);
         //ShowProperties("SPF for EVOTEC.PL " + spfRecord1, healthCheck4.SpfAnalysis);
         Helpers.ShowPropertiesTable("SPF for EVOTEC.PL " + spfRecord1, healthCheck4.SpfAnalysis);
+        var positivesString = RecommendationEngine.FromPositives(healthCheck4.SpfAnalysis.Assessments);
+        Helpers.ShowPropertiesTable("Positive SPF posture for EVOTEC.PL", positivesString);
 
         var spfRecord2 = "v=spf1 ip4:207.68.169.173/30 ip4:207.68.176.1/26 ip4:207.46.132.129/27 ip4:207.68.176.97/27 ip4:65.55.238.129/26 ip4:207.46.222.193/26 ip4:207.46.116.135/29 ip4:65.55.178.129/27 ip4:213.199.161.129/27 ip4:65.55.33.70/28 ~all";
         var healthCheck5 = new DomainHealthCheck();

--- a/DomainDetective.Tests/TestSpfRecommendations.cs
+++ b/DomainDetective.Tests/TestSpfRecommendations.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestSpfRecommendations
+{
+    [Fact]
+    public async Task EmitsPositiveRecommendations()
+    {
+        var hc = new DomainHealthCheck();
+        hc.SpfAnalysis.TestSpfRecords["a.example.com"] = "v=spf1 -all";
+        await hc.CheckSPF("v=spf1 include:a.example.com -all");
+        var positives = RecommendationEngine.FromPositives(hc.SpfAnalysis.Assessments);
+        Assert.Contains(positives, p => p.Code == SpfCodes.IncludeChainValid);
+        Assert.Contains(positives, p => p.Code == SpfCodes.LookupsWithinLimit);
+        Assert.Contains(positives, p => p.Code == SpfCodes.AllEnforced);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/SpfCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SpfCodes.cs
@@ -25,4 +25,5 @@ internal static class SpfCodes {
     public const string StartsV1 = "SPF.Record.StartsV1";
     public const string AllEnforced = "SPF.All.Enforced";
     public const string LookupsWithinLimit = "SPF.Lookups.WithinLimit";
+    public const string IncludeChainValid = "SPF.Include.ChainValid";
 }

--- a/DomainDetective/Diagnostics/Recommendations/SpfRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SpfRecommendations.cs
@@ -226,5 +226,42 @@ internal sealed class SpfRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Record contains minimal or no 'exists:' tokens."
         };
+
+        // Presence/positive signals
+        map[SpfCodes.IncludeChainValid] = new RecommendationAdvice {
+            Code = SpfCodes.IncludeChainValid,
+            Title = "SPF include chain resolves cleanly",
+            Why = "All include/redirect mechanisms resolved without loops, ensuring dependable policy evaluation.",
+            How = "Keep third-party include targets stable and monitor for DNS changes or deprecations.",
+            Domain = RecommendationDomain.Spf,
+            Tags = new [] { "spf", "dns" },
+            Impact = "Improves reliability of SPF processing.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Include and redirect lookups succeed with no cycles."
+        };
+
+        map[SpfCodes.LookupsWithinLimit] = new RecommendationAdvice {
+            Code = SpfCodes.LookupsWithinLimit,
+            Title = "SPF DNS lookups within limit",
+            Why = "Staying under the 10-lookup cap avoids permerrors and speeds evaluation.",
+            How = "Continue using flattened includes and consolidated mechanisms to keep lookups minimal.",
+            Domain = RecommendationDomain.Spf,
+            Tags = new [] { "spf", "dns" },
+            Impact = "Ensures receivers can evaluate the record efficiently.",
+            Effort = RecommendationEffort.Low,
+            Verify = "DNS lookups remain under 10."
+        };
+
+        map[SpfCodes.AllEnforced] = new RecommendationAdvice {
+            Code = SpfCodes.AllEnforced,
+            Title = "SPF policy aligned and enforced",
+            Why = "A terminating '-all' rejects unauthorized senders and aligns with strict DMARC policy.",
+            How = "Maintain '-all' after confirming all legitimate sources are authorized.",
+            Domain = RecommendationDomain.Spf,
+            Tags = new [] { "spf", "policy" },
+            Impact = "Reduces spoofing and supports DMARC alignment.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Record ends with '-all' and passes DMARC alignment tests."
+        };
     }
 }

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -289,6 +289,8 @@ namespace DomainDetective {
                 logger?.WriteInformationCode(SpfCodes.AllEnforced, "SPF ends with -all (enforced)");
             if (!ExceedsDnsLookups)
                 logger?.WriteInformationCode(SpfCodes.LookupsWithinLimit, $"DNS lookups within limit: {DnsLookupsCount}/10");
+            if (DnsLookups.Count > 0 && !CycleDetected)
+                logger?.WriteInformationCode(SpfCodes.IncludeChainValid, "SPF include/redirect chain resolves without loops");
         }
 
 


### PR DESCRIPTION
## Summary
- add IncludeChainValid success code and map positive SPF recommendations
- surface SPF positives in example for DNS and string checks
- test that SPF analysis emits new positive codes

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "EmitsPositiveRecommendations"`

------
https://chatgpt.com/codex/tasks/task_e_68b97a01d84c832e8e795eb3fb3cfbe8