### PR TITLE
feat(http): add narrative and positive redirect guidance

### DIFF
--- a/DomainDetective.Example/ExampleHttpNarrative.cs
+++ b/DomainDetective.Example/ExampleHttpNarrative.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static class ExampleHttpNarrative
+{
+    public static async Task Run()
+    {
+        var analysis = new HttpAnalysis { Subject = "example.com" };
+        var logger = new InternalLogger();
+        await analysis.AnalyzeUrl("https://example.com", checkHsts: true, logger, collectHeaders: true);
+        var sections = HttpNarrative.Build(analysis);
+        Console.WriteLine(sections.Title);
+    }
+}

--- a/DomainDetective.Tests/TestHttpNarrative.cs
+++ b/DomainDetective.Tests/TestHttpNarrative.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestHttpNarrative
+{
+    [Fact]
+    public void BuildsNarrativeWithHighlightsAndPositives()
+    {
+        var analysis = new HttpAnalysis { Subject = "example.com" };
+        typeof(HttpAnalysis).GetProperty("StatusCode")!.SetValue(analysis, 200);
+        analysis.VisitedUrls.Add("http://example.com");
+        analysis.VisitedUrls.Add("https://example.com");
+        analysis.SecurityHeaders["Strict-Transport-Security"] = new SecurityHeader("Strict-Transport-Security", "max-age=31536000");
+        analysis.SecurityHeaders["Content-Security-Policy"] = new SecurityHeader("Content-Security-Policy", "default-src 'self'");
+        typeof(HttpAnalysis).GetProperty("HstsPresent")!.SetValue(analysis, true);
+        analysis.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = HttpCodes.SecureRedirect, Message = "redirects to https" });
+        analysis.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = HttpCodes.HstsPresent, Message = "hsts" });
+        analysis.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = HttpCodes.CspPresent, Message = "csp" });
+
+        var sections = HttpNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("200"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Redirect chain"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Security headers"));
+        Assert.Contains(sections.Details, d => d.Contains("http://example.com"));
+        Assert.Contains(sections.Details, d => d.Contains("https://example.com"));
+        Assert.NotEmpty(sections.Positives);
+    }
+
+    [Fact]
+    public void ProvidesPositiveAdvice()
+    {
+        var assessments = new List<Assessment>
+        {
+            new() { Severity = AssessmentSeverity.Info, Code = HttpCodes.SecureRedirect, Message = "redirect" },
+            new() { Severity = AssessmentSeverity.Info, Code = HttpCodes.HstsPresent, Message = "hsts" },
+            new() { Severity = AssessmentSeverity.Info, Code = HttpCodes.CspPresent, Message = "csp" }
+        };
+        var positives = RecommendationEngine.FromPositives(assessments);
+        Assert.Contains(positives, p => p.Code == HttpCodes.SecureRedirect);
+        Assert.Contains(positives, p => p.Code == HttpCodes.HstsPresent);
+        Assert.Contains(positives, p => p.Code == HttpCodes.CspPresent);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/HttpCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/HttpCodes.cs
@@ -34,6 +34,7 @@ internal static class HttpCodes {
     public const string XFrameOptionsInvalid = "HTTP.XFO.InvalidValue";
     public const string XContentTypeOptionsInvalid = "HTTP.XCTO.InvalidValue";
     // Positive/presence signals to enrich datasets
+    public const string SecureRedirect = "HTTP.Redirect.ToHTTPS";
     public const string HstsPresent = "HTTP.HSTS.Present";
     public const string CspPresent = "HTTP.CSP.Present";
     public const string ReferrerPolicyPresent = "HTTP.Header.Present.ReferrerPolicy";

--- a/DomainDetective/Diagnostics/Recommendations/HttpRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/HttpRecommendations.cs
@@ -251,6 +251,17 @@ internal sealed class HttpRecommendations : IRecommendationProvider {
         };
 
         // Presence/positive signals
+        map[HttpCodes.SecureRedirect] = new RecommendationAdvice {
+            Code = HttpCodes.SecureRedirect,
+            Title = "Redirects to HTTPS",
+            Why = "Automatic redirects ensure users reach a secure endpoint even when typing http://.",
+            How = "Continue enforcing HTTP to HTTPS redirects for all hosts.",
+            Domain = RecommendationDomain.Http,
+            Tags = new [] { "redirect", "https" },
+            Impact = "Users are protected from insecure transport when omitting https://.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Request http:// URL and confirm redirect to https://."
+        };
         map[HttpCodes.HstsPresent] = new RecommendationAdvice {
             Code = HttpCodes.HstsPresent,
             Title = "HSTS present",

--- a/DomainDetective/Narratives/HttpNarrative.cs
+++ b/DomainDetective/Narratives/HttpNarrative.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class HttpNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(HttpAnalysis analysis)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(host)" : analysis.Subject!;
+        var title = $"HTTP Report — {subj}";
+        var subtitle = "HTTP Response and Header Summary";
+        var category = "Web Security";
+        var keywords = $"HTTP, security headers, redirects, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "HTTP responses and headers reveal security posture.";
+        var why = "Redirecting to HTTPS and strong headers protect users.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis != null)
+        {
+            if (analysis.StatusCode.HasValue)
+            {
+                hi.Add($"Final status code {analysis.StatusCode}.");
+            }
+
+            if (analysis.VisitedUrls.Count > 1)
+            {
+                hi.Add($"Redirect chain: {string.Join(" -> ", analysis.VisitedUrls)}.");
+            }
+
+            if (analysis.SecurityHeaders.Count > 0)
+            {
+                hi.Add($"Security headers: {string.Join(", ", analysis.SecurityHeaders.Keys)}.");
+            }
+
+            if (analysis.MissingSecurityHeaders.Count > 0)
+            {
+                det.Add($"Missing headers: {string.Join(", ", analysis.MissingSecurityHeaders)}");
+            }
+
+            foreach (var url in analysis.VisitedUrls)
+            {
+                det.Add($"Visited {url}");
+            }
+
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        }
+        else
+        {
+            hi.Add("No HTTP data available.");
+        }
+
+        var refs = new List<string>
+        {
+            "https://developer.mozilla.org/docs/Web/HTTP/Status",
+            "https://developer.mozilla.org/docs/Web/HTTP/Headers"
+        };
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct().ToList(),
+            Remediations = remediations.Distinct().ToList()
+        };
+    }
+}

--- a/DomainDetective/Protocols/HttpAnalysis.cs
+++ b/DomainDetective/Protocols/HttpAnalysis.cs
@@ -268,6 +268,13 @@ namespace DomainDetective {
 #if !NET6_0_OR_GREATER
                 HstsPreloaded = _hstsPreload.Contains(new Uri(url).Host);
 #endif
+                if (VisitedUrls.Count > 1) {
+                    var first = VisitedUrls.First();
+                    var last = VisitedUrls.Last();
+                    if (first.StartsWith("http://", StringComparison.OrdinalIgnoreCase) && last.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) {
+                        logger?.WriteInformationCode(HttpCodes.SecureRedirect, "Initial HTTP request redirected to HTTPS");
+                    }
+                }
                 sw.Stop();
                 StatusCode = (int)response.StatusCode;
                 ResponseTime = sw.Elapsed;


### PR DESCRIPTION
## Summary
- add HTTP narrative summarizing response codes, redirects, and security headers
- log secure HTTP→HTTPS redirects and expose success recommendation
- include example and tests for HTTP narrative and positive advice

## Testing
- `dotnet build`
- `dotnet test` *(fails: TestCliHelp.RootHelp_IncludesExamples)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68b9af2b31fc832e9332b8667098d370