### PR TITLE
feat(soa): add SOA narrative and positive timer recommendations

### DIFF
--- a/DomainDetective.Example/ExampleSoaNarrative.cs
+++ b/DomainDetective.Example/ExampleSoaNarrative.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates building an SOA narrative from live data.
+    /// </summary>
+    public static async Task ExampleSoaNarrative()
+    {
+        var healthCheck = new DomainHealthCheck { Verbose = false };
+        await healthCheck.Verify("evotec.pl", new[] { HealthCheckType.SOA });
+        var narrative = SoaNarrative.Build(healthCheck.SOAAnalysis);
+        Helpers.ShowPropertiesTable("SOA Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestSOAAnalysis.cs
+++ b/DomainDetective.Tests/TestSOAAnalysis.cs
@@ -72,5 +72,19 @@ namespace DomainDetective.Tests {
 
             Assert.Equal(600, analysis.NegativeCacheTtl);
         }
+
+        [Fact]
+        public async Task EmitsInfoCodesForSaneTimersAndMnameMatch() {
+            var soa = new[] {
+                new DnsAnswer { DataRaw = "ns1.example.com. hostmaster.example.com. 2023102301 3600 600 1209600 300", Type = DnsRecordType.SOA }
+            };
+            var ns = new[] {
+                new DnsAnswer { DataRaw = "ns1.example.com", Type = DnsRecordType.NS }
+            };
+            var analysis = new SOAAnalysis();
+            await analysis.AnalyzeSoaRecords(soa, new InternalLogger(), ns);
+            Assert.Contains(analysis.Assessments, a => a.Code == SOACodes.RefreshSane && a.Severity == AssessmentSeverity.Info);
+            Assert.Contains(analysis.Assessments, a => a.Code == SOACodes.MnameMatchesNs && a.Severity == AssessmentSeverity.Info);
+        }
     }
 }

--- a/DomainDetective.Tests/TestSoaNarrative.cs
+++ b/DomainDetective.Tests/TestSoaNarrative.cs
@@ -1,0 +1,30 @@
+using DnsClientX;
+using DomainDetective.Narratives;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestSoaNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithPositives()
+    {
+        var soaRecords = new List<DnsAnswer>
+        {
+            new DnsAnswer { DataRaw = "ns1.example.com. hostmaster.example.com. 2023102301 3600 600 1209600 300", Type = DnsRecordType.SOA }
+        };
+        var nsRecords = new List<DnsAnswer>
+        {
+            new DnsAnswer { DataRaw = "ns1.example.com", Type = DnsRecordType.NS }
+        };
+        var analysis = new SOAAnalysis();
+        await analysis.AnalyzeSoaRecords(soaRecords, new InternalLogger(), nsRecords);
+        var sections = SoaNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("Primary NS"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Serial"));
+        Assert.Contains(sections.Positives, p => p.Contains("Refresh interval within recommended range"));
+        Assert.Contains(sections.Positives, p => p.Contains("primary NS matches"));
+    }
+}

--- a/DomainDetective.Tests/TestSoaRecommendations.cs
+++ b/DomainDetective.Tests/TestSoaRecommendations.cs
@@ -1,0 +1,19 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestSoaRecommendations
+{
+    [Fact]
+    public void RegistersPositiveCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new SOARecommendations().Register(map);
+        Assert.Contains(SOACodes.RefreshSane, map.Keys);
+        Assert.Contains(SOACodes.RetrySane, map.Keys);
+        Assert.Contains(SOACodes.ExpireSane, map.Keys);
+        Assert.Contains(SOACodes.MnameMatchesNs, map.Keys);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/SOACodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SOACodes.cs
@@ -8,5 +8,9 @@ internal static class SOACodes {
     public const string RefreshExtreme = "SOA.Refresh.Extreme";
     public const string RetryExtreme = "SOA.Retry.Extreme";
     public const string MinimumExtreme = "SOA.Minimum.Extreme";
+    public const string RefreshSane = "SOA.Refresh.Sane";
+    public const string RetrySane = "SOA.Retry.Sane";
+    public const string ExpireSane = "SOA.Expire.Sane";
+    public const string MnameMatchesNs = "SOA.MNAME.MatchesNS";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/SOARecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SOARecommendations.cs
@@ -81,5 +81,49 @@ internal sealed class SOARecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "NXDOMAIN caching duration matches policy."
         };
+        map[SOACodes.RefreshSane] = new RecommendationAdvice {
+            Code = SOACodes.RefreshSane,
+            Title = "SOA Refresh interval within recommended range",
+            Why = "Sensible refresh values keep secondaries updated without undue traffic.",
+            How = "Maintain refresh between 30 minutes and 24 hours based on update needs.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "soa", "timers" },
+            Impact = "Healthy secondary synchronization cadence.",
+            Effort = RecommendationEffort.Low,
+            Verify = "SOA Refresh is between 1800 and 86400 seconds."
+        };
+        map[SOACodes.RetrySane] = new RecommendationAdvice {
+            Code = SOACodes.RetrySane,
+            Title = "SOA Retry interval within recommended range",
+            Why = "Balanced retry timing speeds recovery from transient failures.",
+            How = "Keep retry around 5 minutes to 2 hours depending on operations.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "soa", "timers" },
+            Impact = "Prompt retry without excessive load.",
+            Effort = RecommendationEffort.Low,
+            Verify = "SOA Retry is between 300 and 7200 seconds."
+        };
+        map[SOACodes.ExpireSane] = new RecommendationAdvice {
+            Code = SOACodes.ExpireSane,
+            Title = "SOA Expire interval within recommended range",
+            Why = "Appropriate expire ensures stale zones are discarded after extended outages.",
+            How = "Use an expire around 1–4 weeks depending on tolerance for stale data.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "soa", "timers" },
+            Impact = "Secondaries drop obsolete zones in a timely manner.",
+            Effort = RecommendationEffort.Low,
+            Verify = "SOA Expire is between 604800 and 2419200 seconds."
+        };
+        map[SOACodes.MnameMatchesNs] = new RecommendationAdvice {
+            Code = SOACodes.MnameMatchesNs,
+            Title = "SOA primary NS matches published NS records",
+            Why = "MNAME should point to an authoritative NS for operational consistency.",
+            How = "Use one of the zone's NS hostnames as the SOA MNAME.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "soa", "ns" },
+            Impact = "Accurate reference for zone maintenance and transfers.",
+            Effort = RecommendationEffort.Low,
+            Verify = "SOA MNAME hostname appears in the NS RRset."
+        };
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.Soa.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Soa.cs
@@ -21,8 +21,9 @@ namespace DomainDetective {
                 return;
             }
             var soa = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.SOA, cancellationToken: cancellationToken);
+            var ns = await DnsConfiguration.QueryDNS(domainName, DnsRecordType.NS, cancellationToken: cancellationToken);
             SOAAnalysis.Subject = domainName;
-            await SOAAnalysis.AnalyzeSoaRecords(soa, _logger);
+            await SOAAnalysis.AnalyzeSoaRecords(soa, _logger, ns);
         }
 
         /// <summary>

--- a/DomainDetective/Narratives/SoaNarrative.cs
+++ b/DomainDetective/Narratives/SoaNarrative.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives
+{
+    public static class SoaNarrative
+    {
+        public sealed class Sections : NarrativeSections { }
+
+        public static Sections Build(SOAAnalysis soa)
+        {
+            var subj = string.IsNullOrWhiteSpace(soa?.Subject) ? "(domain)" : soa.Subject;
+            var title = $"SOA Report — {subj}";
+            var subtitle = "Start of Authority Assessment";
+            var category = "DNS Infrastructure";
+            var keywords = $"SOA, DNS, DomainDetective, {subj}";
+            var creator = "DomainDetective";
+            var intro = "The Start of Authority (SOA) record defines zone parameters such as the primary nameserver and timing values.";
+            var why = "Sensible SOA settings ensure reliable zone transfers and predictable caching behaviour.";
+
+            var hi = new List<string>();
+            var det = new List<string>();
+            var positives = new List<string>();
+            var remediations = new List<string>();
+
+            if (soa?.RecordExists == true)
+            {
+                if (!string.IsNullOrWhiteSpace(soa.PrimaryNameServer))
+                {
+                    hi.Add($"Primary NS: {soa.PrimaryNameServer}");
+                }
+                hi.Add($"Serial: {soa.SerialNumber}");
+                hi.Add($"Refresh: {soa.Refresh}s");
+                hi.Add($"Retry: {soa.Retry}s");
+                hi.Add($"Expire: {soa.Expire}s");
+
+                if (!string.IsNullOrWhiteSpace(soa.ResponsibleMailbox))
+                {
+                    det.Add($"RNAME: {soa.ResponsibleMailbox}");
+                }
+                det.Add($"Serial: {soa.SerialNumber}");
+                det.Add($"Refresh: {soa.Refresh}s");
+                det.Add($"Retry: {soa.Retry}s");
+                det.Add($"Expire: {soa.Expire}s");
+                det.Add($"Minimum TTL: {soa.Minimum}s");
+            }
+            else
+            {
+                hi.Add("No SOA record is published.");
+            }
+            if (!string.IsNullOrWhiteSpace(soa?.Subject))
+            {
+                det.Add($"Subject: {soa.Subject}");
+            }
+
+            var refs = new List<string>
+            {
+                "https://www.rfc-editor.org/rfc/rfc1035"
+            };
+
+            try
+            {
+                var assessments = (IEnumerable<Assessment>)(soa?.Assessments ?? new List<Assessment>());
+                var groups = RecommendationEngine.GroupByCode(assessments);
+                foreach (var g in groups)
+                {
+                    var msg = string.IsNullOrWhiteSpace(g.Advice?.Title)
+                        ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
+                        : g.Advice.Title;
+                    if (g.MaxSeverity == AssessmentSeverity.Info)
+                    {
+                        positives.Add(msg);
+                    }
+                    else
+                    {
+                        remediations.Add(msg);
+                    }
+                }
+            }
+            catch
+            {
+            }
+
+            return new Sections
+            {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = refs,
+                Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+            };
+        }
+    }
+}

--- a/DomainDetective/Protocols/SOAAnalysis.cs
+++ b/DomainDetective/Protocols/SOAAnalysis.cs
@@ -30,7 +30,7 @@ namespace DomainDetective {
         /// <summary>
         /// Reads SOA records and populates analysis properties.
         /// </summary>
-        public async Task AnalyzeSoaRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        public async Task AnalyzeSoaRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger, IEnumerable<DnsAnswer>? nsResults = null) {
             using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "SOA") : null;
             await Task.Yield();
 
@@ -97,12 +97,27 @@ namespace DomainDetective {
                 // Heuristic extremes based on common practice
                 if (Refresh < 1800 || Refresh > 86400) {
                     logger?.WriteWarningCode(SOACodes.RefreshExtreme, "SOA Refresh value is extreme: {0}", Refresh);
+                } else {
+                    logger?.WriteInformationCode(SOACodes.RefreshSane, "SOA Refresh value is within recommended range: {0}", Refresh);
                 }
                 if (Retry < 300 || Retry > 7200) {
                     logger?.WriteWarningCode(SOACodes.RetryExtreme, "SOA Retry value is extreme: {0}", Retry);
+                } else {
+                    logger?.WriteInformationCode(SOACodes.RetrySane, "SOA Retry value is within recommended range: {0}", Retry);
+                }
+                if (Expire >= 604800 && Expire <= 2419200) {
+                    logger?.WriteInformationCode(SOACodes.ExpireSane, "SOA Expire value is within recommended range: {0}", Expire);
                 }
                 if (Minimum < 60 || Minimum > 86400) {
                     logger?.WriteWarningCode(SOACodes.MinimumExtreme, "SOA Minimum/negative TTL value is extreme: {0}", Minimum);
+                }
+                if (nsResults != null && !string.IsNullOrWhiteSpace(PrimaryNameServer)) {
+                    var nsHosts = nsResults
+                        .Select(n => n.Data?.TrimEnd('.'))
+                        .Where(n => !string.IsNullOrWhiteSpace(n));
+                    if (nsHosts.Any(n => string.Equals(n, PrimaryNameServer, StringComparison.OrdinalIgnoreCase))) {
+                        logger?.WriteInformationCode(SOACodes.MnameMatchesNs, "SOA MNAME matches published NS records");
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- add SOA narrative summarizing serial and timer parameters
- log positive assessments for sane SOA timers and matching primary NS
- document positive SOA recommendations with examples and tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter "FullyQualifiedName~TestSoaNarrative|FullyQualifiedName~TestSoaRecommendations|FullyQualifiedName~TestSOAAnalysis" --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68b9af141da4832e8aa4f035dc77dbee