### PR TITLE
feat(headers): add message header narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseMessageHeader.cs
+++ b/DomainDetective.Example/ExampleAnalyseMessageHeader.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Example parsing raw email headers.
+    /// </summary>
+    public static Task ExampleAnalyseMessageHeader()
+    {
+        var raw = "From: sender@example.com\nTo: recipient@example.com\nSubject: Test Message\nDate: Tue, 24 Oct 2023 12:34:56 +0000\nAuthentication-Results: mx.example.net; dkim=pass; spf=pass; dmarc=pass; arc=pass";
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        Helpers.ShowPropertiesTable("Headers", analysis.Headers);
+        return Task.CompletedTask;
+    }
+}

--- a/DomainDetective.Tests/TestMessageHeaderNarrative.cs
+++ b/DomainDetective.Tests/TestMessageHeaderNarrative.cs
@@ -1,0 +1,21 @@
+using System.IO;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestMessageHeaderNarrative
+{
+    [Fact]
+    public void BuildsNarrativeAndPositives()
+    {
+        var raw = File.ReadAllText("Data/sample-headers.txt");
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        var sections = MessageHeaderNarrative.Build(analysis, analysis.Assessments);
+        Assert.Contains(sections.Highlights, h => h.Contains("sender@example.com"));
+        Assert.Contains(sections.Details, d => d.Contains("DKIM result: pass"));
+        Assert.Contains(sections.Positives, p => p.Contains("DKIM authentication passed"));
+        Assert.Contains(sections.Highlights, h => h.Contains("Total transit time"));
+    }
+}

--- a/DomainDetective.Tests/TestMessageHeaderRecommendations.cs
+++ b/DomainDetective.Tests/TestMessageHeaderRecommendations.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.IO;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestMessageHeaderRecommendations
+{
+    [Fact]
+    public void RegistersCodes()
+    {
+        var map = new Dictionary<string, RecommendationAdvice>();
+        new MessageHeaderRecommendations().Register(map);
+        Assert.Contains(MessageHeaderCodes.DkimPass, map.Keys);
+        Assert.Contains(MessageHeaderCodes.SpfPass, map.Keys);
+        Assert.Contains(MessageHeaderCodes.DmarcPass, map.Keys);
+        Assert.Contains(MessageHeaderCodes.ArcPass, map.Keys);
+    }
+
+    [Fact]
+    public void EmitsPositiveAdvice()
+    {
+        var raw = File.ReadAllText("Data/sample-headers.txt");
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        Assert.Contains(positives, p => p.Code == MessageHeaderCodes.DkimPass);
+        Assert.Contains(positives, p => p.Code == MessageHeaderCodes.SpfPass);
+        Assert.Contains(positives, p => p.Code == MessageHeaderCodes.DmarcPass);
+        Assert.Contains(positives, p => p.Code == MessageHeaderCodes.ArcPass);
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/MessageHeaderCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/MessageHeaderCodes.cs
@@ -4,5 +4,9 @@ internal static class MessageHeaderCodes {
     public const string MimeParseFailed = "HEADERS.Mime.ParseFailed";
     public const string ParseFailed = "HEADERS.Parse.Failed";
     public const string MalformedLine = "HEADERS.Line.Malformed";
+    public const string DkimPass = "HEADERS.DKIM.Pass";
+    public const string SpfPass = "HEADERS.SPF.Pass";
+    public const string DmarcPass = "HEADERS.DMARC.Pass";
+    public const string ArcPass = "HEADERS.ARC.Pass";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/MessageHeaderRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/MessageHeaderRecommendations.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class MessageHeaderRecommendations : IRecommendationProvider
+{
+    public void Register(IDictionary<string, RecommendationAdvice> map)
+    {
+        map[MessageHeaderCodes.DkimPass] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.DkimPass,
+            Title = "DKIM authentication passed",
+            Why = "A valid DKIM signature confirms the message was authorized by the sending domain.",
+            How = "Continue monitoring DKIM results and rotate keys regularly.",
+            Links = new[] { "https://datatracker.ietf.org/doc/html/rfc6376" },
+            Domain = RecommendationDomain.Dkim,
+            Tags = new[] { "dkim", "email", "authentication" }
+        };
+        map[MessageHeaderCodes.SpfPass] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.SpfPass,
+            Title = "SPF authentication passed",
+            Why = "Passing SPF verifies the sending host was permitted to send on behalf of the domain.",
+            How = "Maintain accurate SPF records for all sending services.",
+            Links = new[] { "https://datatracker.ietf.org/doc/html/rfc7208" },
+            Domain = RecommendationDomain.Spf,
+            Tags = new[] { "spf", "email", "authentication" }
+        };
+        map[MessageHeaderCodes.DmarcPass] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.DmarcPass,
+            Title = "DMARC alignment passed",
+            Why = "Successful DMARC alignment improves deliverability and protects against spoofing.",
+            How = "Monitor DMARC reports and maintain alignment of SPF and DKIM.",
+            Links = new[] { "https://datatracker.ietf.org/doc/html/rfc7489" },
+            Domain = RecommendationDomain.Dmarc,
+            Tags = new[] { "dmarc", "email", "authentication" }
+        };
+        map[MessageHeaderCodes.ArcPass] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.ArcPass,
+            Title = "ARC chain validated",
+            Why = "A valid ARC chain preserves authentication results through forwarding services.",
+            How = "Ensure intermediaries correctly sign and relay ARC headers.",
+            Links = new[] { "https://datatracker.ietf.org/doc/html/rfc8617" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "arc", "email", "authentication" }
+        };
+    }
+}

--- a/DomainDetective/Narratives/MessageHeaderNarrative.cs
+++ b/DomainDetective/Narratives/MessageHeaderNarrative.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using DomainDetective;
+
+namespace DomainDetective.Narratives;
+
+public static class MessageHeaderNarrative
+{
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(MessageHeaderAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var title = "Email Message Headers";
+        var subtitle = "Header Analysis";
+        var category = "Email";
+        var keywords = "email,headers,DomainDetective";
+        var creator = "DomainDetective";
+        var intro = "Parses raw email headers to reveal routing details and authentication results.";
+        var why = "Inspecting message headers helps verify sender authenticity and diagnose delivery delays.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || string.IsNullOrWhiteSpace(analysis.RawHeaders))
+        {
+            hi.Add("No message headers supplied.");
+            return new Sections
+            {
+                Title = title,
+                Subtitle = subtitle,
+                Category = category,
+                Keywords = keywords,
+                Creator = creator,
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = hi,
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        if (!string.IsNullOrWhiteSpace(analysis.From) && !string.IsNullOrWhiteSpace(analysis.To))
+        {
+            hi.Add($"From {analysis.From} to {analysis.To}.");
+        }
+        if (!string.IsNullOrWhiteSpace(analysis.Subject))
+        {
+            hi.Add($"Subject: {analysis.Subject}.");
+        }
+        if (analysis.TotalTransitTime.HasValue)
+        {
+            hi.Add($"Total transit time {analysis.TotalTransitTime.Value.TotalMinutes:F0} minute(s).");
+        }
+
+        if (!string.IsNullOrWhiteSpace(analysis.DkimResult))
+        {
+            det.Add($"DKIM result: {analysis.DkimResult}.");
+        }
+        if (!string.IsNullOrWhiteSpace(analysis.SpfResult))
+        {
+            det.Add($"SPF result: {analysis.SpfResult}.");
+        }
+        if (!string.IsNullOrWhiteSpace(analysis.DmarcResult))
+        {
+            det.Add($"DMARC result: {analysis.DmarcResult}.");
+        }
+        if (!string.IsNullOrWhiteSpace(analysis.ArcResult))
+        {
+            det.Add($"ARC result: {analysis.ArcResult}.");
+        }
+
+        if (analysis.ReceivedHops.Count > 0)
+        {
+            det.Add($"Received hops: {analysis.ReceivedHops.Count}.");
+            foreach (var hop in analysis.ReceivedHops)
+            {
+                var line = $"{hop.FromHost} → {hop.ByHost}";
+                if (hop.HopDelay.HasValue)
+                {
+                    line += $" in {hop.HopDelay.Value.TotalMinutes:F0} minute(s)";
+                }
+                det.Add(line + ".");
+            }
+        }
+
+        try
+        {
+            if (assessments != null)
+            {
+                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+            }
+        }
+        catch
+        {
+        }
+
+        return new Sections
+        {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = DefaultRefs(),
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.rfc-editor.org/rfc/rfc5322",
+        "https://www.rfc-editor.org/rfc/rfc7601"
+    };
+}

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -11,7 +11,7 @@ namespace DomainDetective {
     /// Represents the results from parsing message headers.
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
-    public class MessageHeaderAnalysis {
+    public class MessageHeaderAnalysis : IHasAssessments {
         /// <summary>Raw headers supplied for parsing.</summary>
         public string? RawHeaders { get; private set; }
         /// <summary>All parsed headers keyed by header name.</summary>
@@ -50,18 +50,23 @@ namespace DomainDetective {
         /// <summary>Collection of detected issues.</summary>
         public List<MessageHeaderIssue> Issues { get; } = new();
 
+        public List<Assessment> Assessments { get; } = new();
+        public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
+
         /// <summary>
         /// Parses <paramref name="rawHeaders"/> into strongly typed properties.
         /// </summary>
         /// <param name="rawHeaders">Unparsed header text.</param>
         /// <param name="logger">Logger used for diagnostics.</param>
         public void Parse(string rawHeaders, InternalLogger? logger = null) {
+            using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "HEADERS") : null;
             RawHeaders = rawHeaders;
             Headers.Clear();
             DuplicateHeaders.Clear();
             ReceivedHops.Clear();
             SpamHeaders.Clear();
             Issues.Clear();
+            Assessments.Clear();
             TotalTransitTime = null;
             MaxHopDelay = null;
             MinHopDelay = null;
@@ -105,6 +110,20 @@ namespace DomainDetective {
             } catch (Exception ex) {
                 logger?.WriteErrorCode(MessageHeaderCodes.ParseFailed, "Failed to parse message headers: {0}", ex.Message);
             }
+
+            if (string.Equals(DkimResult, "pass", StringComparison.OrdinalIgnoreCase)) {
+                logger?.WriteInformationCode(MessageHeaderCodes.DkimPass, "DKIM authentication passed");
+            }
+            if (string.Equals(SpfResult, "pass", StringComparison.OrdinalIgnoreCase)) {
+                logger?.WriteInformationCode(MessageHeaderCodes.SpfPass, "SPF authentication passed");
+            }
+            if (string.Equals(DmarcResult, "pass", StringComparison.OrdinalIgnoreCase)) {
+                logger?.WriteInformationCode(MessageHeaderCodes.DmarcPass, "DMARC authentication passed");
+            }
+            if (string.Equals(ArcResult, "pass", StringComparison.OrdinalIgnoreCase)) {
+                logger?.WriteInformationCode(MessageHeaderCodes.ArcPass, "ARC authentication passed");
+            }
+
             DetermineIssues();
         }
 


### PR DESCRIPTION
## Summary
- add codes for DKIM/SPF/DMARC/ARC pass results
- parse message headers into a new narrative highlighting auth results and transit times
- provide positive recommendations and example usage

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bac979f6fc832e8267ac90b53e128e