### PR TITLE
feat(smtp): add SMTP AUTH narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseSmtpAuth.cs
+++ b/DomainDetective.Example/ExampleAnalyseSmtpAuth.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Example analyzing SMTP AUTH mechanisms.
+    /// </summary>
+    public static async Task ExampleAnalyseSmtpAuth()
+    {
+        var analysis = new SmtpAuthAnalysis { InspectCapabilities = true };
+        await analysis.AnalyzeServer("smtp.gmail.com", 587, new InternalLogger());
+        Helpers.ShowPropertiesTable("SMTP AUTH", analysis.ServerMechanisms);
+    }
+}

--- a/DomainDetective.Tests/TestSmtpAuthNarrative.cs
+++ b/DomainDetective.Tests/TestSmtpAuthNarrative.cs
@@ -1,0 +1,21 @@
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestSmtpAuthNarrative
+    {
+        [Fact]
+        public void NarrativeSummarizesMechanismsAndTls()
+        {
+            var analysis = new SmtpAuthAnalysis { Subject = "example.com", InspectCapabilities = true };
+            analysis.ServerMechanisms["smtp.example.com:587"] = new[] { "LOGIN", "PLAIN" };
+            analysis.ServerCapabilities["smtp.example.com:587"] = new[] { "AUTH", "STARTTLS" };
+            analysis.Assessments.Add(new Assessment { Code = SmtpAuthCodes.TlsRequired, Severity = AssessmentSeverity.Info, Message = "TLS required" });
+            var sections = SmtpAuthNarrative.Build(analysis);
+            Assert.Contains("smtp.example.com:587 supports LOGIN PLAIN", sections.Highlights);
+            Assert.Contains("smtp.example.com:587 advertises STARTTLS.", sections.Highlights);
+            Assert.Contains("AUTH protected by TLS", sections.Positives);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestSmtpAuthRecommendations.cs
+++ b/DomainDetective.Tests/TestSmtpAuthRecommendations.cs
@@ -1,0 +1,45 @@
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestSmtpAuthRecommendations
+    {
+        [Fact]
+        public async Task EmitsPositiveRecommendations()
+        {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () =>
+            {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost");
+                await writer.WriteLineAsync("250-8BITMIME");
+                await writer.WriteLineAsync("250-STARTTLS");
+                await writer.WriteLineAsync("250-AUTH LOGIN SCRAM-SHA-256");
+                await writer.WriteLineAsync("250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            try
+            {
+                var analysis = new SmtpAuthAnalysis();
+                await analysis.AnalyzeServer("localhost", port, new InternalLogger());
+                var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+                Assert.Contains(positives, p => p.Code == SmtpAuthCodes.TlsRequired);
+                Assert.Contains(positives, p => p.Code == SmtpAuthCodes.StrongMechanism);
+            }
+            finally
+            {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/SmtpAuthCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SmtpAuthCodes.cs
@@ -6,4 +6,6 @@ internal static class SmtpAuthCodes {
     public const string AuthOverPlaintext = "SMTPAUTH.AuthOverPlaintext";
     public const string ObsoleteMechanism = "SMTPAUTH.ObsoleteMechanism";
     public const string NoStrongMechanism = "SMTPAUTH.NoStrongMechanism";
+    public const string TlsRequired = "SMTPAUTH.TlsRequired";
+    public const string StrongMechanism = "SMTPAUTH.StrongMechanism";
 }

--- a/DomainDetective/Diagnostics/Recommendations/SmtpAuthRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SmtpAuthRecommendations.cs
@@ -4,6 +4,25 @@ namespace DomainDetective.Recommendations;
 
 internal sealed class SmtpAuthRecommendations : IRecommendationProvider {
     public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[SmtpAuthCodes.TlsRequired] = new RecommendationAdvice {
+            Code = SmtpAuthCodes.TlsRequired,
+            Title = "AUTH protected by TLS",
+            Why = "Requiring STARTTLS before AUTH prevents credential interception.",
+            How = "No action required; maintain TLS enforcement before authentication.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc8314" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "smtp", "tls", "auth" }
+        };
+
+        map[SmtpAuthCodes.StrongMechanism] = new RecommendationAdvice {
+            Code = SmtpAuthCodes.StrongMechanism,
+            Title = "Strong AUTH mechanism advertised",
+            Why = "Secure SASL mechanisms like SCRAM or OAuth resist credential attacks.",
+            How = "No action required; keep strong mechanisms enabled.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc5802" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new [] { "smtp", "sasl" }
+        };
         map[SmtpAuthCodes.AuthWithout8BitMime] = new RecommendationAdvice {
             Code = SmtpAuthCodes.AuthWithout8BitMime,
             Title = "AUTH advertised without 8BITMIME",

--- a/DomainDetective/Narratives/SmtpAuthNarrative.cs
+++ b/DomainDetective/Narratives/SmtpAuthNarrative.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class SmtpAuthNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(SmtpAuthAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"SMTP AUTH Report — {subj}";
+        var subtitle = "SMTP AUTH Assessment";
+        var category = "Email Security";
+        var keywords = $"SMTP AUTH, SASL, email, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "SMTP AUTH allows clients to authenticate before sending mail.";
+        var why = "Securing authentication prevents unauthorized use and protects credentials.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || analysis.ServerMechanisms.Count == 0)
+        {
+            hi.Add("No SMTP AUTH data available.");
+        }
+        else
+        {
+            foreach (var kv in analysis.ServerMechanisms)
+            {
+                var mechs = kv.Value.Length == 0 ? "(none)" : string.Join(" ", kv.Value);
+                hi.Add($"{kv.Key} supports {mechs}");
+                if (analysis.InspectCapabilities && analysis.ServerCapabilities.TryGetValue(kv.Key, out var caps))
+                {
+                    hi.Add(caps.Contains("STARTTLS", StringComparer.OrdinalIgnoreCase) ? $"{kv.Key} advertises STARTTLS." : $"{kv.Key} does not advertise STARTTLS.");
+                }
+            }
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+
+        var refs = new List<string>
+        {
+            "https://www.rfc-editor.org/rfc/rfc4954",
+            "https://www.rfc-editor.org/rfc/rfc8314"
+        };
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/SmtpAuthAnalysis.cs
+++ b/DomainDetective/Protocols/SmtpAuthAnalysis.cs
@@ -127,6 +127,10 @@ public class SmtpAuthAnalysis : IHasAssessments {
                     logger?.WriteWarningCode(SmtpAuthCodes.AuthWithout8BitMime, "SMTP server {0}:{1} advertises AUTH but not 8BITMIME.", host, port);
                 }
 
+                if (hasAuth && hasStartTls) {
+                    logger?.WriteInformationCode(SmtpAuthCodes.TlsRequired, "SMTP server {0}:{1} advertises STARTTLS alongside AUTH.", host, port);
+                }
+
                 // AUTH on plaintext (no STARTTLS) on ports expecting STARTTLS (25/587)
                 if (hasAuth && !hasStartTls && (port == 25 || port == 587)) {
                     logger?.WriteWarningCode(SmtpAuthCodes.AuthOverPlaintext, "SMTP server {0}:{1} advertises AUTH without STARTTLS.", host, port);
@@ -137,9 +141,16 @@ public class SmtpAuthAnalysis : IHasAssessments {
                     logger?.WriteWarningCode(SmtpAuthCodes.ObsoleteMechanism, "SMTP server {0}:{1} advertises obsolete AUTH mechanisms: {2}", host, port, string.Join(" ", mechanisms));
                 }
 
-                // Only weak mechanisms present
+                // Assess mechanism strength
                 if (hasAuth && mechanisms.Count > 0) {
-                    var strong = mechanisms.Contains("SCRAM-SHA-256") || mechanisms.Contains("OAUTHBEARER") || mechanisms.Contains("XOAUTH2") || mechanisms.Contains("EXTERNAL");
+                    var strongMechs = mechanisms.Where(m => string.Equals(m, "SCRAM-SHA-256", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(m, "OAUTHBEARER", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(m, "XOAUTH2", StringComparison.OrdinalIgnoreCase)
+                        || string.Equals(m, "EXTERNAL", StringComparison.OrdinalIgnoreCase)).ToList();
+                    var strong = strongMechs.Count > 0;
+                    if (strong) {
+                        logger?.WriteInformationCode(SmtpAuthCodes.StrongMechanism, "SMTP server {0}:{1} advertises strong AUTH mechanisms: {2}", host, port, string.Join(" ", strongMechs));
+                    }
                     var weakOnly = !strong && mechanisms.All(m => string.Equals(m, "PLAIN", StringComparison.OrdinalIgnoreCase) || string.Equals(m, "LOGIN", StringComparison.OrdinalIgnoreCase));
                     if (weakOnly && !hasStartTls) {
                         logger?.WriteWarningCode(SmtpAuthCodes.NoStrongMechanism, "SMTP server {0}:{1} only advertises weak mechanisms (PLAIN/LOGIN) without STARTTLS.", host, port);


### PR DESCRIPTION
## Summary
- describe SMTP AUTH mechanisms and TLS requirements in new narrative
- add success codes and recommendations for TLS-protected and strong mechanisms
- include example and tests for SMTP AUTH narrative and recommendations

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "TestSmtpAuth"`


------
https://chatgpt.com/codex/tasks/task_e_68b97a1e1e7c832ebd375d3829c7da2e