### PR TITLE
feat: add SPF flattening narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleSpfFlattenedNarrative.cs
+++ b/DomainDetective.Example/ExampleSpfFlattenedNarrative.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Demonstrates building a narrative for flattened SPF results.
+    /// </summary>
+    public static async Task ExampleSpfFlattenedNarrative() {
+        var hc = new DomainHealthCheck();
+        await hc.Verify("github.com", [HealthCheckType.SPF]);
+        var narrative = SpfFlattenedNarrative.Build(hc.SpfAnalysis, hc.SpfAnalysis.Assessments);
+        Helpers.ShowPropertiesTable("SPF Flattened Narrative", narrative);
+    }
+}

--- a/DomainDetective.Tests/TestSpfFlattenedNarrative.cs
+++ b/DomainDetective.Tests/TestSpfFlattenedNarrative.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Tests;
+
+public class TestSpfFlattenedNarrative {
+    [Fact]
+    public async Task NarrativeShowsIpAndPositiveCode() {
+        var hc = new DomainHealthCheck();
+        await hc.CheckSPF("v=spf1 ip4:192.0.2.1 -all");
+        await hc.SpfAnalysis.GetFlattenedIpAnalysis("example.com", new InternalLogger());
+
+        var sections = SpfFlattenedNarrative.Build(hc.SpfAnalysis, hc.SpfAnalysis.Assessments);
+
+        Assert.Contains("Unique IPs: 1", string.Join(" ", sections.Highlights));
+        Assert.Contains("DNS lookups used: 0/10", string.Join(" ", sections.Highlights));
+
+        var positives = RecommendationEngine.FromPositives(hc.SpfAnalysis.Assessments);
+        Assert.Contains(positives, p => p.Code == SpfCodes.FlattenedIpSetOptimized);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/SpfCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SpfCodes.cs
@@ -26,4 +26,5 @@ internal static class SpfCodes {
     public const string AllEnforced = "SPF.All.Enforced";
     public const string LookupsWithinLimit = "SPF.Lookups.WithinLimit";
     public const string IncludeChainValid = "SPF.Include.ChainValid";
+    public const string FlattenedIpSetOptimized = "SPF.Flattened.IpSetOptimized";
 }

--- a/DomainDetective/Diagnostics/Recommendations/SpfFlattenedRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SpfFlattenedRecommendations.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class SpfFlattenedRecommendations : IRecommendationProvider {
+    public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[SpfCodes.FlattenedIpSetOptimized] = new RecommendationAdvice {
+            Code = SpfCodes.FlattenedIpSetOptimized,
+            Title = "Flattened SPF IP set optimized",
+            Why = "No duplicate addresses were found after flattening, producing a minimal IP set that reduces DNS lookups.",
+            How = "Regenerate flattened IPs regularly and monitor include targets so the set remains minimal.",
+            Domain = RecommendationDomain.Spf,
+            Tags = new [] { "spf", "flattening" },
+            Impact = "Keeps SPF fast to evaluate and under lookup limits.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Flatten SPF IPs again and confirm duplicates are absent."
+        };
+    }
+}

--- a/DomainDetective/Narratives/SpfFlattenedNarrative.cs
+++ b/DomainDetective/Narratives/SpfFlattenedNarrative.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class SpfFlattenedNarrative {
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(SpfAnalysis? spf, IEnumerable<Assessment>? assessments = null) {
+        var subj = string.IsNullOrWhiteSpace(spf?.Subject) ? "(domain)" : spf!.Subject!;
+        var title = $"SPF Flattened Report — {subj}";
+        var subtitle = "SPF Flattened IP Assessment";
+        var category = "Email Security";
+        var keywords = $"SPF, flattening, email, security, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Flattening expands SPF mechanisms into direct IP addresses, avoiding runtime DNS lookups.";
+        var why = "Minimizing DNS lookups keeps SPF under the 10-lookup limit and produces a deterministic policy.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (spf?.FlattenedIpAnalysis?.UniqueIps?.Count > 0) {
+            hi.Add($"Unique IPs: {spf.FlattenedIpAnalysis.UniqueIps.Count}.");
+            if (spf.FlattenedIpAnalysis.DuplicateIps.Count > 0) {
+                det.Add($"Duplicate IPs: {string.Join(", ", spf.FlattenedIpAnalysis.DuplicateIps)}");
+            } else {
+                det.Add("No duplicate IPs detected; flattened set is minimal.");
+            }
+        } else {
+            hi.Add("No IPs resolved from SPF.");
+        }
+
+        hi.Add($"DNS lookups used: {spf?.DnsLookupsCount ?? 0}/10{(spf?.ExceedsDnsLookups == true ? " (exceeds limit)" : " (within limit)")}");
+
+        var refs = new List<string> { "https://datatracker.ietf.org/doc/html/rfc7208" };
+
+        try {
+            if (assessments != null) {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        } catch { }
+
+        return new Sections {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
+        };
+    }
+}

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -973,6 +973,10 @@ namespace DomainDetective {
                 DuplicateIps = duplicates
             };
 
+            if (duplicates.Count == 0 && addresses.Count > 0) {
+                logger?.WriteInformationCode(SpfCodes.FlattenedIpSetOptimized, "Flattened SPF IP set has no duplicates");
+            }
+
             return FlattenedIpAnalysis;
         }
 


### PR DESCRIPTION
## Summary
- add success code to SPF analysis when flattened IP set has no duplicates
- narrate flattened SPF results and register recommendations
- include example and tests validating flattened SPF narrative

## Testing
- `dotnet test` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bac98c9aa8832eb56da945f6b56835