### PR TITLE
feat(wildcard): add narrative and success code

### DIFF
--- a/DomainDetective.CLI/Program.cs
+++ b/DomainDetective.CLI/Program.cs
@@ -37,6 +37,7 @@ internal static class Program {
         app.Configure(config => {
             config.SetApplicationName("DomainDetective");
             config.AddExample(new[] { "check", "example.com" });
+            config.AddExample(new[] { "wizard", "--domain", "example.com" });
             config.AddCommand<WizardScanCommand>("WizardScan")
                 .WithDescription("Run the Hacker Wizard (parallel, animated)")
                 .WithExample(new[] { "WizardScan", "--domain", "example.com", "--full", "--matrix" })

--- a/DomainDetective.Example/ExampleWildcardNarrative.cs
+++ b/DomainDetective.Example/ExampleWildcardNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example
+{
+    public static partial class Program
+    {
+        /// <summary>
+        /// Demonstrates building a narrative from wildcard DNS analysis.
+        /// </summary>
+        public static async Task ExampleWildcardNarrative()
+        {
+            var health = new DomainHealthCheck();
+            await health.VerifyWildcardDns("example.com");
+            var sections = WildcardNarrative.Build(health.WildcardDnsAnalysis);
+            Helpers.ShowPropertiesTable("Wildcard DNS Narrative", sections);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestWildcardDnsAnalysis.cs
+++ b/DomainDetective.Tests/TestWildcardDnsAnalysis.cs
@@ -145,4 +145,17 @@ public class TestWildcardDnsAnalysis
 
         Assert.True(analysis.CatchAll);
     }
+
+    [Fact]
+    public async Task EmitsNotDetectedCodeWhenNoWildcard()
+    {
+        var analysis = new WildcardDnsAnalysis
+        {
+            QueryDnsOverride = (_, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger(), sampleCount: 1);
+
+        Assert.Contains(analysis.Assessments, a => a.Code == WildcardCodes.NotDetected);
+    }
 }

--- a/DomainDetective.Tests/TestWildcardNarrative.cs
+++ b/DomainDetective.Tests/TestWildcardNarrative.cs
@@ -1,0 +1,25 @@
+using System.Threading.Tasks;
+using DnsClientX;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestWildcardNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWhenCatchAllDetected()
+    {
+        var analysis = new WildcardDnsAnalysis
+        {
+            QueryDnsOverride = (_, _) => Task.FromResult(new[] { new DnsAnswer { Type = DnsRecordType.A, DataRaw = "192.0.2.1" } })
+        };
+
+        await analysis.Analyze("example.com", new InternalLogger(), sampleCount: 1);
+
+        var sections = WildcardNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("Wildcard DNS detected"));
+        Assert.Contains("SOA", string.Join(' ', sections.Details));
+    }
+}

--- a/DomainDetective.Tests/TestWildcardNarrative.cs
+++ b/DomainDetective.Tests/TestWildcardNarrative.cs
@@ -20,6 +20,6 @@ public class TestWildcardNarrative
 
         var sections = WildcardNarrative.Build(analysis);
         Assert.Contains(sections.Highlights, h => h.Contains("Wildcard DNS detected"));
-        Assert.Contains("SOA", string.Join(' ', sections.Details));
+        Assert.Contains("SOA", string.Join(" ", sections.Details));
     }
 }

--- a/DomainDetective.Tests/TestWildcardRecommendations.cs
+++ b/DomainDetective.Tests/TestWildcardRecommendations.cs
@@ -1,0 +1,16 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestWildcardRecommendations
+{
+    [Fact]
+    public void RegistersPositiveCode()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new WildcardRecommendations().Register(map);
+        Assert.Contains(WildcardCodes.NotDetected, map.Keys);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/WildcardCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/WildcardCodes.cs
@@ -2,5 +2,6 @@ namespace DomainDetective;
 
 internal static class WildcardCodes {
     public const string Enabled = "WILDCARD.Enabled";
+    public const string NotDetected = "WILDCARD.NotDetected";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/WildcardRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/WildcardRecommendations.cs
@@ -12,6 +12,15 @@ internal sealed class WildcardRecommendations : IRecommendationProvider {
             Domain = RecommendationDomain.Infrastructure,
             Tags = new [] { "dns", "wildcard" }
         };
+
+        map[WildcardCodes.NotDetected] = new RecommendationAdvice {
+            Code = WildcardCodes.NotDetected,
+            Title = "No wildcard DNS detected",
+            Why = "Explicit DNS records prevent shadow subdomains and simplify troubleshooting.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "dns", "wildcard" }
+        };
     }
 }
 

--- a/DomainDetective/Narratives/WildcardNarrative.cs
+++ b/DomainDetective/Narratives/WildcardNarrative.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+public static class WildcardNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(WildcardDnsAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var title = "Wildcard DNS Report";
+        var subtitle = "Wildcard DNS Assessment";
+        var category = "DNS Infrastructure";
+        var keywords = "wildcard, DNS, DomainDetective";
+        var creator = "DomainDetective";
+        var intro = "Wildcard DNS responds to non-existent subdomains with synthesized records.";
+        var why = "Unintended wildcard records can hide configuration errors and enable phishing or takeover scenarios.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No wildcard data available." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        hi.Add(analysis.CatchAll ? "Wildcard DNS detected." : "No wildcard DNS detected.");
+        if (analysis.TestedNames.Count > 0)
+        {
+            hi.Add($"{analysis.TestedNames.Count} random names tested.");
+            hi.Add($"{analysis.ResolvedNames.Count} resolved; {analysis.ResolvedAddresses.Count} unique address(es).");
+        }
+
+        det.Add(analysis.CatchAll
+            ? "Random subdomains resolved to existing addresses."
+            : "Random subdomains returned NXDOMAIN.");
+        det.Add(analysis.SoaExists ? "SOA record present." : "SOA record missing.");
+        det.Add(analysis.NsExists ? "NS records present." : "NS records missing.");
+
+        var refs = DefaultRefs();
+
+        try
+        {
+            var assess = assessments ?? analysis.Assessments;
+            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.rfc-editor.org/rfc/rfc4592"
+    };
+}

--- a/DomainDetective/Protocols/WildcardDnsAnalysis.cs
+++ b/DomainDetective/Protocols/WildcardDnsAnalysis.cs
@@ -141,6 +141,10 @@ public class WildcardDnsAnalysis : IHasAssessments
         {
             logger?.WriteWarningCode(WildcardCodes.Enabled, "Wildcard DNS detected for {0}", domainName);
         }
+        else
+        {
+            logger?.WriteInformationCode(WildcardCodes.NotDetected, "No wildcard DNS detected for {0}", domainName);
+        }
     }
 
     public List<Assessment> Assessments { get; } = new();


### PR DESCRIPTION
## Summary
- add wildcard DNS narrative describing wildcard detection impacts
- record success when no wildcard DNS detected and expose recommendations
- include example and tests for narrative and success codes

## Testing
- `dotnet test` *(DomainDetective.Tests pass; DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples fails)*

------
https://chatgpt.com/codex/tasks/task_e_68b9af0cd180832eb620ae09c5eaf691