### PR TITLE
feat(mail): add mail latency narrative and recommendations

### DIFF
--- a/DomainDetective.Example/ExampleAnalyseMailLatency.cs
+++ b/DomainDetective.Example/ExampleAnalyseMailLatency.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Example analyzing mail latency for a server.
+    /// </summary>
+    public static async Task ExampleAnalyseMailLatency() {
+        var analysis = new MailLatencyAnalysis();
+        await analysis.AnalyzeServer("smtp.gmail.com", 25, new InternalLogger());
+        if (analysis.ServerResults.TryGetValue("smtp.gmail.com:25", out var result)) {
+            Helpers.ShowPropertiesTable("Mail Latency", result);
+        }
+    }
+}

--- a/DomainDetective.Example/ExampleMailLatencyNarrative.cs
+++ b/DomainDetective.Example/ExampleMailLatencyNarrative.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+
+namespace DomainDetective.Example;
+
+public static partial class Program {
+    /// <summary>
+    /// Demonstrates building a narrative from mail latency analysis.
+    /// </summary>
+    public static async Task ExampleMailLatencyNarrative() {
+        var health = new DomainHealthCheck();
+        await health.CheckMailLatency("smtp.gmail.com");
+        var sections = MailLatencyNarrative.Build(health.MailLatencyAnalysis);
+        Helpers.ShowPropertiesTable("Mail Latency Narrative", sections);
+    }
+}

--- a/DomainDetective.Tests/TestMailLatencyNarrative.cs
+++ b/DomainDetective.Tests/TestMailLatencyNarrative.cs
@@ -1,0 +1,38 @@
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using DomainDetective.Narratives;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestMailLatencyNarrative {
+        [Fact]
+        public async Task BuildIncludesTimesAndPositives() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var accept = listener.AcceptTcpClientAsync();
+            var server = accept.ContinueWith(async t => {
+                using var client = await t;
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream);
+                using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 test");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            }).Unwrap();
+            try {
+                var analysis = new MailLatencyAnalysis { Timeout = System.TimeSpan.FromSeconds(5) };
+                var logger = new InternalLogger();
+                await analysis.AnalyzeServer("127.0.0.1", port, logger);
+                var sections = MailLatencyNarrative.Build(analysis);
+                Assert.Contains(sections.Highlights, h => h.Contains("connect") && h.Contains("banner"));
+                Assert.NotEmpty(sections.Positives);
+                await server;
+            } finally {
+                listener.Stop();
+            }
+        }
+    }
+}

--- a/DomainDetective.Tests/TestMailLatencyRecommendations.cs
+++ b/DomainDetective.Tests/TestMailLatencyRecommendations.cs
@@ -1,0 +1,47 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using DomainDetective.Recommendations;
+using Xunit;
+
+namespace DomainDetective.Tests {
+    public class TestMailLatencyRecommendations {
+        [Fact]
+        public void RegistersCodes() {
+            var map = new Dictionary<string, RecommendationAdvice>();
+            new MailLatencyRecommendations().Register(map);
+            Assert.Contains(MailLatencyCodes.ConnectFast, map.Keys);
+            Assert.Contains(MailLatencyCodes.BannerFast, map.Keys);
+        }
+
+        [Fact]
+        public async Task EmitsPositiveAdvice() {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var accept = listener.AcceptTcpClientAsync();
+            var server = accept.ContinueWith(async t => {
+                using var client = await t;
+                using var stream = client.GetStream();
+                using var reader = new StreamReader(stream);
+                using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 test");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            }).Unwrap();
+            try {
+                var analysis = new MailLatencyAnalysis { Timeout = System.TimeSpan.FromSeconds(5) };
+                var logger = new InternalLogger();
+                await analysis.AnalyzeServer("127.0.0.1", port, logger);
+                var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+                Assert.Contains(positives, p => p.Code == MailLatencyCodes.ConnectFast);
+                Assert.Contains(positives, p => p.Code == MailLatencyCodes.BannerFast);
+                await server;
+            } finally {
+                listener.Stop();
+            }
+        }
+    }
+}

--- a/DomainDetective/Diagnostics/Codes/MailLatencyCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/MailLatencyCodes.cs
@@ -1,0 +1,6 @@
+namespace DomainDetective;
+
+internal static class MailLatencyCodes {
+    public const string ConnectFast = "MAILLATENCY.Connect.Fast";
+    public const string BannerFast = "MAILLATENCY.Banner.Fast";
+}

--- a/DomainDetective/Diagnostics/Recommendations/MailLatencyRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/MailLatencyRecommendations.cs
@@ -1,0 +1,31 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Recommendations;
+
+internal sealed class MailLatencyRecommendations : IRecommendationProvider {
+    public void Register(IDictionary<string, RecommendationAdvice> map) {
+        map[MailLatencyCodes.ConnectFast] = new RecommendationAdvice {
+            Code = MailLatencyCodes.ConnectFast,
+            Title = "SMTP connection latency within threshold",
+            Why = "Quick server responses improve mail flow and diagnostics.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "smtp", "latency" },
+            Impact = "Indicates responsive mail server.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Measure connection latency periodically."
+        };
+
+        map[MailLatencyCodes.BannerFast] = new RecommendationAdvice {
+            Code = MailLatencyCodes.BannerFast,
+            Title = "SMTP banner latency within threshold",
+            Why = "Prompt banner delivery confirms responsive SMTP software.",
+            How = "No action required.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "smtp", "latency" },
+            Impact = "Shows minimal post-connect delay.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Measure banner latency periodically."
+        };
+    }
+}

--- a/DomainDetective/Narratives/MailLatencyNarrative.cs
+++ b/DomainDetective/Narratives/MailLatencyNarrative.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective.Narratives;
+
+public static class MailLatencyNarrative {
+    public sealed class Sections : NarrativeSections { }
+
+    public static Sections Build(MailLatencyAnalysis analysis) {
+        var subj = "(servers)";
+        if (analysis?.ServerResults != null && analysis.ServerResults.Count == 1) {
+            foreach (var key in analysis.ServerResults.Keys) { subj = key; break; }
+        }
+        var title = $"Mail Latency Report — {subj}";
+        var subtitle = "SMTP Latency Assessment";
+        var category = "Email Performance";
+        var keywords = $"mail latency, smtp, DomainDetective, {subj}";
+        var creator = "DomainDetective";
+        var intro = "Mail latency measures time to connect to SMTP servers and receive their greeting banner.";
+        var why = "Responsive servers improve mail delivery speed and troubleshooting.";
+
+        var hi = new List<string>();
+        var det = new List<string>();
+        var positives = new List<string>();
+        var remediations = new List<string>();
+
+        var results = analysis?.ServerResults ?? new Dictionary<string, MailLatencyAnalysis.LatencyResult>();
+        if (results.Count == 0) {
+            hi.Add("No mail latency data available.");
+        } else {
+            foreach (var kv in results) {
+                var r = kv.Value;
+                var connect = r.ConnectSuccess ? $"{(int)r.ConnectTime.TotalMilliseconds} ms" : "failed";
+                var banner = r.BannerSuccess ? $"{(int)r.BannerTime.TotalMilliseconds} ms" : "failed";
+                var line = $"{kv.Key} connect {connect}; banner {banner}";
+                hi.Add(line);
+                det.Add(line);
+            }
+        }
+
+        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+
+        var refs = new List<string> {
+            "https://www.rfc-editor.org/rfc/rfc5321"
+        };
+
+        return new Sections {
+            Title = title,
+            Subtitle = subtitle,
+            Category = category,
+            Keywords = keywords,
+            Creator = creator,
+            Introduction = intro,
+            WhyItMatters = why,
+            Highlights = hi,
+            Details = det,
+            References = refs,
+            Positives = positives,
+            Remediations = remediations
+        };
+    }
+}

--- a/DomainDetective/Protocols/MailLatencyAnalysis.cs
+++ b/DomainDetective/Protocols/MailLatencyAnalysis.cs
@@ -6,12 +6,13 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace DomainDetective {
-    /// <summary>
-    /// Measures connection and banner retrieval latencies of SMTP servers.
-    /// </summary>
-    /// <para>Part of the DomainDetective project.</para>
-    public class MailLatencyAnalysis {
+namespace DomainDetective;
+
+/// <summary>
+/// Measures connection and banner retrieval latencies of SMTP servers.
+/// </summary>
+/// <para>Part of the DomainDetective project.</para>
+public class MailLatencyAnalysis : IHasAssessments {
         /// <summary>Results of a latency check.</summary>
         public class LatencyResult {
             /// <summary>True when the connection succeeded.</summary>
@@ -24,69 +25,83 @@ namespace DomainDetective {
             public TimeSpan BannerTime { get; init; }
         }
 
-        /// <summary>Results for each server.</summary>
-        public Dictionary<string, LatencyResult> ServerResults { get; } = new();
-        /// <summary>Maximum wait time for connection and banner.</summary>
-        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+    /// <summary>Structured assessments captured during checks.</summary>
+    public List<Assessment> Assessments { get; } = new();
+    /// <summary>Recommendations derived from <see cref="Assessments"/>.</summary>
+    public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
+    /// <summary>Results for each server.</summary>
+    public Dictionary<string, LatencyResult> ServerResults { get; } = new();
+    /// <summary>Maximum wait time for connection and banner.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
 
-        /// <summary>Checks a single host.</summary>
-        public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
-            ServerResults.Clear();
+    /// <summary>Checks a single host.</summary>
+    public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+        ServerResults.Clear();
+        Assessments.Clear();
+        using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "MAILLATENCY", target: $"{host}:{port}");
+        ServerResults[$"{host}:{port}"] = await MeasureLatency(host, port, logger, cancellationToken);
+    }
+
+    /// <summary>Checks multiple hosts on the same port.</summary>
+    public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+        ServerResults.Clear();
+        Assessments.Clear();
+        using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "MAILLATENCY");
+        foreach (var host in hosts) {
+            cancellationToken.ThrowIfCancellationRequested();
             ServerResults[$"{host}:{port}"] = await MeasureLatency(host, port, logger, cancellationToken);
         }
+    }
 
-        /// <summary>Checks multiple hosts on the same port.</summary>
-        public async Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
-            ServerResults.Clear();
-            foreach (var host in hosts) {
-                cancellationToken.ThrowIfCancellationRequested();
-                ServerResults[$"{host}:{port}"] = await MeasureLatency(host, port, logger, cancellationToken);
-            }
-        }
-
-        private async Task<LatencyResult> MeasureLatency(string host, int port, InternalLogger logger, CancellationToken token) {
-            using var client = new TcpClient();
-            using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
-            cts.CancelAfter(Timeout);
-            var sw = Stopwatch.StartNew();
-            TimeSpan connectElapsed = TimeSpan.Zero;
-            try {
+    private async Task<LatencyResult> MeasureLatency(string host, int port, InternalLogger logger, CancellationToken token) {
+        using var client = new TcpClient();
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+        cts.CancelAfter(Timeout);
+        var sw = Stopwatch.StartNew();
+        TimeSpan connectElapsed = TimeSpan.Zero;
+        try {
 #if NET6_0_OR_GREATER
-                await client.ConnectAsync(host, port, cts.Token);
+            await client.ConnectAsync(host, port, cts.Token);
 #else
-                await client.ConnectAsync(host, port).WaitWithCancellation(cts.Token);
+            await client.ConnectAsync(host, port).WaitWithCancellation(cts.Token);
 #endif
-                connectElapsed = sw.Elapsed;
-                var bannerStart = sw.Elapsed;
-                using NetworkStream network = client.GetStream();
-                using var reader = new StreamReader(network);
-                using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
-#if NET8_0_OR_GREATER
-                var banner = await reader.ReadLineAsync(cts.Token);
-#else
-                var banner = await reader.ReadLineAsync().WaitWithCancellation(cts.Token);
-#endif
-                var bannerElapsed = sw.Elapsed;
-                try {
-                    await writer.WriteLineAsync("QUIT").WaitWithCancellation(cts.Token);
-                    await writer.FlushAsync().WaitWithCancellation(cts.Token);
-                    await reader.ReadLineAsync().WaitWithCancellation(cts.Token);
-                } catch (IOException) { }
-                return new LatencyResult {
-                    ConnectSuccess = true,
-                    BannerSuccess = banner != null,
-                    ConnectTime = connectElapsed,
-                    BannerTime = bannerElapsed - bannerStart
-                };
-            } catch (Exception ex) when (ex is SocketException || ex is IOException || ex is OperationCanceledException || ex is TaskCanceledException) {
-                logger?.WriteVerbose("Mail latency check failed for {0}:{1} - {2}", host, port, ex.Message);
-                return new LatencyResult {
-                    ConnectSuccess = client.Connected,
-                    BannerSuccess = false,
-                    ConnectTime = connectElapsed == TimeSpan.Zero ? sw.Elapsed : connectElapsed,
-                    BannerTime = TimeSpan.Zero
-                };
+            connectElapsed = sw.Elapsed;
+            if (connectElapsed < TimeSpan.FromSeconds(1)) {
+                logger?.WriteInformationCode(MailLatencyCodes.ConnectFast, "Connection to {0}:{1} in {2} ms", host, port, (int)connectElapsed.TotalMilliseconds);
             }
+            var bannerStart = sw.Elapsed;
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network);
+            using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
+#if NET8_0_OR_GREATER
+            var banner = await reader.ReadLineAsync(cts.Token);
+#else
+            var banner = await reader.ReadLineAsync().WaitWithCancellation(cts.Token);
+#endif
+            var bannerElapsed = sw.Elapsed;
+            var bannerTime = bannerElapsed - bannerStart;
+            if (banner != null && bannerTime < TimeSpan.FromSeconds(1)) {
+                logger?.WriteInformationCode(MailLatencyCodes.BannerFast, "Banner on {0}:{1} in {2} ms", host, port, (int)bannerTime.TotalMilliseconds);
+            }
+            try {
+                await writer.WriteLineAsync("QUIT").WaitWithCancellation(cts.Token);
+                await writer.FlushAsync().WaitWithCancellation(cts.Token);
+                await reader.ReadLineAsync().WaitWithCancellation(cts.Token);
+            } catch (IOException) { }
+            return new LatencyResult {
+                ConnectSuccess = true,
+                BannerSuccess = banner != null,
+                ConnectTime = connectElapsed,
+                BannerTime = bannerTime
+            };
+        } catch (Exception ex) when (ex is SocketException || ex is IOException || ex is OperationCanceledException || ex is TaskCanceledException) {
+            logger?.WriteVerbose("Mail latency check failed for {0}:{1} - {2}", host, port, ex.Message);
+            return new LatencyResult {
+                ConnectSuccess = client.Connected,
+                BannerSuccess = false,
+                ConnectTime = connectElapsed == TimeSpan.Zero ? sw.Elapsed : connectElapsed,
+                BannerTime = TimeSpan.Zero
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- add MailLatency narrative with connection and banner timing highlights
- log positive assessments for fast SMTP connect and banner times
- provide recommendations and examples for acceptable mail latency

## Testing
- `dotnet test --filter MailLatency`

------
https://chatgpt.com/codex/tasks/task_e_68bb31f54014832eab02db8d187619c6