### PR TITLE
feat(openresolver): add narrative and closed-resolver recommendations

### DIFF
--- a/DomainDetective.Example/ExampleOpenResolverNarrative.cs
+++ b/DomainDetective.Example/ExampleOpenResolverNarrative.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building an Open Resolver narrative from analysis results.
+    /// </summary>
+    public static async Task ExampleOpenResolverNarrative()
+    {
+        var analysis = new OpenResolverAnalysis
+        {
+            RecursionTestOverride = (_, _) => Task.FromResult(false)
+        };
+        var logger = new InternalLogger();
+        await analysis.AnalyzeServer("resolver.example.com", 53, logger);
+        var narrative = OpenResolverNarrative.Build(analysis, analysis.Assessments);
+        Helpers.ShowPropertiesTable("Open Resolver Narrative", narrative);
+    }
+}
+

--- a/DomainDetective.Tests/TestOpenResolverNarrative.cs
+++ b/DomainDetective.Tests/TestOpenResolverNarrative.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestOpenResolverNarrative
+{
+    [Fact]
+    public async Task OpenResolverNarrativeShowsClosedAndPositive()
+    {
+        var analysis = new OpenResolverAnalysis
+        {
+            RecursionTestOverride = (_, _) => Task.FromResult(false)
+        };
+        var logger = new InternalLogger();
+        await analysis.AnalyzeServer("1.1.1.1", 53, logger);
+        var narrative = OpenResolverNarrative.Build(analysis, analysis.Assessments);
+        Assert.Contains("No open resolvers detected.", narrative.Highlights);
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == OpenResolverCodes.RecursionClosed);
+    }
+}
+

--- a/DomainDetective.Tests/TestOpenResolverRecommendations.cs
+++ b/DomainDetective.Tests/TestOpenResolverRecommendations.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestOpenResolverRecommendations
+{
+    [Fact]
+    public void RegistersClosedCode()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new OpenResolverRecommendations().Register(map);
+        Assert.Contains(OpenResolverCodes.RecursionClosed, map.Keys);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/OpenResolverCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/OpenResolverCodes.cs
@@ -2,6 +2,7 @@ namespace DomainDetective;
 
 internal static class OpenResolverCodes {
     public const string RecursionDetected = "OPENRESOLVER.Recursion.Detected";
+    public const string RecursionClosed = "OPENRESOLVER.Recursion.Closed";
     public const string CheckFailed = "OPENRESOLVER.Check.Failed";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/OpenResolverRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/OpenResolverRecommendations.cs
@@ -15,6 +15,17 @@ internal sealed class OpenResolverRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Queries for unrelated domains return REFUSED and RA bit is not set."
         };
+        map[OpenResolverCodes.RecursionClosed] = new RecommendationAdvice {
+            Code = OpenResolverCodes.RecursionClosed,
+            Title = "Recursive queries denied",
+            Why = "Server refuses recursion from arbitrary clients, reducing amplification risk.",
+            How = "No action required; maintain current recursion restrictions.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "recursion" },
+            Impact = "Prevents reflection and cache-poisoning abuse.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Queries for unrelated domains return REFUSED and RA bit is unset."
+        };
         map[OpenResolverCodes.CheckFailed] = new RecommendationAdvice {
             Code = OpenResolverCodes.CheckFailed,
             Title = "Open resolver test failed",

--- a/DomainDetective/Narratives/OpenResolverNarrative.cs
+++ b/DomainDetective/Narratives/OpenResolverNarrative.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class OpenResolverNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(OpenResolverAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subject = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(resolver)" : analysis.Subject!;
+        var title = $"Open Resolver Report — {subject}";
+        var subtitle = "DNS Recursion Assessment";
+        var category = "DNS Security";
+        var keywords = $"open resolver, dns, recursion, amplification, DomainDetective, {subject}";
+        var creator = "DomainDetective";
+        var intro = "Open resolver tests check whether DNS servers perform recursion for arbitrary clients.";
+        var why = "Open resolvers can be abused for amplification attacks and cache poisoning.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        var details = analysis?.ServerDetails ?? new Dictionary<string, OpenResolverResult>();
+        var total = details.Count;
+        var openCount = details.Count(d => d.Value.IsOpenResolver);
+        var closedCount = total - openCount;
+
+        if (total > 0)
+            hi.Add($"Servers tested: {total}");
+        if (openCount > 0)
+            hi.Add($"{openCount} server(s) allow recursion.");
+        else
+            hi.Add("No open resolvers detected.");
+        if (closedCount > 0 && openCount > 0)
+            hi.Add($"{closedCount} server(s) refuse recursion.");
+
+        foreach (var kv in details)
+        {
+            var status = kv.Value.IsOpenResolver ? "open recursion" : "recursion disabled";
+            det.Add($"{kv.Key}: {status}");
+            if (kv.Value.ResponseBytes is int bytes)
+                det.Add($"  Response size: {bytes} bytes");
+        }
+
+        var refs = new List<string>
+        {
+            "https://www.rfc-editor.org/rfc/rfc5358"
+        };
+
+        try
+        {
+            var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
+            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}
+

--- a/DomainDetective/Protocols/OpenResolverAnalysis.cs
+++ b/DomainDetective/Protocols/OpenResolverAnalysis.cs
@@ -36,6 +36,8 @@ public class OpenResolverAnalysis : IHasAssessments {
         ServerDetails[$"{host}:{port}"] = detail;
         if (detail.IsOpenResolver) {
             logger?.WriteWarningCode(OpenResolverCodes.RecursionDetected, "Recursion allowed on {0}:{1}", host, port);
+        } else {
+            logger?.WriteInformationCode(OpenResolverCodes.RecursionClosed, "Recursion disabled on {0}:{1}", host, port);
         }
     }
 
@@ -52,6 +54,8 @@ public class OpenResolverAnalysis : IHasAssessments {
                 ServerDetails[$"{host}:{port}"] = detail;
                 if (detail.IsOpenResolver) {
                     logger?.WriteWarningCode(OpenResolverCodes.RecursionDetected, "Recursion allowed on {0}:{1}", host, port);
+                } else {
+                    logger?.WriteInformationCode(OpenResolverCodes.RecursionClosed, "Recursion disabled on {0}:{1}", host, port);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add open resolver narrative describing recursion checks and amplification risk
- flag closed resolvers with informational code and recommendation
- provide example usage and unit tests for narrative and positive recommendation

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68b9af214a44832eabc4258361ea4803