### PR TITLE
feat: add security.txt narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleSecurityTxtNarrative.cs
+++ b/DomainDetective.Example/ExampleSecurityTxtNarrative.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Demonstrates building a security.txt narrative for a domain.
+    /// </summary>
+    public static async Task ExampleSecurityTxtNarrative() {
+        var healthCheck = new DomainHealthCheck();
+        await healthCheck.Verify("securitytxt.org", new[] { HealthCheckType.SECURITYTXT });
+        var narrative = SecurityTxtNarrative.Build(healthCheck.SecurityTXTAnalysis);
+        Helpers.ShowPropertiesTable("security.txt Narrative", narrative);
+    }
+}
+

--- a/DomainDetective.Tests/TestSecurityTxtNarrative.cs
+++ b/DomainDetective.Tests/TestSecurityTxtNarrative.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestSecurityTxtNarrative {
+    [Fact]
+    public void BuildsNarrativeAndPositiveAdvice() {
+        var analysis = new SecurityTXTAnalysis {
+            Domain = "example.com",
+            RecordPresent = true,
+            RecordValid = true
+        };
+
+        analysis.ContactEmail.Add("admin@example.com");
+        analysis.Encryption.Add("https://example.com/pgp.txt");
+        analysis.Policy.Add("https://example.com/policy");
+
+        analysis.Assessments.Add(new Assessment {
+            Code = SecurityTxtCodes.RecordPresent,
+            Severity = AssessmentSeverity.Info,
+            Message = "security.txt present"
+        });
+        analysis.Assessments.Add(new Assessment {
+            Code = SecurityTxtCodes.RecordValid,
+            Severity = AssessmentSeverity.Info,
+            Message = "security.txt syntax valid"
+        });
+
+        var sections = SecurityTxtNarrative.Build(analysis);
+        Assert.Contains("admin@example.com", string.Join(" ", sections.Highlights));
+        Assert.Contains("pgp.txt", string.Join(" ", sections.Highlights));
+        Assert.Contains("policy", string.Join(" ", sections.Highlights));
+
+        var codes = analysis.Recommendations.Select(r => r.Code).ToList();
+        Assert.Contains(SecurityTxtCodes.RecordPresent, codes);
+        Assert.Contains(SecurityTxtCodes.RecordValid, codes);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/SecurityTxtCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SecurityTxtCodes.cs
@@ -15,4 +15,8 @@ internal static class SecurityTxtCodes {
     public const string CanonicalNotHttps = "SECURITYTXT.Canonical.NotHttps";
     public const string CanonicalMismatch = "SECURITYTXT.Canonical.Mismatch";
     public const string InvalidFile = "SECURITYTXT.Invalid.File";
+
+    // Positive/posture signals
+    public const string RecordPresent = "SECURITYTXT.Record.Present";
+    public const string RecordValid = "SECURITYTXT.Record.Valid";
 }

--- a/DomainDetective/Diagnostics/Recommendations/SecurityTxtRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SecurityTxtRecommendations.cs
@@ -4,6 +4,32 @@ namespace DomainDetective.Recommendations;
 
 internal sealed class SecurityTxtRecommendations : IRecommendationProvider {
     public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[SecurityTxtCodes.RecordPresent] = new RecommendationAdvice {
+            Code = SecurityTxtCodes.RecordPresent,
+            Title = "security.txt present",
+            Why = "A published security.txt gives researchers a defined channel to report issues.",
+            How = "Serve /.well-known/security.txt over HTTPS with contact and policy details.",
+            Links = new [] { "https://securitytxt.org/" },
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "security.txt" },
+            Impact = "Facilitates responsible disclosure.",
+            Effort = RecommendationEffort.Low,
+            Verify = "GET https://<domain>/.well-known/security.txt returns policy file."
+        };
+
+        map[SecurityTxtCodes.RecordValid] = new RecommendationAdvice {
+            Code = SecurityTxtCodes.RecordValid,
+            Title = "security.txt syntax valid",
+            Why = "Valid syntax ensures automated tools can parse the disclosure policy.",
+            How = "Include required fields and follow formatting guidance.",
+            Links = new [] { "https://securitytxt.org/" },
+            Domain = RecommendationDomain.Privacy,
+            Tags = new [] { "security.txt" },
+            Impact = "Improves trust and interoperability.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Run a security.txt parser without errors."
+        };
+
         map[SecurityTxtCodes.MissingContact] = new RecommendationAdvice {
             Code = SecurityTxtCodes.MissingContact,
             Title = "security.txt: missing Contact",

--- a/DomainDetective/Narratives/SecurityTxtNarrative.cs
+++ b/DomainDetective/Narratives/SecurityTxtNarrative.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives {
+    public static class SecurityTxtNarrative {
+        public sealed class Sections {
+            public string Title { get; init; } = string.Empty;
+            public string Subtitle { get; init; } = string.Empty;
+            public string Category { get; init; } = string.Empty;
+            public string Keywords { get; init; } = string.Empty;
+            public string Creator { get; init; } = string.Empty;
+            public string Introduction { get; init; } = string.Empty;
+            public string WhyItMatters { get; init; } = string.Empty;
+            public List<string> Highlights { get; init; } = new();
+            public List<string> Details { get; init; } = new();
+            public List<string> References { get; init; } = new();
+            public List<string> Positives { get; init; } = new();
+            public List<string> Remediations { get; init; } = new();
+        }
+
+        public static Sections Build(SecurityTXTAnalysis analysis) {
+            var subj = string.IsNullOrWhiteSpace(analysis?.Domain) ? "(domain)" : analysis.Domain;
+            var title = $"security.txt Report — {subj}";
+            var subtitle = "Security Policy";
+            var category = "Vulnerability Disclosure";
+            var keywords = $"security.txt, vulnerability disclosure, DomainDetective, {subj}";
+            var creator = "DomainDetective";
+            var intro = "security.txt provides a standard location for vulnerability disclosure policies and contacts.";
+            var why = "Publishing security.txt helps researchers report vulnerabilities responsibly and securely.";
+
+            var hi = new List<string>();
+            var det = new List<string>();
+            var positives = new List<string>();
+            var remediations = new List<string>();
+
+            var contacts = analysis.ContactEmail.Concat(analysis.ContactWebsite).ToList();
+            hi.Add(contacts.Count > 0
+                ? $"Contacts: {string.Join(", ", contacts)}"
+                : "No contact methods provided.");
+
+            if (analysis.Encryption.Count > 0) {
+                hi.Add($"Encryption keys: {string.Join(", ", analysis.Encryption)}");
+            }
+
+            if (analysis.Policy.Count > 0) {
+                hi.Add($"Policies: {string.Join(", ", analysis.Policy)}");
+            }
+
+            if (analysis.PGPSigned) {
+                det.Add("PGP signed file.");
+            }
+
+            if (analysis.Canonical.Count > 0) {
+                det.Add($"Canonical: {string.Join(", ", analysis.Canonical)}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(analysis.Expires)) {
+                det.Add($"Expires: {analysis.Expires}");
+            }
+
+            var refs = new List<string> { "https://securitytxt.org/" };
+
+            try {
+                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            } catch { }
+
+            return new Sections {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = refs,
+                Positives = positives,
+                Remediations = remediations
+            };
+        }
+    }
+}
+

--- a/DomainDetective/Protocols/SecurityTXTAnalysis.cs
+++ b/DomainDetective/Protocols/SecurityTXTAnalysis.cs
@@ -92,6 +92,7 @@ public class SecurityTXTAnalysis : IHasAssessments {
                 RecordPresent = true;
                 Url = url;
                 FallbackUsed = fallback;
+                Logger?.WriteInformationCode(SecurityTxtCodes.RecordPresent, "security.txt present");
                 ParseSecurityTxt(response, pgpPublicKey, url);
 
                 if (DateTimeOffset.TryParse(Expires, out var expires)) {
@@ -293,6 +294,8 @@ public class SecurityTXTAnalysis : IHasAssessments {
 
             if (!RecordValid) {
                 Logger.WriteWarningCode(SecurityTxtCodes.InvalidFile, "Invalid security.txt file");
+            } else {
+                Logger.WriteInformationCode(SecurityTxtCodes.RecordValid, "security.txt syntax valid");
             }
         }
 


### PR DESCRIPTION
## Summary
- add positive codes for security.txt presence and syntax
- provide SecurityTxt narrative with contact, encryption, and policy details
- include example and tests confirming narrative and recommendations

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b97a592ec0832eb1dd14b4cc2f346f