### PR TITLE
chore(reports): enable nullable context

### DIFF
--- a/DomainDetective.Reports/Artifacts/RunCoordinator.cs
+++ b/DomainDetective.Reports/Artifacts/RunCoordinator.cs
@@ -45,14 +45,15 @@ public sealed class RunCoordinator : IDisposable
         if (Uri.TryCreate(subject, UriKind.Absolute, out _)) meta.SubjectKind = "Url";
         var safeSubject = FilePathHelper.MakeFileSafe(subject);
         var stamp = meta.GeneratedAt.ToUniversalTime().ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
-        var runDir = Path.Combine(baseDirectory ?? ".", "artifacts", safeSubject, stamp);
+        var baseDir = baseDirectory ?? ".";
+        var runDir = Path.Combine(baseDir, "artifacts", safeSubject, stamp);
         Directory.CreateDirectory(runDir);
 
         var hub = new ProgressHub(logger);
         var jsonl = new JsonlProgressSink(Path.Combine(runDir, "progress.jsonl"));
         hub.AddSink(jsonl);
 
-        var coord = new RunCoordinator(baseDirectory, subject, logger, runDir, meta, hub, jsonl);
+        var coord = new RunCoordinator(baseDir, subject, logger, runDir, meta, hub, jsonl);
         coord._sw.Start();
         return coord;
     }
@@ -67,7 +68,7 @@ public sealed class RunCoordinator : IDisposable
             RecommendationCount = hc.RecommendationViews?.Count ?? 0,
             HostCount = hc.WebStaticScanAnalysis?.Hosts?.Count ?? 0,
             ResourceCount = hc.WebStaticScanAnalysis?.Requests?.Count ?? 0,
-            TransferBytes = hc.WebStaticScanAnalysis?.Requests?.Where(r => r != null && r.ContentLength.HasValue).Sum(r => (long)r.ContentLength.Value) ?? 0,
+            TransferBytes = hc.WebStaticScanAnalysis?.Requests?.Sum(r => r?.ContentLength ?? 0) ?? 0,
             TotalDurationSeconds = _sw.Elapsed.TotalSeconds
         };
 

--- a/DomainDetective.Reports/DomainDetective.Reports.csproj
+++ b/DomainDetective.Reports/DomainDetective.Reports.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <Reference Include="System.IO.Compression" />

--- a/DomainDetective.Reports/ReportDispatcher.cs
+++ b/DomainDetective.Reports/ReportDispatcher.cs
@@ -91,14 +91,28 @@ public sealed class ReportDispatcher
             {
                 Type[] types;
                 try { types = asm.GetTypes(); } catch { continue; }
-                foreach (var t in types)
-                {
-                    if (t.IsAbstract) continue;
-                    if (!typeof(IReportGenerator).IsAssignableFrom(t)) continue;
-                    IReportGenerator gen;
-                    try { gen = (IReportGenerator)Activator.CreateInstance(t); } catch { continue; }
-                    try { if (gen.CanGenerate(options)) return gen; } catch { }
-                }
+                    foreach (var t in types)
+                    {
+                        if (t.IsAbstract) continue;
+                        if (!typeof(IReportGenerator).IsAssignableFrom(t)) continue;
+                        IReportGenerator? gen;
+                        try
+                        {
+                            gen = Activator.CreateInstance(t) as IReportGenerator;
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+                        if (gen == null) continue;
+                        try
+                        {
+                            if (gen.CanGenerate(options)) return gen;
+                        }
+                        catch
+                        {
+                        }
+                    }
             }
         }
         catch { }


### PR DESCRIPTION
## Summary
- enable nullable reference types for reports project
- clean up RunCoordinator null handling
- guard ReportDispatcher generator creation against nulls

## Testing
- `dotnet build DomainDetective.Reports/DomainDetective.Reports.csproj`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f1d14094832e9738f6d6c5a48270