### PR TITLE
feat(threatfeed): add narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseThreatFeed.cs
+++ b/DomainDetective.Example/ExampleAnalyseThreatFeed.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using DomainDetective.Narratives;
 
 namespace DomainDetective.Example;
 
@@ -11,5 +12,8 @@ public static partial class Program {
         healthCheck.AbuseIpDbApiKey = "YOUR_API_KEY"; // replace with your key
         await healthCheck.VerifyThreatFeed("8.8.8.8");
         Helpers.ShowPropertiesTable("Threat feed for 8.8.8.8", healthCheck.ThreatFeedAnalysis);
+        var narrative = ThreatFeedNarrative.Build(healthCheck.ThreatFeedAnalysis);
+        Helpers.ShowPropertiesTable("Threat feed narrative", narrative);
+        Helpers.ShowPropertiesTable("Threat feed recommendations", healthCheck.ThreatFeedAnalysis.Recommendations);
     }
 }

--- a/DomainDetective.Tests/TestThreatFeedNarrative.cs
+++ b/DomainDetective.Tests/TestThreatFeedNarrative.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestThreatFeedNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithPositives()
+    {
+        var analysis = new ThreatFeedAnalysis
+        {
+            VirusTotalObjectOverride = _ => Task.FromResult<VirusTotalObject?>(new VirusTotalObject
+            {
+                Attributes = new VirusTotalAttributes
+                {
+                    LastAnalysisStats = new VirusTotalStats { Malicious = 0 }
+                }
+            }),
+            AbuseIpDbOverride = _ => Task.FromResult("{\"data\":{\"abuseConfidenceScore\":0}}")
+        };
+
+        await analysis.Analyze("8.8.8.8", "v", "a", new InternalLogger());
+        var sections = ThreatFeedNarrative.Build(analysis);
+        Assert.Contains(sections.Highlights, h => h.Contains("No threat feed listings"));
+        Assert.Contains(sections.Positives, p => p.Contains("No threat feed listings"));
+    }
+}

--- a/DomainDetective.Tests/TestThreatFeedRecommendations.cs
+++ b/DomainDetective.Tests/TestThreatFeedRecommendations.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestThreatFeedRecommendations
+{
+    [Fact]
+    public async Task EmitsPositiveRecommendations()
+    {
+        var analysis = new ThreatFeedAnalysis
+        {
+            VirusTotalObjectOverride = _ => Task.FromResult<VirusTotalObject?>(new VirusTotalObject
+            {
+                Attributes = new VirusTotalAttributes
+                {
+                    LastAnalysisStats = new VirusTotalStats { Malicious = 0 }
+                }
+            }),
+            AbuseIpDbOverride = _ => Task.FromResult("{\"data\":{\"abuseConfidenceScore\":0}}")
+        };
+
+        await analysis.Analyze("8.8.8.8", "v", "a", new InternalLogger());
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == ThreatFeedCodes.NoListings);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/ThreatFeedCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/ThreatFeedCodes.cs
@@ -1,0 +1,6 @@
+namespace DomainDetective;
+
+internal static class ThreatFeedCodes
+{
+    public const string NoListings = "THREATFEED.Success.NoListings";
+}

--- a/DomainDetective/Diagnostics/Recommendations/ThreatFeedRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/ThreatFeedRecommendations.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class ThreatFeedRecommendations : IRecommendationProvider
+{
+    public void Register(IDictionary<string, RecommendationAdvice> map)
+    {
+        map[ThreatFeedCodes.NoListings] = new RecommendationAdvice
+        {
+            Code = ThreatFeedCodes.NoListings,
+            Title = "No threat feed listings detected",
+            Why = "None of the checked IP reputation feeds flag the address, indicating a clean reputation.",
+            How = "Maintain good security practices and monitor feeds regularly.",
+            Domain = RecommendationDomain.ThreatIntel,
+            Tags = new[] { "reputation" }
+        };
+    }
+}

--- a/DomainDetective/Narratives/ThreatFeedNarrative.cs
+++ b/DomainDetective/Narratives/ThreatFeedNarrative.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+public static class ThreatFeedNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(ThreatFeedAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(IP)" : analysis.Subject!;
+        var title = $"Threat Feed Report — {subj}";
+        var subtitle = "Threat Feed";
+        var category = "Threat Intelligence";
+        var keywords = $"threat feed, reputation, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "External threat feeds track malicious IP reputation across services.";
+        var why = "Regular checks help detect compromised or abusive hosts early.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No threat feed data available." },
+                Details = det,
+                References = new List<string> { "https://www.virustotal.com/", "https://www.abuseipdb.com/" }
+            };
+        }
+
+        foreach (var f in analysis.Listings)
+        {
+            det.Add($"{Label(f.Source)}: {(f.IsListed ? "listed" : "not listed")}");
+            if (f.IsListed)
+            {
+                hi.Add($"{Label(f.Source)} reports malicious activity.");
+            }
+        }
+
+        if (hi.Count == 0)
+        {
+            hi.Add("No threat feed listings detected.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(analysis.FailureReason))
+        {
+            det.Add($"Failure reason: {analysis.FailureReason}");
+        }
+
+        var refs = new List<string>
+        {
+            "https://www.virustotal.com/",
+            "https://www.abuseipdb.com/"
+        };
+
+        try
+        {
+            var ass = assessments ?? analysis.Assessments;
+            if (ass != null)
+            {
+                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+            }
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static string Label(ThreatIntelSource source)
+    {
+        return source switch
+        {
+            ThreatIntelSource.VirusTotal => "VirusTotal",
+            ThreatIntelSource.AbuseIpDb => "AbuseIPDB",
+            _ => source.ToString()
+        };
+    }
+}

--- a/DomainDetective/Protocols/ThreatFeedAnalysis.cs
+++ b/DomainDetective/Protocols/ThreatFeedAnalysis.cs
@@ -117,6 +117,11 @@ public class ThreatFeedAnalysis : IHasAssessments {
 
         Listings.Add(new ThreatIntelFinding { Source = ThreatIntelSource.VirusTotal, IsListed = vtListed });
         Listings.Add(new ThreatIntelFinding { Source = ThreatIntelSource.AbuseIpDb, IsListed = abuseListed });
+
+        if (!vtListed && !abuseListed)
+        {
+            logger?.WriteInformationCode(ThreatFeedCodes.NoListings, "No threat feed providers reported malicious activity.");
+        }
     }
 
     public List<Assessment> Assessments { get; } = new();


### PR DESCRIPTION
## Summary
- add ThreatFeedNarrative for IP reputation summaries
- register ThreatFeedRecommendations with clean result success code
- expand examples and tests for narrative sections and positive recommendations

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`
- `dotnet test` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68bac9847748832eab0d0709837c04b1