### PR TITLE
feat: add DNS tunneling narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleDnsTunnelingNarrative.cs
+++ b/DomainDetective.Example/ExampleDnsTunnelingNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a DNS tunneling narrative.
+    /// </summary>
+    public static async Task ExampleDnsTunnelingNarrative()
+    {
+        var hc = new DomainHealthCheck { Verbose = false };
+        hc.DnsTunnelingLogs = new[] { "2024-01-01T00:00:00Z verylonglabelthatexceedslimit.example.com" };
+        await hc.CheckDnsTunnelingAsync("example.com");
+        var narrative = DnsTunnelingNarrative.Build(hc.DnsTunnelingAnalysis, hc.DnsTunnelingAnalysis.Assessments);
+        Helpers.ShowPropertiesTable("DNS Tunneling Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestDnsTunnelingNarrative.cs
+++ b/DomainDetective.Tests/TestDnsTunnelingNarrative.cs
@@ -1,0 +1,18 @@
+using System;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsTunnelingNarrative
+{
+    [Fact]
+    public void NarrativeShowsNoIndicators()
+    {
+        var analysis = new DnsTunnelingAnalysis();
+        analysis.Analyze("example.com", Array.Empty<string>());
+        var narrative = DnsTunnelingNarrative.Build(analysis, analysis.Assessments);
+        Assert.Contains("No tunneling indicators detected.", narrative.Highlights);
+    }
+}

--- a/DomainDetective.Tests/TestDnsTunnelingRecommendations.cs
+++ b/DomainDetective.Tests/TestDnsTunnelingRecommendations.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using DomainDetective;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsTunnelingRecommendations
+{
+    [Fact]
+    public void RegistersSuccessCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new DnsTunnelingRecommendations().Register(map);
+        Assert.Contains(DnsTunnelingCodes.NoIndicators, map.Keys);
+    }
+
+    [Fact]
+    public void EmitsPositiveRecommendation()
+    {
+        var analysis = new DnsTunnelingAnalysis();
+        analysis.Analyze("example.com", Array.Empty<string>());
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == DnsTunnelingCodes.NoIndicators);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/DnsTunnelingCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/DnsTunnelingCodes.cs
@@ -3,5 +3,6 @@ namespace DomainDetective;
 internal static class DnsTunnelingCodes {
     public const string SuspiciousLabel = "DNSTUN.SuspiciousLabel";
     public const string HighFrequency = "DNSTUN.HighFrequency";
+    public const string NoIndicators = "DNSTUN.Success.NoIndicators";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/DnsTunnelingRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/DnsTunnelingRecommendations.cs
@@ -26,6 +26,14 @@ internal sealed class DnsTunnelingRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Medium,
             Verify = "Query volumes return to baseline after containment."
         };
+        map[DnsTunnelingCodes.NoIndicators] = new RecommendationAdvice {
+            Code = DnsTunnelingCodes.NoIndicators,
+            Title = "No tunneling indicators detected",
+            Why = "DNS query patterns appear normal without signs of tunneling or exfiltration.",
+            How = "Maintain logging and monitoring to detect future anomalies.",
+            Domain = RecommendationDomain.ThreatIntel,
+            Tags = new [] { "dns", "tunneling", "monitoring" },
+        };
     }
 }
 

--- a/DomainDetective/Narratives/DnsTunnelingNarrative.cs
+++ b/DomainDetective/Narratives/DnsTunnelingNarrative.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class DnsTunnelingNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(DnsTunnelingAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"DNS Tunneling Report — {subj}";
+        var subtitle = "DNS tunneling analysis";
+        var category = "Threat Intel";
+        var keywords = $"DNS, tunneling, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "DNS tunneling can covertly transfer data or commands within DNS queries.";
+        var why = "Detecting abnormal query labels and burst rates helps uncover misuse of DNS for exfiltration or C2.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No DNS tunneling data available." },
+                Details = det,
+                References = new List<string> { "https://en.wikipedia.org/wiki/DNS_tunneling" }
+            };
+        }
+
+        if (analysis.Alerts.Count == 0)
+        {
+            hi.Add("No tunneling indicators detected.");
+        }
+        else
+        {
+            hi.Add($"{analysis.Alerts.Count} potential tunneling indicators detected.");
+            foreach (var a in analysis.Alerts)
+            {
+                det.Add($"{a.Domain}: {a.Reason}");
+            }
+        }
+
+        hi.Add($"Frequency threshold: {analysis.FrequencyThreshold} queries/{analysis.FrequencyInterval.TotalSeconds:0.##}s");
+
+        var refs = new List<string> { "https://en.wikipedia.org/wiki/DNS_tunneling" };
+
+        try
+        {
+            var ass = assessments ?? analysis.Assessments;
+            if (ass != null)
+            {
+                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/DnsTunnelingAnalysis.cs
+++ b/DomainDetective/Protocols/DnsTunnelingAnalysis.cs
@@ -30,6 +30,7 @@ public class DnsTunnelingAnalysis : IHasAssessments
     {
         Subject = domainName;
         Alerts = new List<DnsTunnelingAlert>();
+        Assessments.Clear();
         var queue = new Queue<DateTimeOffset>();
         if (logLines == null)
         {
@@ -93,6 +94,18 @@ public class DnsTunnelingAnalysis : IHasAssessments
                     queue.Clear();
                 }
             }
+        }
+
+        if (Alerts.Count == 0)
+        {
+            Assessments.Add(new Assessment
+            {
+                Severity = AssessmentSeverity.Info,
+                Category = "DnsTunneling",
+                Target = domainName,
+                Code = DnsTunnelingCodes.NoIndicators,
+                Message = "No tunneling indicators found in DNS logs",
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- add DNS tunneling narrative describing alert counts and frequency metrics
- advise on normal DNS tunneling posture with new success recommendation
- include example and tests for narrative and positive advice

## Testing
- `dotnet build -c Release`
- `dotnet test` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build --filter "FullyQualifiedName~DnsTunneling"`


------
https://chatgpt.com/codex/tasks/task_e_68b9af3b4864832e876640c28c491b47