### PR TITLE
feat(rpki): add narrative and success recommendations

### DIFF
--- a/DomainDetective.Example/ExampleRpkiNarrative.cs
+++ b/DomainDetective.Example/ExampleRpkiNarrative.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    public static async Task ExampleRpkiNarrative()
+    {
+        var healthCheck = new DomainHealthCheck();
+        healthCheck.Verbose = false;
+        await healthCheck.VerifyRPKI("example.com");
+        var narrative = RpkiNarrative.Build(healthCheck.RpkiAnalysis, healthCheck.RpkiAnalysis.Assessments);
+        Helpers.ShowPropertiesTable("RPKI Narrative", narrative);
+    }
+}
+

--- a/DomainDetective.Tests/TestRpkiNarrative.cs
+++ b/DomainDetective.Tests/TestRpkiNarrative.cs
@@ -1,0 +1,33 @@
+using System.Linq;
+using System.Threading.Tasks;
+using DnsClientX;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestRpkiNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeAndPositiveAdvice()
+    {
+        var analysis = new RPKIAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (n, t) => t == DnsRecordType.A
+                ? Task.FromResult(new[] { new DnsAnswer { DataRaw = "1.1.1.1" } })
+                : Task.FromResult(Array.Empty<DnsAnswer>()),
+            QueryRpkiOverride = _ => Task.FromResult(("1.1.1.0/24", 64512, true))
+        };
+        await analysis.Analyze("example.com", new InternalLogger());
+        var sections = RpkiNarrative.Build(analysis, analysis.Assessments);
+        Assert.Contains("AS64512", string.Join(" ", sections.Highlights));
+        Assert.NotEmpty(sections.Positives);
+        var pos = RecommendationEngine.FromPositives(analysis.Assessments)
+            .Select(r => r.Code)
+            .ToList();
+        Assert.Contains(RpkiCodes.ValidRoa, pos);
+        Assert.Contains(RpkiCodes.PrefixCovered, pos);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/RpkiCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/RpkiCodes.cs
@@ -2,5 +2,7 @@ namespace DomainDetective;
 
 internal static class RpkiCodes {
     public const string QueryFailed = "RPKI.Query.Failed";
+    public const string ValidRoa = "RPKI.ROA.Valid";
+    public const string PrefixCovered = "RPKI.Prefix.Covered";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/RpkiRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/RpkiRecommendations.cs
@@ -4,6 +4,30 @@ namespace DomainDetective.Recommendations;
 
 internal sealed class RpkiRecommendations : IRecommendationProvider {
     public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[RpkiCodes.ValidRoa] = new RecommendationAdvice {
+            Code = RpkiCodes.ValidRoa,
+            Title = "ROA valid for origin ASN",
+            Why = "A valid route origin authorization confirms the announced prefix is authorised for this ASN.",
+            How = "Maintain ROAs in RPKI repositories for all announced prefixes and monitor their expiry.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "rpki", "roa" },
+            Impact = "Improves resistance to BGP hijacking.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Check ROA status with a validator or RIPE Stat."
+        };
+
+        map[RpkiCodes.PrefixCovered] = new RecommendationAdvice {
+            Code = RpkiCodes.PrefixCovered,
+            Title = "Prefix covered by ROA",
+            Why = "Covering prefixes ensure each routed address range is authorised in RPKI.",
+            How = "Publish ROAs for every originated prefix with the correct ASN and prefix length.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "rpki", "routing" },
+            Impact = "Reduces risk of unauthorised sub-prefix announcements.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Confirm each prefix is listed in validator output."
+        };
+
         map[RpkiCodes.QueryFailed] = new RecommendationAdvice {
             Code = RpkiCodes.QueryFailed,
             Title = "RPKI validation query failed",

--- a/DomainDetective/Narratives/RpkiNarrative.cs
+++ b/DomainDetective/Narratives/RpkiNarrative.cs
@@ -35,14 +35,8 @@ public static class RpkiNarrative
                 hi.Add($"{r.IpAddress} ⇒ {r.Prefix} (AS{r.Asn}) {status}.");
                 det.Add($"IP {r.IpAddress} prefix {r.Prefix} ASN {r.Asn} valid={r.Valid}");
             }
-            try
-            {
-                var assess = assessments ?? analysis.Assessments;
-                AssessmentSplit.SplitTitles(assess, out positives, out remediations);
-            }
-            catch
-            {
-            }
+            var assess = assessments ?? analysis.Assessments ?? new List<Assessment>();
+            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
         }
 
         var refs = new List<string>

--- a/DomainDetective/Narratives/RpkiNarrative.cs
+++ b/DomainDetective/Narratives/RpkiNarrative.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class RpkiNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(RPKIAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subject = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject!;
+        var title = $"RPKI Report — {subject}";
+        var subtitle = "RPKI Assessment";
+        var category = "Infrastructure";
+        var keywords = $"RPKI, BGP, routing, DomainDetective, {subject}";
+        var creator = "DomainDetective";
+        var intro = "Resource Public Key Infrastructure (RPKI) validates that IP prefixes are authorised for an autonomous system.";
+        var why = "Valid Route Origin Authorisations (ROAs) help prevent BGP hijacking by ensuring only authorised ASNs announce prefixes.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || analysis.Results.Count == 0)
+        {
+            hi.Add("No RPKI data available.");
+        }
+        else
+        {
+            foreach (var r in analysis.Results)
+            {
+                var status = r.Valid ? "valid" : "invalid";
+                hi.Add($"{r.IpAddress} ⇒ {r.Prefix} (AS{r.Asn}) {status}.");
+                det.Add($"IP {r.IpAddress} prefix {r.Prefix} ASN {r.Asn} valid={r.Valid}");
+            }
+            try
+            {
+                var assess = assessments ?? analysis.Assessments;
+                AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            }
+            catch
+            {
+            }
+        }
+
+        var refs = new List<string>
+        {
+            "https://www.rfc-editor.org/rfc/rfc6483",
+            "https://rpki.readthedocs.io/"
+        };
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}
+

--- a/DomainDetective/Protocols/RPKIAnalysis.cs
+++ b/DomainDetective/Protocols/RPKIAnalysis.cs
@@ -57,8 +57,19 @@ public class RPKIAnalysis : IHasAssessments
             prefixResp.EnsureSuccessStatusCode();
             using var prefixStream = await prefixResp.Content.ReadAsStreamAsync();
             var prefixDoc = await JsonDocument.ParseAsync(prefixStream);
-            string? prefix = prefixDoc.RootElement.GetProperty("data").GetProperty("resource").GetString();
-            int asn = prefixDoc.RootElement.GetProperty("data").GetProperty("asns")[0].GetProperty("asn").GetInt32();
+            var data = prefixDoc.RootElement.GetProperty("data");
+            string? prefix = data.GetProperty("resource").GetString();
+            var asnsElement = data.GetProperty("asns");
+            int asn = 0;
+            if (asnsElement.ValueKind == JsonValueKind.Array && asnsElement.GetArrayLength() > 0)
+            {
+                asn = asnsElement[0].GetProperty("asn").GetInt32();
+            }
+            else
+            {
+                logger?.WriteErrorCode(RpkiCodes.QueryFailed, "No ASN data for {0}.", ip);
+                return (prefix ?? string.Empty, 0, false);
+            }
             string rpkiUrl = $"https://stat.ripe.net/data/rpki-validation/data.json?prefix={prefix}&resource=AS{asn}";
             using var rpkiResp = await client.GetAsync(rpkiUrl);
             rpkiResp.EnsureSuccessStatusCode();
@@ -71,7 +82,7 @@ public class RPKIAnalysis : IHasAssessments
         catch (Exception ex)
         {
             logger?.WriteErrorCode(RpkiCodes.QueryFailed, "RPKI query failed for {0}: {1}", ip, ex.Message);
-            return (string.Empty, 0, true);
+            return (string.Empty, 0, false);
         }
     }
 

--- a/DomainDetective/Protocols/RPKIAnalysis.cs
+++ b/DomainDetective/Protocols/RPKIAnalysis.cs
@@ -104,6 +104,15 @@ public class RPKIAnalysis : IHasAssessments
                     Valid = valid
                 });
             }
+
+            if (!string.IsNullOrWhiteSpace(prefix))
+            {
+                logger?.WriteInformationCode(RpkiCodes.PrefixCovered, $"IP {ip} covered by {prefix} (AS{asn}).");
+                if (valid)
+                {
+                    logger?.WriteInformationCode(RpkiCodes.ValidRoa, $"ROA valid for {prefix} (AS{asn}).");
+                }
+            }
         });
 
         await Task.WhenAll(tasks);

--- a/DomainDetective/Protocols/RPKIAnalysis.cs
+++ b/DomainDetective/Protocols/RPKIAnalysis.cs
@@ -13,8 +13,7 @@ namespace DomainDetective;
 /// Validates IP prefixes against RPKI data.
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
-public class RPKIAnalysis : IHasAssessments
-{
+public class RPKIAnalysis : IHasAssessments {
     /// <summary>DNS configuration for lookups.</summary>
     public DnsConfiguration DnsConfiguration { get; set; } = new();
 
@@ -34,42 +33,40 @@ public class RPKIAnalysis : IHasAssessments
     /// <summary>True when all IPs are valid per RPKI.</summary>
     public bool AllValid => Results.All(r => r.Valid);
 
-    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type)
-    {
-        if (QueryDnsOverride != null)
-        {
+    private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {
+        if (QueryDnsOverride != null) {
             return await QueryDnsOverride(name, type);
         }
         return await DnsConfiguration.QueryDNS(name, type);
     }
 
-    private async Task<(string Prefix, int Asn, bool Valid)> QueryRpki(string ip, InternalLogger? logger)
-    {
-        if (QueryRpkiOverride != null)
-        {
+    private async Task<(string Prefix, int Asn, bool Valid)> QueryRpki(string ip, InternalLogger? logger) {
+        if (QueryRpkiOverride != null) {
             return await QueryRpkiOverride(ip);
         }
 
-        try
-        {
+        string? prefix = null;
+        try {
             HttpClient client = SharedHttpClient.Instance;
             using var prefixResp = await client.GetAsync($"https://stat.ripe.net/data/prefix-overview/data.json?resource={ip}");
             prefixResp.EnsureSuccessStatusCode();
             using var prefixStream = await prefixResp.Content.ReadAsStreamAsync();
             var prefixDoc = await JsonDocument.ParseAsync(prefixStream);
             var data = prefixDoc.RootElement.GetProperty("data");
-            string? prefix = data.GetProperty("resource").GetString();
+            prefix = data.GetProperty("resource").GetString();
             var asnsElement = data.GetProperty("asns");
             int asn = 0;
-            if (asnsElement.ValueKind == JsonValueKind.Array && asnsElement.GetArrayLength() > 0)
-            {
-                asn = asnsElement[0].GetProperty("asn").GetInt32();
+            if (asnsElement.ValueKind == JsonValueKind.Array && asnsElement.GetArrayLength() > 0) {
+                var asnElement = asnsElement[0];
+                if (asnElement.TryGetProperty("asn", out var asnProperty)) {
+                    asn = asnProperty.GetInt32();
+                } else {
+                    return Fail(prefix, logger, "ASN property missing for {0}.", ip);
+                }
+            } else {
+                return Fail(prefix, logger, "No ASN data for {0}.", ip);
             }
-            else
-            {
-                logger?.WriteErrorCode(RpkiCodes.QueryFailed, "No ASN data for {0}.", ip);
-                return (prefix ?? string.Empty, 0, false);
-            }
+
             string rpkiUrl = $"https://stat.ripe.net/data/rpki-validation/data.json?prefix={prefix}&resource=AS{asn}";
             using var rpkiResp = await client.GetAsync(rpkiUrl);
             rpkiResp.EnsureSuccessStatusCode();
@@ -78,19 +75,20 @@ public class RPKIAnalysis : IHasAssessments
             string? status = rpkiDoc.RootElement.GetProperty("data").GetProperty("status").GetString();
             bool valid = !string.Equals(status, "invalid", StringComparison.OrdinalIgnoreCase);
             return (prefix ?? string.Empty, asn, valid);
+        } catch (Exception ex) {
+            return Fail(prefix, logger, "RPKI query failed for {0}: {1}", ip, ex.Message);
         }
-        catch (Exception ex)
-        {
-            logger?.WriteErrorCode(RpkiCodes.QueryFailed, "RPKI query failed for {0}: {1}", ip, ex.Message);
-            return (string.Empty, 0, false);
-        }
+    }
+
+    private static (string Prefix, int Asn, bool Valid) Fail(string? prefix, InternalLogger? logger, string message, params object[] args) {
+        logger?.WriteErrorCode(RpkiCodes.QueryFailed, message, args);
+        return (prefix ?? string.Empty, 0, false);
     }
 
     /// <summary>
     /// Validates IP addresses of <paramref name="domainName"/> against RPKI repositories.
     /// </summary>
-    public async Task Analyze(string domainName, InternalLogger? logger = null, CancellationToken ct = default)
-    {
+    public async Task Analyze(string domainName, InternalLogger? logger = null, CancellationToken ct = default) {
         Subject = domainName;
         Results = new List<RPKIResult>();
         using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "RPKI", target: domainName) : null;
@@ -101,14 +99,11 @@ public class RPKIAnalysis : IHasAssessments
             .Select(r => r.Data)
             .Distinct(StringComparer.Ordinal);
 
-        var tasks = addresses.Select(async ip =>
-        {
+        var tasks = addresses.Select(async ip => {
             ct.ThrowIfCancellationRequested();
             var (prefix, asn, valid) = await QueryRpki(ip, logger);
-            lock (Results)
-            {
-                Results.Add(new RPKIResult
-                {
+            lock (Results) {
+                Results.Add(new RPKIResult {
                     IpAddress = ip,
                     Prefix = prefix,
                     Asn = asn,
@@ -116,11 +111,9 @@ public class RPKIAnalysis : IHasAssessments
                 });
             }
 
-            if (!string.IsNullOrWhiteSpace(prefix))
-            {
+            if (!string.IsNullOrWhiteSpace(prefix)) {
                 logger?.WriteInformationCode(RpkiCodes.PrefixCovered, $"IP {ip} covered by {prefix} (AS{asn}).");
-                if (valid)
-                {
+                if (valid) {
                     logger?.WriteInformationCode(RpkiCodes.ValidRoa, $"ROA valid for {prefix} (AS{asn}).");
                 }
             }
@@ -132,8 +125,7 @@ public class RPKIAnalysis : IHasAssessments
 
 /// <summary>Represents RPKI validation for a single IP.</summary>
 /// <para>Part of the DomainDetective project.</para>
-public class RPKIResult
-{
+public class RPKIResult {
     /// <summary>IP address being verified.</summary>
     public string IpAddress { get; init; } = string.Empty;
     /// <summary>Origin prefix as reported by RIPE.</summary>


### PR DESCRIPTION
## Summary
- add RPKI narrative outlining ROA validation and ASN coverage
- log success codes for valid ROAs and covering prefixes with recommendations
- include example and tests for positive RPKI advice

## Testing
- `dotnet build DomainDetective.Example/DomainDetective.Example.csproj`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter TestRpkiNarrative`


------
https://chatgpt.com/codex/tasks/task_e_68b9af178d38832e9f1132f54d0f9e07