### PR TITLE
feat: add DNS health narrative and positive recommendations

### DIFF
--- a/DomainDetective.Example/ExampleDnsHealthNarrative.cs
+++ b/DomainDetective.Example/ExampleDnsHealthNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a DNS health narrative from live data.
+    /// </summary>
+    public static async Task ExampleDnsHealthNarrative()
+    {
+        var healthCheck = new DomainHealthCheck();
+        healthCheck.Verbose = false;
+        await healthCheck.Verify("evotec.pl", new[] { HealthCheckType.DNSHEALTH });
+        var narrative = DnsHealthNarrative.Build(healthCheck.DnsHealthAnalysis);
+        Helpers.ShowPropertiesTable("DNS Health Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestDnsHealthNarrative.cs
+++ b/DomainDetective.Tests/TestDnsHealthNarrative.cs
@@ -39,9 +39,11 @@ public class TestDnsHealthNarrative
         };
         await analysis.Analyze("example.com", new InternalLogger());
         var sections = DnsHealthNarrative.Build(analysis);
-        Assert.Contains(sections.Highlights, h => h.Contains("SOA serial numbers match", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(sections.Highlights, h => h.Contains("authoritative servers responded", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(sections.Positives, p => p.Contains("SOA serial numbers", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(sections.Positives, p => p.Contains("name servers responded", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(sections.Highlights, h => h.IndexOf("SOA serial numbers match", StringComparison.OrdinalIgnoreCase) >= 0);
+        Assert.Contains(
+            sections.Highlights,
+            h => h.IndexOf("authoritative servers responded", StringComparison.OrdinalIgnoreCase) >= 0);
+        Assert.Contains(sections.Positives, p => p.IndexOf("SOA serial numbers", StringComparison.OrdinalIgnoreCase) >= 0);
+        Assert.Contains(sections.Positives, p => p.IndexOf("name servers responded", StringComparison.OrdinalIgnoreCase) >= 0);
     }
 }

--- a/DomainDetective.Tests/TestDnsHealthNarrative.cs
+++ b/DomainDetective.Tests/TestDnsHealthNarrative.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using DnsClientX;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsHealthNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithPositives()
+    {
+        var analysis = new DnsHealthAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration
+            {
+                QueryDnsOverride = (name, type) =>
+                {
+                    return (name, type) switch
+                    {
+                        ("example.com", DnsRecordType.NS) => Task.FromResult(new[]
+                        {
+                            new DnsAnswer { DataRaw = "ns1.example.com", Type = DnsRecordType.NS },
+                            new DnsAnswer { DataRaw = "ns2.example.com", Type = DnsRecordType.NS }
+                        }),
+                        ("ns1.example.com", DnsRecordType.A) => Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1", Type = DnsRecordType.A } }),
+                        ("ns1.example.com", DnsRecordType.AAAA) => Task.FromResult(Array.Empty<DnsAnswer>()),
+                        ("ns2.example.com", DnsRecordType.A) => Task.FromResult(new[] { new DnsAnswer { DataRaw = "2.2.2.2", Type = DnsRecordType.A } }),
+                        ("ns2.example.com", DnsRecordType.AAAA) => Task.FromResult(Array.Empty<DnsAnswer>()),
+                        ("example.com", DnsRecordType.SOA) => Task.FromResult(new[] { new DnsAnswer { DataRaw = "ns1.example.com hostmaster.example.com 12345 7200 900 1209600 3600", Type = DnsRecordType.SOA } }),
+                        ("example.com", DnsRecordType.A) => Task.FromResult(new[] { new DnsAnswer { DataRaw = "9.9.9.9", Type = DnsRecordType.A } }),
+                        ("example.com", DnsRecordType.AAAA) => Task.FromResult(Array.Empty<DnsAnswer>()),
+                        _ => Task.FromResult(Array.Empty<DnsAnswer>())
+                    };
+                }
+            }
+        };
+        await analysis.Analyze("example.com", new InternalLogger());
+        var sections = DnsHealthNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("SOA serial numbers match", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(sections.Highlights, h => h.Contains("authoritative servers responded", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(sections.Positives, p => p.Contains("SOA serial numbers", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(sections.Positives, p => p.Contains("name servers responded", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/DomainDetective.Tests/TestDnsHealthNarrative.cs
+++ b/DomainDetective.Tests/TestDnsHealthNarrative.cs
@@ -35,7 +35,8 @@ public class TestDnsHealthNarrative
                         _ => Task.FromResult(Array.Empty<DnsAnswer>())
                     };
                 }
-            }
+            },
+            QueryUdpOverride = (ip, query, token) => Task.FromResult<byte[]?>(null)
         };
         await analysis.Analyze("example.com", new InternalLogger());
         var sections = DnsHealthNarrative.Build(analysis);

--- a/DomainDetective/Diagnostics/Codes/DnsHealthCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/DnsHealthCodes.cs
@@ -3,5 +3,7 @@ namespace DomainDetective;
 internal static class DnsHealthCodes {
     public const string SoaSerialSkew = "DNS.Health.SOA.SerialSkew";
     public const string ApexInconsistent = "DNS.Health.Apex.Inconsistent";
+    public const string SoaSerialConsistent = "DNS.Health.SOA.SerialConsistent";
+    public const string ServersResponsive = "DNS.Health.Servers.Responsive";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/DnsHealthRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/DnsHealthRecommendations.cs
@@ -14,9 +14,8 @@ internal sealed class DnsHealthRecommendations : IRecommendationProvider {
             Tags = new [] { "dns", "soa", "consistency" },
             Impact = "Clients may see inconsistent answers; DNSSEC signatures may not match if records differ.",
             Effort = RecommendationEffort.Medium,
-            Verify = "Query SOA serial from each NS and confirm they match."
+            Verify = "Query SOA serial from each NS and confirm they match.",
         };
-
         map[DnsHealthCodes.ApexInconsistent] = new RecommendationAdvice {
             Code = DnsHealthCodes.ApexInconsistent,
             Title = "A/AAAA answers for apex differ across NS",
@@ -27,7 +26,21 @@ internal sealed class DnsHealthRecommendations : IRecommendationProvider {
             Tags = new [] { "dns", "consistency" },
             Impact = "Resolvers may receive different data depending on which NS they query.",
             Effort = RecommendationEffort.Medium,
-            Verify = "Query A/AAAA for the zone apex via each authoritative server and compare."
+            Verify = "Query A/AAAA for the zone apex via each authoritative server and compare.",
+        };
+        map[DnsHealthCodes.SoaSerialConsistent] = new RecommendationAdvice {
+            Code = DnsHealthCodes.SoaSerialConsistent,
+            Title = "SOA serial numbers consistent across NS",
+            Why = "Matching SOA serials show zone data is synchronized among authoritative servers.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "soa", "consistency" }
+        };
+        map[DnsHealthCodes.ServersResponsive] = new RecommendationAdvice {
+            Code = DnsHealthCodes.ServersResponsive,
+            Title = "Authoritative name servers responded to queries",
+            Why = "Responsive authoritative servers improve resolver reliability and confidence.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "ns", "availability" }
         };
     }
 }

--- a/DomainDetective/Narratives/DnsHealthNarrative.cs
+++ b/DomainDetective/Narratives/DnsHealthNarrative.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class DnsHealthNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(DnsHealthAnalysis analysis)
+    {
+        var subject = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"DNS Health Report — {subject}";
+        var subtitle = "DNS Health Assessment";
+        var category = "DNS Infrastructure";
+        var keywords = $"DNS, infrastructure, DomainDetective, {subject}";
+        var creator = "DomainDetective";
+        var intro = "Evaluates authoritative nameserver consistency and responsiveness.";
+        var why = "Consistent, responsive nameservers ensure reliable DNS resolution.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis != null)
+        {
+            hi.Add(analysis.SoaSerialConsistent
+                ? "SOA serial numbers match across authoritative servers."
+                : "SOA serial numbers differ across authoritative servers.");
+            hi.Add(analysis.ApexAddressesConsistent
+                ? "A/AAAA records for zone apex are consistent across servers."
+                : "A/AAAA records for zone apex differ among servers.");
+            hi.Add(analysis.ServersResponsive
+                ? "All authoritative servers responded to queries."
+                : "Some authoritative servers did not respond.");
+
+            if (analysis.NameServers?.Count > 0)
+            {
+                det.Add($"NS set: {string.Join(", ", analysis.NameServers)}");
+            }
+            foreach (var kv in analysis.SoaSerialByServer)
+            {
+                det.Add($"SOA serial from {kv.Key}: {kv.Value}");
+            }
+            foreach (var kv in analysis.ApexAddressesByServer)
+            {
+                det.Add($"Apex answers from {kv.Key}: {string.Join(", ", kv.Value)}");
+            }
+
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        else
+        {
+            hi.Add("No DNS health data available.");
+        }
+
+        var refs = new List<string>
+        {
+            "https://datatracker.ietf.org/doc/html/rfc1034",
+            "https://datatracker.ietf.org/doc/html/rfc1035"
+        };
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/DnsHealthAnalysis.cs
+++ b/DomainDetective/Protocols/DnsHealthAnalysis.cs
@@ -17,6 +17,8 @@ namespace DomainDetective {
         public string? Subject { get; set; }
         public DnsConfiguration DnsConfiguration { get; set; }
 
+        public Func<IPAddress, byte[], CancellationToken, Task<byte[]?>>? QueryUdpOverride { get; set; }
+
         public List<string> NameServers { get; private set; } = new();
         public Dictionary<string, long> SoaSerialByServer { get; } = new();
         public bool SoaSerialConsistent { get; private set; }
@@ -175,7 +177,11 @@ namespace DomainDetective {
             offset += 4; return v;
         }
 
-        private static async Task<byte[]?> QueryUdp(IPAddress server, byte[] query, CancellationToken token) {
+        private async Task<byte[]?> QueryUdp(IPAddress server, byte[] query, CancellationToken token) {
+            if (QueryUdpOverride != null) {
+                return await QueryUdpOverride(server, query, token);
+            }
+
             using var udp = new UdpClient(new IPEndPoint(server.AddressFamily == AddressFamily.InterNetworkV6 ? IPAddress.IPv6Any : IPAddress.Any, 0));
             udp.Client.ReceiveTimeout = 4000;
 #if NET6_0_OR_GREATER

--- a/DomainDetective/Protocols/DnsHealthAnalysis.cs
+++ b/DomainDetective/Protocols/DnsHealthAnalysis.cs
@@ -24,6 +24,8 @@ namespace DomainDetective {
         public Dictionary<string, List<string>> ApexAddressesByServer { get; } = new();
         public bool ApexAddressesConsistent { get; private set; }
 
+        public bool ServersResponsive { get; private set; }
+
         public List<Assessment> Assessments { get; } = new();
 
         private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {
@@ -38,6 +40,7 @@ namespace DomainDetective {
             ApexAddressesByServer.Clear();
             SoaSerialConsistent = true;
             ApexAddressesConsistent = true;
+            ServersResponsive = true;
 
             // Discover NS hostnames and their addresses
             var nsAnswers = await QueryDns(domainName, DnsRecordType.NS);
@@ -88,6 +91,8 @@ namespace DomainDetective {
 
             if (!SoaSerialConsistent) {
                 logger?.WriteWarningCode(DnsHealthCodes.SoaSerialSkew, "SOA serial numbers differ across authoritative servers");
+            } else {
+                logger?.WriteInformationCode(DnsHealthCodes.SoaSerialConsistent, "SOA serial numbers consistent across authoritative servers");
             }
 
             if (ApexAddressesByServer.Count > 1) {
@@ -106,6 +111,11 @@ namespace DomainDetective {
 
             if (!ApexAddressesConsistent) {
                 logger?.WriteWarningCode(DnsHealthCodes.ApexInconsistent, "A/AAAA answers for zone apex differ across authoritative servers");
+            }
+
+            ServersResponsive = SoaSerialByServer.Count == nsIps.Count && ApexAddressesByServer.Count == nsIps.Count;
+            if (ServersResponsive) {
+                logger?.WriteInformationCode(DnsHealthCodes.ServersResponsive, "All authoritative name servers responded to queries");
             }
         }
 

--- a/DomainDetective/Views/Converters.DnsHealth.cs
+++ b/DomainDetective/Views/Converters.DnsHealth.cs
@@ -19,6 +19,7 @@ public static partial class Converters
             SoaSerialConsistent = analysis.SoaSerialConsistent,
             ApexAddressesByServer = analysis.ApexAddressesByServer,
             ApexAddressesConsistent = analysis.ApexAddressesConsistent,
+            ServersResponsive = analysis.ServersResponsive,
             Assessments = analysis.Assessments,
             Status = status,
             WarningCount = warn,
@@ -42,6 +43,7 @@ public class DnsHealthInfo
     public bool SoaSerialConsistent { get; set; }
     public IReadOnlyDictionary<string, List<string>> ApexAddressesByServer { get; set; }
     public bool ApexAddressesConsistent { get; set; }
+    public bool ServersResponsive { get; set; }
     public IReadOnlyList<Assessment> Assessments { get; set; }
     public string Status { get; set; }
     public int WarningCount { get; set; }


### PR DESCRIPTION
## Summary
- add DNS health narrative summarizing zone consistency and resolver responsiveness
- log success when SOA serials align and servers reply, with matching recommendations
- include example and test for DNS health narrative

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter DnsHealthNarrative`


------
https://chatgpt.com/codex/tasks/task_e_68b9af3e5258832ea22bff40b0d12169