### PR TITLE
feat(mx): add narrative and success advisories

### DIFF
--- a/DomainDetective.Example/ExampleMxNarrative.cs
+++ b/DomainDetective.Example/ExampleMxNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example
+{
+    public static partial class Program
+    {
+        /// <summary>
+        /// Demonstrates building a narrative from MX analysis.
+        /// </summary>
+        public static async Task ExampleMxNarrative()
+        {
+            var health = new DomainHealthCheck();
+            await health.VerifyMX("gmail.com");
+            var sections = MxNarrative.Build(health.MXAnalysis);
+            Helpers.ShowPropertiesTable("MX Narrative", sections);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestMxNarrative.cs
+++ b/DomainDetective.Tests/TestMxNarrative.cs
@@ -1,0 +1,57 @@
+using DnsClientX;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestMxNarrative
+    {
+        private static MXAnalysis CreateAnalysis()
+        {
+            var map = new Dictionary<(string, DnsRecordType), DnsAnswer[]>
+            {
+                [("mail1.example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "1.1.1.1" } },
+                [("mail1.example.com", DnsRecordType.AAAA)] = System.Array.Empty<DnsAnswer>(),
+                [("mail2.example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "2.2.2.2" } },
+                [("mail2.example.com", DnsRecordType.AAAA)] = new[] { new DnsAnswer { DataRaw = "2001::1" } }
+            };
+            return new MXAnalysis
+            {
+                DnsConfiguration = new DnsConfiguration(),
+                QueryDnsOverride = (name, type) => Task.FromResult(map.TryGetValue((name, type), out var v) ? v : System.Array.Empty<DnsAnswer>())
+            };
+        }
+
+        [Fact]
+        public async Task BuildsNarrative()
+        {
+            var answers = new List<DnsAnswer>
+            {
+                new DnsAnswer { DataRaw = "10 mail1.example.com", Type = DnsRecordType.MX },
+                new DnsAnswer { DataRaw = "20 mail2.example.com", Type = DnsRecordType.MX }
+            };
+            var analysis = CreateAnalysis();
+            await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+            var sections = MxNarrative.Build(analysis);
+            Assert.Contains(sections.Highlights, h => h.Contains("MX records: 2"));
+            Assert.Contains(sections.Highlights, h => h.Contains("ascending order"));
+            Assert.Contains(sections.Highlights, h => h.Contains("IPv6"));
+        }
+
+        [Fact]
+        public void GeneratesPositiveAdvice()
+        {
+            var assessments = new List<Assessment>
+            {
+                new Assessment { Code = MxCodes.RedundantHosts, Severity = AssessmentSeverity.Info },
+                new Assessment { Code = MxCodes.TlsSupported, Severity = AssessmentSeverity.Info }
+            };
+            var positives = RecommendationEngine.FromPositives(assessments);
+            Assert.Contains(positives, p => p.Code == MxCodes.RedundantHosts);
+            Assert.Contains(positives, p => p.Code == MxCodes.TlsSupported);
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/MxCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/MxCodes.cs
@@ -14,5 +14,7 @@ internal static class MxCodes {
     public const string TargetAddressInconsistentAcrossNs = "MX.Target.Address.InconsistentAcrossNS";
     public const string TtlNonUniform = "MX.TTL.NonUniform";
     public const string TargetTtlNonUniform = "MX.Target.TTL.NonUniform";
+    public const string RedundantHosts = "MX.Success.RedundantHosts";
+    public const string TlsSupported = "MX.Success.TlsSupported";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/MxRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/MxRecommendations.cs
@@ -125,6 +125,24 @@ internal sealed class MxRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "dig +ttlid A/AAAA mx1.example.com shows equal TTLs."
         };
+
+        map[MxCodes.RedundantHosts] = new RecommendationAdvice {
+            Code = MxCodes.RedundantHosts,
+            Title = "Redundant MX hosts configured",
+            Why = "Multiple MX hosts improve resilience and availability of inbound mail.",
+            How = "Maintain at least two MX records with differing preferences hosted on separate infrastructure.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "mx", "resilience" }
+        };
+
+        map[MxCodes.TlsSupported] = new RecommendationAdvice {
+            Code = MxCodes.TlsSupported,
+            Title = "MX hosts support STARTTLS",
+            Why = "TLS encryption protects email in transit and is widely expected by modern mail servers.",
+            How = "Keep TLS enabled and certificates valid on all MX hosts.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "mx", "tls" }
+        };
     }
 }
 

--- a/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
@@ -22,6 +22,9 @@ namespace DomainDetective {
             _logger?.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, port, string.Join(", ", tlsHosts));
             StartTlsAnalysis.Subject = domainName;
             await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { port }, _logger, cancellationToken);
+            if (StartTlsAnalysis.ServerResults.Count > 0 && StartTlsAnalysis.ServerResults.Values.All(v => v)) {
+                _logger?.WriteInformationCode(MxCodes.TlsSupported, "All MX hosts support STARTTLS");
+            }
         }
 
         /// <summary>

--- a/DomainDetective/Narratives/MxNarrative.cs
+++ b/DomainDetective/Narratives/MxNarrative.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class MxNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(MXAnalysis mx)
+    {
+        var subj = string.IsNullOrWhiteSpace(mx?.Subject) ? "(domain)" : mx.Subject;
+        var title = $"MX Report — {subj}";
+        var subtitle = "MX Assessment";
+        var category = "Email Security";
+        var keywords = $"MX, email, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Mail Exchanger (MX) records direct email for a domain to the correct mail servers.";
+        var why = "Proper MX configuration ensures reliable and resilient inbound mail delivery.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        hi.Add($"MX records: {mx.MxRecords?.Count ?? 0}");
+        hi.Add(mx.PrioritiesInOrder ? "Priorities are in ascending order." : "Priorities appear out of order.");
+        hi.Add(mx.Ipv6Supported ? "IPv6 supported on at least one MX host." : "No IPv6 support detected on MX hosts.");
+
+        det.Add(mx.HasBackupServers ? "Multiple MX preferences provide redundancy." : "Only a single MX preference detected.");
+        if (!mx.Ipv6Supported)
+            det.Add("Consider adding AAAA records for IPv6 reachability.");
+
+        var refs = mx.RfcReferences?.Select(r => string.IsNullOrWhiteSpace(r.Url) ? r.Reference : r.Url).ToList()
+            ?? new List<string> { "https://www.rfc-editor.org/rfc/rfc5321" };
+
+        try
+        {
+            var assessments = (IEnumerable<Assessment>)(mx.Assessments ?? new List<Assessment>());
+            var groups = RecommendationEngine.GroupByCode(assessments);
+            foreach (var g in groups)
+            {
+                var msg = string.IsNullOrWhiteSpace(g.Advice?.Title)
+                    ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
+                    : g.Advice.Title;
+                if (g.MaxSeverity == AssessmentSeverity.Info)
+                    positives.Add(msg);
+                else
+                    remediations.Add(msg);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+        };
+    }
+}

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -54,6 +54,9 @@ namespace DomainDetective {
         /// <summary>True when an MX host points to localhost.</summary>
         public bool PointsToLocalhost { get; private set; }
 
+        /// <summary>True when at least one MX host has an AAAA record.</summary>
+        public bool Ipv6Supported { get; private set; }
+
         // Integrity checks
         public bool MxTtlUniform { get; private set; } = true;
         public bool MxRrsetConsistentAcrossNs { get; private set; } = true;
@@ -89,6 +92,7 @@ namespace DomainDetective {
             HasBackupServers = false;
             HasNullMx = false;
             PointsToLocalhost = false;
+            Ipv6Supported = false;
             MxTtlUniform = true;
             MxRrsetConsistentAcrossNs = true;
             TargetAddressConsistentAcrossNs = true;
@@ -152,6 +156,7 @@ namespace DomainDetective {
                 var aaaaResults = await QueryDns(host, DnsRecordType.AAAA);
                 var noA = aResults == null || !aResults.Any();
                 var noAAAA = aaaaResults == null || !aaaaResults.Any();
+                Ipv6Supported = Ipv6Supported || !noAAAA;
 
                 if (noA && noAAAA) {
                     var nsResults = await QueryDns(host, DnsRecordType.NS);
@@ -188,7 +193,10 @@ namespace DomainDetective {
                 using (_collector?.PushTarget(Subject ?? string.Empty))
                     logger?.WriteWarningCode(MxCodes.PrioritiesOutOfOrder, "MX priorities are not in ascending stable order");
             }
-            if (!HasBackupServers && evaluationList.Count >= 1 && !HasNullMx) {
+            if (HasBackupServers) {
+                using (_collector?.PushTarget(Subject ?? string.Empty))
+                    logger?.WriteInformationCode(MxCodes.RedundantHosts, "Multiple MX preferences detected");
+            } else if (evaluationList.Count >= 1 && !HasNullMx) {
                 using (_collector?.PushTarget(Subject ?? string.Empty))
                     logger?.WriteWarningCode(MxCodes.NoBackupServers, "Only a single MX preference detected; consider a backup MX");
             }

--- a/DomainDetective/Views/Converters.Mx.cs
+++ b/DomainDetective/Views/Converters.Mx.cs
@@ -25,6 +25,7 @@ public static partial class Converters
             HasBackupServers = analysis.HasBackupServers,
             HasNullMx = analysis.HasNullMx,
             PointsToLocalhost = analysis.PointsToLocalhost,
+            Ipv6Supported = analysis.Ipv6Supported,
             MxTtlUniform = analysis.MxTtlUniform,
             MxRrsetConsistentAcrossNs = analysis.MxRrsetConsistentAcrossNs,
             TargetAddressConsistentAcrossNs = analysis.TargetAddressConsistentAcrossNs,
@@ -56,6 +57,7 @@ public class MxInfo
     public bool HasBackupServers { get; set; }
     public bool HasNullMx { get; set; }
     public bool PointsToLocalhost { get; set; }
+    public bool Ipv6Supported { get; set; }
     public bool MxTtlUniform { get; set; }
     public bool MxRrsetConsistentAcrossNs { get; set; }
     public bool TargetAddressConsistentAcrossNs { get; set; }


### PR DESCRIPTION
## Summary
- add MX narrative covering record count, priority order and IPv6 support
- expose IPv6 support and redundant-host success codes for MX analysis
- surface positive MX guidance for redundancy and STARTTLS in recommendations

## Testing
- `dotnet build`
- `dotnet test` *(fails: DomainDetective.Tests.TestDnsPropagationProgress.ProgressCompletesWhenNoServers)*

------
https://chatgpt.com/codex/tasks/task_e_68b97a0e0894832eba617c2374baa824