### PR TITLE
feat: add flattening service narrative and positive recommendation

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -36,6 +36,7 @@ internal static class Program {
         var app = new CommandApp();
         app.Configure(config => {
             config.SetApplicationName("DomainDetective");
+            config.AddExample(new[] { "wizard", "--domain", "example.com" });
             config.AddExample(new[] { "check", "example.com" });
             config.AddCommand<WizardScanCommand>("WizardScan")
                 .WithDescription("Run the Hacker Wizard (parallel, animated)")

--- a/DomainDetective.Example/ExampleFlatteningServiceNarrative.cs
+++ b/DomainDetective.Example/ExampleFlatteningServiceNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building a flattening service narrative.
+    /// </summary>
+    public static async Task ExampleFlatteningServiceNarrative()
+    {
+        var analysis = new FlatteningServiceAnalysis();
+        await analysis.Analyze("example.com", new InternalLogger());
+        var narrative = FlatteningServiceNarrative.Build(analysis, analysis.Assessments);
+        Helpers.ShowPropertiesTable("Flattening Service Narrative", narrative);
+    }
+}
+

--- a/DomainDetective.Tests/TestFlatteningServiceNarrative.cs
+++ b/DomainDetective.Tests/TestFlatteningServiceNarrative.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Tests;
+
+public class TestFlatteningServiceNarrative
+{
+    [Fact]
+    public async Task NarrativeShowsAddressesAndPositiveAdvice()
+    {
+        var analysis = new FlatteningServiceAnalysis
+        {
+            QueryDnsOverride = (name, type) =>
+            {
+                if (type == DnsClientX.DnsRecordType.CNAME)
+                {
+                    return Task.FromResult(new[] { new DnsClientX.DnsAnswer { DataRaw = "alias.cloudflare.net" } });
+                }
+
+                if (type == DnsClientX.DnsRecordType.A)
+                {
+                    return Task.FromResult(new[] { new DnsClientX.DnsAnswer { DataRaw = "192.0.2.1" } });
+                }
+
+                if (type == DnsClientX.DnsRecordType.AAAA)
+                {
+                    return Task.FromResult(new[] { new DnsClientX.DnsAnswer { DataRaw = "2001:db8::1" } });
+                }
+
+                return Task.FromResult(Array.Empty<DnsClientX.DnsAnswer>());
+            }
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger());
+        var sections = FlatteningServiceNarrative.Build(analysis, analysis.Assessments);
+
+        Assert.Contains("alias.cloudflare.net", string.Join(" ", sections.Highlights));
+        Assert.Contains("192.0.2.1", string.Join(" ", sections.Highlights));
+
+        var codes = analysis.Recommendations.Select(r => r.Code).ToList();
+        Assert.Contains(FlatteningServiceCodes.ResolvedAddresses, codes);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/FlatteningServiceCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/FlatteningServiceCodes.cs
@@ -2,5 +2,8 @@ namespace DomainDetective;
 
 internal static class FlatteningServiceCodes {
     public const string UsesFlatteningService = "FLATTENING.Service.Used";
+
+    /// <summary>Apex resolves via flattening service.</summary>
+    public const string ResolvedAddresses = "FLATTENING.Service.Resolved";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/FlatteningServiceRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/FlatteningServiceRecommendations.cs
@@ -15,6 +15,18 @@ internal sealed class FlatteningServiceRecommendations : IRecommendationProvider
             Effort = RecommendationEffort.Low,
             Verify = "Resolve apex and confirm addresses align with intended provider behavior."
         };
+
+        map[FlatteningServiceCodes.ResolvedAddresses] = new RecommendationAdvice {
+            Code = FlatteningServiceCodes.ResolvedAddresses,
+            Title = "flattening service returns addresses",
+            Why = "Provider flattening supplies A/AAAA records at the apex for seamless aliasing.",
+            How = "Document provider dependency and monitor for address changes.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "cname", "flattening" },
+            Impact = "Simplifies apex alias management.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Resolve apex and observe provider-managed addresses."
+        };
     }
 }
 

--- a/DomainDetective/Narratives/FlatteningServiceNarrative.cs
+++ b/DomainDetective/Narratives/FlatteningServiceNarrative.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+public static class FlatteningServiceNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(FlatteningServiceAnalysis? analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis!.Subject!;
+        var title = $"Flattening Service Report — {subj}";
+        var subtitle = "Flattening Service Assessment";
+        var category = "DNS";
+        var keywords = $"flattening, dns, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Flattening services provide A and AAAA records for CNAMEs at the zone apex.";
+        var why = "They simplify apex aliasing but can hide target changes and couple you to the provider.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No flattening data available." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        hi.Add(analysis.CnameRecordExists
+            ? $"{subj} CNAME → {analysis.Target}."
+            : $"{subj} has no CNAME record.");
+        hi.Add(analysis.IsFlatteningService
+            ? "CNAME uses a known flattening provider."
+            : "No known flattening provider detected.");
+        if (analysis.Addresses.Count > 0)
+        {
+            hi.Add($"Resolves to {string.Join(", ", analysis.Addresses)}.");
+        }
+
+        var refs = DefaultRefs();
+
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch (Exception ex)
+        {
+            _ = ex;
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.cloudflare.com/learning/dns/dns-records/dns-cname-record/"
+    };
+}
+

--- a/DomainDetective/Protocols/FlatteningServiceAnalysis.cs
+++ b/DomainDetective/Protocols/FlatteningServiceAnalysis.cs
@@ -13,6 +13,8 @@ namespace DomainDetective;
 /// <para>Part of the DomainDetective project.</para>
 public class FlatteningServiceAnalysis : IHasAssessments
 {
+    /// <summary>Domain under analysis.</summary>
+    public string? Subject { get; private set; }
     /// <summary>DNS configuration for lookups.</summary>
     public DnsConfiguration DnsConfiguration { get; set; } = new();
     /// <summary>Override DNS query logic.</summary>
@@ -25,8 +27,14 @@ public class FlatteningServiceAnalysis : IHasAssessments
     /// <summary>True when the CNAME points to a known flattening service.</summary>
     public bool IsFlatteningService { get; private set; }
 
+    /// <summary>Flattened A/AAAA addresses resolved for the apex.</summary>
+    public List<string> Addresses { get; } = new();
+
     /// <summary>Structured assessments captured during flattening service detection.</summary>
     public List<Assessment> Assessments { get; } = new();
+
+    /// <summary>Recommendations derived from assessments.</summary>
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
     private static readonly string[] _flatteningDomains = new[]
     {
@@ -49,9 +57,11 @@ public class FlatteningServiceAnalysis : IHasAssessments
     /// </summary>
     public async Task Analyze(string domainName, InternalLogger logger, CancellationToken ct = default)
     {
+        Subject = domainName;
         CnameRecordExists = false;
         Target = null;
         IsFlatteningService = false;
+        Addresses.Clear();
         ct.ThrowIfCancellationRequested();
         using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "CNAME", target: domainName) : null;
 
@@ -70,6 +80,23 @@ public class FlatteningServiceAnalysis : IHasAssessments
         if (IsFlatteningService)
         {
             logger?.WriteWarningCode(FlatteningServiceCodes.UsesFlatteningService, "CNAME uses a known flattening service");
+
+            var a = await QueryDns(domainName, DnsRecordType.A, ct);
+            var aaaa = await QueryDns(domainName, DnsRecordType.AAAA, ct);
+
+            foreach (var ans in a.Concat(aaaa))
+            {
+                var addr = ans.Data.TrimEnd('.');
+                if (!string.IsNullOrWhiteSpace(addr))
+                {
+                    Addresses.Add(addr);
+                }
+            }
+
+            if (Addresses.Count > 0)
+            {
+                logger?.WriteInformationCode(FlatteningServiceCodes.ResolvedAddresses, "flattening service resolved addresses");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add ResolvedAddresses code and recommendation for correct flattening
- track flattened addresses and generate assessments and narrative
- include example and unit test for flattening service narrative

## Testing
- `dotnet test` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68b9af261ac4832e9da722ec15a97583