### PR TITLE
Add DNSBL narrative and clean check recommendations

### DIFF
--- a/DomainDetective.Example/ExampleDnsblNarrative.cs
+++ b/DomainDetective.Example/ExampleDnsblNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a DNSBL narrative.
+    /// </summary>
+    public static async Task ExampleDnsblNarrative()
+    {
+        var health = new DomainHealthCheck();
+        await health.CheckDNSBL("example.com");
+        var sections = DnsblNarrative.Build(health.DNSBLAnalysis);
+        Helpers.ShowPropertiesTable("DNSBL Narrative", sections);
+    }
+}
+

--- a/DomainDetective.Tests/TestDnsblRecommendations.cs
+++ b/DomainDetective.Tests/TestDnsblRecommendations.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DomainDetective;
+using DnsClientX;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDnsblRecommendations
+{
+    [Fact]
+    public async Task EmitsPositiveRecommendations()
+    {
+        var analysis = new DNSBLAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsFullOverride = (names, _) =>
+            {
+                var responses = new List<DnsResponse>();
+                foreach (var name in names)
+                {
+                    responses.Add(new DnsResponse { Answers = System.Array.Empty<DnsAnswer>() });
+                }
+                return Task.FromResult<IEnumerable<DnsResponse>>(responses);
+            }
+        };
+        analysis.ClearDNSBL();
+        analysis.AddDNSBL("example.test");
+
+        await foreach (var _ in analysis.AnalyzeDNSBLRecords("1.2.3.4", new InternalLogger()))
+        {
+        }
+
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == DnsblCodes.NotListed);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/DnsblCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/DnsblCodes.cs
@@ -4,6 +4,7 @@ internal static class DnsblCodes {
     public const string Listed = "DNSBL.Listed";
     public const string QueryFailed = "DNSBL.Query.Failed";
     public const string ProviderTimeout = "DNSBL.Provider.Timeout";
+    public const string NotListed = "DNSBL.NotListed";
     public const string Summary = "DNSBL.Summary";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/DnsblRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/DnsblRecommendations.cs
@@ -38,6 +38,18 @@ internal sealed class DnsblRecommendations : IRecommendationProvider {
             Verify = "Subsequent queries succeed within normal latency."
         };
 
+        map[DnsblCodes.NotListed] = new RecommendationAdvice {
+            Code = DnsblCodes.NotListed,
+            Title = "No DNSBL listings detected",
+            Why = "The queried host or domain was not listed by any checked DNSBL provider.",
+            How = "Monitor periodically to ensure continued clean reputation.",
+            Domain = RecommendationDomain.ThreatIntel,
+            Tags = new [] { "dnsbl", "clean" },
+            Impact = "Indicates no blacklist impact at time of check.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Repeat the check; expect NXDOMAIN or not listed responses."
+        };
+
         // Informational summary of the DNSBL check sweep (coded for consistent views)
         map[DnsblCodes.Summary] = new RecommendationAdvice {
             Code = DnsblCodes.Summary,

--- a/DomainDetective/Narratives/DnsblNarrative.cs
+++ b/DomainDetective/Narratives/DnsblNarrative.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class DnsblNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(DNSBLAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(host)" : analysis.Subject!;
+        var title = $"DNSBL Report — {subj}";
+        var subtitle = "DNS Blocklist Assessment";
+        var category = "Threat Intelligence";
+        var keywords = $"DNSBL, blacklist, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "DNS-based block lists (DNSBL) report hosts associated with spam or abuse.";
+        var why = "Regularly checking DNSBLs helps protect delivery reputation and detect compromise.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No DNSBL data available." },
+                Details = det,
+                References = new List<string> { "https://datatracker.ietf.org/doc/html/rfc5782" }
+            };
+        }
+
+        hi.Add($"Providers checked: {analysis.GetDNSBL().Count}");
+        hi.Add($"Hosts checked: {analysis.RecordChecked}");
+        hi.Add(analysis.Blacklisted > 0
+            ? $"Hosts listed: {analysis.Blacklisted}"
+            : "No hosts were listed on DNSBLs.");
+
+        foreach (var kv in analysis.Results)
+        {
+            det.Add($"{kv.Key}: listed {kv.Value.Listed}/{kv.Value.Total}");
+        }
+
+        var refs = new List<string> { "https://datatracker.ietf.org/doc/html/rfc5782" };
+
+        try
+        {
+            var ass = assessments ?? analysis.Assessments;
+            if (ass != null)
+            {
+                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}
+

--- a/DomainDetective/Protocols/DNSBLAnalysis.cs
+++ b/DomainDetective/Protocols/DNSBLAnalysis.cs
@@ -429,6 +429,11 @@ namespace DomainDetective {
                     Logger?.WriteWarningCode(DnsblCodes.Listed, "{0} listed on {1}", reason, rec.BlackList);
                 }
             }
+
+            if (!queryResult.IsBlacklisted) {
+                using var _collector = Logger != null ? AssessmentCollector.ForAnalysis(Logger, this, category: "DNSBL", target: ipAddressOrHostname) : null;
+                _collector?.AddInfo("Not listed on any DNSBL", DnsblCodes.NotListed);
+            }
         }
 
         private static async Task<List<T>> ToListAsync<T>(IAsyncEnumerable<T> source) {


### PR DESCRIPTION
## Summary
- add informational DNSBL recommendation for clean results
- log positive DNSBL assessments and build DNSBL narrative
- provide DNSBL narrative example and tests

## Testing
- `dotnet build`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b9af37a978832e8796be080c062afb