### PR TITLE
feat(website): add composite website narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleWebsiteNarrative.cs
+++ b/DomainDetective.Example/ExampleWebsiteNarrative.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example
+{
+    public static class ExampleWebsiteNarrative
+    {
+        public static async Task Run()
+        {
+            var logger = new InternalLogger();
+            var http = new HttpAnalysis { Subject = "example.com" };
+            await http.AnalyzeUrl("https://example.com", checkHsts: true, logger, collectHeaders: true);
+            using var tls = new TlsAnalysis { Subject = "example.com" };
+            await tls.AnalyzeServer("example.com", 443, logger);
+            var sections = WebsiteNarrative.Build(http, tls);
+            Console.WriteLine(sections.Title);
+        }
+    }
+}
+

--- a/DomainDetective.Tests/TestWebsiteNarrative.cs
+++ b/DomainDetective.Tests/TestWebsiteNarrative.cs
@@ -1,0 +1,57 @@
+using System.Collections.Generic;
+using System.Security.Authentication;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestWebsiteNarrative
+    {
+        [Fact]
+        public void BuildsCompositeNarrative()
+        {
+            var http = new HttpAnalysis { Subject = "example.com" };
+            typeof(HttpAnalysis).GetProperty("StatusCode")!.SetValue(http, 200);
+            http.SecurityHeaders["Strict-Transport-Security"] = new SecurityHeader("Strict-Transport-Security", "max-age=31536000");
+            http.SecurityHeaders["Content-Security-Policy"] = new SecurityHeader("Content-Security-Policy", "default-src 'self'");
+            typeof(HttpAnalysis).GetProperty("HstsPresent")!.SetValue(http, true);
+            http.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = HttpCodes.HstsPresent, Message = "hsts" });
+            http.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = HttpCodes.CspPresent, Message = "csp" });
+
+            using var tls = new TlsAnalysis { Subject = "example.com" };
+            tls.ServerResults["www.example.com:443"] = new TlsProbe.Result
+            {
+#if NET8_0_OR_GREATER
+                Protocol = SslProtocols.Tls13,
+#else
+                Protocol = SslProtocols.Tls12,
+#endif
+                CipherSuite = "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+                CertificateValid = true,
+                HostnameMatch = true
+            };
+            tls.Assessments.Add(new Assessment { Severity = AssessmentSeverity.Info, Code = TlsCodes.StrongProtocol, Message = "tls" });
+
+            var sections = WebsiteNarrative.Build(http, tls);
+            Assert.Contains(sections.Highlights, h => h.Contains("HTTP"));
+            Assert.Contains(sections.Highlights, h => h.Contains("TLS"));
+            Assert.NotEmpty(sections.Positives);
+        }
+
+        [Fact]
+        public void ProvidesPositiveAdvice()
+        {
+            var assessments = new List<Assessment>
+            {
+                new() { Severity = AssessmentSeverity.Info, Code = HttpCodes.HstsPresent, Message = "hsts" },
+                new() { Severity = AssessmentSeverity.Info, Code = HttpCodes.CspPresent, Message = "csp" },
+                new() { Severity = AssessmentSeverity.Info, Code = TlsCodes.StrongProtocol, Message = "tls" }
+            };
+            var positives = RecommendationEngine.FromPositives(assessments);
+            Assert.Contains(positives, p => p.Code == HttpCodes.HstsPresent);
+            Assert.Contains(positives, p => p.Code == HttpCodes.CspPresent);
+            Assert.Contains(positives, p => p.Code == TlsCodes.StrongProtocol);
+        }
+    }
+}
+

--- a/DomainDetective/Diagnostics/Recommendations/WebsiteRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/WebsiteRecommendations.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations
+{
+    internal sealed class WebsiteRecommendations : IRecommendationProvider
+    {
+        public void Register(IDictionary<string, RecommendationAdvice> map)
+        {
+            if (!map.ContainsKey(HttpCodes.HstsPresent))
+            {
+                map[HttpCodes.HstsPresent] = new RecommendationAdvice
+                {
+                    Code = HttpCodes.HstsPresent,
+                    Title = "HSTS enabled",
+                    Why = "HSTS enforces HTTPS and mitigates downgrade attacks.",
+                    How = "Maintain Strict-Transport-Security with adequate max-age and includeSubDomains when ready.",
+                    Domain = RecommendationDomain.Http,
+                    Tags = new[] { "hsts" },
+                    Impact = "Improves transport security for browsers.",
+                    Effort = RecommendationEffort.Low,
+                    Verify = "Fetch a page and confirm the Strict-Transport-Security header."
+                };
+            }
+
+            if (!map.ContainsKey(HttpCodes.CspPresent))
+            {
+                map[HttpCodes.CspPresent] = new RecommendationAdvice
+                {
+                    Code = HttpCodes.CspPresent,
+                    Title = "Content Security Policy present",
+                    Why = "CSP restricts sources of executable content and reduces XSS risk.",
+                    How = "Keep a strict CSP using nonces or hashes and avoid unsafe directives.",
+                    Domain = RecommendationDomain.Http,
+                    Tags = new[] { "csp" },
+                    Impact = "Hardens client-side security.",
+                    Effort = RecommendationEffort.Medium,
+                    Verify = "Inspect responses for the Content-Security-Policy header."
+                };
+            }
+
+            if (!map.ContainsKey(TlsCodes.StrongProtocol))
+            {
+                map[TlsCodes.StrongProtocol] = new RecommendationAdvice
+                {
+                    Code = TlsCodes.StrongProtocol,
+                    Title = "Modern TLS protocol negotiated",
+                    Why = "TLS 1.2 or 1.3 provides strong, interoperable encryption.",
+                    How = "Enable TLS 1.2 and 1.3 while disabling legacy protocols.",
+                    Links = new[] { "https://datatracker.ietf.org/doc/rfc8996/" },
+                    Domain = RecommendationDomain.Tls,
+                    Tags = new[] { "tls" },
+                    Impact = "Protects data in transit with robust ciphers.",
+                    Effort = RecommendationEffort.Low,
+                    Verify = "Confirm handshake negotiates TLS 1.2 or TLS 1.3."
+                };
+            }
+        }
+    }
+}
+

--- a/DomainDetective/Narratives/WebsiteNarrative.cs
+++ b/DomainDetective/Narratives/WebsiteNarrative.cs
@@ -1,0 +1,99 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives
+{
+    public static class WebsiteNarrative
+    {
+        public sealed class Sections : NarrativeSections { }
+
+        public static Sections Build(HttpAnalysis? http, TlsAnalysis? tls)
+        {
+            var subj = http?.Subject ?? tls?.Subject;
+            subj = string.IsNullOrWhiteSpace(subj) ? "(host)" : subj!;
+            var title = $"Website Security Report — {subj}";
+            const string subtitle = "HTTPS and TLS Assessment";
+            const string category = "Web Security";
+            var keywords = $"website, https, tls, headers, DomainDetective, {subj}";
+            const string creator = "DomainDetective";
+            const string intro = "Combines HTTP headers and TLS handshake data to summarize website security.";
+            const string why = "Strong TLS and defensive headers protect visitors from interception and injection.";
+
+            var hi = new List<string>();
+            var det = new List<string>();
+            var positives = new List<string>();
+            var remediations = new List<string>();
+
+            if (http != null)
+            {
+                if (http.StatusCode.HasValue)
+                {
+                    hi.Add($"HTTP {http.StatusCode}.");
+                }
+                if (http.SecurityHeaders.Count > 0)
+                {
+                    hi.Add($"Security headers: {string.Join(", ", http.SecurityHeaders.Keys)}.");
+                }
+                if (http.MissingSecurityHeaders.Count > 0)
+                {
+                    det.Add($"Missing headers: {string.Join(", ", http.MissingSecurityHeaders)}");
+                }
+                foreach (var url in http.VisitedUrls)
+                {
+                    det.Add($"Visited {url}");
+                }
+            }
+            else
+            {
+                hi.Add("No HTTP data available.");
+            }
+
+            if (tls != null)
+            {
+                foreach (var kv in tls.ServerResults)
+                {
+                    var r = kv.Value;
+                    var cipher = string.IsNullOrWhiteSpace(r.CipherSuite) ? r.KeyExchangeAlgorithm : r.CipherSuite;
+                    var certStatus = r.CertificateValid && r.ChainValid && r.HostnameMatch ? "valid certificate" : "certificate issues";
+                    hi.Add($"{kv.Key} negotiated {r.Protocol} ({cipher}) — {certStatus}.");
+                    if (!string.IsNullOrWhiteSpace(r.CertificateSubject) || !string.IsNullOrWhiteSpace(r.CertificateIssuer))
+                    {
+                        det.Add($"{kv.Key} certificate: {r.CertificateSubject} issued by {r.CertificateIssuer}");
+                    }
+                }
+            }
+            else
+            {
+                hi.Add("No TLS data available.");
+            }
+
+            var allAssessments = new List<Assessment>();
+            if (http?.Assessments != null) allAssessments.AddRange(http.Assessments);
+            if (tls?.Assessments != null) allAssessments.AddRange(tls.Assessments);
+            AssessmentSplit.SplitTitles(allAssessments, out positives, out remediations);
+
+            var refs = new List<string>
+            {
+                "https://developer.mozilla.org/docs/Web/HTTP/Headers",
+                "https://datatracker.ietf.org/doc/rfc8446/"
+            };
+
+            return new Sections
+            {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = refs,
+                Positives = positives.Distinct().ToList(),
+                Remediations = remediations.Distinct().ToList()
+            };
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- combine HTTP and TLS findings into WebsiteNarrative
- add WebsiteRecommendations for HSTS, CSP, and modern TLS success signals
- provide example and unit tests for website narrative

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter WebsiteNarrative`


------
https://chatgpt.com/codex/tasks/task_e_68bac9928ddc832e9c921b962c1a1017