### PR TITLE
feat(apex): add apex address narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleApexAddressNarrative.cs
+++ b/DomainDetective.Example/ExampleApexAddressNarrative.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example
+{
+    public static partial class Program
+    {
+        /// <summary>
+        /// Demonstrates building a narrative from apex address analysis.
+        /// </summary>
+        public static async Task ExampleApexAddressNarrative()
+        {
+            var health = new DomainHealthCheck();
+            await health.Verify("gmail.com", new[] { HealthCheckType.APEXADDRESS });
+            var sections = ApexAddressNarrative.Build(health.ApexAddressAnalysis);
+            Helpers.ShowPropertiesTable("Apex Address Narrative", sections);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestApexAddressAdvisories.cs
+++ b/DomainDetective.Tests/TestApexAddressAdvisories.cs
@@ -1,0 +1,32 @@
+using DnsClientX;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestApexAddressAdvisories
+{
+    [Fact]
+    public async Task LogsPublicAndFcrDns()
+    {
+        var map = new Dictionary<(string, DnsRecordType), DnsAnswer[]>
+        {
+            [("example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "8.8.8.8", Type = DnsRecordType.A } },
+            [("8.8.8.8.in-addr.arpa", DnsRecordType.PTR)] = new[] { new DnsAnswer { DataRaw = "apex.example.com.", Type = DnsRecordType.PTR } },
+            [("apex.example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "8.8.8.8", Type = DnsRecordType.A } }
+        };
+        var infos = new List<LogEventArgs>();
+        var logger = new InternalLogger();
+        logger.OnInformationMessage += (_, e) => infos.Add(e);
+        var analysis = new ApexAddressAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (name, type) => Task.FromResult(map.TryGetValue((name, type), out var v) ? v : System.Array.Empty<DnsAnswer>())
+        };
+        await analysis.AnalyzeAsync("example.com", logger);
+        Assert.Contains(infos, i => i.Code == ApexAddressCodes.PubliclyRoutable);
+        Assert.Contains(infos, i => i.Code == ApexAddressCodes.FcrDnsValid);
+    }
+}

--- a/DomainDetective.Tests/TestApexAddressNarrative.cs
+++ b/DomainDetective.Tests/TestApexAddressNarrative.cs
@@ -1,0 +1,45 @@
+using DnsClientX;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestApexAddressNarrative
+{
+    [Fact]
+    public async Task BuildsNarrative()
+    {
+        var map = new Dictionary<(string, DnsRecordType), DnsAnswer[]>
+        {
+            [("example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "8.8.8.8", Type = DnsRecordType.A } },
+            [("8.8.8.8.in-addr.arpa", DnsRecordType.PTR)] = new[] { new DnsAnswer { DataRaw = "apex.example.com.", Type = DnsRecordType.PTR } },
+            [("apex.example.com", DnsRecordType.A)] = new[] { new DnsAnswer { DataRaw = "8.8.8.8", Type = DnsRecordType.A } }
+        };
+        var analysis = new ApexAddressAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (name, type) => Task.FromResult(map.TryGetValue((name, type), out var v) ? v : System.Array.Empty<DnsAnswer>())
+        };
+        await analysis.AnalyzeAsync("example.com");
+        var sections = ApexAddressNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("A records"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Reverse DNS"));
+        Assert.Contains(sections.Details, d => d.Contains("8.8.8.8"));
+    }
+
+    [Fact]
+    public void GeneratesPositiveAdvice()
+    {
+        var assessments = new List<Assessment>
+        {
+            new Assessment { Code = ApexAddressCodes.PubliclyRoutable, Severity = AssessmentSeverity.Info },
+            new Assessment { Code = ApexAddressCodes.FcrDnsValid, Severity = AssessmentSeverity.Info }
+        };
+        var positives = RecommendationEngine.FromPositives(assessments);
+        Assert.Contains(positives, p => p.Code == ApexAddressCodes.PubliclyRoutable);
+        Assert.Contains(positives, p => p.Code == ApexAddressCodes.FcrDnsValid);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/ApexAddressCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/ApexAddressCodes.cs
@@ -1,0 +1,6 @@
+namespace DomainDetective;
+
+internal static class ApexAddressCodes {
+    public const string PubliclyRoutable = "APEX.Success.PubliclyRoutable";
+    public const string FcrDnsValid = "APEX.Success.FcrDnsValid";
+}

--- a/DomainDetective/Diagnostics/Recommendations/ApexAddressRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/ApexAddressRecommendations.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class ApexAddressRecommendations : IRecommendationProvider {
+    public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[ApexAddressCodes.PubliclyRoutable] = new RecommendationAdvice {
+            Code = ApexAddressCodes.PubliclyRoutable,
+            Title = "Apex addresses are publicly routable",
+            Why = "Publicly routable A/AAAA records allow external services to reach your domain.",
+            How = "Keep apex A/AAAA records on globally reachable IP addresses.",
+            Links = new[] { "https://www.rfc-editor.org/rfc/rfc6890" },
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "dns", "apex", "ip" }
+        };
+
+        map[ApexAddressCodes.FcrDnsValid] = new RecommendationAdvice {
+            Code = ApexAddressCodes.FcrDnsValid,
+            Title = "Apex addresses have forward-confirmed reverse DNS",
+            Why = "FCrDNS improves deliverability and trust by ensuring PTR names resolve back to their IPs.",
+            How = "Publish PTR records whose hostnames contain A/AAAA records pointing back to the originating IPs.",
+            Links = new[] { "https://www.rfc-editor.org/rfc/rfc1912#section-2.1" },
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "dns", "ptr", "fcrdns" }
+        };
+    }
+}

--- a/DomainDetective/Narratives/ApexAddressNarrative.cs
+++ b/DomainDetective/Narratives/ApexAddressNarrative.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class ApexAddressNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(ApexAddressAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject;
+        var title = $"Apex Address Report — {subj}";
+        var subtitle = "Apex Address Assessment";
+        var category = "DNS Infrastructure";
+        var keywords = $"Apex address, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Apex A and AAAA records provide fallback routing when MX records are absent.";
+        var why = "Public, diverse apex addresses with valid reverse DNS improve resilience and deliverability.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        hi.Add($"A records: {analysis.IPv4Count}");
+        hi.Add($"AAAA records: {analysis.IPv6Count}");
+        hi.Add($"IPv4 subnets: {analysis.DistinctSubnetCountV4}");
+        hi.Add($"IPv6 subnets: {analysis.DistinctSubnetCountV6}");
+        hi.Add(analysis.AllFcrDnsValid
+            ? "Reverse DNS is forward-confirmed for all addresses."
+            : analysis.AnyPtrPresent ? "Some addresses have reverse DNS." : "No reverse DNS for addresses.");
+
+        foreach (var kv in analysis.PtrByIp)
+        {
+            var ptrs = kv.Value != null && kv.Value.Count > 0 ? string.Join(", ", kv.Value) : "(no PTR)";
+            det.Add($"{kv.Key} -> {ptrs}");
+        }
+
+        var refs = analysis.RfcReferences?.Select(r => r.Url).ToList() ?? new List<string>();
+
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/ApexAddressAnalysis.cs
+++ b/DomainDetective/Protocols/ApexAddressAnalysis.cs
@@ -154,6 +154,9 @@ public sealed class ApexAddressAnalysis {
                     if (isPublic) PublicAddressCount++;
                 }
             }
+            if (PublicAddressCount > 0) {
+                logger?.WriteInformationCode(ApexAddressCodes.PubliclyRoutable, "Apex addresses are publicly routable");
+            }
             return Task.CompletedTask;
         }
 
@@ -196,6 +199,9 @@ public sealed class ApexAddressAnalysis {
                 }
             }
             AllFcrDnsValid = (PtrByIp.Count > 0) && (FcrDnsValidCount == PtrByIp.Count);
+            if (AllFcrDnsValid) {
+                logger?.WriteInformationCode(ApexAddressCodes.FcrDnsValid, "Apex addresses have forward-confirmed reverse DNS");
+            }
         }
 
         private static int DistinctSubnets(IEnumerable<string> records) {


### PR DESCRIPTION
## Summary
- add narrative summarizing apex A/AAAA diversity and reverse DNS
- introduce success recommendations for publicly routable and FCrDNS-valid apex addresses
- document usage with example and tests

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj -c Release --filter ApexAddress`
- `dotnet build DomainDetective/DomainDetective.csproj -c Release -f net472`


------
https://chatgpt.com/codex/tasks/task_e_68bac98fdc00832eaa0fa84eaeb40869