### PR TITLE
feat(contact): ✨ add contact narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseContact.cs
+++ b/DomainDetective.Example/ExampleAnalyseContact.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+/// <summary>
+/// Demonstrates analysis of contact TXT records.
+/// </summary>
+public static partial class Program {
+    /// <summary>Runs the contact TXT analysis example.</summary>
+    public static async Task ExampleAnalyseContact() {
+        var healthCheck = new DomainHealthCheck();
+        healthCheck.Verbose = false;
+        await healthCheck.CheckContactInfo("email=admin@example.com; phone=12345");
+        Helpers.ShowPropertiesTable(analysisOf: "Contact record", objs: healthCheck.ContactInfoAnalysis);
+
+        await healthCheck.VerifyContactInfo("example.com");
+        Helpers.ShowPropertiesTable(analysisOf: "Contact TXT for example.com", objs: healthCheck.ContactInfoAnalysis);
+    }
+}

--- a/DomainDetective.Tests/TestContactInfoAnalysis.cs
+++ b/DomainDetective.Tests/TestContactInfoAnalysis.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System.Linq;
 
 namespace DomainDetective.Tests {
     public class TestContactInfoAnalysis {
@@ -11,6 +12,8 @@ namespace DomainDetective.Tests {
             Assert.True(healthCheck.ContactInfoAnalysis.RecordExists);
             Assert.Equal("admin@example.com", healthCheck.ContactInfoAnalysis.Fields["email"]);
             Assert.Equal("12345", healthCheck.ContactInfoAnalysis.Fields["phone"]);
+            Assert.Contains(healthCheck.ContactInfoAnalysis.Assessments, a => a.Code == ContactCodes.RecordFound);
+            Assert.Contains(healthCheck.ContactInfoAnalysis.Assessments, a => a.Code == ContactCodes.FieldsWellFormed);
         }
     }
 }

--- a/DomainDetective.Tests/TestContactNarrative.cs
+++ b/DomainDetective.Tests/TestContactNarrative.cs
@@ -1,0 +1,18 @@
+using DomainDetective.Narratives;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestContactNarrative
+{
+    [Fact]
+    public async Task BuildsNarrativeWithFields()
+    {
+        var healthCheck = new DomainHealthCheck();
+        await healthCheck.CheckContactInfo("email=admin@example.com; phone=12345");
+        var sections = ContactNarrative.Build(healthCheck.ContactInfoAnalysis, healthCheck.ContactInfoAnalysis.Assessments);
+        Assert.Contains(sections.Highlights, h => h.Contains("Contact TXT record found"));
+        Assert.Contains(sections.Details, d => d.Contains("email"));
+    }
+}

--- a/DomainDetective.Tests/TestContactRecommendations.cs
+++ b/DomainDetective.Tests/TestContactRecommendations.cs
@@ -1,0 +1,17 @@
+using DomainDetective.Recommendations;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestContactRecommendations
+{
+    [Fact]
+    public void RegistersCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new ContactRecommendations().Register(map);
+        Assert.Contains(ContactCodes.RecordFound, map.Keys);
+        Assert.Contains(ContactCodes.FieldsWellFormed, map.Keys);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/ContactCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/ContactCodes.cs
@@ -1,0 +1,6 @@
+namespace DomainDetective;
+
+internal static class ContactCodes {
+    public const string RecordFound = "CONTACT.Record.Found";
+    public const string FieldsWellFormed = "CONTACT.Fields.WellFormed";
+}

--- a/DomainDetective/Diagnostics/Recommendations/ContactRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/ContactRecommendations.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class ContactRecommendations : IRecommendationProvider {
+    public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[ContactCodes.RecordFound] = new RecommendationAdvice {
+            Code = ContactCodes.RecordFound,
+            Title = "contact record found",
+            Why = "Publishing a contact TXT record makes it easier to reach administrators.",
+            How = "Maintain a contact TXT record at contact.<domain> with up-to-date details.",
+            Domain = RecommendationDomain.Other,
+            Tags = new[] { "contact", "txt" },
+            Impact = "Improves ability to reach responsible parties.",
+            Effort = RecommendationEffort.Low,
+            Verify = "TXT record exists at contact.<domain>."
+        };
+        map[ContactCodes.FieldsWellFormed] = new RecommendationAdvice {
+            Code = ContactCodes.FieldsWellFormed,
+            Title = "contact record fields well-formed",
+            Why = "Well-formed key=value pairs allow automated parsing of contact details.",
+            How = "Publish semicolon-delimited key=value pairs such as email=admin@example.com.",
+            Domain = RecommendationDomain.Other,
+            Tags = new[] { "contact", "fields" },
+            Impact = "Consumers can parse contact details automatically.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Fields parse as key=value pairs."
+        };
+    }
+}

--- a/DomainDetective/Narratives/ContactNarrative.cs
+++ b/DomainDetective/Narratives/ContactNarrative.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+public static class ContactNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(ContactInfoAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var subj = string.IsNullOrWhiteSpace(analysis?.Subject) ? "(domain)" : analysis.Subject;
+        var title = $"Contact Record Report — {subj}";
+        var subtitle = "Contact TXT Assessment";
+        var category = "Contact Details";
+        var keywords = $"contact, txt, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Contact TXT records publish administrative contact information.";
+        var why = "Providing contact records helps external parties reach administrators.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || !analysis.RecordExists)
+        {
+            hi.Add("No contact TXT record found.");
+            return new Sections
+            {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        hi.Add("Contact TXT record found.");
+        if (analysis.Fields.Count > 0)
+        {
+            hi.Add($"Fields parsed: {analysis.Fields.Count}.");
+            det.AddRange(analysis.Fields.Select(kv => $"{kv.Key}: {kv.Value}"));
+        }
+
+        var refs = DefaultRefs();
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch (Exception)
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.rfc-editor.org/rfc/rfc2142"
+    };
+}

--- a/DomainDetective/Protocols/ContactInfoAnalysis.cs
+++ b/DomainDetective/Protocols/ContactInfoAnalysis.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace DomainDetective;
 /// The TXT record format follows draft security.txt guidelines and may include
 /// multiple fields such as contact email addresses or policy links.
 /// </remarks>
-public class ContactInfoAnalysis {
+public class ContactInfoAnalysis : IHasAssessments {
     /// <summary>Domain under analysis.</summary>
     public string? Subject { get; set; }
     /// <summary>Raw contact TXT record.</summary>
@@ -25,10 +26,15 @@ public class ContactInfoAnalysis {
     /// <summary>Parsed key-value fields from the record.</summary>
     public Dictionary<string, string> Fields { get; } = new();
 
+    /// <summary>Collected assessments for this analysis.</summary>
+    public List<Assessment> Assessments { get; } = new();
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
+
     /// <summary>
     /// Processes TXT records to extract contact information.
     /// </summary>
     public async Task AnalyzeContactRecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "CONTACT", target: Subject);
         await Task.Yield();
 
         ContactRecord = null;
@@ -47,6 +53,8 @@ public class ContactInfoAnalysis {
             return;
         }
 
+        logger?.WriteInformationCode(ContactCodes.RecordFound, "contact TXT record present");
+
         ContactRecord = string.Join(" ", recordList.Select(r => r.Data));
         logger?.WriteVerbose($"Analyzing contact TXT record {ContactRecord}");
 
@@ -55,6 +63,10 @@ public class ContactInfoAnalysis {
             if (kv.Length == 2) {
                 Fields[kv[0].Trim().ToLowerInvariant()] = kv[1].Trim();
             }
+        }
+
+        if (Fields.Count > 0) {
+            logger?.WriteInformationCode(ContactCodes.FieldsWellFormed, "contact TXT fields well-formed");
         }
     }
 }

--- a/DomainDetective/Views/Converters.Contact.cs
+++ b/DomainDetective/Views/Converters.Contact.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace DomainDetective.Views;
@@ -6,12 +7,9 @@ public static partial class Converters
 {
     public static ContactInfo Convert(ContactInfoAnalysis analysis)
     {
-        // ContactInfoAnalysis does not surface assessments; derive simple status
-        var assessments = new List<Assessment>();
-        int warn = analysis.RecordExists ? 0 : 1;
-        string status = analysis.RecordExists ? "OK" : "Warning";
-        var recs = RecommendationEngine.FromProblems(assessments);
-        var positives = RecommendationEngine.FromPositives(assessments);
+        var recs = RecommendationEngine.FromProblems(analysis.Assessments);
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Summarize(analysis.Assessments, out var warn, out var err, out var status);
         return new ContactInfo
         {
             Check = HealthCheckType.CONTACT,
@@ -20,14 +18,14 @@ public static partial class Converters
             RecordExists = analysis.RecordExists,
             ContactRecord = analysis.ContactRecord,
             Fields = analysis.Fields,
-            Assessments = assessments,
+            Assessments = analysis.Assessments,
             Status = status,
             WarningCount = warn,
-            ErrorCount = 0,
+            ErrorCount = err,
             Summary = analysis.RecordExists ? "present" : "missing",
             Recommendations = recs,
             Positives = positives,
-            References = BuildReferences(System.Array.Empty<StandardReference>(), recs),
+            References = BuildReferences(Array.Empty<StandardReference>(), recs),
             Raw = analysis
         };
     }


### PR DESCRIPTION
## Summary
- add contact TXT narrative reporting presence and parsed fields
- surface contact assessments with informational codes and recommendations
- demonstrate contact analysis in examples and tests

## Testing
- `dotnet build`
- `dotnet test` *(fails: DomainDetective.CLI.Tests.TestCliHelp.RootHelp_IncludesExamples)*

------
https://chatgpt.com/codex/tasks/task_e_68bac9767b94832e9dc33791b5f3417d