### PR TITLE
feat(narratives): add negatives support

### DIFF
--- a/DomainDetective.Reports.Html/Sections/SpfHtmlSectionWriter.cs
+++ b/DomainDetective.Reports.Html/Sections/SpfHtmlSectionWriter.cs
@@ -30,6 +30,13 @@ public static class SpfHtmlSectionWriter
                 html.AddList(spf.Highlights);
             }
 
+            var negatives = spf.Narrative?.Negatives ?? new System.Collections.Generic.List<string>();
+            if (negatives.Count > 0)
+            {
+                html.AddHeading("Negatives", 3);
+                html.AddList(negatives);
+            }
+
             // Good posture (positives)
             var positives = spf.Positives?
                 .Select(p => p?.Title)

--- a/DomainDetective.Reports.Office/Sections/SpfWordSectionWriter.cs
+++ b/DomainDetective.Reports.Office/Sections/SpfWordSectionWriter.cs
@@ -26,22 +26,19 @@ public static class SpfWordSectionWriter
         if (headings == null) throw new ArgumentNullException(nameof(headings));
         if (spf == null) throw new ArgumentNullException(nameof(spf));
 
+        var nar = spf.Narrative;
         // Narrative-backed sections
-        if (includeNarrative)
+        if (includeNarrative && nar != null)
         {
-            var nar = spf.Narrative;
-            if (nar != null)
+            if (!string.IsNullOrWhiteSpace(nar.Introduction))
             {
-                if (!string.IsNullOrWhiteSpace(nar.Introduction))
-                {
-                    headings.AddItem("Introduction", baseLevel);
-                    doc.AddParagraph(nar.Introduction);
-                }
-                if (!string.IsNullOrWhiteSpace(nar.WhyItMatters))
-                {
-                    headings.AddItem("Why this matters", baseLevel);
-                    doc.AddParagraph(nar.WhyItMatters);
-                }
+                headings.AddItem("Introduction", baseLevel);
+                doc.AddParagraph(nar.Introduction);
+            }
+            if (!string.IsNullOrWhiteSpace(nar.WhyItMatters))
+            {
+                headings.AddItem("Why this matters", baseLevel);
+                doc.AddParagraph(nar.WhyItMatters);
             }
         }
 
@@ -67,6 +64,15 @@ public static class SpfWordSectionWriter
             doc.AddParagraph("Notable observations:");
             var list = doc.AddList(WordListStyle.Bulleted);
             foreach (var h in spf.Highlights) list.AddItem(h);
+        }
+
+        // Negatives from narrative
+        if (nar?.Negatives != null && nar.Negatives.Count > 0)
+        {
+            headings.AddItem("Negatives", baseLevel);
+            doc.AddParagraph("Areas needing improvement:");
+            var nlist = doc.AddList(WordListStyle.Bulleted);
+            foreach (var n in nar.Negatives) nlist.AddItem(n);
         }
 
         // Good posture (positives)

--- a/DomainDetective.Tests/TestCertificateHttpNarrative.cs
+++ b/DomainDetective.Tests/TestCertificateHttpNarrative.cs
@@ -87,6 +87,7 @@ public class TestCertificateHttpNarrative {
         var sections = CertificateHttpNarrative.Build(analysis, analysis.Assessments);
         Assert.Equal(200, analysis.Assessments.Count);
         Assert.Single(sections.Positives);
+        Assert.Single(sections.Negatives);
         Assert.Single(sections.Remediations);
     }
 }

--- a/DomainDetective/Diagnostics/AssessmentSplit.cs
+++ b/DomainDetective/Diagnostics/AssessmentSplit.cs
@@ -7,22 +7,38 @@ namespace DomainDetective;
 public static class AssessmentSplit
 {
     /// <summary>
-    /// Splits assessments into positive posture titles (Info) and remediation titles (Warning/Error), grouped by code.
+    /// Splits assessments into positives (Info) and negatives (Warning/Error) titles, grouped by code.
+    /// Negatives are also added to the remediation list for backward compatibility.
     /// </summary>
-    public static void SplitTitles(IEnumerable<Assessment> assessments, out List<string> positives, out List<string> remediations)
+    public static void SplitTitles(
+        IEnumerable<Assessment> assessments,
+        out List<string> positives,
+        out List<string> negatives,
+        out List<string> remediations)
     {
         positives = new List<string>();
+        negatives = new List<string>();
         remediations = new List<string>();
         if (assessments == null) return;
         var grouped = RecommendationEngine.GroupByCode(assessments);
         foreach (var g in grouped)
         {
             var adviceTitle = g.Advice?.Title;
-            var title = string.IsNullOrWhiteSpace(adviceTitle) ? (g.Instances.FirstOrDefault()?.Message ?? g.Code ?? string.Empty) : adviceTitle;
-            if (g.MaxSeverity == AssessmentSeverity.Info) positives.Add(title ?? string.Empty);
-            else remediations.Add(title ?? string.Empty);
+            var title = string.IsNullOrWhiteSpace(adviceTitle)
+                ? (g.Instances.FirstOrDefault()?.Message ?? g.Code ?? string.Empty)
+                : adviceTitle;
+            if (g.MaxSeverity == AssessmentSeverity.Info)
+            {
+                positives.Add(title ?? string.Empty);
+            }
+            else
+            {
+                negatives.Add(title ?? string.Empty);
+                remediations.Add(title ?? string.Empty);
+            }
         }
         positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
     }
 }

--- a/DomainDetective/Narratives/ApexAddressNarrative.cs
+++ b/DomainDetective/Narratives/ApexAddressNarrative.cs
@@ -22,6 +22,7 @@ public static class ApexAddressNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add($"A records: {analysis.IPv4Count}");
@@ -44,7 +45,7 @@ public static class ApexAddressNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch
@@ -64,6 +65,7 @@ public static class ApexAddressNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/ArcNarrative.cs
+++ b/DomainDetective/Narratives/ArcNarrative.cs
@@ -21,6 +21,7 @@ public static class ArcNarrative
         var highlights = new List<string>();
         var details = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         highlights.Add(arc.ArcHeadersFound ? "ARC headers present." : "No ARC headers present.");
@@ -52,7 +53,7 @@ public static class ArcNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(arc.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(arc.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch (Exception)
         {
@@ -72,6 +73,7 @@ public static class ArcNarrative
             Details = details,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/AutodiscoverNarrative.cs
+++ b/DomainDetective/Narratives/AutodiscoverNarrative.cs
@@ -22,6 +22,7 @@ public static class AutodiscoverNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -78,7 +79,7 @@ public static class AutodiscoverNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -96,6 +97,7 @@ public static class AutodiscoverNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/BimiNarrative.cs
+++ b/DomainDetective/Narratives/BimiNarrative.cs
@@ -27,6 +27,7 @@ public static class BimiNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add(bimi.BimiRecordExists
@@ -80,6 +81,7 @@ public static class BimiNarrative
                 }
                 else
                 {
+                    negatives.Add(msg);
                     remediations.Add(msg);
                 }
             }
@@ -103,6 +105,7 @@ public static class BimiNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/CaaNarrative.cs
+++ b/DomainDetective/Narratives/CaaNarrative.cs
@@ -23,6 +23,7 @@ public static class CaaNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add(caa.AnalysisResults.Count > 0 ? "CAA record is published." : "No CAA record is published.");
@@ -43,7 +44,7 @@ public static class CaaNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(caa.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(caa.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch (Exception ex)
         {
@@ -64,6 +65,7 @@ public static class CaaNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/CertificateHttpNarrative.cs
+++ b/DomainDetective/Narratives/CertificateHttpNarrative.cs
@@ -30,6 +30,7 @@ public static class CertificateHttpNarrative {
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add(analysis.IsReachable
@@ -48,7 +49,7 @@ public static class CertificateHttpNarrative {
 
         try {
             if (assessments != null) {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         } catch (Exception ex) {
             System.Diagnostics.Debug.WriteLine(ex);
@@ -66,6 +67,7 @@ public static class CertificateHttpNarrative {
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/CnameNarrative.cs
+++ b/DomainDetective/Narratives/CnameNarrative.cs
@@ -21,6 +21,7 @@ public static class CnameNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -51,7 +52,7 @@ public static class CnameNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch (Exception ex)
@@ -73,6 +74,7 @@ public static class CnameNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/ContactNarrative.cs
+++ b/DomainDetective/Narratives/ContactNarrative.cs
@@ -22,6 +22,7 @@ public static class ContactNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || !analysis.RecordExists)
@@ -54,7 +55,7 @@ public static class ContactNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch (Exception)
@@ -74,6 +75,7 @@ public static class ContactNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DaneNarrative.cs
+++ b/DomainDetective/Narratives/DaneNarrative.cs
@@ -25,6 +25,7 @@ public static class DaneNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (dane == null || dane.NumberOfRecords == 0)
@@ -51,7 +52,7 @@ public static class DaneNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch (ArgumentException ex)
@@ -76,6 +77,7 @@ public static class DaneNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DirectoryExposureNarrative.cs
+++ b/DomainDetective/Narratives/DirectoryExposureNarrative.cs
@@ -38,6 +38,7 @@ public static class DirectoryExposureNarrative
         };
 
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
         try
         {
@@ -53,6 +54,7 @@ public static class DirectoryExposureNarrative
                 }
                 else
                 {
+                    negatives.Add(msg);
                     remediations.Add(msg);
                 }
             }
@@ -72,6 +74,7 @@ public static class DirectoryExposureNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/DkimNarrative.cs
+++ b/DomainDetective/Narratives/DkimNarrative.cs
@@ -24,6 +24,7 @@ public static class DkimNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         // Highlights
@@ -108,7 +109,7 @@ public static class DkimNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -126,6 +127,7 @@ public static class DkimNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DmarcNarrative.cs
+++ b/DomainDetective/Narratives/DmarcNarrative.cs
@@ -23,6 +23,7 @@ public static class DmarcNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         // Highlights
@@ -96,7 +97,7 @@ public static class DmarcNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(dmarc.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(dmarc.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch { }
 
@@ -113,6 +114,7 @@ public static class DmarcNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DnsHealthNarrative.cs
+++ b/DomainDetective/Narratives/DnsHealthNarrative.cs
@@ -22,6 +22,7 @@ public static class DnsHealthNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis != null)
@@ -49,7 +50,7 @@ public static class DnsHealthNarrative
                 det.Add($"Apex answers from {kv.Key}: {string.Join(", ", kv.Value)}");
             }
 
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         else
         {
@@ -75,6 +76,7 @@ public static class DnsHealthNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DnsTunnelingNarrative.cs
+++ b/DomainDetective/Narratives/DnsTunnelingNarrative.cs
@@ -22,6 +22,7 @@ public static class DnsTunnelingNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -58,7 +59,7 @@ public static class DnsTunnelingNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch (Exception ex)
@@ -81,6 +82,7 @@ public static class DnsTunnelingNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DnsblNarrative.cs
+++ b/DomainDetective/Narratives/DnsblNarrative.cs
@@ -23,6 +23,7 @@ public static class DnsblNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -55,7 +56,7 @@ public static class DnsblNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -73,6 +74,7 @@ public static class DnsblNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/DnssecNarrative.cs
+++ b/DomainDetective/Narratives/DnssecNarrative.cs
@@ -25,6 +25,7 @@ public static class DnssecNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -83,7 +84,7 @@ public static class DnssecNarrative
         try
         {
             var assess = assessments ?? analysis.Assessments;
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
         catch
         {
@@ -102,6 +103,7 @@ public static class DnssecNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/EdnsNarrative.cs
+++ b/DomainDetective/Narratives/EdnsNarrative.cs
@@ -22,6 +22,7 @@ public static class EdnsNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || analysis.ServerSupport.Count == 0)
@@ -76,7 +77,7 @@ public static class EdnsNarrative
         try
         {
             var assess = assessments ?? analysis.Assessments;
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
         catch
         {
@@ -95,6 +96,7 @@ public static class EdnsNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/FlatteningServiceNarrative.cs
+++ b/DomainDetective/Narratives/FlatteningServiceNarrative.cs
@@ -21,6 +21,7 @@ public static class FlatteningServiceNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -52,7 +53,7 @@ public static class FlatteningServiceNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch (Exception ex)
@@ -73,6 +74,7 @@ public static class FlatteningServiceNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/HpkpNarrative.cs
+++ b/DomainDetective/Narratives/HpkpNarrative.cs
@@ -17,6 +17,7 @@ namespace DomainDetective.Narratives {
             var hi = new List<string>();
             var det = new List<string>();
             var positives = new List<string>();
+        var negatives = new List<string>();
             var remediations = new List<string>();
 
             if (analysis != null) {
@@ -34,7 +35,7 @@ namespace DomainDetective.Narratives {
                 } else {
                     hi.Add("No Public-Key-Pins header found.");
                 }
-                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
             } else {
                 hi.Add("No HPKP data available.");
             }
@@ -56,7 +57,8 @@ namespace DomainDetective.Narratives {
                 Details = det,
                 References = refs,
                 Positives = positives,
-                Remediations = remediations
+                Negatives = negatives,
+            Remediations = remediations
             };
         }
     }

--- a/DomainDetective/Narratives/HttpNarrative.cs
+++ b/DomainDetective/Narratives/HttpNarrative.cs
@@ -21,6 +21,7 @@ public static class HttpNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis != null)
@@ -50,7 +51,7 @@ public static class HttpNarrative
                 det.Add($"Visited {url}");
             }
 
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         else
         {
@@ -76,6 +77,7 @@ public static class HttpNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct().ToList(),
+            Negatives = negatives,
             Remediations = remediations.Distinct().ToList()
         };
     }

--- a/DomainDetective/Narratives/IpNeighborNarrative.cs
+++ b/DomainDetective/Narratives/IpNeighborNarrative.cs
@@ -22,6 +22,7 @@ namespace DomainDetective.Narratives
             var hi = new List<string>();
             var det = new List<string>();
             var positives = new List<string>();
+        var negatives = new List<string>();
             var remediations = new List<string>();
 
             foreach (var r in analysis?.Results ?? new List<IPNeighborResult>())
@@ -43,7 +44,7 @@ namespace DomainDetective.Narratives
 
             try
             {
-                AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+                AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
             }
             catch
             {
@@ -62,7 +63,8 @@ namespace DomainDetective.Narratives
                 Details = det,
                 References = refs,
                 Positives = positives,
-                Remediations = remediations
+                Negatives = negatives,
+            Remediations = remediations
             };
         }
     }

--- a/DomainDetective/Narratives/MailClassificationNarrative.cs
+++ b/DomainDetective/Narratives/MailClassificationNarrative.cs
@@ -22,6 +22,7 @@ public static class MailClassificationNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add($"Classification: {result.Classification}");
@@ -47,9 +48,14 @@ public static class MailClassificationNarrative
                     ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
                     : g.Advice.Title;
                 if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
                     positives.Add(msg);
+                }
                 else
+                {
+                    negatives.Add(msg);
                     remediations.Add(msg);
+                }
             }
         }
         catch { }
@@ -67,6 +73,7 @@ public static class MailClassificationNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/MailLatencyNarrative.cs
+++ b/DomainDetective/Narratives/MailLatencyNarrative.cs
@@ -22,6 +22,7 @@ public static class MailLatencyNarrative {
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         var results = analysis?.ServerResults ?? new Dictionary<string, MailLatencyAnalysis.LatencyResult>();
@@ -38,7 +39,7 @@ public static class MailLatencyNarrative {
             }
         }
 
-        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
 
         var refs = new List<string> {
             "https://www.rfc-editor.org/rfc/rfc5321"
@@ -56,6 +57,7 @@ public static class MailLatencyNarrative {
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/MailTlsNarrative.cs
+++ b/DomainDetective/Narratives/MailTlsNarrative.cs
@@ -29,6 +29,7 @@ namespace DomainDetective.Narratives
             var hi = new List<string>();
             var det = new List<string>();
             var positives = new List<string>();
+        var negatives = new List<string>();
             var remediations = new List<string>();
 
             if (analysis != null)
@@ -41,7 +42,7 @@ namespace DomainDetective.Narratives
                     hi.Add($"{kv.Key} negotiated {r.Protocol} ({cipher}) — {certStatus}.");
                     det.Add($"{kv.Key} expires in {r.DaysToExpire} days");
                 }
-                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
             }
             else
             {
@@ -67,7 +68,8 @@ namespace DomainDetective.Narratives
                 Details = det,
                 References = refs,
                 Positives = positives.Distinct().ToList(),
-                Remediations = remediations.Distinct().ToList()
+                Negatives = negatives,
+            Remediations = remediations.Distinct().ToList()
             };
         }
     }

--- a/DomainDetective/Narratives/MessageHeaderNarrative.cs
+++ b/DomainDetective/Narratives/MessageHeaderNarrative.cs
@@ -21,6 +21,7 @@ public static class MessageHeaderNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || string.IsNullOrWhiteSpace(analysis.RawHeaders))
@@ -89,7 +90,7 @@ public static class MessageHeaderNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch
@@ -109,6 +110,7 @@ public static class MessageHeaderNarrative
             Details = det,
             References = DefaultRefs(),
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/MtaStsNarrative.cs
+++ b/DomainDetective/Narratives/MtaStsNarrative.cs
@@ -31,6 +31,7 @@ public static class MtaStsNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -79,7 +80,7 @@ public static class MtaStsNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch (Exception ex)
@@ -100,6 +101,7 @@ public static class MtaStsNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/MxNarrative.cs
+++ b/DomainDetective/Narratives/MxNarrative.cs
@@ -23,6 +23,7 @@ public static class MxNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add($"MX records: {mx.MxRecords?.Count ?? 0}");
@@ -62,9 +63,14 @@ public static class MxNarrative
                     ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
                     : g.Advice.Title;
                 if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
                     positives.Add(msg);
+                }
                 else
+                {
+                    negatives.Add(msg);
                     remediations.Add(msg);
+                }
             }
         }
         catch { }
@@ -82,6 +88,7 @@ public static class MxNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/NSNarrative.cs
+++ b/DomainDetective/Narratives/NSNarrative.cs
@@ -23,6 +23,7 @@ public static class NSNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         // Highlights
@@ -84,9 +85,14 @@ public static class NSNarrative
                     ? (g.Instances.FirstOrDefault()?.Message ?? g.Code)
                     : g.Advice.Title;
                 if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
                     positives.Add(msg);
+                }
                 else
+                {
+                    negatives.Add(msg);
                     remediations.Add(msg);
+                }
             }
         }
         catch { }
@@ -104,6 +110,7 @@ public static class NSNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/NarrativeSections.cs
+++ b/DomainDetective/Narratives/NarrativeSections.cs
@@ -38,6 +38,9 @@ public class NarrativeSections
     /// <summary>Gets the list of positive notes.</summary>
     public List<string> Positives { get; init; } = new();
 
+    /// <summary>Gets the list of negative notes.</summary>
+    public List<string> Negatives { get; init; } = new();
+
     /// <summary>Gets the list of remediation steps.</summary>
     public List<string> Remediations { get; init; } = new();
 }

--- a/DomainDetective/Narratives/NtpNarrative.cs
+++ b/DomainDetective/Narratives/NtpNarrative.cs
@@ -18,6 +18,7 @@ public static class NtpNarrative {
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         var results = analysis?.ServerResults ?? new Dictionary<string, NtpAnalysis.NtpResult>();
@@ -36,7 +37,7 @@ public static class NtpNarrative {
             }
         }
 
-        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
 
         var refs = new List<string> {
             "https://datatracker.ietf.org/doc/html/rfc5905"
@@ -54,6 +55,7 @@ public static class NtpNarrative {
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/OpenRelayNarrative.cs
+++ b/DomainDetective/Narratives/OpenRelayNarrative.cs
@@ -22,6 +22,7 @@ public static class OpenRelayNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         var results = analysis?.ServerResults ?? new Dictionary<string, OpenRelayAnalysis.OpenRelayResult>();
@@ -54,7 +55,7 @@ public static class OpenRelayNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch (Exception ex)
         {
@@ -74,6 +75,7 @@ public static class OpenRelayNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/OpenResolverNarrative.cs
+++ b/DomainDetective/Narratives/OpenResolverNarrative.cs
@@ -23,6 +23,7 @@ public static class OpenResolverNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         var details = analysis?.ServerDetails ?? new Dictionary<string, OpenResolverResult>();
@@ -55,7 +56,7 @@ public static class OpenResolverNarrative
         try
         {
             var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
         catch
         {
@@ -74,6 +75,7 @@ public static class OpenResolverNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/PortAvailabilityNarrative.cs
+++ b/DomainDetective/Narratives/PortAvailabilityNarrative.cs
@@ -26,6 +26,7 @@ public static class PortAvailabilityNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || analysis.ServerResults.Count == 0)
@@ -62,7 +63,7 @@ public static class PortAvailabilityNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -80,6 +81,7 @@ public static class PortAvailabilityNarrative
             Details = det,
             References = DefaultRefs(),
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/PortScanNarrative.cs
+++ b/DomainDetective/Narratives/PortScanNarrative.cs
@@ -33,6 +33,7 @@ public static class PortScanNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || analysis.Results.Count == 0)
@@ -79,7 +80,7 @@ public static class PortScanNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -97,6 +98,7 @@ public static class PortScanNarrative
             Details = det,
             References = DefaultRefs(),
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/RdapNarrative.cs
+++ b/DomainDetective/Narratives/RdapNarrative.cs
@@ -21,6 +21,7 @@ public static class RdapNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (!string.IsNullOrWhiteSpace(rdap.CreationDate))
@@ -43,7 +44,7 @@ public static class RdapNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(rdap.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(rdap.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch (Exception)
         {
@@ -63,6 +64,7 @@ public static class RdapNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/ReverseDnsNarrative.cs
+++ b/DomainDetective/Narratives/ReverseDnsNarrative.cs
@@ -22,6 +22,7 @@ public static class ReverseDnsNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         var total = rdns?.Results?.Count ?? 0;
@@ -58,6 +59,7 @@ public static class ReverseDnsNarrative
                 }
                 else
                 {
+                    negatives.Add(msg);
                     remediations.Add(msg);
                 }
             }
@@ -80,6 +82,7 @@ public static class ReverseDnsNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/RobotsTxtNarrative.cs
+++ b/DomainDetective/Narratives/RobotsTxtNarrative.cs
@@ -23,6 +23,7 @@ public static class RobotsTxtNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || !analysis.RecordPresent)
@@ -73,7 +74,7 @@ public static class RobotsTxtNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch (Exception ex)
@@ -94,6 +95,7 @@ public static class RobotsTxtNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/RpkiNarrative.cs
+++ b/DomainDetective/Narratives/RpkiNarrative.cs
@@ -21,6 +21,7 @@ public static class RpkiNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || analysis.Results.Count == 0)
@@ -36,7 +37,7 @@ public static class RpkiNarrative
                 det.Add($"IP {r.IpAddress} prefix {r.Prefix} ASN {r.Asn} valid={r.Valid}");
             }
             var assess = assessments ?? analysis.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
 
         var refs = new List<string>
@@ -58,6 +59,7 @@ public static class RpkiNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/SecurityTxtNarrative.cs
+++ b/DomainDetective/Narratives/SecurityTxtNarrative.cs
@@ -19,6 +19,7 @@ namespace DomainDetective.Narratives {
             var hi = new List<string>();
             var det = new List<string>();
             var positives = new List<string>();
+        var negatives = new List<string>();
             var remediations = new List<string>();
 
             var contacts = analysis.ContactEmail.Concat(analysis.ContactWebsite).ToList();
@@ -49,7 +50,7 @@ namespace DomainDetective.Narratives {
             var refs = new List<string> { "https://securitytxt.org/" };
 
             try {
-                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
             } catch { }
 
             return new Sections {
@@ -64,6 +65,7 @@ namespace DomainDetective.Narratives {
                 Details = det,
                 References = refs,
                 Positives = positives,
+                Negatives = negatives,
                 Remediations = remediations
             };
         }

--- a/DomainDetective/Narratives/SmimeaNarrative.cs
+++ b/DomainDetective/Narratives/SmimeaNarrative.cs
@@ -45,14 +45,16 @@ public static class SmimeaNarrative
         var refs = new List<string> { "https://www.rfc-editor.org/rfc/rfc8162" };
 
         List<string> positives;
+        List<string> negatives;
         List<string> remediations;
         try
         {
-            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch (Exception)
         {
             positives = new List<string>();
+            negatives = new List<string>();
             remediations = new List<string>();
         }
 
@@ -69,6 +71,7 @@ public static class SmimeaNarrative
             Details = details,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/SmtpAuthNarrative.cs
+++ b/DomainDetective/Narratives/SmtpAuthNarrative.cs
@@ -22,6 +22,7 @@ public static class SmtpAuthNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || analysis.ServerMechanisms.Count == 0)
@@ -39,7 +40,7 @@ public static class SmtpAuthNarrative
                     hi.Add(caps.Contains("STARTTLS", StringComparer.OrdinalIgnoreCase) ? $"{kv.Key} advertises STARTTLS." : $"{kv.Key} does not advertise STARTTLS.");
                 }
             }
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
 
         var refs = new List<string>
@@ -61,6 +62,7 @@ public static class SmtpAuthNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/SmtpBannerNarrative.cs
+++ b/DomainDetective/Narratives/SmtpBannerNarrative.cs
@@ -22,6 +22,7 @@ public static class SmtpBannerNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null || analysis.ServerResults.Count == 0)
@@ -53,7 +54,7 @@ public static class SmtpBannerNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -71,6 +72,7 @@ public static class SmtpBannerNarrative
             Details = det,
             References = DefaultRefs(),
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/SnmpNarrative.cs
+++ b/DomainDetective/Narratives/SnmpNarrative.cs
@@ -21,6 +21,7 @@ public static class SnmpNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         foreach (var kv in analysis?.ServerResults ?? new Dictionary<string, bool>())
@@ -38,7 +39,7 @@ public static class SnmpNarrative
         try
         {
             var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
         catch
         {
@@ -57,6 +58,7 @@ public static class SnmpNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/SoaNarrative.cs
+++ b/DomainDetective/Narratives/SoaNarrative.cs
@@ -22,6 +22,7 @@ namespace DomainDetective.Narratives
             var hi = new List<string>();
             var det = new List<string>();
             var positives = new List<string>();
+        var negatives = new List<string>();
             var remediations = new List<string>();
 
             if (soa?.RecordExists == true)
@@ -74,6 +75,7 @@ namespace DomainDetective.Narratives
                     }
                     else
                     {
+                        negatives.Add(msg);
                         remediations.Add(msg);
                     }
                 }
@@ -95,6 +97,7 @@ namespace DomainDetective.Narratives
                 Details = det,
                 References = refs,
                 Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+                Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
                 Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
             };
         }

--- a/DomainDetective/Narratives/SpfFlattenedNarrative.cs
+++ b/DomainDetective/Narratives/SpfFlattenedNarrative.cs
@@ -20,6 +20,7 @@ public static class SpfFlattenedNarrative {
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (spf?.FlattenedIpAnalysis?.UniqueIps?.Count > 0) {
@@ -39,7 +40,7 @@ public static class SpfFlattenedNarrative {
 
         try {
             if (assessments != null) {
-                AssessmentSplit.SplitTitles(assessments, out positives, out remediations);
+                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
             }
         } catch { }
 
@@ -55,6 +56,7 @@ public static class SpfFlattenedNarrative {
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives,
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/SpfNarrative.cs
+++ b/DomainDetective/Narratives/SpfNarrative.cs
@@ -23,6 +23,7 @@ public static class SpfNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         // High-level highlights
@@ -67,9 +68,14 @@ public static class SpfNarrative
             {
                 var msg = string.IsNullOrWhiteSpace(g.Advice?.Title) ? (g.Instances.FirstOrDefault()?.Message ?? g.Code) : g.Advice.Title;
                 if (g.MaxSeverity == AssessmentSeverity.Info)
+                {
                     positives.Add(msg);
+                }
                 else
+                {
+                    negatives.Add(msg);
                     remediations.Add(msg);
+                }
             }
         }
         catch { }
@@ -87,6 +93,7 @@ public static class SpfNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/StartTlsNarrative.cs
+++ b/DomainDetective/Narratives/StartTlsNarrative.cs
@@ -22,6 +22,7 @@ public static class StartTlsNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis != null && analysis.ServerDetails.Count > 0)
@@ -42,7 +43,7 @@ public static class StartTlsNarrative
                 hi.Add($"{kv.Key} [{proto}] {status} and {upgrade}{downgrade}.");
                 det.Add($"{kv.Key} downgrade detected: {r.DowngradeDetected}");
             }
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         else
         {
@@ -69,6 +70,7 @@ public static class StartTlsNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct().ToList(),
+            Negatives = negatives,
             Remediations = remediations.Distinct().ToList()
         };
     }

--- a/DomainDetective/Narratives/ThreatFeedNarrative.cs
+++ b/DomainDetective/Narratives/ThreatFeedNarrative.cs
@@ -21,6 +21,7 @@ public static class ThreatFeedNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -65,7 +66,7 @@ public static class ThreatFeedNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch
@@ -85,6 +86,7 @@ public static class ThreatFeedNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/ThreatIntelNarrative.cs
+++ b/DomainDetective/Narratives/ThreatIntelNarrative.cs
@@ -20,6 +20,7 @@ public static class ThreatIntelNarrative {
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (ti?.Listings != null) {
@@ -55,7 +56,7 @@ public static class ThreatIntelNarrative {
         };
 
         try {
-            AssessmentSplit.SplitTitles(ti?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(ti?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         } catch {
         }
 
@@ -71,6 +72,7 @@ public static class ThreatIntelNarrative {
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/TlsNarrative.cs
+++ b/DomainDetective/Narratives/TlsNarrative.cs
@@ -21,6 +21,7 @@ public static class TlsNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis != null)
@@ -36,7 +37,7 @@ public static class TlsNarrative
                     det.Add($"{kv.Key} certificate: {r.CertificateSubject} issued by {r.CertificateIssuer}");
                 }
             }
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         else
         {
@@ -62,6 +63,7 @@ public static class TlsNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct().ToList(),
+            Negatives = negatives,
             Remediations = remediations.Distinct().ToList()
         };
     }

--- a/DomainDetective/Narratives/TlsRptNarrative.cs
+++ b/DomainDetective/Narratives/TlsRptNarrative.cs
@@ -22,6 +22,7 @@ public static class TlsRptNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         hi.Add(analysis.TlsRptRecordExists ? "TLS-RPT record is published." : "No TLS-RPT record is published.");
@@ -59,7 +60,7 @@ public static class TlsRptNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out remediations);
+            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
         }
         catch (Exception ex)
         {
@@ -81,6 +82,7 @@ public static class TlsRptNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/TtlNarrative.cs
+++ b/DomainDetective/Narratives/TtlNarrative.cs
@@ -23,6 +23,7 @@ public static class TtlNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -104,7 +105,7 @@ public static class TtlNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out remediations);
+                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
             }
         }
         catch { }
@@ -122,6 +123,7 @@ public static class TtlNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/TyposquattingNarrative.cs
+++ b/DomainDetective/Narratives/TyposquattingNarrative.cs
@@ -46,6 +46,7 @@ public static class TyposquattingNarrative
         };
 
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
         try
         {
@@ -61,6 +62,7 @@ public static class TyposquattingNarrative
                 }
                 else
                 {
+                    negatives.Add(msg);
                     remediations.Add(msg);
                 }
             }
@@ -80,6 +82,7 @@ public static class TyposquattingNarrative
             Details = det,
             References = refs,
             Positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
+            Negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList(),
             Remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
         };
     }

--- a/DomainDetective/Narratives/WebsiteNarrative.cs
+++ b/DomainDetective/Narratives/WebsiteNarrative.cs
@@ -22,6 +22,7 @@ namespace DomainDetective.Narratives
             var hi = new List<string>();
             var det = new List<string>();
             var positives = new List<string>();
+        var negatives = new List<string>();
             var remediations = new List<string>();
 
             if (http != null)
@@ -70,7 +71,7 @@ namespace DomainDetective.Narratives
             var allAssessments = new List<Assessment>();
             if (http?.Assessments != null) allAssessments.AddRange(http.Assessments);
             if (tls?.Assessments != null) allAssessments.AddRange(tls.Assessments);
-            AssessmentSplit.SplitTitles(allAssessments, out positives, out remediations);
+            AssessmentSplit.SplitTitles(allAssessments, out positives, out negatives, out remediations);
 
             var refs = new List<string>
             {
@@ -91,7 +92,8 @@ namespace DomainDetective.Narratives
                 Details = det,
                 References = refs,
                 Positives = positives.Distinct().ToList(),
-                Remediations = remediations.Distinct().ToList()
+                Negatives = negatives,
+            Remediations = remediations.Distinct().ToList()
             };
         }
     }

--- a/DomainDetective/Narratives/WhoisNarrative.cs
+++ b/DomainDetective/Narratives/WhoisNarrative.cs
@@ -22,6 +22,7 @@ public static class WhoisNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (!string.IsNullOrWhiteSpace(whois?.RegisteredTo))
@@ -68,7 +69,7 @@ public static class WhoisNarrative
             "https://datatracker.ietf.org/doc/html/rfc3912"
         };
 
-        AssessmentSplit.SplitTitles(whois?.Assessments ?? new List<Assessment>(), out positives, out remediations);
+        AssessmentSplit.SplitTitles(whois?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
 
         return new Sections
         {
@@ -83,6 +84,7 @@ public static class WhoisNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/WildcardNarrative.cs
+++ b/DomainDetective/Narratives/WildcardNarrative.cs
@@ -20,6 +20,7 @@ public static class WildcardNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         if (analysis == null)
@@ -52,7 +53,7 @@ public static class WildcardNarrative
         try
         {
             var assess = assessments ?? analysis.Assessments;
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
         catch
         {
@@ -71,6 +72,7 @@ public static class WildcardNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }

--- a/DomainDetective/Narratives/ZoneTransferNarrative.cs
+++ b/DomainDetective/Narratives/ZoneTransferNarrative.cs
@@ -23,6 +23,7 @@ public static class ZoneTransferNarrative
         var hi = new List<string>();
         var det = new List<string>();
         var positives = new List<string>();
+        var negatives = new List<string>();
         var remediations = new List<string>();
 
         var results = analysis?.ServerResults ?? new Dictionary<string, bool>();
@@ -49,7 +50,7 @@ public static class ZoneTransferNarrative
         try
         {
             var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out remediations);
+            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
         }
         catch (Exception ex)
         {
@@ -69,6 +70,7 @@ public static class ZoneTransferNarrative
             Details = det,
             References = refs,
             Positives = positives,
+            Negatives = negatives,
             Remediations = remediations
         };
     }


### PR DESCRIPTION
## Summary
- support negative findings in narratives and reports
- surface negatives in SPF Word and HTML reports
- validate narratives return positives and negatives

## Testing
- `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj` *(fails: The type or namespace name 'Excel' does not exist in the namespace 'OfficeIMO')*

------
https://chatgpt.com/codex/tasks/task_e_68c65ecb63a4832e91b9ac5d69ebc1e1