### PR TITLE
feat: add DNSSEC narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleDnssecNarrative.cs
+++ b/DomainDetective.Example/ExampleDnssecNarrative.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a DNSSEC narrative.
+    /// </summary>
+    public static async Task ExampleDnssecNarrative()
+    {
+        var analysis = new DnsSecAnalysis();
+        await analysis.Analyze("example.com", new InternalLogger());
+        var narrative = DnssecNarrative.Build(analysis);
+        Helpers.ShowPropertiesTable("DNSSEC Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestDnssecNarrative.cs
+++ b/DomainDetective.Tests/TestDnssecNarrative.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDnssecNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithHighlightsAndPositives()
+    {
+        var hc = new DomainHealthCheck { Verbose = false };
+        await hc.Verify("cloudflare.com", [HealthCheckType.DNSSEC]);
+        var sections = DnssecNarrative.Build(hc.DnsSecAnalysis, hc.DnsSecAnalysis.Assessments);
+        Assert.Contains(sections.Highlights, h => h.Contains("DS record"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Key algorithms"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Chain of trust"));
+        Assert.NotEmpty(sections.Positives);
+    }
+}

--- a/DomainDetective.Tests/TestDnssecRecommendations.cs
+++ b/DomainDetective.Tests/TestDnssecRecommendations.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDnssecRecommendations
+{
+    [Fact]
+    public void RegistersSuccessCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new DnssecRecommendations().Register(map);
+        Assert.Contains(DnssecCodes.SignaturesValid, map.Keys);
+        Assert.Contains(DnssecCodes.ChainValid, map.Keys);
+    }
+
+    [Fact]
+    public async Task EmitsPositiveRecommendations()
+    {
+        var hc = new DomainHealthCheck { Verbose = false };
+        await hc.Verify("cloudflare.com", [HealthCheckType.DNSSEC]);
+        var positives = RecommendationEngine.FromPositives(hc.DnsSecAnalysis.Assessments);
+        Assert.Contains(positives, p => p.Code == DnssecCodes.SignaturesValid);
+        Assert.Contains(positives, p => p.Code == DnssecCodes.ChainValid);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/DnssecCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/DnssecCodes.cs
@@ -12,4 +12,6 @@ internal static class DnssecCodes {
     public const string DsNotAuthenticated = "DNSSEC.DS.NotAuthenticated";
     public const string DsMismatch = "DNSSEC.DS.Mismatch";
     public const string Nsec3OptOutRisk = "DNSSEC.NSEC3.OptOutRisk";
+    public const string SignaturesValid = "DNSSEC.Signatures.Valid";
+    public const string ChainValid = "DNSSEC.Chain.Valid";
 }

--- a/DomainDetective/Diagnostics/Recommendations/DnssecRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/DnssecRecommendations.cs
@@ -112,5 +112,25 @@ internal sealed class DnssecRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Medium,
             Verify = "Query NSEC3PARAM/NSEC3; Flags should be 0 when Opt-Out is not used."
         };
+
+        map[DnssecCodes.SignaturesValid] = new RecommendationAdvice {
+            Code = DnssecCodes.SignaturesValid,
+            Title = "DNSSEC signatures validated",
+            Why = "Valid signatures ensure DNS responses are authentic and unaltered.",
+            How = "Maintain key rollover procedures and monitor signature expiration windows.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc4035" },
+            Domain = RecommendationDomain.Dnssec,
+            Tags = new [] { "dnssec", "signatures" }
+        };
+
+        map[DnssecCodes.ChainValid] = new RecommendationAdvice {
+            Code = DnssecCodes.ChainValid,
+            Title = "DNSSEC chain of trust intact",
+            Why = "A complete chain of trust prevents spoofed DNS responses.",
+            How = "Ensure DS records are published and keys are rotated before expiry to preserve validation.",
+            Links = new [] { "https://www.rfc-editor.org/rfc/rfc4035" },
+            Domain = RecommendationDomain.Dnssec,
+            Tags = new [] { "dnssec", "integrity" }
+        };
     }
 }

--- a/DomainDetective/Narratives/DnssecNarrative.cs
+++ b/DomainDetective/Narratives/DnssecNarrative.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using DomainDetective;
+using DomainDetective.Protocols;
+
+namespace DomainDetective.Narratives;
+
+public static class DnssecNarrative
+{
+    public sealed class Sections
+    {
+        public string Title { get; init; } = string.Empty;
+        public string Subtitle { get; init; } = string.Empty;
+        public string Category { get; init; } = string.Empty;
+        public string Keywords { get; init; } = string.Empty;
+        public string Creator { get; init; } = string.Empty;
+        public string Introduction { get; init; } = string.Empty;
+        public string WhyItMatters { get; init; } = string.Empty;
+        public List<string> Highlights { get; init; } = new();
+        public List<string> Details { get; init; } = new();
+        public List<string> References { get; init; } = new();
+        public List<string> Positives { get; init; } = new();
+        public List<string> Remediations { get; init; } = new();
+    }
+
+    public static Sections Build(DnsSecAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subject = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"DNSSEC Report — {subject}";
+        var subtitle = "DNSSEC Assessment";
+        var category = "DNS Security";
+        var keywords = $"DNSSEC, DNS, security, DomainDetective, {subject}";
+        var creator = "DomainDetective";
+        var intro = "Domain Name System Security Extensions (DNSSEC) add digital signatures to DNS records to verify their integrity.";
+        var why = "Valid DNSSEC signatures help protect users from forged DNS responses and cache poisoning.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No DNSSEC data available." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        hi.Add(analysis.DsRecords.Count > 0 ? "DS record present at parent." : "No DS record found at parent.");
+
+        if (analysis.DnsKeys.Count > 0)
+        {
+            var algs = new List<string>();
+            foreach (var key in analysis.DnsKeys)
+            {
+                var parts = key.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length > 3 && int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var alg))
+                {
+                    var name = DNSKeyAnalysis.AlgorithmName(alg);
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        algs.Add(name);
+                    }
+                }
+            }
+            var distinct = algs.Distinct().ToList();
+            hi.Add(distinct.Count > 0
+                ? $"Key algorithms: {string.Join(", ", distinct)}."
+                : "Key algorithms: unknown.");
+        }
+        else
+        {
+            hi.Add("No DNSKEY records returned.");
+        }
+
+        hi.Add(analysis.ChainValid ? "Chain of trust validated." : "Chain of trust invalid.");
+        hi.Add(analysis.DsMatch ? "DS and DNSKEY match." : "DS and DNSKEY mismatch.");
+        if (analysis.KeyExpiresSoon)
+        {
+            hi.Add("Some signatures expire soon.");
+        }
+
+        if (analysis.DsRecords.Count > 0)
+        {
+            det.AddRange(analysis.DsRecords.Select((d, i) => $"DS[{i + 1}]: {d}"));
+        }
+
+        var refs = DefaultRefs();
+
+        try
+        {
+            var assess = assessments ?? analysis.Assessments;
+            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.rfc-editor.org/rfc/rfc4033",
+        "https://www.rfc-editor.org/rfc/rfc4035"
+    };
+}

--- a/DomainDetective/Protocols/DnsSecAnalysis.cs
+++ b/DomainDetective/Protocols/DnsSecAnalysis.cs
@@ -268,6 +268,11 @@ namespace DomainDetective {
             } catch (Exception ex) {
                 logger?.WriteDebug("NSEC3 Opt-Out check skipped: {0}", ex.Message);
             }
+
+            if (ChainValid) {
+                logger?.WriteInformationCode(DnssecCodes.SignaturesValid, "DNSSEC signatures validated");
+                logger?.WriteInformationCode(DnssecCodes.ChainValid, "DNSSEC chain validated");
+            }
         }
 
         private static async Task<bool> HasNsec3OptOutAsync(string domain, CancellationToken ct) {


### PR DESCRIPTION
## Summary
- build DNSSEC narrative detailing DS records, algorithms, and validation results
- log success codes for valid signatures and chain of trust with matching recommendations
- add example and tests for DNSSEC narrative and recommendations

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b97a64e4a4832e830f4da43f59742b