### PR TITLE
feat(diagnostics): split assessment titles by severity

### DIFF
--- a/DomainDetective.Tests/TestAssessmentSplit.cs
+++ b/DomainDetective.Tests/TestAssessmentSplit.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Tests;
+
+public class TestAssessmentSplit
+{
+    [Fact]
+    public void SplitTitlesSeparatesBySeverity()
+    {
+        var assessments = new List<Assessment>
+        {
+            new() { Severity = AssessmentSeverity.Info, Message = "Info", Code = "I1" },
+            new() { Severity = AssessmentSeverity.Warning, Message = "Warn", Code = "W1" },
+            new() { Severity = AssessmentSeverity.Error, Message = "Err", Code = "E1" }
+        };
+
+        var (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
+
+        Assert.Single(positives);
+        Assert.Contains("Info", positives);
+
+        Assert.Single(negatives);
+        Assert.Contains("Warn", negatives);
+
+        Assert.Single(remediations);
+        Assert.Contains("Err", remediations);
+    }
+}

--- a/DomainDetective/Diagnostics/AssessmentSplit.cs
+++ b/DomainDetective/Diagnostics/AssessmentSplit.cs
@@ -7,19 +7,18 @@ namespace DomainDetective;
 public static class AssessmentSplit
 {
     /// <summary>
-    /// Splits assessments into positives (Info) and negatives (Warning/Error) titles, grouped by code.
-    /// Negatives are also added to the remediation list for backward compatibility.
+    /// Splits assessments into positives (Info), negatives (Warning), and remediations (Error) titles, grouped by code.
     /// </summary>
-    public static void SplitTitles(
-        IEnumerable<Assessment> assessments,
-        out List<string> positives,
-        out List<string> negatives,
-        out List<string> remediations)
+    public static (List<string> positives, List<string> negatives, List<string> remediations) SplitTitles(
+        IEnumerable<Assessment>? assessments)
     {
-        positives = new List<string>();
-        negatives = new List<string>();
-        remediations = new List<string>();
-        if (assessments == null) return;
+        var positives = new List<string>();
+        var negatives = new List<string>();
+        var remediations = new List<string>();
+        if (assessments == null)
+        {
+            return (positives, negatives, remediations);
+        }
         var grouped = RecommendationEngine.GroupByCode(assessments);
         foreach (var g in grouped)
         {
@@ -31,15 +30,19 @@ public static class AssessmentSplit
             {
                 positives.Add(title ?? string.Empty);
             }
-            else
+            else if (g.MaxSeverity == AssessmentSeverity.Warning)
             {
                 negatives.Add(title ?? string.Empty);
+            }
+            else if (g.MaxSeverity == AssessmentSeverity.Error)
+            {
                 remediations.Add(title ?? string.Empty);
             }
         }
         positives = positives.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         negatives = negatives.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         remediations = remediations.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        return (positives, negatives, remediations);
     }
 }
 

--- a/DomainDetective/Narratives/ApexAddressNarrative.cs
+++ b/DomainDetective/Narratives/ApexAddressNarrative.cs
@@ -45,7 +45,7 @@ public static class ApexAddressNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch

--- a/DomainDetective/Narratives/ArcNarrative.cs
+++ b/DomainDetective/Narratives/ArcNarrative.cs
@@ -53,7 +53,7 @@ public static class ArcNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(arc.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(arc.Assessments ?? new List<Assessment>());
         }
         catch (Exception)
         {

--- a/DomainDetective/Narratives/AutodiscoverNarrative.cs
+++ b/DomainDetective/Narratives/AutodiscoverNarrative.cs
@@ -79,7 +79,7 @@ public static class AutodiscoverNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/CaaNarrative.cs
+++ b/DomainDetective/Narratives/CaaNarrative.cs
@@ -44,7 +44,7 @@ public static class CaaNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(caa.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(caa.Assessments ?? new List<Assessment>());
         }
         catch (Exception ex)
         {

--- a/DomainDetective/Narratives/CertificateHttpNarrative.cs
+++ b/DomainDetective/Narratives/CertificateHttpNarrative.cs
@@ -49,7 +49,7 @@ public static class CertificateHttpNarrative {
 
         try {
             if (assessments != null) {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         } catch (Exception ex) {
             System.Diagnostics.Debug.WriteLine(ex);

--- a/DomainDetective/Narratives/CnameNarrative.cs
+++ b/DomainDetective/Narratives/CnameNarrative.cs
@@ -52,7 +52,7 @@ public static class CnameNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch (Exception ex)

--- a/DomainDetective/Narratives/ContactNarrative.cs
+++ b/DomainDetective/Narratives/ContactNarrative.cs
@@ -55,7 +55,7 @@ public static class ContactNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch (Exception)

--- a/DomainDetective/Narratives/DaneNarrative.cs
+++ b/DomainDetective/Narratives/DaneNarrative.cs
@@ -52,7 +52,7 @@ public static class DaneNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch (ArgumentException ex)

--- a/DomainDetective/Narratives/DkimNarrative.cs
+++ b/DomainDetective/Narratives/DkimNarrative.cs
@@ -109,7 +109,7 @@ public static class DkimNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/DmarcNarrative.cs
+++ b/DomainDetective/Narratives/DmarcNarrative.cs
@@ -97,7 +97,7 @@ public static class DmarcNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(dmarc.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(dmarc.Assessments ?? new List<Assessment>());
         }
         catch { }
 

--- a/DomainDetective/Narratives/DnsHealthNarrative.cs
+++ b/DomainDetective/Narratives/DnsHealthNarrative.cs
@@ -50,7 +50,7 @@ public static class DnsHealthNarrative
                 det.Add($"Apex answers from {kv.Key}: {string.Join(", ", kv.Value)}");
             }
 
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
         }
         else
         {

--- a/DomainDetective/Narratives/DnsTunnelingNarrative.cs
+++ b/DomainDetective/Narratives/DnsTunnelingNarrative.cs
@@ -59,7 +59,7 @@ public static class DnsTunnelingNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch (Exception ex)

--- a/DomainDetective/Narratives/DnsblNarrative.cs
+++ b/DomainDetective/Narratives/DnsblNarrative.cs
@@ -56,7 +56,7 @@ public static class DnsblNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/DnssecNarrative.cs
+++ b/DomainDetective/Narratives/DnssecNarrative.cs
@@ -84,7 +84,7 @@ public static class DnssecNarrative
         try
         {
             var assess = assessments ?? analysis.Assessments;
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
         catch
         {

--- a/DomainDetective/Narratives/EdnsNarrative.cs
+++ b/DomainDetective/Narratives/EdnsNarrative.cs
@@ -77,7 +77,7 @@ public static class EdnsNarrative
         try
         {
             var assess = assessments ?? analysis.Assessments;
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
         catch
         {

--- a/DomainDetective/Narratives/FlatteningServiceNarrative.cs
+++ b/DomainDetective/Narratives/FlatteningServiceNarrative.cs
@@ -53,7 +53,7 @@ public static class FlatteningServiceNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch (Exception ex)

--- a/DomainDetective/Narratives/HpkpNarrative.cs
+++ b/DomainDetective/Narratives/HpkpNarrative.cs
@@ -35,7 +35,7 @@ namespace DomainDetective.Narratives {
                 } else {
                     hi.Add("No Public-Key-Pins header found.");
                 }
-                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
             } else {
                 hi.Add("No HPKP data available.");
             }

--- a/DomainDetective/Narratives/HttpNarrative.cs
+++ b/DomainDetective/Narratives/HttpNarrative.cs
@@ -51,7 +51,7 @@ public static class HttpNarrative
                 det.Add($"Visited {url}");
             }
 
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
         }
         else
         {

--- a/DomainDetective/Narratives/IpNeighborNarrative.cs
+++ b/DomainDetective/Narratives/IpNeighborNarrative.cs
@@ -44,7 +44,7 @@ namespace DomainDetective.Narratives
 
             try
             {
-                AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>());
             }
             catch
             {

--- a/DomainDetective/Narratives/MailLatencyNarrative.cs
+++ b/DomainDetective/Narratives/MailLatencyNarrative.cs
@@ -39,7 +39,7 @@ public static class MailLatencyNarrative {
             }
         }
 
-        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+        (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>());
 
         var refs = new List<string> {
             "https://www.rfc-editor.org/rfc/rfc5321"

--- a/DomainDetective/Narratives/MailTlsNarrative.cs
+++ b/DomainDetective/Narratives/MailTlsNarrative.cs
@@ -42,7 +42,7 @@ namespace DomainDetective.Narratives
                     hi.Add($"{kv.Key} negotiated {r.Protocol} ({cipher}) — {certStatus}.");
                     det.Add($"{kv.Key} expires in {r.DaysToExpire} days");
                 }
-                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
             }
             else
             {

--- a/DomainDetective/Narratives/MessageHeaderNarrative.cs
+++ b/DomainDetective/Narratives/MessageHeaderNarrative.cs
@@ -90,7 +90,7 @@ public static class MessageHeaderNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch

--- a/DomainDetective/Narratives/MtaStsNarrative.cs
+++ b/DomainDetective/Narratives/MtaStsNarrative.cs
@@ -80,7 +80,7 @@ public static class MtaStsNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch (Exception ex)

--- a/DomainDetective/Narratives/NtpNarrative.cs
+++ b/DomainDetective/Narratives/NtpNarrative.cs
@@ -37,7 +37,7 @@ public static class NtpNarrative {
             }
         }
 
-        AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+        (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>());
 
         var refs = new List<string> {
             "https://datatracker.ietf.org/doc/html/rfc5905"

--- a/DomainDetective/Narratives/OpenRelayNarrative.cs
+++ b/DomainDetective/Narratives/OpenRelayNarrative.cs
@@ -55,7 +55,7 @@ public static class OpenRelayNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>());
         }
         catch (Exception ex)
         {

--- a/DomainDetective/Narratives/OpenResolverNarrative.cs
+++ b/DomainDetective/Narratives/OpenResolverNarrative.cs
@@ -56,7 +56,7 @@ public static class OpenResolverNarrative
         try
         {
             var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
         catch
         {

--- a/DomainDetective/Narratives/PortAvailabilityNarrative.cs
+++ b/DomainDetective/Narratives/PortAvailabilityNarrative.cs
@@ -63,7 +63,7 @@ public static class PortAvailabilityNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/PortScanNarrative.cs
+++ b/DomainDetective/Narratives/PortScanNarrative.cs
@@ -80,7 +80,7 @@ public static class PortScanNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/RdapNarrative.cs
+++ b/DomainDetective/Narratives/RdapNarrative.cs
@@ -44,7 +44,7 @@ public static class RdapNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(rdap.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(rdap.Assessments ?? new List<Assessment>());
         }
         catch (Exception)
         {

--- a/DomainDetective/Narratives/RobotsTxtNarrative.cs
+++ b/DomainDetective/Narratives/RobotsTxtNarrative.cs
@@ -74,7 +74,7 @@ public static class RobotsTxtNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch (Exception ex)

--- a/DomainDetective/Narratives/RpkiNarrative.cs
+++ b/DomainDetective/Narratives/RpkiNarrative.cs
@@ -37,7 +37,7 @@ public static class RpkiNarrative
                 det.Add($"IP {r.IpAddress} prefix {r.Prefix} ASN {r.Asn} valid={r.Valid}");
             }
             var assess = assessments ?? analysis.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
 
         var refs = new List<string>

--- a/DomainDetective/Narratives/SecurityTxtNarrative.cs
+++ b/DomainDetective/Narratives/SecurityTxtNarrative.cs
@@ -50,7 +50,7 @@ namespace DomainDetective.Narratives {
             var refs = new List<string> { "https://securitytxt.org/" };
 
             try {
-                AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
             } catch { }
 
             return new Sections {

--- a/DomainDetective/Narratives/SmimeaNarrative.cs
+++ b/DomainDetective/Narratives/SmimeaNarrative.cs
@@ -49,7 +49,7 @@ public static class SmimeaNarrative
         List<string> remediations;
         try
         {
-            AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis?.Assessments ?? new List<Assessment>());
         }
         catch (Exception)
         {

--- a/DomainDetective/Narratives/SmtpAuthNarrative.cs
+++ b/DomainDetective/Narratives/SmtpAuthNarrative.cs
@@ -40,7 +40,7 @@ public static class SmtpAuthNarrative
                     hi.Add(caps.Contains("STARTTLS", StringComparer.OrdinalIgnoreCase) ? $"{kv.Key} advertises STARTTLS." : $"{kv.Key} does not advertise STARTTLS.");
                 }
             }
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
         }
 
         var refs = new List<string>

--- a/DomainDetective/Narratives/SmtpBannerNarrative.cs
+++ b/DomainDetective/Narratives/SmtpBannerNarrative.cs
@@ -54,7 +54,7 @@ public static class SmtpBannerNarrative
         {
             if (assessments != null)
             {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/SnmpNarrative.cs
+++ b/DomainDetective/Narratives/SnmpNarrative.cs
@@ -39,7 +39,7 @@ public static class SnmpNarrative
         try
         {
             var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
         catch
         {

--- a/DomainDetective/Narratives/SpfFlattenedNarrative.cs
+++ b/DomainDetective/Narratives/SpfFlattenedNarrative.cs
@@ -40,7 +40,7 @@ public static class SpfFlattenedNarrative {
 
         try {
             if (assessments != null) {
-                AssessmentSplit.SplitTitles(assessments, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assessments);
             }
         } catch { }
 

--- a/DomainDetective/Narratives/StartTlsNarrative.cs
+++ b/DomainDetective/Narratives/StartTlsNarrative.cs
@@ -43,7 +43,7 @@ public static class StartTlsNarrative
                 hi.Add($"{kv.Key} [{proto}] {status} and {upgrade}{downgrade}.");
                 det.Add($"{kv.Key} downgrade detected: {r.DowngradeDetected}");
             }
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
         }
         else
         {

--- a/DomainDetective/Narratives/ThreatFeedNarrative.cs
+++ b/DomainDetective/Narratives/ThreatFeedNarrative.cs
@@ -66,7 +66,7 @@ public static class ThreatFeedNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch

--- a/DomainDetective/Narratives/ThreatIntelNarrative.cs
+++ b/DomainDetective/Narratives/ThreatIntelNarrative.cs
@@ -56,7 +56,7 @@ public static class ThreatIntelNarrative {
         };
 
         try {
-            AssessmentSplit.SplitTitles(ti?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ti?.Assessments ?? new List<Assessment>());
         } catch {
         }
 

--- a/DomainDetective/Narratives/TlsNarrative.cs
+++ b/DomainDetective/Narratives/TlsNarrative.cs
@@ -37,7 +37,7 @@ public static class TlsNarrative
                     det.Add($"{kv.Key} certificate: {r.CertificateSubject} issued by {r.CertificateIssuer}");
                 }
             }
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
         }
         else
         {

--- a/DomainDetective/Narratives/TlsRptNarrative.cs
+++ b/DomainDetective/Narratives/TlsRptNarrative.cs
@@ -60,7 +60,7 @@ public static class TlsRptNarrative
 
         try
         {
-            AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(analysis.Assessments ?? new List<Assessment>());
         }
         catch (Exception ex)
         {

--- a/DomainDetective/Narratives/TtlNarrative.cs
+++ b/DomainDetective/Narratives/TtlNarrative.cs
@@ -105,7 +105,7 @@ public static class TtlNarrative
             var ass = assessments ?? analysis.Assessments;
             if (ass != null)
             {
-                AssessmentSplit.SplitTitles(ass, out positives, out negatives, out remediations);
+                (positives, negatives, remediations) = AssessmentSplit.SplitTitles(ass);
             }
         }
         catch { }

--- a/DomainDetective/Narratives/WebsiteNarrative.cs
+++ b/DomainDetective/Narratives/WebsiteNarrative.cs
@@ -71,7 +71,7 @@ namespace DomainDetective.Narratives
             var allAssessments = new List<Assessment>();
             if (http?.Assessments != null) allAssessments.AddRange(http.Assessments);
             if (tls?.Assessments != null) allAssessments.AddRange(tls.Assessments);
-            AssessmentSplit.SplitTitles(allAssessments, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(allAssessments);
 
             var refs = new List<string>
             {

--- a/DomainDetective/Narratives/WhoisNarrative.cs
+++ b/DomainDetective/Narratives/WhoisNarrative.cs
@@ -69,7 +69,7 @@ public static class WhoisNarrative
             "https://datatracker.ietf.org/doc/html/rfc3912"
         };
 
-        AssessmentSplit.SplitTitles(whois?.Assessments ?? new List<Assessment>(), out positives, out negatives, out remediations);
+        (positives, negatives, remediations) = AssessmentSplit.SplitTitles(whois?.Assessments ?? new List<Assessment>());
 
         return new Sections
         {

--- a/DomainDetective/Narratives/WildcardNarrative.cs
+++ b/DomainDetective/Narratives/WildcardNarrative.cs
@@ -53,7 +53,7 @@ public static class WildcardNarrative
         try
         {
             var assess = assessments ?? analysis.Assessments;
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
         catch
         {

--- a/DomainDetective/Narratives/ZoneTransferNarrative.cs
+++ b/DomainDetective/Narratives/ZoneTransferNarrative.cs
@@ -50,7 +50,7 @@ public static class ZoneTransferNarrative
         try
         {
             var assess = assessments ?? analysis?.Assessments ?? new List<Assessment>();
-            AssessmentSplit.SplitTitles(assess, out positives, out negatives, out remediations);
+            (positives, negatives, remediations) = AssessmentSplit.SplitTitles(assess);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- separate warning and error titles into negatives and remediations
- switch narratives to new `(positives, negatives, remediations)` tuple signature
- test assessment title splitting

## Testing
- `dotnet build DomainDetective/DomainDetective.csproj`
- `dotnet test` *(fails: The referenced project ../Projects/OfficeIMO/OfficeIMO.Excel/OfficeIMO.Excel.csproj does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68c6e5cfc8c8832e8838f25d7188cac0