### PR TITLE
refactor: centralize narrative sections class

### DIFF
--- a/DomainDetective/Narratives/ArcNarrative.cs
+++ b/DomainDetective/Narratives/ArcNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class ArcNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(ARCAnalysis arc)
     {

--- a/DomainDetective/Narratives/AutodiscoverNarrative.cs
+++ b/DomainDetective/Narratives/AutodiscoverNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class AutodiscoverNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(AutodiscoverAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/BimiNarrative.cs
+++ b/DomainDetective/Narratives/BimiNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class BimiNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(BimiAnalysis bimi)
     {

--- a/DomainDetective/Narratives/CaaNarrative.cs
+++ b/DomainDetective/Narratives/CaaNarrative.cs
@@ -7,44 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class CaaNarrative
 {
-    public sealed class Sections
-    {
-        /// <summary>Gets the narrative title.</summary>
-        public string Title { get; init; } = string.Empty;
-
-        /// <summary>Gets the narrative subtitle.</summary>
-        public string Subtitle { get; init; } = string.Empty;
-
-        /// <summary>Gets the category describing the narrative.</summary>
-        public string Category { get; init; } = string.Empty;
-
-        /// <summary>Gets keywords associated with the narrative.</summary>
-        public string Keywords { get; init; } = string.Empty;
-
-        /// <summary>Gets the narrative creator name.</summary>
-        public string Creator { get; init; } = string.Empty;
-
-        /// <summary>Gets the introductory text.</summary>
-        public string Introduction { get; init; } = string.Empty;
-
-        /// <summary>Gets the description why CAA matters.</summary>
-        public string WhyItMatters { get; init; } = string.Empty;
-
-        /// <summary>Gets highlighted summary lines.</summary>
-        public List<string> Highlights { get; init; } = new();
-
-        /// <summary>Gets detailed lines explaining the analysis.</summary>
-        public List<string> Details { get; init; } = new();
-
-        /// <summary>Gets reference links for further reading.</summary>
-        public List<string> References { get; init; } = new();
-
-        /// <summary>Gets positive assessment titles.</summary>
-        public List<string> Positives { get; init; } = new();
-
-        /// <summary>Gets remediation assessment titles.</summary>
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(CAAAnalysis caa)
     {

--- a/DomainDetective/Narratives/CertificateHttpNarrative.cs
+++ b/DomainDetective/Narratives/CertificateHttpNarrative.cs
@@ -4,22 +4,8 @@ using System.Collections.Generic;
 namespace DomainDetective.Narratives;
 
 public static class CertificateHttpNarrative {
-    public sealed class Sections {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
-    /// <summary>Builds narrative sections for HTTP certificate analysis.</summary>
     public static Sections Build(CertificateAnalysis? analysis, IEnumerable<Assessment>? assessments = null) {
         var intro = "Retrieves the TLS certificate over HTTPS and evaluates chain trust and expiry.";
         var why = "Trusted certificates with reasonable lifetimes prevent browser warnings and ensure secure connections.";

--- a/DomainDetective/Narratives/CnameNarrative.cs
+++ b/DomainDetective/Narratives/CnameNarrative.cs
@@ -5,21 +5,7 @@ namespace DomainDetective.Narratives;
 
 public static class CnameNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(CnameAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/DaneNarrative.cs
+++ b/DomainDetective/Narratives/DaneNarrative.cs
@@ -9,21 +9,7 @@ public static class DaneNarrative
 {
     private static string FormatRecord(string domain, object selector, object matching) =>
         $"TLSA record for {domain} uses selector {selector} and matching {matching}.";
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(DANEAnalysis? dane, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/DirectoryExposureNarrative.cs
+++ b/DomainDetective/Narratives/DirectoryExposureNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class DirectoryExposureNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(DirectoryExposureAnalysis analysis)
     {

--- a/DomainDetective/Narratives/DkimNarrative.cs
+++ b/DomainDetective/Narratives/DkimNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class DkimNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(DkimRecordAnalysis dkim, string? selector = null, System.Collections.Generic.IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/DmarcNarrative.cs
+++ b/DomainDetective/Narratives/DmarcNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class DmarcNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(DmarcAnalysis dmarc)
     {

--- a/DomainDetective/Narratives/DnssecNarrative.cs
+++ b/DomainDetective/Narratives/DnssecNarrative.cs
@@ -9,21 +9,7 @@ namespace DomainDetective.Narratives;
 
 public static class DnssecNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(DnsSecAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/EdnsNarrative.cs
+++ b/DomainDetective/Narratives/EdnsNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class EdnsNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(EdnsSupportAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/MailTlsNarrative.cs
+++ b/DomainDetective/Narratives/MailTlsNarrative.cs
@@ -6,23 +6,9 @@ namespace DomainDetective.Narratives
 {
     public static class MailTlsNarrative
     {
-        public sealed class Sections
-        {
-            public string Title { get; init; } = string.Empty;
-            public string Subtitle { get; init; } = string.Empty;
-            public string Category { get; init; } = string.Empty;
-            public string Keywords { get; init; } = string.Empty;
-            public string Creator { get; init; } = string.Empty;
-            public string Introduction { get; init; } = string.Empty;
-            public string WhyItMatters { get; init; } = string.Empty;
-            public List<string> Highlights { get; init; } = new();
-            public List<string> Details { get; init; } = new();
-            public List<string> References { get; init; } = new();
-            public List<string> Positives { get; init; } = new();
-            public List<string> Remediations { get; init; } = new();
-        }
+        public sealed class Sections : NarrativeSections { }
 
-        public static Sections Build(MailTlsAnalysis analysis, MailTlsAnalysis.MailProtocol protocol)
+    public static Sections Build(MailTlsAnalysis analysis, MailTlsAnalysis.MailProtocol protocol)
         {
             var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
             var protoName = protocol switch

--- a/DomainDetective/Narratives/MtaStsNarrative.cs
+++ b/DomainDetective/Narratives/MtaStsNarrative.cs
@@ -9,21 +9,7 @@ namespace DomainDetective.Narratives;
 
 public static class MtaStsNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(MTASTSAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/MxNarrative.cs
+++ b/DomainDetective/Narratives/MxNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class MxNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(MXAnalysis mx)
     {

--- a/DomainDetective/Narratives/NSNarrative.cs
+++ b/DomainDetective/Narratives/NSNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class NSNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(NSAnalysis ns)
     {

--- a/DomainDetective/Narratives/NarrativeSections.cs
+++ b/DomainDetective/Narratives/NarrativeSections.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+/// <summary>Represents narrative metadata and content sections used in reports.</summary>
+public class NarrativeSections
+{
+    /// <summary>Gets or sets the primary title.</summary>
+    public string Title { get; init; } = string.Empty;
+
+    /// <summary>Gets or sets the secondary title or subtitle.</summary>
+    public string Subtitle { get; init; } = string.Empty;
+
+    /// <summary>Gets or sets the category of the narrative content.</summary>
+    public string Category { get; init; } = string.Empty;
+
+    /// <summary>Gets or sets comma-separated keywords associated with the narrative.</summary>
+    public string Keywords { get; init; } = string.Empty;
+
+    /// <summary>Gets or sets the creator or author of the narrative.</summary>
+    public string Creator { get; init; } = string.Empty;
+
+    /// <summary>Gets or sets the introductory text.</summary>
+    public string Introduction { get; init; } = string.Empty;
+
+    /// <summary>Gets or sets a description of why the topic matters.</summary>
+    public string WhyItMatters { get; init; } = string.Empty;
+
+    /// <summary>Gets the list of highlight bullet points.</summary>
+    public List<string> Highlights { get; init; } = new();
+
+    /// <summary>Gets the list of detailed bullet points.</summary>
+    public List<string> Details { get; init; } = new();
+
+    /// <summary>Gets the list of reference links.</summary>
+    public List<string> References { get; init; } = new();
+
+    /// <summary>Gets the list of positive notes.</summary>
+    public List<string> Positives { get; init; } = new();
+
+    /// <summary>Gets the list of remediation steps.</summary>
+    public List<string> Remediations { get; init; } = new();
+}

--- a/DomainDetective/Narratives/OpenRelayNarrative.cs
+++ b/DomainDetective/Narratives/OpenRelayNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class OpenRelayNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(OpenRelayAnalysis analysis, InternalLogger? logger = null)
     {

--- a/DomainDetective/Narratives/RdapNarrative.cs
+++ b/DomainDetective/Narratives/RdapNarrative.cs
@@ -5,21 +5,7 @@ namespace DomainDetective.Narratives;
 
 public static class RdapNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(RdapAnalysis rdap)
     {

--- a/DomainDetective/Narratives/RobotsTxtNarrative.cs
+++ b/DomainDetective/Narratives/RobotsTxtNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class RobotsTxtNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(RobotsTxtAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/SecurityTxtNarrative.cs
+++ b/DomainDetective/Narratives/SecurityTxtNarrative.cs
@@ -4,22 +4,9 @@ using System.Linq;
 
 namespace DomainDetective.Narratives {
     public static class SecurityTxtNarrative {
-        public sealed class Sections {
-            public string Title { get; init; } = string.Empty;
-            public string Subtitle { get; init; } = string.Empty;
-            public string Category { get; init; } = string.Empty;
-            public string Keywords { get; init; } = string.Empty;
-            public string Creator { get; init; } = string.Empty;
-            public string Introduction { get; init; } = string.Empty;
-            public string WhyItMatters { get; init; } = string.Empty;
-            public List<string> Highlights { get; init; } = new();
-            public List<string> Details { get; init; } = new();
-            public List<string> References { get; init; } = new();
-            public List<string> Positives { get; init; } = new();
-            public List<string> Remediations { get; init; } = new();
-        }
+        public sealed class Sections : NarrativeSections { }
 
-        public static Sections Build(SecurityTXTAnalysis analysis) {
+    public static Sections Build(SecurityTXTAnalysis analysis) {
             var subj = string.IsNullOrWhiteSpace(analysis?.Domain) ? "(domain)" : analysis.Domain;
             var title = $"security.txt Report — {subj}";
             var subtitle = "Security Policy";

--- a/DomainDetective/Narratives/SmimeaNarrative.cs
+++ b/DomainDetective/Narratives/SmimeaNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class SmimeaNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(SMIMEAAnalysis analysis)
     {

--- a/DomainDetective/Narratives/SmtpAuthNarrative.cs
+++ b/DomainDetective/Narratives/SmtpAuthNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class SmtpAuthNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(SmtpAuthAnalysis analysis)
     {

--- a/DomainDetective/Narratives/SmtpBannerNarrative.cs
+++ b/DomainDetective/Narratives/SmtpBannerNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class SmtpBannerNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(SMTPBannerAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/SpfNarrative.cs
+++ b/DomainDetective/Narratives/SpfNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class SpfNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(SpfAnalysis spf)
     {

--- a/DomainDetective/Narratives/StartTlsNarrative.cs
+++ b/DomainDetective/Narratives/StartTlsNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class StartTlsNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(STARTTLSAnalysis analysis)
     {

--- a/DomainDetective/Narratives/ThreatIntelNarrative.cs
+++ b/DomainDetective/Narratives/ThreatIntelNarrative.cs
@@ -5,20 +5,7 @@ using DomainDetective;
 namespace DomainDetective.Narratives;
 
 public static class ThreatIntelNarrative {
-    public sealed class Sections {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(ThreatIntelAnalysis ti) {
         var subj = string.IsNullOrWhiteSpace(ti?.Subject) ? "(domain)" : ti.Subject;

--- a/DomainDetective/Narratives/TlsNarrative.cs
+++ b/DomainDetective/Narratives/TlsNarrative.cs
@@ -5,21 +5,7 @@ namespace DomainDetective.Narratives;
 
 public static class TlsNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(TlsAnalysis analysis)
     {

--- a/DomainDetective/Narratives/TlsRptNarrative.cs
+++ b/DomainDetective/Narratives/TlsRptNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class TlsRptNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(TLSRPTAnalysis analysis, InternalLogger? logger = null)
     {

--- a/DomainDetective/Narratives/TtlNarrative.cs
+++ b/DomainDetective/Narratives/TtlNarrative.cs
@@ -7,21 +7,7 @@ namespace DomainDetective.Narratives;
 
 public static class TtlNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(DnsTtlAnalysis analysis, IEnumerable<Assessment>? assessments = null)
     {

--- a/DomainDetective/Narratives/TyposquattingNarrative.cs
+++ b/DomainDetective/Narratives/TyposquattingNarrative.cs
@@ -6,21 +6,7 @@ namespace DomainDetective.Narratives;
 
 public static class TyposquattingNarrative
 {
-    public sealed class Sections
-    {
-        public string Title { get; init; } = string.Empty;
-        public string Subtitle { get; init; } = string.Empty;
-        public string Category { get; init; } = string.Empty;
-        public string Keywords { get; init; } = string.Empty;
-        public string Creator { get; init; } = string.Empty;
-        public string Introduction { get; init; } = string.Empty;
-        public string WhyItMatters { get; init; } = string.Empty;
-        public List<string> Highlights { get; init; } = new();
-        public List<string> Details { get; init; } = new();
-        public List<string> References { get; init; } = new();
-        public List<string> Positives { get; init; } = new();
-        public List<string> Remediations { get; init; } = new();
-    }
+    public sealed class Sections : NarrativeSections { }
 
     public static Sections Build(TyposquattingAnalysis analysis)
     {


### PR DESCRIPTION
## Summary
- refactor narratives to use a shared `NarrativeSections` type with XML docs
- simplify each narrative by inheriting from the shared type

## Testing
- `dotnet build`
- `dotnet test` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68b99ba2df10832eaf53e879570ac0dc