### PR TITLE
feat(ntp): add NTP narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleNtpNarrative.cs
+++ b/DomainDetective.Example/ExampleNtpNarrative.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>Demonstrates building an NTP narrative.</summary>
+    public static Task ExampleNtpNarrative() {
+        var analysis = new NtpAnalysis();
+        analysis.ServerResults["pool.ntp.org:123"] = new NtpAnalysis.NtpResult {
+            Success = true,
+            Offset = TimeSpan.FromMilliseconds(15),
+            Stratum = 2
+        };
+        analysis.Assessments.Add(new Assessment { Code = "NTP.Offset.Reasonable", Severity = AssessmentSeverity.Info });
+        analysis.Assessments.Add(new Assessment { Code = "NTP.Stratum.Trusted", Severity = AssessmentSeverity.Info });
+        var narrative = NtpNarrative.Build(analysis);
+        Helpers.ShowPropertiesTable("NTP Narrative", narrative);
+        return Task.CompletedTask;
+    }
+}
+

--- a/DomainDetective.Tests/TestNtpNarrative.cs
+++ b/DomainDetective.Tests/TestNtpNarrative.cs
@@ -22,5 +22,19 @@ public class TestNtpNarrative {
         Assert.Contains("Clock offset within acceptable range", sections.Positives);
         Assert.Contains("NTP server reports trusted stratum", sections.Positives);
     }
+
+    [Fact]
+    public void FormatsLargeOffsetsInLargerUnits() {
+        var analysis = new NtpAnalysis();
+        analysis.ServerResults["time.example:123"] = new NtpAnalysis.NtpResult {
+            Success = true,
+            Offset = System.TimeSpan.FromSeconds(2),
+            Stratum = 1
+        };
+
+        var sections = NtpNarrative.Build(analysis);
+
+        Assert.Contains(sections.Highlights, h => h.Contains("2.00 s"));
+    }
 }
 

--- a/DomainDetective.Tests/TestNtpNarrative.cs
+++ b/DomainDetective.Tests/TestNtpNarrative.cs
@@ -1,0 +1,26 @@
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestNtpNarrative {
+    [Fact]
+    public void BuildsNarrativeWithPositives() {
+        var analysis = new NtpAnalysis();
+        analysis.ServerResults["time.example:123"] = new NtpAnalysis.NtpResult {
+            Success = true,
+            Offset = System.TimeSpan.FromMilliseconds(20),
+            Stratum = 2
+        };
+        analysis.Assessments.Add(new Assessment { Code = NtpCodes.ReasonableOffset, Severity = AssessmentSeverity.Info, Message = "Offset ok" });
+        analysis.Assessments.Add(new Assessment { Code = NtpCodes.TrustedStratum, Severity = AssessmentSeverity.Info, Message = "Stratum ok" });
+
+        var sections = NtpNarrative.Build(analysis);
+
+        Assert.Contains(sections.Highlights, h => h.Contains("stratum 2"));
+        Assert.Contains("Clock offset within acceptable range", sections.Positives);
+        Assert.Contains("NTP server reports trusted stratum", sections.Positives);
+    }
+}
+

--- a/DomainDetective.Tests/TestNtpRecommendations.cs
+++ b/DomainDetective.Tests/TestNtpRecommendations.cs
@@ -1,0 +1,17 @@
+using DomainDetective;
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestNtpRecommendations {
+    [Fact]
+    public void RegistersPositiveCodes() {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new NtpRecommendations().Register(map);
+        Assert.Contains(NtpCodes.ReasonableOffset, map.Keys);
+        Assert.Contains(NtpCodes.TrustedStratum, map.Keys);
+    }
+}
+

--- a/DomainDetective/Diagnostics/Codes/NtpCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/NtpCodes.cs
@@ -1,0 +1,7 @@
+namespace DomainDetective;
+
+internal static class NtpCodes {
+    public const string ReasonableOffset = "NTP.Offset.Reasonable";
+    public const string TrustedStratum = "NTP.Stratum.Trusted";
+}
+

--- a/DomainDetective/Diagnostics/Recommendations/NtpRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/NtpRecommendations.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class NtpRecommendations : IRecommendationProvider {
+    public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[NtpCodes.ReasonableOffset] = new RecommendationAdvice {
+            Code = NtpCodes.ReasonableOffset,
+            Title = "Clock offset within acceptable range",
+            Why = "Small time offsets keep logs and security protocols reliable.",
+            How = "Ensure systems sync with reliable NTP servers and monitor drift.",
+            Links = new [] { "https://datatracker.ietf.org/doc/html/rfc5905" },
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "ntp", "time" }
+        };
+
+        map[NtpCodes.TrustedStratum] = new RecommendationAdvice {
+            Code = NtpCodes.TrustedStratum,
+            Title = "NTP server reports trusted stratum",
+            Why = "Low stratum values indicate proximity to authoritative time sources.",
+            How = "Use servers with stratum 1-4 or reputable public pools.",
+            Links = new [] { "https://datatracker.ietf.org/doc/html/rfc5905" },
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new [] { "ntp", "time" }
+        };
+    }
+}
+

--- a/DomainDetective/Narratives/NtpNarrative.cs
+++ b/DomainDetective/Narratives/NtpNarrative.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace DomainDetective.Narratives;
@@ -26,7 +27,7 @@ public static class NtpNarrative {
             foreach (var kv in results) {
                 var r = kv.Value;
                 if (r.Success) {
-                    var line = $"{kv.Key} offset {r.Offset.TotalMilliseconds:F0} ms; stratum {r.Stratum}";
+                    var line = $"{kv.Key} offset {FormatOffset(r.Offset)}; stratum {r.Stratum}";
                     hi.Add(line);
                     det.Add(line);
                 } else {
@@ -55,6 +56,26 @@ public static class NtpNarrative {
             Positives = positives,
             Remediations = remediations
         };
+    }
+
+    private static string FormatOffset(TimeSpan offset) {
+        var ms = offset.TotalMilliseconds;
+        var absMs = Math.Abs(ms);
+        if (absMs < 1000) {
+            return $"{ms:F0} ms";
+        }
+
+        var absSec = Math.Abs(offset.TotalSeconds);
+        if (absSec < 60) {
+            return $"{offset.TotalSeconds:F2} s";
+        }
+
+        var absMin = Math.Abs(offset.TotalMinutes);
+        if (absMin < 60) {
+            return $"{offset.TotalMinutes:F2} m";
+        }
+
+        return $"{offset.TotalHours:F2} h";
     }
 }
 

--- a/DomainDetective/Narratives/NtpNarrative.cs
+++ b/DomainDetective/Narratives/NtpNarrative.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+public static class NtpNarrative {
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(NtpAnalysis analysis) {
+        var title = "NTP Report";
+        var subtitle = "Network Time Protocol Assessment";
+        var category = "Infrastructure";
+        var keywords = "ntp, time, DomainDetective";
+        var creator = "DomainDetective";
+        var intro = "NTP synchronizes clocks across systems.";
+        var why = "Accurate time underpins authentication, logging and security.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        var results = analysis?.ServerResults ?? new Dictionary<string, NtpAnalysis.NtpResult>();
+        if (results.Count == 0) {
+            hi.Add("No NTP data available.");
+        } else {
+            foreach (var kv in results) {
+                var r = kv.Value;
+                if (r.Success) {
+                    var line = $"{kv.Key} offset {r.Offset.TotalMilliseconds:F0} ms; stratum {r.Stratum}";
+                    hi.Add(line);
+                    det.Add(line);
+                } else {
+                    hi.Add($"{kv.Key} no response");
+                }
+            }
+        }
+
+        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+
+        var refs = new List<string> {
+            "https://datatracker.ietf.org/doc/html/rfc5905"
+        };
+
+        return new Sections {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}
+

--- a/DomainDetective/Protocols/NtpAnalysis.cs
+++ b/DomainDetective/Protocols/NtpAnalysis.cs
@@ -55,7 +55,9 @@ public class NtpAnalysis : IHasAssessments {
     public Task AnalyzeServers(IEnumerable<NtpServer> servers, int port, InternalLogger? logger, CancellationToken cancellationToken = default) =>
         AnalyzeServers(servers.Select(s => s.ToHost()), port, logger, cancellationToken);
 
-    private static ulong ReadUInt32(byte[] data, int offset) => ((ulong)data[offset] << 24) | ((ulong)data[offset + 1] << 16) | ((ulong)data[offset + 2] << 8) | data[offset + 3];
+    private static uint ReadUInt32(byte[] data, int offset) =>
+        ((uint)data[offset] << 24) | ((uint)data[offset + 1] << 16) |
+        ((uint)data[offset + 2] << 8) | data[offset + 3];
 
     private async Task<NtpResult> QueryServer(string host, int port, InternalLogger? logger, CancellationToken token) {
         using var udp = new UdpClient();
@@ -77,11 +79,11 @@ public class NtpAnalysis : IHasAssessments {
                 return new NtpResult { Success = false };
             }
             byte stratum = resp.Buffer[1];
-            ulong sec = ReadUInt32(resp.Buffer, 40);
-            ulong frac = ReadUInt32(resp.Buffer, 44);
-            const ulong epoch = 2208988800UL;
+            uint sec = ReadUInt32(resp.Buffer, 40);
+            uint frac = ReadUInt32(resp.Buffer, 44);
+            const double epoch = 2208988800.0;
             double seconds = sec - epoch + frac / 4294967296.0;
-            var serverTime = DateTimeOffset.FromUnixTimeSeconds((long)(sec - epoch)).AddSeconds(frac / 4294967296.0);
+            var serverTime = DateTimeOffset.FromUnixTimeMilliseconds((long)(seconds * 1000));
             var offset = serverTime - DateTimeOffset.UtcNow;
             return new NtpResult { Success = true, Stratum = stratum, Offset = offset };
         } catch (Exception ex) when (ex is SocketException || ex is OperationCanceledException) {

--- a/DomainDetective/Protocols/NtpAnalysis.cs
+++ b/DomainDetective/Protocols/NtpAnalysis.cs
@@ -11,7 +11,7 @@ namespace DomainDetective;
 /// Queries NTP servers for clock information.
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
-public class NtpAnalysis {
+public class NtpAnalysis : IHasAssessments {
     /// <summary>Result of an NTP query.</summary>
     public class NtpResult {
         /// <summary>True when a valid reply was received.</summary>
@@ -26,6 +26,11 @@ public class NtpAnalysis {
     public Dictionary<string, NtpResult> ServerResults { get; } = new();
     /// <summary>Timeout for UDP operations.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(3);
+
+    /// <summary>Structured assessments from NTP probing.</summary>
+    public List<Assessment> Assessments { get; } = new();
+    /// <summary>Recommendations derived from assessments.</summary>
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
     /// <summary>Queries a single NTP server.</summary>
     public async Task AnalyzeServer(string host, int port, InternalLogger? logger, CancellationToken cancellationToken = default) {


### PR DESCRIPTION
## Summary
- add NTP narrative showing clock offset and stratum
- introduce NTP recommendation codes and mapping for positive posture
- demonstrate narrative via example and verify with unit tests

## Testing
- `dotnet build DomainDetective/DomainDetective.csproj`
- `dotnet build DomainDetective.Example/DomainDetective.Example.csproj`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter "NtpNarrative|NtpRecommendations"`


------
https://chatgpt.com/codex/tasks/task_e_68bac9955978832ea90c26c285e76268