### PR TITLE
feat: add port availability narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExamplePortAvailability.cs
+++ b/DomainDetective.Example/ExamplePortAvailability.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program
+{
+    /// <summary>
+    /// Demonstrates checking connectivity to common service ports.
+    /// </summary>
+    public static async Task ExamplePortAvailability()
+    {
+        var analysis = new PortAvailabilityAnalysis { Timeout = TimeSpan.FromSeconds(1) };
+        var logger = new InternalLogger();
+        await analysis.AnalyzeServers(new[] { "example.com" }, new[] { 80, 443 }, logger);
+        Helpers.ShowPropertiesTable("Port Availability", analysis.ServerResults);
+    }
+}

--- a/DomainDetective.Example/ExamplePortAvailabilityNarrative.cs
+++ b/DomainDetective.Example/ExamplePortAvailabilityNarrative.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static class ExamplePortAvailabilityNarrative
+{
+    public static async Task Run(string host, IEnumerable<int> ports)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new ArgumentException("Host is required.", nameof(host));
+        }
+
+        if (ports == null)
+        {
+            throw new ArgumentNullException(nameof(ports));
+        }
+
+        var valid = ports.Where(p => p > 0 && p <= 65535).Distinct().ToArray();
+        if (valid.Length == 0)
+        {
+            throw new ArgumentException("No valid ports specified.", nameof(ports));
+        }
+
+        var analysis = new PortAvailabilityAnalysis();
+        var logger = new InternalLogger();
+        await analysis.AnalyzeServers(new[] { host }, valid, logger);
+        var sections = PortAvailabilityNarrative.Build(analysis);
+        Console.WriteLine(sections.Title);
+    }
+}

--- a/DomainDetective.Tests/TestPortAvailabilityNarrative.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityNarrative.cs
@@ -1,0 +1,20 @@
+using System;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestPortAvailabilityNarrative
+    {
+        [Fact]
+        public void NarrativeSummarizesPorts()
+        {
+            var analysis = new PortAvailabilityAnalysis();
+            analysis.ServerResults["host:25"] = new PortAvailabilityAnalysis.PortResult { Success = true, Latency = TimeSpan.FromMilliseconds(5) };
+            analysis.ServerResults["host:80"] = new PortAvailabilityAnalysis.PortResult { Success = false, Latency = TimeSpan.FromMilliseconds(5) };
+            var sections = PortAvailabilityNarrative.Build(analysis);
+            Assert.Contains("host:25 reachable", sections.Highlights);
+            Assert.Contains("host:80 unreachable", sections.Details);
+        }
+    }
+}

--- a/DomainDetective.Tests/TestPortAvailabilityRecommendations.cs
+++ b/DomainDetective.Tests/TestPortAvailabilityRecommendations.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests
+{
+    public class TestPortAvailabilityRecommendations
+    {
+        [Fact]
+        public void RegistersSuccessCode()
+        {
+            var map = new Dictionary<string, RecommendationAdvice>();
+            new PortAvailabilityRecommendations().Register(map);
+            Assert.Contains(PortAvailabilityCodes.HttpResponding, map.Keys);
+        }
+
+        [Fact]
+        public async Task EmitsPositiveAdvice()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            PortAvailabilityAnalysis.ExpectedPorts[port] = (PortAvailabilityCodes.HttpResponding, "HTTP");
+            var acceptTask = listener.AcceptTcpClientAsync();
+            try
+            {
+                var analysis = new PortAvailabilityAnalysis();
+                var logger = new InternalLogger();
+                await analysis.AnalyzeServer("127.0.0.1", port, logger);
+                var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+                Assert.Contains(positives, p => p.Code == PortAvailabilityCodes.HttpResponding);
+                using var c = await acceptTask;
+            }
+            finally
+            {
+                listener.Stop();
+                PortAvailabilityAnalysis.ExpectedPorts.Remove(port);
+            }
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/PortAvailabilityCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/PortAvailabilityCodes.cs
@@ -1,0 +1,10 @@
+namespace DomainDetective;
+
+internal static class PortAvailabilityCodes
+{
+    public const string SmtpResponding = "PORTAVAIL.SMTP.Responding";
+    public const string HttpResponding = "PORTAVAIL.HTTP.Responding";
+    public const string HttpsResponding = "PORTAVAIL.HTTPS.Responding";
+    public const string SmtpsResponding = "PORTAVAIL.SMTPS.Responding";
+    public const string SubmissionResponding = "PORTAVAIL.SUBMISSION.Responding";
+}

--- a/DomainDetective/Diagnostics/Recommendations/PortAvailabilityRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/PortAvailabilityRecommendations.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class PortAvailabilityRecommendations : IRecommendationProvider
+{
+    public void Register(IDictionary<string, RecommendationAdvice> map)
+    {
+        map[PortAvailabilityCodes.HttpResponding] = new RecommendationAdvice
+        {
+            Code = PortAvailabilityCodes.HttpResponding,
+            Title = "HTTP service responded",
+            Why = "Expected HTTP service is reachable on port 80.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "http", "availability" },
+            Impact = "Confirms web service availability.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Fetch http://host/ to confirm response."
+        };
+
+        map[PortAvailabilityCodes.HttpsResponding] = new RecommendationAdvice
+        {
+            Code = PortAvailabilityCodes.HttpsResponding,
+            Title = "HTTPS service responded",
+            Why = "Expected HTTPS service is reachable on port 443.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "https", "availability" },
+            Impact = "Confirms secure web service availability.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Fetch https://host/ to confirm response."
+        };
+
+        map[PortAvailabilityCodes.SmtpResponding] = new RecommendationAdvice
+        {
+            Code = PortAvailabilityCodes.SmtpResponding,
+            Title = "SMTP service responded",
+            Why = "Expected SMTP service is reachable on port 25.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "smtp", "availability" },
+            Impact = "Confirms mail server connectivity.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Connect using telnet host 25 to confirm response."
+        };
+
+        map[PortAvailabilityCodes.SmtpsResponding] = new RecommendationAdvice
+        {
+            Code = PortAvailabilityCodes.SmtpsResponding,
+            Title = "SMTPS service responded",
+            Why = "Expected SMTPS service is reachable on port 465.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "smtps", "availability" },
+            Impact = "Confirms secure mail submission service.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Connect using openssl s_client -connect host:465."
+        };
+
+        map[PortAvailabilityCodes.SubmissionResponding] = new RecommendationAdvice
+        {
+            Code = PortAvailabilityCodes.SubmissionResponding,
+            Title = "Submission service responded",
+            Why = "Expected SMTP submission service is reachable on port 587.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "submission", "availability" },
+            Impact = "Confirms authenticated mail submission service.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Connect using telnet host 587 to confirm response."
+        };
+    }
+}

--- a/DomainDetective/Narratives/PortAvailabilityNarrative.cs
+++ b/DomainDetective/Narratives/PortAvailabilityNarrative.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Narratives;
+
+/// <summary>
+/// Generates narrative sections summarizing port availability results.
+/// </summary>
+public static class PortAvailabilityNarrative
+{
+    /// <summary>
+    /// Container for generated narrative sections.
+    /// </summary>
+    public sealed class Sections : NarrativeSections { }
+
+    /// <summary>
+    /// Builds narrative sections from a <see cref="PortAvailabilityAnalysis"/>.
+    /// </summary>
+    /// <param name="analysis">The port availability analysis to summarize.</param>
+    /// <param name="assessments">Optional assessments to include.</param>
+    /// <returns>The narrative sections describing the analysis.</returns>
+    public static Sections Build(PortAvailabilityAnalysis analysis, IEnumerable<Assessment>? assessments = null)
+    {
+        var intro = "Port availability checks verify that expected services accept connections.";
+        var why = "Ensuring required ports respond confirms service uptime and firewall configuration.";
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        if (analysis == null || analysis.ServerResults.Count == 0)
+        {
+            return new Sections
+            {
+                Introduction = intro,
+                WhyItMatters = why,
+                Highlights = new List<string> { "No port availability data." },
+                Details = det,
+                References = DefaultRefs()
+            };
+        }
+
+        var sorted = analysis.ServerResults.OrderBy(kv => kv.Key).ToList();
+        foreach (var kv in sorted)
+        {
+            var res = kv.Value;
+            var status = res.Success ? "reachable" : "unreachable";
+            det.Add($"{kv.Key} {status}");
+            if (res.Success)
+            {
+                hi.Add($"{kv.Key} reachable");
+            }
+        }
+
+        if (hi.Count == 0)
+        {
+            hi.Add("No ports were reachable.");
+        }
+
+        try
+        {
+            var ass = assessments ?? analysis.Assessments;
+            if (ass != null)
+            {
+                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+            }
+        }
+        catch { }
+
+        return new Sections
+        {
+            Title = "Port Availability Check",
+            Subtitle = "Port Availability Assessment",
+            Category = "Network Availability",
+            Keywords = "Port availability, services, DomainDetective",
+            Creator = "DomainDetective",
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = DefaultRefs(),
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+
+    private static List<string> DefaultRefs() => new()
+    {
+        "https://www.rfc-editor.org/rfc/rfc793"
+    };
+}

--- a/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
+++ b/DomainDetective/Protocols/PortAvailabilityAnalysis.cs
@@ -11,7 +11,7 @@ namespace DomainDetective;
 ///     Attempts TCP connections to common service ports and records latency.
 /// </summary>
 /// <para>Part of the DomainDetective project.</para>
-public class PortAvailabilityAnalysis
+public class PortAvailabilityAnalysis : IHasAssessments
 {
     /// <summary>Represents the result of a single port check.</summary>
     /// <para>Part of the DomainDetective project.</para>
@@ -23,16 +23,32 @@ public class PortAvailabilityAnalysis
         public TimeSpan Latency { get; init; }
     }
 
+    /// <summary>Structured assessments captured during checks.</summary>
+    public List<Assessment> Assessments { get; } = new();
+    /// <summary>Recommendations derived from <see cref="Assessments"/>.</summary>
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
+
     /// <summary>Results for each host and port.</summary>
     public Dictionary<string, PortResult> ServerResults { get; } = new();
     /// <summary>Maximum time to wait for a connection.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
     internal Func<TcpClient> TcpClientFactory { get; set; } = static () => new TcpClient();
 
+    internal static Dictionary<int, (string Code, string Name)> ExpectedPorts { get; } = new()
+    {
+        [25] = (PortAvailabilityCodes.SmtpResponding, "SMTP"),
+        [80] = (PortAvailabilityCodes.HttpResponding, "HTTP"),
+        [443] = (PortAvailabilityCodes.HttpsResponding, "HTTPS"),
+        [465] = (PortAvailabilityCodes.SmtpsResponding, "SMTPS"),
+        [587] = (PortAvailabilityCodes.SubmissionResponding, "SUBMISSION")
+    };
+
     /// <summary>Checks a single host and port.</summary>
     public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
     {
         ServerResults.Clear();
+        Assessments.Clear();
+        using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "PORTAVAIL", target: $"{host}:{port}");
         ServerResults[$"{host}:{port}"] = await CheckPort(host, port, logger, cancellationToken);
     }
 
@@ -40,6 +56,8 @@ public class PortAvailabilityAnalysis
     public async Task AnalyzeServers(IEnumerable<string> hosts, IEnumerable<int> ports, InternalLogger logger, CancellationToken cancellationToken = default)
     {
         ServerResults.Clear();
+        Assessments.Clear();
+        using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "PORTAVAIL");
         foreach (var host in hosts)
         {
             foreach (var port in ports)
@@ -66,6 +84,10 @@ public class PortAvailabilityAnalysis
         await client.ConnectAsync(host, port).WaitWithCancellation(cts.Token);
 #endif
         sw.Stop();
+        if (ExpectedPorts.TryGetValue(port, out var svc))
+        {
+            logger?.WriteInformationCode(svc.Code, "{0} responded on {1}:{2}", svc.Name, host, port);
+        }
         return new PortResult { Success = true, Latency = sw.Elapsed };
         }
         catch (Exception ex) when (ex is SocketException || ex is OperationCanceledException)


### PR DESCRIPTION
## Summary
- add narrative summarizing reachable and unreachable ports
- provide port availability success codes with recommendations
- demonstrate port availability usage and narrative with examples and tests

## Testing
- `dotnet build DomainDetective.sln`
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter PortAvailability`

------
https://chatgpt.com/codex/tasks/task_e_68bac97d08e0832ea42a36a209037905