### PR TITLE
Add mail classification narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleMailClassificationNarrative.cs
+++ b/DomainDetective.Example/ExampleMailClassificationNarrative.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example
+{
+    public static partial class Program
+    {
+        /// <summary>
+        /// Demonstrates building a narrative from mail domain classification.
+        /// </summary>
+        public static async Task ExampleMailClassificationNarrative()
+        {
+            var health = new DomainHealthCheck();
+            var classifier = new MailDomainClassifier(health, new InternalLogger());
+            var result = await classifier.ClassifyAsync("gmail.com");
+            var sections = MailClassificationNarrative.Build(result);
+            Helpers.ShowPropertiesTable("Mail Classification Narrative", sections);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestMailClassificationNarrative.cs
+++ b/DomainDetective.Tests/TestMailClassificationNarrative.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+using DomainDetective;
+using DomainDetective.Definitions;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestMailClassificationNarrative
+    {
+        [Fact]
+        public void BuildsNarrativeWithPositives()
+        {
+            var result = new MailDomainClassificationResult
+            {
+                Domain = "example.com",
+                Classification = MailDomainClassificationCategory.SendingAndReceiving,
+                Confidence = MailDomainClassificationConfidence.High,
+                ReceivingSignals = new List<string> { "MX" },
+                SendingSignals = new List<string> { "SPF" },
+                Assessments = new List<Assessment>
+                {
+                    new Assessment { Code = MailClassificationCodes.SendingAndReceiving, Severity = AssessmentSeverity.Info, Message = "Domain supports sending and receiving mail" }
+                }
+            };
+            var sections = MailClassificationNarrative.Build(result);
+            Assert.Contains(sections.Highlights, h => h.Contains("Classification"));
+            Assert.Contains("Domain supports sending and receiving mail", sections.Positives);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestMailDomainClassifier.cs
+++ b/DomainDetective.Tests/TestMailDomainClassifier.cs
@@ -1,90 +1,92 @@
-using DnsClientX;
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace DomainDetective.Tests;
-
-public class TestMailDomainClassifier {
-    private static Func<string, DnsRecordType, Task<DnsAnswer[]>> MakeOverride(Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> map) =>
-        (name, type) => Task.FromResult(
-            map.TryGetValue(name, out var inner) && inner != null && inner.TryGetValue(type, out var v)
-                ? v
-                : Array.Empty<DnsAnswer>());
-
-    [Fact]
-    public async Task Classify_Parked_NullMX_NoSending() {
-        var hc = new DomainDetective.DomainHealthCheck();
-        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
-            ["parked.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
-                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "0 .", Type = DnsRecordType.MX } },
-                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 -all", Type = DnsRecordType.TXT } }
-            }
-        };
-        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
-        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
-        var result = await classifier.ClassifyAsync("parked.test");
-        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.Parked, result.Classification);
-        Assert.True(result.Signals.HasNullMX);
-        Assert.False(result.Signals.EffectiveSpfSends);
-    }
-
-    [Fact]
-    public async Task Classify_SendingOnly_NullMX_WithSpfAuth() {
-        var hc = new DomainDetective.DomainHealthCheck();
-        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
-            ["senderonly.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
-                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "0 .", Type = DnsRecordType.MX } },
-                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 ip4:192.0.2.0/24 -all", Type = DnsRecordType.TXT } }
-            }
-        };
-        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
-        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
-        var result = await classifier.ClassifyAsync("senderonly.test");
-        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.SendingOnly, result.Classification);
-        Assert.True(result.Signals.EffectiveSpfSends);
-    }
-
-    [Fact]
-    public async Task Classify_ReceivingOnly_MX_Present_NoSending() {
-        var hc = new DomainDetective.DomainHealthCheck();
-        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
-            ["rxonly.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
-                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "10 mx.rxonly.test", Type = DnsRecordType.MX } },
-                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 -all", Type = DnsRecordType.TXT } }
-            },
-            ["mx.rxonly.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
-                [DnsRecordType.A] = new[]{ new DnsAnswer{ DataRaw = "198.51.100.10", Type = DnsRecordType.A } }
-            }
-        };
-        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
-        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
-        var result = await classifier.ClassifyAsync("rxonly.test");
-        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.ReceivingOnly, result.Classification);
-        Assert.True(result.Signals.HasMX);
-        Assert.False(result.Signals.EffectiveSpfSends);
-    }
-
-    [Fact]
-    public async Task Classify_SendingAndReceiving_MX_And_Spf() {
-        var hc = new DomainDetective.DomainHealthCheck();
-        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
-            ["both.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
-                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "10 mx.both.test", Type = DnsRecordType.MX } },
-                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 ip4:198.51.100.0/24 -all", Type = DnsRecordType.TXT } },
-                [DnsRecordType.A] = new[]{ new DnsAnswer{ DataRaw = "198.51.100.7", Type = DnsRecordType.A } },
-                [DnsRecordType.AAAA] = Array.Empty<DnsAnswer>()
-            },
-            ["mx.both.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
-                [DnsRecordType.A] = new[]{ new DnsAnswer{ DataRaw = "198.51.100.7", Type = DnsRecordType.A } }
-            }
-        };
-        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
-        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
-        var result = await classifier.ClassifyAsync("both.test");
-        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.SendingAndReceiving, result.Classification);
-        Assert.True(result.Signals.HasMX);
-        Assert.True(result.Signals.EffectiveSpfSends);
-    }
-}
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using DomainDetective;
+
+namespace DomainDetective.Tests;
+
+public class TestMailDomainClassifier {
+    private static Func<string, DnsRecordType, Task<DnsAnswer[]>> MakeOverride(Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> map) =>
+        (name, type) => Task.FromResult(
+            map.TryGetValue(name, out var inner) && inner != null && inner.TryGetValue(type, out var v)
+                ? v
+                : Array.Empty<DnsAnswer>());
+
+    [Fact]
+    public async Task Classify_Parked_NullMX_NoSending() {
+        var hc = new DomainDetective.DomainHealthCheck();
+        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
+            ["parked.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
+                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "0 .", Type = DnsRecordType.MX } },
+                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 -all", Type = DnsRecordType.TXT } }
+            }
+        };
+        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
+        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
+        var result = await classifier.ClassifyAsync("parked.test");
+        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.Parked, result.Classification);
+        Assert.True(result.Signals.HasNullMX);
+        Assert.False(result.Signals.EffectiveSpfSends);
+    }
+
+    [Fact]
+    public async Task Classify_SendingOnly_NullMX_WithSpfAuth() {
+        var hc = new DomainDetective.DomainHealthCheck();
+        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
+            ["senderonly.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
+                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "0 .", Type = DnsRecordType.MX } },
+                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 ip4:192.0.2.0/24 -all", Type = DnsRecordType.TXT } }
+            }
+        };
+        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
+        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
+        var result = await classifier.ClassifyAsync("senderonly.test");
+        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.SendingOnly, result.Classification);
+        Assert.True(result.Signals.EffectiveSpfSends);
+    }
+
+    [Fact]
+    public async Task Classify_ReceivingOnly_MX_Present_NoSending() {
+        var hc = new DomainDetective.DomainHealthCheck();
+        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
+            ["rxonly.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
+                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "10 mx.rxonly.test", Type = DnsRecordType.MX } },
+                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 -all", Type = DnsRecordType.TXT } }
+            },
+            ["mx.rxonly.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
+                [DnsRecordType.A] = new[]{ new DnsAnswer{ DataRaw = "198.51.100.10", Type = DnsRecordType.A } }
+            }
+        };
+        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
+        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
+        var result = await classifier.ClassifyAsync("rxonly.test");
+        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.ReceivingOnly, result.Classification);
+        Assert.True(result.Signals.HasMX);
+        Assert.False(result.Signals.EffectiveSpfSends);
+    }
+
+    [Fact]
+    public async Task Classify_SendingAndReceiving_MX_And_Spf() {
+        var hc = new DomainDetective.DomainHealthCheck();
+        var map = new Dictionary<string, Dictionary<DnsRecordType, DnsAnswer[]>> {
+            ["both.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
+                [DnsRecordType.MX] = new[]{ new DnsAnswer{ DataRaw = "10 mx.both.test", Type = DnsRecordType.MX } },
+                [DnsRecordType.TXT] = new[]{ new DnsAnswer{ DataRaw = "v=spf1 ip4:198.51.100.0/24 -all", Type = DnsRecordType.TXT } },
+                [DnsRecordType.A] = new[]{ new DnsAnswer{ DataRaw = "198.51.100.7", Type = DnsRecordType.A } },
+                [DnsRecordType.AAAA] = Array.Empty<DnsAnswer>()
+            },
+            ["mx.both.test"] = new Dictionary<DnsRecordType, DnsAnswer[]> {
+                [DnsRecordType.A] = new[]{ new DnsAnswer{ DataRaw = "198.51.100.7", Type = DnsRecordType.A } }
+            }
+        };
+        hc.DnsConfiguration.QueryDnsOverride = MakeOverride(map);
+        var classifier = new DomainDetective.MailDomainClassifier(hc, new InternalLogger(false));
+        var result = await classifier.ClassifyAsync("both.test");
+        Assert.Equal(DomainDetective.Definitions.MailDomainClassificationCategory.SendingAndReceiving, result.Classification);
+        Assert.True(result.Signals.HasMX);
+        Assert.True(result.Signals.EffectiveSpfSends);
+        Assert.Contains(result.Assessments, a => a.Code == MailClassificationCodes.SendingAndReceiving);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/MailClassificationCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/MailClassificationCodes.cs
@@ -1,0 +1,8 @@
+namespace DomainDetective;
+
+internal static class MailClassificationCodes {
+    public const string SendingAndReceiving = "MailClassification.Success.SendingAndReceiving";
+    public const string ReceivingOnly = "MailClassification.Success.ReceivingOnly";
+    public const string SendingOnly = "MailClassification.Success.SendingOnly";
+    public const string Parked = "MailClassification.Success.Parked";
+}

--- a/DomainDetective/Diagnostics/Recommendations/MailClassificationRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/MailClassificationRecommendations.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class MailClassificationRecommendations : IRecommendationProvider {
+    public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[MailClassificationCodes.SendingAndReceiving] = new RecommendationAdvice {
+            Code = MailClassificationCodes.SendingAndReceiving,
+            Title = "Domain supports sending and receiving mail",
+            Why = "Domain authorizes outbound mail and accepts inbound delivery.",
+            How = "Maintain current authentication and delivery configurations.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "classification", "email" }
+        };
+        map[MailClassificationCodes.ReceivingOnly] = new RecommendationAdvice {
+            Code = MailClassificationCodes.ReceivingOnly,
+            Title = "Domain configured to receive mail only",
+            Why = "Inbound delivery is enabled but no sending authorization was found.",
+            How = "No action needed if intentional; add SPF/DKIM if outbound mail is required.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "classification", "email" }
+        };
+        map[MailClassificationCodes.SendingOnly] = new RecommendationAdvice {
+            Code = MailClassificationCodes.SendingOnly,
+            Title = "Domain configured to send mail only",
+            Why = "Domain authorizes sending but does not advertise inbound mail servers.",
+            How = "Maintain SPF/DKIM records; publish MX if inbound mail should be accepted.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "classification", "email" }
+        };
+        map[MailClassificationCodes.Parked] = new RecommendationAdvice {
+            Code = MailClassificationCodes.Parked,
+            Title = "Domain explicitly parked for email",
+            Why = "Null MX and absence of sending signals indicate the domain is not used for email.",
+            How = "No action required unless email service will be introduced.",
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "classification", "email" }
+        };
+    }
+}

--- a/DomainDetective/Mail/MailDomainClassifier.cs
+++ b/DomainDetective/Mail/MailDomainClassifier.cs
@@ -188,6 +188,21 @@ public sealed class MailDomainClassifier {
         Pull(_health.BimiAnalysis);
         // ApexAddressAnalysis does not implement IHasAssessments; skip
 
+        string? classificationCode = category switch
+        {
+            MailDomainClassificationCategory.SendingAndReceiving => MailClassificationCodes.SendingAndReceiving,
+            MailDomainClassificationCategory.ReceivingOnly => MailClassificationCodes.ReceivingOnly,
+            MailDomainClassificationCategory.SendingOnly => MailClassificationCodes.SendingOnly,
+            MailDomainClassificationCategory.Parked => MailClassificationCodes.Parked,
+            _ => null
+        };
+
+        if (!string.IsNullOrWhiteSpace(classificationCode))
+        {
+            agg.Add(new Assessment { Code = classificationCode, Severity = AssessmentSeverity.Info, Message = reason, Category = "MailClassification" });
+            _logger?.WriteInformationCode(classificationCode, reason);
+        }
+
         return new MailDomainClassificationResult {
             Domain = domain,
             Classification = category,

--- a/DomainDetective/Narratives/MailClassificationNarrative.cs
+++ b/DomainDetective/Narratives/MailClassificationNarrative.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class MailClassificationNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(MailDomainClassificationResult result)
+    {
+        var subj = string.IsNullOrWhiteSpace(result?.Domain) ? "(domain)" : result.Domain;
+        var title = $"Mail Classification — {subj}";
+        var subtitle = "Mail Posture";
+        var category = "Email Security";
+        var keywords = $"mail, classification, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Determines whether a domain sends or receives email.";
+        var why = "Understanding mail posture helps manage risk and expectations.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        hi.Add($"Classification: {result.Classification}");
+        hi.Add($"Confidence: {result.Confidence}");
+
+        if (result.ReceivingSignals?.Count > 0)
+            det.Add($"Receiving signals: {string.Join(", ", result.ReceivingSignals)}");
+        if (result.SendingSignals?.Count > 0)
+            det.Add($"Sending signals: {string.Join(", ", result.SendingSignals)}");
+        if (!string.IsNullOrWhiteSpace(result.ClassificationReason))
+            det.Add(result.ClassificationReason);
+
+        var refs = result.RfcReferences?.Select(r => string.IsNullOrWhiteSpace(r.Url) ? r.Reference : r.Url).ToList()
+            ?? new List<string>();
+
+        try
+        {
+            var assessments = (IEnumerable<Assessment>)(result.Assessments ?? new List<Assessment>());
+            var groups = RecommendationEngine.GroupByCode(assessments);
+            foreach (var g in groups)
+            {
+                var msg = string.IsNullOrWhiteSpace(g.Advice?.Title)
+                    ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
+                    : g.Advice.Title;
+                if (g.MaxSeverity == AssessmentSeverity.Info)
+                    positives.Add(msg);
+                else
+                    remediations.Add(msg);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add success codes and recommendations for mail classification results
- implement mail classification narrative and sample usage
- test mail classification narrative and positive recommendations

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Debug`


------
https://chatgpt.com/codex/tasks/task_e_68bac9986ce4832e874102ef76fc6044