### PR TITLE
feat(hpkp): add HPKP narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseHPKP.cs
+++ b/DomainDetective.Example/ExampleAnalyseHPKP.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example {
+    public static partial class Program {
+        /// <summary>
+        /// Demonstrates running HPKP analysis for a given URL.
+        /// </summary>
+        public static async Task ExampleAnalyseHPKP() {
+            var analysis = new HPKPAnalysis();
+            await analysis.AnalyzeUrl("https://www.google.com", new InternalLogger());
+            Helpers.ShowPropertiesTable("HPKP Analysis for google.com", analysis);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestHpkpNarrative.cs
+++ b/DomainDetective.Tests/TestHpkpNarrative.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    [Collection("HttpListener")]
+    public class TestHpkpNarrative {
+        [Fact]
+        public async Task BuildsNarrativeAndPositives() {
+            Skip.If(!HttpListener.IsSupported, "HttpListener not supported");
+            using var listener = new HttpListener();
+            var port = PortHelper.GetFreePort();
+            var prefix = $"http://localhost:{port}/";
+            listener.Prefixes.Add(prefix);
+            listener.Start();
+            PortHelper.ReleasePort(port);
+            var pin1 = Convert.ToBase64String(Enumerable.Repeat((byte)1, 32).ToArray());
+            var pin2 = Convert.ToBase64String(Enumerable.Repeat((byte)2, 32).ToArray());
+            var header = $"pin-sha256=\"{pin1}\"; pin-sha256=\"{pin2}\"; max-age=100; includeSubDomains";
+            var task = Task.Run(async () => {
+                var ctx = await listener.GetContextAsync();
+                ctx.Response.Headers.Add("Public-Key-Pins", header);
+                var buffer = Encoding.UTF8.GetBytes("ok");
+                await ctx.Response.OutputStream.WriteAsync(buffer, 0, buffer.Length);
+                ctx.Response.Close();
+            });
+            try {
+                var analysis = new HPKPAnalysis();
+                await analysis.AnalyzeUrl(prefix, new InternalLogger());
+                var sections = HpkpNarrative.Build(analysis);
+                Assert.Contains(sections.Highlights, h => h.Contains("header present"));
+                Assert.Contains(sections.Highlights, h => h.Contains("includeSubDomains"));
+                var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+                Assert.Contains(positives, p => p.Code == HpkpCodes.PinsValid);
+                Assert.Contains(positives, p => p.Code == HpkpCodes.IncludeSubDomains);
+            } finally {
+                listener.Stop();
+                await task;
+            }
+        }
+    }
+}

--- a/DomainDetective.Tests/TestHpkpRecommendations.cs
+++ b/DomainDetective.Tests/TestHpkpRecommendations.cs
@@ -1,0 +1,15 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestHpkpRecommendations {
+        [Fact]
+        public void RegistersPositiveCodes() {
+            var map = new Dictionary<string, RecommendationAdvice>();
+            new HpkpRecommendations().Register(map);
+            Assert.Contains(HpkpCodes.PinsValid, map.Keys);
+            Assert.Contains(HpkpCodes.IncludeSubDomains, map.Keys);
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/HpkpCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/HpkpCodes.cs
@@ -3,4 +3,6 @@ namespace DomainDetective;
 internal static class HpkpCodes {
     public const string Deprecated = "HPKP.Header.Deprecated";
     public const string CheckFailed = "HPKP.Check.Failed";
+    public const string PinsValid = "HPKP.Pins.Valid";
+    public const string IncludeSubDomains = "HPKP.IncludeSubDomains";
 }

--- a/DomainDetective/Diagnostics/Recommendations/HpkpRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/HpkpRecommendations.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations {
+    internal sealed class HpkpRecommendations : IRecommendationProvider {
+        public void Register(IDictionary<string, RecommendationAdvice> map) {
+            map[HpkpCodes.PinsValid] = new RecommendationAdvice {
+                Code = HpkpCodes.PinsValid,
+                Title = "HPKP pins are valid",
+                Why = "Valid pins indicate the header is syntactically correct, though HPKP is deprecated.",
+                How = "Consider removing HPKP entirely or ensure pins remain current.",
+                Domain = RecommendationDomain.Http,
+                Tags = new[] { "hpkp", "pins" },
+                Impact = "Confirms pin syntax but HPKP should generally be avoided.",
+                Effort = RecommendationEffort.Low,
+                Verify = "Fetch a page and confirm pins decode to 32-byte SHA-256 hashes."
+            };
+
+            map[HpkpCodes.IncludeSubDomains] = new RecommendationAdvice {
+                Code = HpkpCodes.IncludeSubDomains,
+                Title = "HPKP includeSubDomains set",
+                Why = "Extends HPKP policy to all subdomains.",
+                How = "Maintain deliberately or remove HPKP to avoid accidental outages.",
+                Domain = RecommendationDomain.Http,
+                Tags = new[] { "hpkp", "subdomains" },
+                Impact = "Pins apply to subdomains which can increase management complexity.",
+                Effort = RecommendationEffort.Low,
+                Verify = "Check Public-Key-Pins header includes includeSubDomains directive."
+            };
+        }
+    }
+}

--- a/DomainDetective/Narratives/HpkpNarrative.cs
+++ b/DomainDetective/Narratives/HpkpNarrative.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives {
+    public static class HpkpNarrative {
+        public sealed class Sections : NarrativeSections { }
+
+        public static Sections Build(HPKPAnalysis analysis) {
+            var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(host)" : analysis.Subject!;
+            var title = $"HPKP Report — {subj}";
+            var subtitle = "HPKP Assessment";
+            var category = "Web Security";
+            var keywords = $"HPKP, security, DomainDetective, {subj}";
+            var creator = "DomainDetective";
+            var intro = "HTTP Public Key Pinning (HPKP) once bound browsers to specific certificate public keys.";
+            var why = "HPKP is deprecated and misconfiguration can lock users out.";
+
+            var hi = new List<string>();
+            var det = new List<string>();
+            var positives = new List<string>();
+            var remediations = new List<string>();
+
+            if (analysis != null) {
+                if (analysis.HeaderPresent) {
+                    hi.Add("Public-Key-Pins header present.");
+                    hi.Add(analysis.PinsValid ? "Pins are valid." : "Pins are invalid.");
+                    if (analysis.IncludesSubDomains) {
+                        hi.Add("includeSubDomains directive present.");
+                    }
+                    hi.Add("HPKP is deprecated; consider removing the header.");
+                    det.Add($"max-age: {analysis.MaxAge}");
+                    if (analysis.Pins.Count > 0) {
+                        det.Add($"pins: {string.Join(", ", analysis.Pins)}");
+                    }
+                } else {
+                    hi.Add("No Public-Key-Pins header found.");
+                }
+                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            } else {
+                hi.Add("No HPKP data available.");
+            }
+
+            var refs = new List<string> {
+                "https://datatracker.ietf.org/doc/html/rfc7469",
+                "https://developer.chrome.com/blog/chrome-security-headers/#public-key-pinning-hpkp"
+            };
+
+            return new Sections {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = refs,
+                Positives = positives,
+                Remediations = remediations
+            };
+        }
+    }
+}

--- a/DomainDetective/Protocols/HPKPAnalysis.cs
+++ b/DomainDetective/Protocols/HPKPAnalysis.cs
@@ -9,7 +9,9 @@ namespace DomainDetective {
     /// Analyzes HTTP Public Key Pinning (HPKP) headers.
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
-    public class HPKPAnalysis {
+    public class HPKPAnalysis : IHasAssessments {
+        /// <summary>The analyzed URL or host.</summary>
+        public string? Subject { get; set; }
         /// <summary>Gets a value indicating whether the Public-Key-Pins header was present.</summary>
         public bool HeaderPresent { get; private set; }
         /// <summary>Gets a value indicating whether all retrieved pins were syntactically valid.</summary>
@@ -29,6 +31,12 @@ namespace DomainDetective {
         /// <see cref="PinsValid"/> to be false.
         /// </summary>
         public bool SelfSignedCertificate { get; set; }
+
+        /// <summary>Collected assessments during analysis.</summary>
+        public List<Assessment> Assessments { get; } = new();
+
+        /// <summary>Positive and negative recommendations derived from assessments.</summary>
+        public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
         private record CacheEntry(string? Header, DateTimeOffset Expires);
         private static readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.OrdinalIgnoreCase);
@@ -89,9 +97,17 @@ namespace DomainDetective {
                 }
             }
             PinsValid = valid && (SelfSignedCertificate ? Pins.Count >= 1 : Pins.Count >= 2);
+            if (PinsValid) {
+                logger?.WriteInformationCode(HpkpCodes.PinsValid, "HPKP pins are valid.");
+            }
+            if (IncludesSubDomains) {
+                logger?.WriteInformationCode(HpkpCodes.IncludeSubDomains, "HPKP includeSubDomains directive present.");
+            }
         }
 
         public async Task AnalyzeUrl(string url, InternalLogger logger) {
+            using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "HPKP", target: url);
+            Subject = url;
             HeaderPresent = false;
             PinsValid = false;
             Pins = new List<string>();
@@ -126,4 +142,5 @@ namespace DomainDetective {
                 logger?.WriteErrorCode(HpkpCodes.CheckFailed, "HPKP check failed for {0}: {1}", url, ex.Message);
             }
         }
-    }}
+    }
+}


### PR DESCRIPTION
## Summary
- add structured HPKP narrative to summarize header presence, pin validity, and deprecation
- log HPKP positives and surface as recommendations
- include example and tests for HPKP narrative and recommendation codes

## Testing
- `dotnet build DomainDetective.Example/DomainDetective.Example.csproj`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bac972bf64832e858578b24f4a13d1