### PR TITLE
feat(smimea): add S/MIMEA narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseSMIMEA.cs
+++ b/DomainDetective.Example/ExampleAnalyseSMIMEA.cs
@@ -1,0 +1,13 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    public static async Task ExampleAnalyseSMIMEA() {
+        var healthCheck = new DomainHealthCheck();
+        await healthCheck.VerifySMIMEA("user@example.com");
+        Helpers.ShowPropertiesTable("SMIMEA for user@example.com", healthCheck.SmimeaAnalysis);
+        Helpers.ShowPropertiesTable("SMIMEA recommendations", healthCheck.SmimeaAnalysis.Recommendations);
+    }
+}
+

--- a/DomainDetective.Tests/TestSmimeaNarrative.cs
+++ b/DomainDetective.Tests/TestSmimeaNarrative.cs
@@ -1,0 +1,19 @@
+using DnsClientX;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestSmimeaNarrative {
+    [Fact]
+    public async Task NarrativeSummarizesRecords() {
+        var record = "3 1 1 " + new string('A', 64);
+        var analysis = new SMIMEAAnalysis { Subject = "user@example.com" };
+        await analysis.AnalyzeSMIMEARecords(new[] { new DnsAnswer { DataRaw = record } }, new InternalLogger());
+        var sections = SmimeaNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("SMIMEA record"));
+        Assert.Contains(sections.Positives, p => p.Contains("SMIMEA record present"));
+    }
+}
+

--- a/DomainDetective.Tests/TestSmimeaRecommendations.cs
+++ b/DomainDetective.Tests/TestSmimeaRecommendations.cs
@@ -1,0 +1,18 @@
+using DnsClientX;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestSmimeaRecommendations {
+    [Fact]
+    public async Task EmitsPositiveRecommendations() {
+        var record = "3 1 1 " + new string('A', 64);
+        var analysis = new SMIMEAAnalysis();
+        await analysis.AnalyzeSMIMEARecords(new[] { new DnsAnswer { DataRaw = record } }, new InternalLogger());
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == SmimeaCodes.RecordPresent);
+        Assert.Contains(positives, p => p.Code == SmimeaCodes.CertificateValid);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/SmimeaCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SmimeaCodes.cs
@@ -9,4 +9,6 @@ internal static class SmimeaCodes {
     public const string MatchingTypeNotNumeric = "SMIMEA.MatchingType.NotNumeric";
     public const string MatchingTypeInvalid = "SMIMEA.MatchingType.Invalid";
     public const string NoRecords = "SMIMEA.Records.Missing";
+    public const string RecordPresent = "SMIMEA.Record.Present";
+    public const string CertificateValid = "SMIMEA.Certificate.Valid";
 }

--- a/DomainDetective/Diagnostics/Recommendations/SmimeaRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SmimeaRecommendations.cs
@@ -29,5 +29,26 @@ internal sealed class SmimeaRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Confirm owner name matches <hash>._smimecert.<domain>."
         };
+
+        map[SmimeaCodes.RecordPresent] = new RecommendationAdvice {
+            Code = SmimeaCodes.RecordPresent,
+            Title = "SMIMEA record present",
+            Why = "Publishing SMIMEA enables DNSSEC-backed discovery of S/MIME certificates.",
+            How = "Maintain SMIMEA records for addresses that use S/MIME.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc8162" },
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "smimea" }
+        };
+
+        map[SmimeaCodes.CertificateValid] = new RecommendationAdvice {
+            Code = SmimeaCodes.CertificateValid,
+            Title = "Valid S/MIME certificate association",
+            Why = "Correct usage, selector, and matching type allow clients to verify certificates.",
+            How = "Continue renewing and monitoring published S/MIME certificates.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc8162" },
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "smimea", "certificate" }
+        };
     }
 }
+

--- a/DomainDetective/Narratives/SmimeaNarrative.cs
+++ b/DomainDetective/Narratives/SmimeaNarrative.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Collections.Generic;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class SmimeaNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(SMIMEAAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(email)" : analysis.Subject;
+        var title = $"SMIMEA Report — {subj}";
+        var subtitle = "SMIMEA Assessment";
+        var category = "Email Security";
+        var keywords = $"SMIMEA, email, security, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "SMIMEA publishes S/MIME certificate associations in DNS, secured by DNSSEC.";
+        var why = "Publishing SMIMEA allows recipients to validate S/MIME certificates before trusting messages.";
+
+        var highlights = new List<string>();
+        var details = new List<string>();
+
+        if (analysis == null || analysis.NumberOfRecords == 0)
+        {
+            highlights.Add("No SMIMEA records found.");
+        }
+        else
+        {
+            highlights.Add($"{analysis.NumberOfRecords} SMIMEA record(s) found.");
+            if (analysis.HasDuplicateRecords) highlights.Add("Duplicate SMIMEA records detected.");
+            if (analysis.HasInvalidRecords) highlights.Add("One or more SMIMEA records are invalid.");
+            else highlights.Add("All SMIMEA records are valid.");
+        }
+
+        if (analysis?.AnalysisResults != null)
+        {
+            foreach (var r in analysis.AnalysisResults)
+            {
+                details.Add($"{r.EmailAddress ?? string.Empty} — {r.CertificateUsage}, {r.SelectorField}, {r.MatchingTypeField}");
+            }
+        }
+
+        var refs = new List<string> { "https://www.rfc-editor.org/rfc/rfc8162" };
+
+        List<string> positives;
+        List<string> remediations;
+        try
+        {
+            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        catch (Exception)
+        {
+            positives = new List<string>();
+            remediations = new List<string>();
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = highlights,
+            Details = details,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}
+

--- a/DomainDetective/Protocols/SMIMEAAnalysis.cs
+++ b/DomainDetective/Protocols/SMIMEAAnalysis.cs
@@ -114,6 +114,12 @@ namespace DomainDetective {
                 AnalysisResults.Add(analysis);
             }
             HasInvalidRecords = AnalysisResults.Any(x => !x.ValidSMIMEARecord);
+            if (NumberOfRecords > 0) {
+                logger?.WriteInformationCode(SmimeaCodes.RecordPresent, "SMIMEA record present");
+            }
+            if (AnalysisResults.Any(x => x.ValidSMIMEARecord)) {
+                logger?.WriteInformationCode(SmimeaCodes.CertificateValid, "Valid SMIMEA certificate association");
+            }
         }
 
         private bool ValidateUsage(int usage) => usage switch { 0 or 1 or 2 or 3 => true, _ => false };


### PR DESCRIPTION
## Summary
- add SMIMEA narrative summarising records and certificate usage
- surface success recommendations for published SMIMEA certificates
- exercise narrative and recommendation paths with examples and tests

## Testing
- `dotnet build`
- `dotnet test -v n`

------
https://chatgpt.com/codex/tasks/task_e_68b97a08db74832e9ce635040007a379