### PR TITLE
feat(ttl): Collect authoritative DNS TTLs and prefer them in views

### DIFF
--- a/DomainDetective.CLI/Wizard/DomainWizard.cs
+++ b/DomainDetective.CLI/Wizard/DomainWizard.cs
@@ -1014,10 +1014,25 @@ file static partial class Ui
         AnsiConsole.Write(root);
         AnsiConsole.WriteLine();
 
+        IReadOnlyDictionary<string, IReadOnlyList<int>> pickDkim()
+        {
+            var ttl = hc.DnsTtlAnalysis;
+            if (ttl == null) return new Dictionary<string, IReadOnlyList<int>>();
+            if (ttl.AuthoritativeDkimTxtTtls != null && ttl.AuthoritativeDkimTxtTtls.Count > 0)
+            {
+                return ttl.AuthoritativeDkimTxtTtls;
+            }
+            return ttl.DkimTxtTtls ?? new Dictionary<string, IReadOnlyList<int>>();
+        }
         var ttlAll = (hc.DnsTtlAnalysis?.ATtls ?? Array.Empty<int>())
             .Concat(hc.DnsTtlAnalysis?.AaaaTtls ?? Array.Empty<int>())
             .Concat(hc.DnsTtlAnalysis?.MxTtls ?? Array.Empty<int>())
             .Concat(hc.DnsTtlAnalysis?.NsTtls ?? Array.Empty<int>())
+            .Concat(hc.DnsTtlAnalysis?.SpfTxtTtls ?? Array.Empty<int>())
+            .Concat(hc.DnsTtlAnalysis?.DmarcTxtTtls ?? Array.Empty<int>())
+            .Concat(hc.DnsTtlAnalysis?.MtastsTxtTtls ?? Array.Empty<int>())
+            .Concat(hc.DnsTtlAnalysis?.TlsRptTxtTtls ?? Array.Empty<int>())
+            .Concat(pickDkim().SelectMany(kv => kv.Value ?? Array.Empty<int>()))
             .Where(x => x > 0).ToArray();
         var panel = new Panel(new Rows(
             new Markup($"DNSSEC: {(hc.DnsSecAnalysis?.ChainValid == true ? "[green]OK[/]" : "[red]NO[/]")}"),

--- a/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
+++ b/DomainDetective.PowerShell/CmdletTestDomainHealth.cs
@@ -62,6 +62,10 @@ namespace DomainDetective.PowerShell {
         [Parameter(Mandatory = false)]
         public PortScanProfile[]? PortScanProfile;
 
+        /// <summary>When set, collects authoritative (configured) TTLs from NS hosts alongside observed resolver TTLs.</summary>
+        [Parameter(Mandatory = false)]
+        public SwitchParameter CollectAuthoritativeTtls { get; set; }
+
         private InternalLogger _logger = null!;
         private DomainHealthCheck _healthCheck = null!;
 
@@ -79,6 +83,7 @@ namespace DomainDetective.PowerShell {
                 this.WriteInformation);
             internalLoggerPowerShell.ResetActivityIdCounter();
             _healthCheck = new DomainHealthCheck(DnsEndpoint, _logger);
+            _healthCheck.CollectAuthoritativeTtls = CollectAuthoritativeTtls.IsPresent;
             if (DnsEndpoints != null && DnsEndpoints.Length > 0)
             {
                 _healthCheck.DnsEndpoints.AddRange(DnsEndpoints);

--- a/DomainDetective.Reports/Composition/SectionProjectors.cs
+++ b/DomainDetective.Reports/Composition/SectionProjectors.cs
@@ -284,7 +284,10 @@ public static class SectionProjectors
         if (sec == null) return null;
         try
         {
-            if (ttl?.DkimTxtTtls != null && ttl.DkimTxtTtls.Count > 0)
+            var ttlMap = (ttl?.AuthoritativeDkimTxtTtls != null && ttl.AuthoritativeDkimTxtTtls.Count > 0)
+                ? ttl.AuthoritativeDkimTxtTtls
+                : ttl?.DkimTxtTtls;
+            if (ttlMap != null && ttlMap.Count > 0)
             {
                 foreach (var row in sec.Rows)
                 {
@@ -297,7 +300,7 @@ public static class SectionProjectors
                         if (string.IsNullOrWhiteSpace(fqdn) && !string.IsNullOrWhiteSpace(src.Subject) && !string.IsNullOrWhiteSpace(src.Selector))
                             fqdn = $"{src.Selector}._domainkey.{src.Subject}";
                     }
-                    if (!string.IsNullOrWhiteSpace(fqdn) && ttl.DkimTxtTtls.TryGetValue(fqdn!, out var ttls) && ttls != null && ttls.Count > 0)
+                    if (!string.IsNullOrWhiteSpace(fqdn) && ttlMap.TryGetValue(fqdn!, out var ttls) && ttls != null && ttls.Count > 0)
                     {
                         // Use minimum TTL observed across authoritative servers as conservative value
                         row.TtlSeconds = ttls.Min();

--- a/DomainDetective.Tests/TestTtlFields.cs
+++ b/DomainDetective.Tests/TestTtlFields.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using DomainDetective;
+using DomainDetective.Reports;
+using DomainDetective.Views;
+using DnsClientX;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestTtlFields
+{
+    [Fact]
+    public async Task DmarcAnalysisCapturesTtls()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 300, DataRaw = "v=DMARC1; p=none", Type = DnsRecordType.TXT },
+            new DnsAnswer { TTL = 900, DataRaw = "v=DMARC1; p=reject", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new DmarcAnalysis();
+        await analysis.AnalyzeDmarcRecords(answers, new InternalLogger());
+
+        Assert.Equal(new[] { 300, 900 }, analysis.DnsRecordTtls);
+        Assert.Equal(300, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task DmarcTtlIgnoresCnameHops()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 60, DataRaw = "cname.example.net", Type = DnsRecordType.CNAME },
+            new DnsAnswer { TTL = 86400, DataRaw = "v=DMARC1; p=reject", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new DmarcAnalysis();
+        await analysis.AnalyzeDmarcRecords(answers, new InternalLogger());
+
+        Assert.Equal(new[] { 86400 }, analysis.DnsRecordTtls);
+        Assert.Equal(86400, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task SpfAnalysisCapturesTtls()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 120, DataRaw = "v=spf1 -all", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new SpfAnalysis { DnsConfiguration = new DnsConfiguration() };
+        await analysis.AnalyzeSpfRecords(answers, new InternalLogger());
+
+        Assert.Equal(new[] { 120 }, analysis.DnsRecordTtls);
+        Assert.Equal(120, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task DkimAnalysisCapturesTtls()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 600, DataRaw = "v=DKIM1; p=AAA", Name = "s1._domainkey.example.com", Type = DnsRecordType.TXT },
+            new DnsAnswer { TTL = 450, DataRaw = "v=DKIM1; p=BBB", Name = "s1._domainkey.example.com", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new DkimAnalysis();
+        await analysis.AnalyzeDkimRecords("s1", answers, new InternalLogger());
+
+        var result = analysis.AnalysisResults["s1"];
+        Assert.Equal(new[] { 600, 450 }, result.Ttls);
+        Assert.Equal(450, result.Ttl);
+    }
+
+    [Fact]
+    public async Task MtastsAnalysisCapturesDnsTtls()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 7200, DataRaw = "v=STSv1; id=20240101", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new MTASTSAnalysis
+        {
+            QueryDnsOverride = (_, _) => Task.FromResult(answers),
+            PolicyUrlOverride = "http://127.0.0.1:0/.well-known/mta-sts.txt"
+        };
+
+        await analysis.AnalyzePolicy("example.com", new InternalLogger());
+
+        Assert.Equal(new[] { 7200 }, analysis.DnsRecordTtls);
+        Assert.Equal(7200, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task MtastsTtlIgnoresCnameHops()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 60, DataRaw = "mta-sts.example.net", Type = DnsRecordType.CNAME },
+            new DnsAnswer { TTL = 86400, DataRaw = "v=STSv1; id=20240101", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new MTASTSAnalysis
+        {
+            QueryDnsOverride = (_, _) => Task.FromResult(answers),
+            PolicyUrlOverride = "http://127.0.0.1:0/.well-known/mta-sts.txt"
+        };
+
+        await analysis.AnalyzePolicy("example.com", new InternalLogger());
+
+        Assert.Equal(new[] { 86400 }, analysis.DnsRecordTtls);
+        Assert.Equal(86400, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task TlsRptAnalysisCapturesDnsTtls()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 1800, DataRaw = "v=TLSRPTv1; rua=mailto:reports@example.com", Type = DnsRecordType.TXT },
+            new DnsAnswer { TTL = 900, DataRaw = "v=TLSRPTv1; rua=mailto:reports@example.com", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new TLSRPTAnalysis();
+        await analysis.AnalyzeTlsRptRecords(answers, new InternalLogger());
+
+        Assert.Equal(new[] { 1800, 900 }, analysis.DnsRecordTtls);
+        Assert.Equal(900, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task TlsRptTtlIgnoresCnameHops()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 60, DataRaw = "tlsrpt.example.net", Type = DnsRecordType.CNAME },
+            new DnsAnswer { TTL = 86400, DataRaw = "v=TLSRPTv1; rua=mailto:reports@example.com", Type = DnsRecordType.TXT }
+        };
+
+        var analysis = new TLSRPTAnalysis();
+        await analysis.AnalyzeTlsRptRecords(answers, new InternalLogger());
+
+        Assert.Equal(new[] { 86400 }, analysis.DnsRecordTtls);
+        Assert.Equal(86400, analysis.DnsRecordTtl);
+    }
+
+    [Fact]
+    public async Task MxAnalysisCapturesDnsTtls()
+    {
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 500, Data = "10 mail.example.com", Type = DnsRecordType.MX },
+            new DnsAnswer { TTL = 400, Data = "20 backup.example.com", Type = DnsRecordType.MX }
+        };
+
+        var analysis = new MXAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (_, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+        };
+
+        await analysis.AnalyzeMxRecords(answers, new InternalLogger());
+
+        Assert.Equal(new[] { 500, 400 }, analysis.MxRecordTtls);
+        Assert.Equal(400, analysis.MinMxTtl);
+    }
+
+    [Fact]
+    public void MxConverterSurfacesTtls()
+    {
+        var analysis = new MXAnalysis
+        {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (_, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+        };
+
+        var answers = new[]
+        {
+            new DnsAnswer { TTL = 250, Data = "10 mail.example.com", Type = DnsRecordType.MX }
+        };
+
+        analysis.AnalyzeMxRecords(answers, new InternalLogger()).GetAwaiter().GetResult();
+
+        var view = Converters.Convert(analysis);
+        Assert.Equal(250, view.MxRecordTtl);
+        Assert.True(view.MxRecordTtls.SequenceEqual(new[] { 250 }));
+    }
+
+    [Fact]
+    public void TtlViewPrefersAuthoritativeValuesWhenPresent()
+    {
+        static void SetProperty<T>(object target, string name, T value)
+        {
+            var prop = target.GetType().GetProperty(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            Assert.NotNull(prop);
+            prop!.SetValue(target, value);
+        }
+
+        var analysis = new DnsTtlAnalysis { Subject = "example.com" };
+        SetProperty(analysis, nameof(DnsTtlAnalysis.SoaTtl), 600);
+        SetProperty(analysis, nameof(DnsTtlAnalysis.AuthoritativeSoaTtl), 3600);
+        SetProperty(analysis, nameof(DnsTtlAnalysis.ATtls), new[] { 300 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.AuthoritativeATtls), new[] { 1200 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.DmarcTxtTtls), new[] { 3600 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.AuthoritativeDmarcTxtTtls), new[] { 86400 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.MtastsTxtTtls), new[] { 1800 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.AuthoritativeMtastsTxtTtls), new[] { 7200 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.TlsRptTxtTtls), new[] { 900 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.AuthoritativeTlsRptTxtTtls), new[] { 21600 });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.DkimTxtTtls), new Dictionary<string, IReadOnlyList<int>>
+        {
+            ["s1._domainkey.example.com"] = new[] { 300 }
+        });
+        SetProperty(analysis, nameof(DnsTtlAnalysis.AuthoritativeDkimTxtTtls), new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["s1._domainkey.example.com"] = new[] { 172800 }
+        });
+
+        var view = Converters.Convert(analysis);
+
+        Assert.Equal(3600, view.SoaTtl);
+        Assert.Equal(new[] { 1200 }, view.ATtls);
+        Assert.Equal(new[] { 86400 }, view.DmarcTxtTtls);
+        Assert.Equal(new[] { 7200 }, view.MtastsTxtTtls);
+        Assert.Equal(new[] { 21600 }, view.TlsRptTxtTtls);
+        Assert.True(view.DkimTxtTtls.TryGetValue("s1._domainkey.example.com", out var ttls));
+        Assert.Equal(172800, ttls.Min());
+    }
+
+    [Fact]
+    public void DkimSectionUsesAuthoritativeTtlWhenAvailable()
+    {
+        var dkim = new[]
+        {
+            new DkimRecordInfo
+            {
+                Selector = "s1",
+                Subject = "example.com",
+                Name = "s1._domainkey.example.com",
+                DkimRecord = "v=DKIM1; p=AAA",
+                Assessments = Array.Empty<Assessment>()
+            }
+        };
+        var ttl = new TtlInfo
+        {
+            DkimTxtTtls = new Dictionary<string, IReadOnlyList<int>>
+            {
+                ["s1._domainkey.example.com"] = new[] { 300 }
+            },
+            AuthoritativeDkimTxtTtls = new Dictionary<string, IReadOnlyList<int>>
+            {
+                ["s1._domainkey.example.com"] = new[] { 86400 }
+            }
+        };
+
+        var section = SectionProjectors.BuildDkim(dkim, ttl);
+
+        Assert.NotNull(section);
+        Assert.Single(section!.Rows);
+        Assert.Equal(86400, section.Rows[0].TtlSeconds);
+    }
+}

--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -25,20 +25,44 @@ namespace DomainDetective {
 
         /// <summary>Gets TTL values for A records including zero values.</summary>
         public IReadOnlyList<int> ATtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for A records (queried from NS hosts).</summary>
+        public IReadOnlyList<int> AuthoritativeATtls { get; private set; } = Array.Empty<int>();
         /// <summary>Gets TTL values for AAAA records including zero values.</summary>
         public IReadOnlyList<int> AaaaTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for AAAA records.</summary>
+        public IReadOnlyList<int> AuthoritativeAaaaTtls { get; private set; } = Array.Empty<int>();
         /// <summary>Gets TTL values for MX records including zero values.</summary>
         public IReadOnlyList<int> MxTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for MX records.</summary>
+        public IReadOnlyList<int> AuthoritativeMxTtls { get; private set; } = Array.Empty<int>();
         /// <summary>Gets TTL values for NS records including zero values.</summary>
         public IReadOnlyList<int> NsTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for NS records.</summary>
+        public IReadOnlyList<int> AuthoritativeNsTtls { get; private set; } = Array.Empty<int>();
         /// <summary>Gets the TTL value for the SOA record; zero indicates no TTL or missing record.</summary>
         public int SoaTtl { get; private set; }
+        /// <summary>Authoritative SOA TTL (queried directly from NS); null when unavailable.</summary>
+        public int? AuthoritativeSoaTtl { get; private set; }
         /// <summary>TTL values for SPF TXT at the zone apex.</summary>
         public IReadOnlyList<int> SpfTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for SPF TXT at the zone apex.</summary>
+        public IReadOnlyList<int> AuthoritativeSpfTxtTtls { get; private set; } = Array.Empty<int>();
         /// <summary>TTL values for _dmarc TXT.</summary>
         public IReadOnlyList<int> DmarcTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for _dmarc TXT.</summary>
+        public IReadOnlyList<int> AuthoritativeDmarcTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>TTL values for _mta-sts TXT records.</summary>
+        public IReadOnlyList<int> MtastsTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for _mta-sts TXT records.</summary>
+        public IReadOnlyList<int> AuthoritativeMtastsTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>TTL values for _smtp._tls TXT records.</summary>
+        public IReadOnlyList<int> TlsRptTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for _smtp._tls TXT records.</summary>
+        public IReadOnlyList<int> AuthoritativeTlsRptTxtTtls { get; private set; } = Array.Empty<int>();
         /// <summary>TTL values for DKIM selector TXT records, keyed by FQDN (selector._domainkey.domain).</summary>
         public Dictionary<string, IReadOnlyList<int>> DkimTxtTtls { get; private set; } = new();
+        /// <summary>Authoritative TTL values for DKIM selector TXT records.</summary>
+        public Dictionary<string, IReadOnlyList<int>> AuthoritativeDkimTxtTtls { get; private set; } = new();
         /// <summary>Collection of warning messages produced during analysis.</summary>
         public IReadOnlyList<string> Warnings => _warnings;
 
@@ -54,6 +78,10 @@ namespace DomainDetective {
         public int MinTtlSpfSeconds { get; set; } = 3600;
         /// <summary>Minimum TTL for DMARC TXT records (seconds).</summary>
         public int MinTtlDmarcSeconds { get; set; } = 3600;
+        /// <summary>Minimum TTL for MTA-STS TXT records (seconds).</summary>
+        public int MinTtlMtastsSeconds { get; set; } = 3600;
+        /// <summary>Minimum TTL for TLS-RPT TXT records (seconds).</summary>
+        public int MinTtlTlsRptSeconds { get; set; } = 3600;
         /// <summary>Minimum TTL for DKIM selector TXT records (seconds).</summary>
         public int MinTtlDkimSelectorSeconds { get; set; } = 3600;
 
@@ -64,6 +92,9 @@ namespace DomainDetective {
         public Dictionary<string, int?> ServerTtlCname { get; private set; } = new();
         public Dictionary<string, int?> ServerTtlTxtSpf { get; private set; } = new();
         public Dictionary<string, int?> ServerTtlTxtDmarc { get; private set; } = new();
+        public Dictionary<string, int?> ServerTtlMx { get; private set; } = new();
+        public Dictionary<string, int?> ServerTtlTxtMtasts { get; private set; } = new();
+        public Dictionary<string, int?> ServerTtlTxtTlsRpt { get; private set; } = new();
         /// <summary>Per-name TXT TTLs across authoritative servers. Key is the record name (e.g., s1._domainkey.example.com).</summary>
         public Dictionary<string, Dictionary<string, int?>> ServerTtlTxtPerName { get; private set; } = new();
         public bool AUniformAcrossServers { get; private set; }
@@ -75,6 +106,50 @@ namespace DomainDetective {
         /// Optional override for DNS queries, primarily used for testing.
         /// </summary>
         public Func<string, DnsRecordType, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+        /// <summary>
+        /// When true, queries authoritative name servers to collect configured TTL values alongside observed TTLs.
+        /// </summary>
+        public bool CollectAuthoritativeTtls { get; set; }
+
+        private static IReadOnlyList<int> ExtractTxtTtls(IEnumerable<DnsAnswer> answers, string marker)
+        {
+            return answers
+                .Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf(marker, StringComparison.OrdinalIgnoreCase) >= 0)
+                .Select(r => r.TTL)
+                .ToArray();
+        }
+
+        private async Task<IReadOnlyList<int>> QueryTxtTtlsWithAlias(string name, string marker)
+        {
+            var answers = await QueryDns(name, DnsRecordType.TXT);
+            var ttls = ExtractTxtTtls(answers, marker);
+            if (ttls.Count > 0)
+            {
+                return ttls;
+            }
+
+            var cnameTargets = answers
+                .Where(r => r.Type == DnsRecordType.CNAME && !string.IsNullOrWhiteSpace(r.Data))
+                .Select(r => r.Data!.Trim('.'))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            foreach (var target in cnameTargets)
+            {
+                try
+                {
+                    var follow = await QueryDns(target, DnsRecordType.TXT);
+                    var followTtls = ExtractTxtTtls(follow, marker);
+                    if (followTtls.Count > 0)
+                    {
+                        return followTtls;
+                    }
+                }
+                catch { }
+            }
+
+            return Array.Empty<int>();
+        }
 
         private async Task<DnsAnswer[]> QueryDns(string name, DnsRecordType type) {
             if (QueryDnsOverride != null) {
@@ -96,11 +171,12 @@ namespace DomainDetective {
             if (trailingDot) ms.WriteByte(0);
             return ms.ToArray();
         }
-        private static byte[] BuildQuery(string domain, ushort qtype) {
+        private static byte[] BuildQuery(string domain, ushort qtype, bool recursionDesired = true) {
             var header = new byte[12];
             var id = (ushort)new Random().Next(ushort.MaxValue);
             header[0] = (byte)(id >> 8); header[1] = (byte)(id & 0xFF);
-            header[2] = 0x01; header[5] = 0x01;
+            header[2] = recursionDesired ? (byte)0x01 : (byte)0x00; // RD flag
+            header[5] = 0x01;
             var qname = EncodeDomainName(domain, true);
             var query = new byte[header.Length + qname.Length + 4];
             Buffer.BlockCopy(header, 0, query, 0, header.Length);
@@ -147,6 +223,7 @@ namespace DomainDetective {
             var an = ReadUInt16(data, ref offset);
             offset += 4; // nscount + arcount
             for (int i = 0; i < qd; i++) { SkipName(data, ref offset); offset += 4; }
+            int? cnameTtl = null;
             for (int i = 0; i < an; i++) {
                 SkipName(data, ref offset);
                 var type = ReadUInt16(data, ref offset);
@@ -155,13 +232,24 @@ namespace DomainDetective {
                 offset += 4;
                 var rdlen = ReadUInt16(data, ref offset);
                 if (type == qtype) return ttl;
+                // For TXT queries, capture CNAME TTL as fallback (aliased records)
+                if (qtype == 16 && type == 5 && !cnameTtl.HasValue) cnameTtl = ttl;
                 offset += rdlen;
             }
-            return null;
+            // If querying TXT and got CNAME but no TXT, return the CNAME TTL
+            // This handles aliased SPF/DMARC records
+            return cnameTtl;
         }
         private async Task<int?> QueryTtlFromServer(System.Net.IPAddress ip, string name, ushort qtype, System.Threading.CancellationToken ct) {
-            var q = BuildQuery(name, qtype);
+            // Prefer non-recursive queries to capture configured TTLs directly from authoritative servers.
+            var q = BuildQuery(name, qtype, recursionDesired: false);
             var buf = await QueryUdp(ip, q, ct);
+            var ttl = buf != null ? ParseFirstAnswerTtl(buf, qtype) : null;
+            if (ttl.HasValue) return ttl;
+
+            // Fallback to recursive queries when no direct answer is returned (e.g., CNAME chains).
+            q = BuildQuery(name, qtype, recursionDesired: true);
+            buf = await QueryUdp(ip, q, ct);
             return buf != null ? ParseFirstAnswerTtl(buf, qtype) : null;
         }
 
@@ -175,13 +263,25 @@ namespace DomainDetective {
             Subject = domainName;
             _warnings.Clear();
             ATtls = Array.Empty<int>();
+            AuthoritativeATtls = Array.Empty<int>();
             AaaaTtls = Array.Empty<int>();
+            AuthoritativeAaaaTtls = Array.Empty<int>();
             MxTtls = Array.Empty<int>();
+            AuthoritativeMxTtls = Array.Empty<int>();
             NsTtls = Array.Empty<int>();
+            AuthoritativeNsTtls = Array.Empty<int>();
             SoaTtl = 0;
+            AuthoritativeSoaTtl = null;
             SpfTxtTtls = Array.Empty<int>();
+            AuthoritativeSpfTxtTtls = Array.Empty<int>();
             DmarcTxtTtls = Array.Empty<int>();
+            AuthoritativeDmarcTxtTtls = Array.Empty<int>();
+            MtastsTxtTtls = Array.Empty<int>();
+            AuthoritativeMtastsTxtTtls = Array.Empty<int>();
+            TlsRptTxtTtls = Array.Empty<int>();
+            AuthoritativeTlsRptTxtTtls = Array.Empty<int>();
             DkimTxtTtls = new Dictionary<string, IReadOnlyList<int>>();
+            AuthoritativeDkimTxtTtls = new Dictionary<string, IReadOnlyList<int>>();
 
             var aRecords = await QueryDns(domainName, DnsRecordType.A);
             var aaaaRecords = await QueryDns(domainName, DnsRecordType.AAAA);
@@ -190,7 +290,9 @@ namespace DomainDetective {
             var soaRecords = await QueryDns(domainName, DnsRecordType.SOA);
             var dsRecords = await QueryDns(domainName, DnsRecordType.DS);
             var txtApex = await QueryDns(domainName, DnsRecordType.TXT);
-            var txtDmarc = await QueryDns($"_dmarc.{domainName}", DnsRecordType.TXT);
+            var txtDmarc = await QueryTxtTtlsWithAlias($"_dmarc.{domainName}", "v=DMARC1");
+            var txtMtasts = await QueryTxtTtlsWithAlias($"_mta-sts.{domainName}", "v=STSv1");
+            var txtTlsRpt = await QueryTxtTtlsWithAlias($"_smtp._tls.{domainName}", "v=TLSRPTv1");
 
             DnsSecSigned = dsRecords.Length > 0;
 
@@ -205,11 +307,9 @@ namespace DomainDetective {
                 .Where(r => (r.Data ?? string.Empty).IndexOf("v=spf1", StringComparison.OrdinalIgnoreCase) >= 0)
                 .Select(r => r.TTL)
                 .ToArray();
-            // Only treat TXT at _dmarc as DMARC when it actually contains a DMARC record
-            DmarcTxtTtls = txtDmarc
-                .Where(r => (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=DMARC1", StringComparison.OrdinalIgnoreCase) >= 0)
-                .Select(r => r.TTL)
-                .ToArray();
+            DmarcTxtTtls = txtDmarc.ToArray();
+            MtastsTxtTtls = txtMtasts.ToArray();
+            TlsRptTxtTtls = txtTlsRpt.ToArray();
 
             if (DkimSelectors != null && DkimSelectors.Count > 0)
             {
@@ -235,6 +335,8 @@ namespace DomainDetective {
             // Evaluate TXT categories with specific minima
             if (SpfTxtTtls.Any()) Evaluate("SPF TXT", SpfTxtTtls, MinTtlSpfSeconds, 86400, false, logger);
             if (DmarcTxtTtls.Any()) Evaluate("DMARC TXT", DmarcTxtTtls, MinTtlDmarcSeconds, 86400, false, logger);
+            if (MtastsTxtTtls.Any()) Evaluate("MTA-STS TXT", MtastsTxtTtls, MinTtlMtastsSeconds, 86400, false, logger);
+            if (TlsRptTxtTtls.Any()) Evaluate("TLS-RPT TXT", TlsRptTxtTtls, MinTtlTlsRptSeconds, 86400, false, logger);
         }
 
         /// <summary>
@@ -243,7 +345,9 @@ namespace DomainDetective {
         public async Task AnalyzeUniformityAcrossServers(string domainName, InternalLogger logger, System.Threading.CancellationToken ct = default) {
             ServerTtlA = new(); ServerTtlAaaa = new(); ServerTtlNs = new(); ServerTtlCname = new();
             ServerTtlTxtSpf = new(); ServerTtlTxtDmarc = new(); ServerTtlTxtPerName = new();
+            ServerTtlMx = new(); ServerTtlTxtMtasts = new(); ServerTtlTxtTlsRpt = new();
             AUniformAcrossServers = AaaaUniformAcrossServers = NsUniformAcrossServers = CnameUniformAcrossServers = true;
+            var authoritativeSoa = CollectAuthoritativeTtls ? new List<int>() : null;
 
             // Discover authoritative NS hosts and IPs via resolver
             var nsAnswers = await QueryDns(domainName, DnsRecordType.NS);
@@ -267,6 +371,13 @@ namespace DomainDetective {
                 // TXT names: apex (SPF) and _dmarc
                 try { ServerTtlTxtSpf[key] = await QueryTtlFromServer(ip, domainName, 16, ct); } catch { ServerTtlTxtSpf[key] = null; }
                 try { ServerTtlTxtDmarc[key] = await QueryTtlFromServer(ip, $"_dmarc.{domainName}", 16, ct); } catch { ServerTtlTxtDmarc[key] = null; }
+                if (CollectAuthoritativeTtls)
+                {
+                    try { var soa = await QueryTtlFromServer(ip, domainName, 6, ct); if (soa.HasValue) authoritativeSoa?.Add(soa.Value); } catch { }
+                    try { ServerTtlMx[key] = await QueryTtlFromServer(ip, domainName, 15, ct); } catch { ServerTtlMx[key] = null; }
+                    try { ServerTtlTxtMtasts[key] = await QueryTtlFromServer(ip, $"_mta-sts.{domainName}", 16, ct); } catch { ServerTtlTxtMtasts[key] = null; }
+                    try { ServerTtlTxtTlsRpt[key] = await QueryTtlFromServer(ip, $"_smtp._tls.{domainName}", 16, ct); } catch { ServerTtlTxtTlsRpt[key] = null; }
+                }
                 // DKIM selectors
                 if (DkimSelectors != null && DkimSelectors.Count > 0)
                 {
@@ -327,6 +438,27 @@ namespace DomainDetective {
                     var uniform = IsUniform(kv.Value);
                     if (!uniform) logger?.WriteWarningCode(TtlCodes.NonUniformAcrossNS_TXT_DKIM, $"DKIM TXT TTL differs across authoritative servers for {kv.Key}");
                     else logger?.WriteInformationCode(TtlCodes.UniformAcrossNS_TXT_DKIM, $"DKIM TXT TTL consistent across authoritative servers for {kv.Key}");
+                }
+            }
+
+            if (CollectAuthoritativeTtls)
+            {
+                static IReadOnlyList<int> Aggregate(Dictionary<string, int?> map) =>
+                    map.Values.Where(v => v.HasValue).Select(v => v!.Value).ToArray();
+
+                AuthoritativeATtls = Aggregate(ServerTtlA);
+                AuthoritativeAaaaTtls = Aggregate(ServerTtlAaaa);
+                AuthoritativeNsTtls = Aggregate(ServerTtlNs);
+                AuthoritativeMxTtls = Aggregate(ServerTtlMx);
+                AuthoritativeSpfTxtTtls = Aggregate(ServerTtlTxtSpf);
+                AuthoritativeDmarcTxtTtls = Aggregate(ServerTtlTxtDmarc);
+                AuthoritativeMtastsTxtTtls = Aggregate(ServerTtlTxtMtasts);
+                AuthoritativeTlsRptTxtTtls = Aggregate(ServerTtlTxtTlsRpt);
+                AuthoritativeSoaTtl = authoritativeSoa?.Count > 0 ? authoritativeSoa.Min() : null;
+                AuthoritativeDkimTxtTtls = new Dictionary<string, IReadOnlyList<int>>(StringComparer.OrdinalIgnoreCase);
+                foreach (var kv in ServerTtlTxtPerName)
+                {
+                    AuthoritativeDkimTxtTtls[kv.Key] = Aggregate(kv.Value);
                 }
             }
         }

--- a/DomainDetective/DomainHealthCheck.Settings.cs
+++ b/DomainDetective/DomainHealthCheck.Settings.cs
@@ -128,6 +128,11 @@ namespace DomainDetective {
         public List<string> TyposquattingBrandKeywords { get; } = new();
 
         /// <summary>
+        /// When true, TTL analysis collects authoritative (configured) TTLs from NS hosts alongside observed resolver TTLs.
+        /// </summary>
+        public bool CollectAuthoritativeTtls { get; set; }
+
+        /// <summary>
         /// When true, DNSSEC queries use local validation (validateDnsSec: true) in DnsClientX.
         /// </summary>
         public bool DnsSecValidateLocally { get; set; }

--- a/DomainDetective/DomainHealthCheck.Verification.Security.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Security.cs
@@ -21,8 +21,34 @@ namespace DomainDetective {
                 }
             } catch { /* best effort */ }
 
+            DnsTtlAnalysis.CollectAuthoritativeTtls = CollectAuthoritativeTtls;
             await DnsTtlAnalysis.Analyze(domainName, _logger);
             await DnsTtlAnalysis.AnalyzeUniformityAcrossServers(domainName, _logger, cancellationToken);
+
+            // If authoritative DKIM TTLs were gathered, push them into DKIM analysis results for display.
+            try
+            {
+                if (CollectAuthoritativeTtls &&
+                    DKIMAnalysis?.AnalysisResults != null &&
+                    DKIMAnalysis.AnalysisResults.Count > 0 &&
+                    DnsTtlAnalysis.AuthoritativeDkimTxtTtls != null &&
+                    DnsTtlAnalysis.AuthoritativeDkimTxtTtls.Count > 0)
+                {
+                    foreach (var kv in DKIMAnalysis.AnalysisResults)
+                    {
+                        var selector = kv.Key;
+                        var result = kv.Value;
+                        var name = !string.IsNullOrWhiteSpace(result.Name)
+                            ? result.Name
+                            : $"{selector}._domainkey.{domainName}";
+                        if (name != null && DnsTtlAnalysis.AuthoritativeDkimTxtTtls.TryGetValue(name, out var ttls) && ttls != null && ttls.Count > 0)
+                        {
+                            result.AuthoritativeTtls = ttls;
+                        }
+                    }
+                }
+            }
+            catch { /* non-fatal */ }
         }
 
         private Task VerifyFlatteningServiceAsync(string domainName, CancellationToken cancellationToken) {

--- a/DomainDetective/DomainHealthCheck.Verification.TlsRpt.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.TlsRpt.cs
@@ -31,7 +31,7 @@ namespace DomainDetective {
             }
             domainName = NormalizeDomain(domainName);
             UpdateIsPublicSuffix(domainName);
-            TLSRPTAnalysis = new TLSRPTAnalysis { Subject = domainName };
+            TLSRPTAnalysis = new TLSRPTAnalysis { Subject = domainName, DnsConfiguration = DnsConfiguration };
             var tlsrpt = await DnsConfiguration.QueryDNS("_smtp._tls." + domainName, DnsRecordType.TXT, cancellationToken: cancellationToken);
             await TLSRPTAnalysis.AnalyzeTlsRptRecords(tlsrpt, _logger, cancellationToken);
         }

--- a/DomainDetective/DomainHealthCheck.cs
+++ b/DomainDetective/DomainHealthCheck.cs
@@ -425,6 +425,7 @@ namespace DomainDetective {
 
             // Ensure DKIM analysis can perform auxiliary DNS lookups (CNAME for provider mapping)
             DKIMAnalysis.DnsConfiguration = DnsConfiguration;
+            TLSRPTAnalysis.DnsConfiguration = DnsConfiguration;
 
             PortAvailabilityAnalysis = new PortAvailabilityAnalysis();
             PortScanAnalysis = new PortScanAnalysis();

--- a/DomainDetective/Narratives/TtlNarrative.cs
+++ b/DomainDetective/Narratives/TtlNarrative.cs
@@ -26,6 +26,36 @@ public static class TtlNarrative
         var negatives = new List<string>();
         var remediations = new List<string>();
 
+        void AppendTtlRange(List<string> target, IReadOnlyList<int>? ttls, string label)
+        {
+            if (ttls == null || ttls.Count == 0)
+            {
+                return;
+            }
+
+            target.Add($"{label} TTLs min/max {ttls.Min()}/{ttls.Max()}s.");
+        }
+
+        void AppendAuthoritativeRange(List<string> target, IReadOnlyList<int>? ttls, string label)
+        {
+            if (ttls == null || ttls.Count == 0)
+            {
+                return;
+            }
+
+            target.Add($"{label} TTLs (authoritative) min/max {ttls.Min()}/{ttls.Max()}s.");
+        }
+
+        void AppendDetail(List<string> target, IReadOnlyList<int>? ttls, string label)
+        {
+            if (ttls == null || ttls.Count == 0)
+            {
+                return;
+            }
+
+            target.Add($"{label}: {string.Join(", ", ttls)}");
+        }
+
         if (analysis == null)
         {
             return new Sections
@@ -39,14 +69,14 @@ public static class TtlNarrative
         }
 
         hi.Add($"SOA TTL: {analysis.SoaTtl}s.");
-        if (analysis.ATtls?.Count > 0)
+        if (analysis.AuthoritativeSoaTtl.HasValue)
         {
-            hi.Add($"A TTLs min/max {analysis.ATtls.Min()}/{analysis.ATtls.Max()}s.");
+            hi.Add($"SOA TTL (authoritative): {analysis.AuthoritativeSoaTtl.Value}s.");
         }
-        if (analysis.AaaaTtls?.Count > 0)
-        {
-            hi.Add($"AAAA TTLs min/max {analysis.AaaaTtls.Min()}/{analysis.AaaaTtls.Max()}s.");
-        }
+        AppendTtlRange(hi, analysis.ATtls, "A");
+        AppendTtlRange(hi, analysis.AaaaTtls, "AAAA");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeATtls, "A");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeAaaaTtls, "AAAA");
         if (analysis.AUniformAcrossServers)
         {
             hi.Add("A TTLs uniform across name servers.");
@@ -71,6 +101,26 @@ public static class TtlNarrative
         {
             hi.Add("NS TTLs vary across name servers.");
         }
+        AppendTtlRange(hi, analysis.MxTtls, "MX");
+        AppendTtlRange(hi, analysis.SpfTxtTtls, "SPF TXT");
+        AppendTtlRange(hi, analysis.DmarcTxtTtls, "DMARC TXT");
+        AppendTtlRange(hi, analysis.MtastsTxtTtls, "MTA-STS TXT");
+        AppendTtlRange(hi, analysis.TlsRptTxtTtls, "TLS-RPT TXT");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeMxTtls, "MX");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeSpfTxtTtls, "SPF TXT");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeDmarcTxtTtls, "DMARC TXT");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeMtastsTxtTtls, "MTA-STS TXT");
+        AppendAuthoritativeRange(hi, analysis.AuthoritativeTlsRptTxtTtls, "TLS-RPT TXT");
+        var dkimAll = analysis.DkimTxtTtls?.Values?.SelectMany(v => v ?? Array.Empty<int>()).ToArray() ?? Array.Empty<int>();
+        if (dkimAll.Length > 0)
+        {
+            AppendTtlRange(hi, dkimAll, "DKIM TXT");
+        }
+        var dkimAuthAll = analysis.AuthoritativeDkimTxtTtls?.Values?.SelectMany(v => v ?? Array.Empty<int>()).ToArray() ?? Array.Empty<int>();
+        if (dkimAuthAll.Length > 0)
+        {
+            AppendAuthoritativeRange(hi, dkimAuthAll, "DKIM TXT");
+        }
 
         if (analysis.Warnings != null && analysis.Warnings.Count > 0)
         {
@@ -89,9 +139,36 @@ public static class TtlNarrative
         {
             det.Add($"AAAA: {string.Join(", ", analysis.AaaaTtls)}");
         }
-        if (analysis.MxTtls?.Count > 0)
+        AppendDetail(det, analysis.MxTtls, "MX");
+        AppendDetail(det, analysis.SpfTxtTtls, "SPF TXT");
+        AppendDetail(det, analysis.DmarcTxtTtls, "DMARC TXT");
+        AppendDetail(det, analysis.MtastsTxtTtls, "MTA-STS TXT");
+        AppendDetail(det, analysis.TlsRptTxtTtls, "TLS-RPT TXT");
+        if (analysis.DkimTxtTtls != null && analysis.DkimTxtTtls.Count > 0)
         {
-            det.Add($"MX: {string.Join(", ", analysis.MxTtls)}");
+            var dkimDetails = analysis.DkimTxtTtls
+                .Where(kv => kv.Value != null && kv.Value.Count > 0)
+                .Select(kv => $"{kv.Key}: {string.Join(", ", kv.Value)}")
+                .ToArray();
+            if (dkimDetails.Length > 0)
+            {
+                det.Add($"DKIM TXT: {string.Join("; ", dkimDetails)}");
+            }
+        }
+        AppendDetail(det, analysis.AuthoritativeSpfTxtTtls, "SPF TXT (authoritative)");
+        AppendDetail(det, analysis.AuthoritativeDmarcTxtTtls, "DMARC TXT (authoritative)");
+        AppendDetail(det, analysis.AuthoritativeMtastsTxtTtls, "MTA-STS TXT (authoritative)");
+        AppendDetail(det, analysis.AuthoritativeTlsRptTxtTtls, "TLS-RPT TXT (authoritative)");
+        if (analysis.AuthoritativeDkimTxtTtls != null && analysis.AuthoritativeDkimTxtTtls.Count > 0)
+        {
+            var dkimAuthDetails = analysis.AuthoritativeDkimTxtTtls
+                .Where(kv => kv.Value != null && kv.Value.Count > 0)
+                .Select(kv => $"{kv.Key}: {string.Join(", ", kv.Value)}")
+                .ToArray();
+            if (dkimAuthDetails.Length > 0)
+            {
+                det.Add($"DKIM TXT (authoritative): {string.Join("; ", dkimAuthDetails)}");
+            }
         }
         if (analysis.NsTtls?.Count > 0)
         {

--- a/DomainDetective/Protocols/DMARCAnalysis.cs
+++ b/DomainDetective/Protocols/DMARCAnalysis.cs
@@ -50,6 +50,10 @@ namespace DomainDetective {
         public bool DmarcRecordExists { get; private set; } // should be true
         public bool MultipleRecords { get; private set; }
         public bool StartsCorrectly { get; private set; } // should be true
+        /// <summary>TTL values observed for DMARC TXT responses.</summary>
+        public IReadOnlyList<int> DnsRecordTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Minimum TTL across DMARC answers.</summary>
+        public int? DnsRecordTtl => (DnsRecordTtls?.Count ?? 0) > 0 ? DnsRecordTtls.Min() : null;
         public bool ExceedsCharacterLimit { get; private set; } // should be false
         public bool HasMandatoryTags { get; private set; }
         public bool IsPolicyValid { get; private set; }
@@ -126,6 +130,7 @@ namespace DomainDetective {
             DmarcRecordExists = false;
             MultipleRecords = false;
             StartsCorrectly = false;
+            DnsRecordTtls = Array.Empty<int>();
             ExceedsCharacterLimit = false;
             HasMandatoryTags = false;
             IsPolicyValid = false;
@@ -162,11 +167,37 @@ namespace DomainDetective {
             }
 
             var dmarcRecordList = dnsResults.ToList();
-            DmarcRecordExists = dmarcRecordList.Any();
-            MultipleRecords = dmarcRecordList.Count > 1;
+            var dmarcTxtRecords = dmarcRecordList
+                .Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=DMARC1", StringComparison.OrdinalIgnoreCase) >= 0)
+                .ToList();
+            var cnameTargets = dmarcRecordList
+                .Where(r => r.Type == DnsRecordType.CNAME && !string.IsNullOrWhiteSpace(r.Data))
+                .Select(r => r.Data!.Trim('.'))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (dmarcTxtRecords.Count == 0 || cnameTargets.Length > 0)
+            {
+                foreach (var target in cnameTargets)
+                {
+                    try
+                    {
+                        var follow = await DnsConfiguration.QueryDNS(target, DnsRecordType.TXT, "DMARC1");
+                        var followTxt = follow.Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=DMARC1", StringComparison.OrdinalIgnoreCase) >= 0).ToList();
+                        if (followTxt.Count > 0)
+                        {
+                            dmarcTxtRecords = followTxt;
+                            break;
+                        }
+                    }
+                    catch { }
+                }
+            }
+            DnsRecordTtls = dmarcTxtRecords.Select(r => r.TTL).ToArray();
+            DmarcRecordExists = dmarcTxtRecords.Any();
+            MultipleRecords = dmarcTxtRecords.Count > 1;
 
             // concatenate all TXT chunks into a single string separated by spaces
-            DmarcRecord = string.Join(" ", dmarcRecordList.Select(record => record.Data));
+            DmarcRecord = string.Join(" ", dmarcTxtRecords.Select(record => record.Data));
 
             if (!DmarcRecordExists || DmarcRecord == null) {
                 logger.WriteVerbose("No DMARC record found.");

--- a/DomainDetective/Protocols/DkimAnalysis.cs
+++ b/DomainDetective/Protocols/DkimAnalysis.cs
@@ -74,7 +74,8 @@ namespace DomainDetective {
             var analysis = new DkimRecordAnalysis {
                 DkimRecordExists = dkimRecordList.Any(),
                 ValidKeyType = true,
-                ValidFlags = true
+                ValidFlags = true,
+                Ttls = dkimRecordList.Select(r => r.TTL).ToArray()
             };
 
             // create a single string from the list of DnsResult objects
@@ -468,6 +469,20 @@ namespace DomainDetective {
         public string Name { get; set; }
         /// <summary>Gets or sets the full DKIM record text.</summary>
         public string DkimRecord { get; set; }
+        /// <summary>TTL values observed for the selector.</summary>
+        public IReadOnlyList<int> Ttls { get; set; } = Array.Empty<int>();
+        /// <summary>Authoritative TTL values for the selector (from NS hosts), when available.</summary>
+        public IReadOnlyList<int> AuthoritativeTtls { get; set; } = Array.Empty<int>();
+        /// <summary>Minimum TTL observed, preferring authoritative values when available.</summary>
+        public int? Ttl
+        {
+            get
+            {
+                if ((AuthoritativeTtls?.Count ?? 0) > 0) return AuthoritativeTtls.Min();
+                if ((Ttls?.Count ?? 0) > 0) return Ttls.Min();
+                return null;
+            }
+        }
         /// <summary>Gets or sets a value indicating whether the record exists.</summary>
         public bool DkimRecordExists { get; set; }
         /// <summary>Gets or sets a value indicating whether the record starts with <c>v=DKIM1</c>.</summary>

--- a/DomainDetective/Protocols/MTASTSAnalysis.cs
+++ b/DomainDetective/Protocols/MTASTSAnalysis.cs
@@ -125,6 +125,11 @@ public class MTASTSAnalysis : IHasAssessments {
         /// </summary>
         public bool DnsRecordValid { get; private set; }
 
+        /// <summary>TTL values observed for the DNS TXT record.</summary>
+        public IReadOnlyList<int> DnsRecordTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Minimum TTL across TXT answers.</summary>
+        public int? DnsRecordTtl => (DnsRecordTtls?.Count ?? 0) > 0 ? DnsRecordTtls.Min() : null;
+
         /// <summary>
         /// Gets the policy ID extracted from the TXT record.
         /// </summary>
@@ -162,6 +167,7 @@ public class MTASTSAnalysis : IHasAssessments {
             Policy = null;
             DnsRecordPresent = false;
             DnsRecordValid = false;
+            DnsRecordTtls = Array.Empty<int>();
             PolicyId = null;
             Advisory = string.Empty;
             MxAligned = false;
@@ -185,14 +191,40 @@ public class MTASTSAnalysis : IHasAssessments {
             Domain = domainName;
 
             var dns = await QueryDns($"_mta-sts.{domainName}", DnsRecordType.TXT);
-            DnsRecordPresent = dns?.Any() == true;
+            var txtRecords = dns?
+                .Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=STSv1", StringComparison.OrdinalIgnoreCase) >= 0)
+                .ToArray() ?? Array.Empty<DnsAnswer>();
+            var cnameTargets = dns?
+                .Where(r => r.Type == DnsRecordType.CNAME && !string.IsNullOrWhiteSpace(r.Data))
+                .Select(r => r.Data!.Trim('.'))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray() ?? Array.Empty<string>();
+            if ((txtRecords.Length == 0 || cnameTargets.Length > 0) && dns != null)
+            {
+                foreach (var target in cnameTargets)
+                {
+                    try
+                    {
+                        var follow = await QueryDns(target, DnsRecordType.TXT);
+                        var followTxt = follow.Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=STSv1", StringComparison.OrdinalIgnoreCase) >= 0).ToArray();
+                        if (followTxt.Length > 0)
+                        {
+                            txtRecords = followTxt;
+                            break;
+                        }
+                    }
+                    catch { }
+                }
+            }
+            DnsRecordPresent = txtRecords.Any();
+            DnsRecordTtls = txtRecords.Select(r => r.TTL).ToArray();
             if (!DnsRecordPresent) {
                 PolicyValid = false;
                 UpdateAdvisory();
                 return;
             }
 
-            ParseDnsRecord(string.Join(string.Empty, dns.Select(r => r.Data)));
+            ParseDnsRecord(string.Join(string.Empty, txtRecords.Select(r => r.Data)));
             if (!DnsRecordValid) {
                 PolicyValid = false;
                 UpdateAdvisory();

--- a/DomainDetective/Protocols/MXAnalysis.cs
+++ b/DomainDetective/Protocols/MXAnalysis.cs
@@ -60,6 +60,10 @@ namespace DomainDetective {
 
         // Integrity checks
         public bool MxTtlUniform { get; private set; } = true;
+        /// <summary>TTL values observed for MX RRset.</summary>
+        public IReadOnlyList<int> MxRecordTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Minimum TTL across MX records.</summary>
+        public int? MinMxTtl => (MxRecordTtls?.Count ?? 0) > 0 ? MxRecordTtls.Min() : null;
         public bool MxRrsetConsistentAcrossNs { get; private set; } = true;
         public bool TargetAddressConsistentAcrossNs { get; private set; } = true;
 
@@ -97,6 +101,7 @@ namespace DomainDetective {
             MxTtlUniform = true;
             MxRrsetConsistentAcrossNs = true;
             TargetAddressConsistentAcrossNs = true;
+            MxRecordTtls = Array.Empty<int>();
 
             if (dnsResults == null) {
                 logger?.WriteVerbose("DNS query returned no results.");
@@ -105,6 +110,7 @@ namespace DomainDetective {
 
             var mxRecordList = dnsResults.ToList();
             MxRecordExists = mxRecordList.Any();
+            MxRecordTtls = mxRecordList.Select(r => r.TTL).ToArray();
 
             var parsed = new List<(int Preference, string Host)>();
             foreach (var record in mxRecordList) {

--- a/DomainDetective/Protocols/SPFAnalysis.cs
+++ b/DomainDetective/Protocols/SPFAnalysis.cs
@@ -24,6 +24,10 @@ namespace DomainDetective {
 
         /// <summary>Combined SPF record text.</summary>
         public string SpfRecord { get; private set; }
+        /// <summary>TTL values observed for SPF TXT responses.</summary>
+        public IReadOnlyList<int> DnsRecordTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Minimum TTL observed across SPF TXT answers.</summary>
+        public int? DnsRecordTtl => (DnsRecordTtls?.Count ?? 0) > 0 ? DnsRecordTtls.Min() : null;
         public List<string> SpfRecords { get; private set; } = new List<string>();
         public bool SpfRecordExists { get; private set; } // should be true
         public bool MultipleSpfRecords { get; private set; } // should be false
@@ -116,6 +120,7 @@ namespace DomainDetective {
             SpfRecordExists = false;
             MultipleSpfRecords = false;
             StartsCorrectly = false;
+            DnsRecordTtls = Array.Empty<int>();
             ExceedsTotalCharacterLimit = false;
             ExceedsCharacterLimit = false;
             DnsLookups = new List<string>();
@@ -169,6 +174,7 @@ namespace DomainDetective {
                 return;
             }
             var spfRecordList = dnsResults.ToList();
+            DnsRecordTtls = spfRecordList.Select(r => r.TTL).ToArray();
             SpfRecordExists = spfRecordList.Any();
             MultipleSpfRecords = spfRecordList.Count > 1;
 

--- a/DomainDetective/Protocols/TLSRPTAnalysis.cs
+++ b/DomainDetective/Protocols/TLSRPTAnalysis.cs
@@ -17,6 +17,8 @@ public class TLSRPTAnalysis : IHasAssessments {
         public string? Subject { get; set; }
         /// <summary>The concatenated TLSRPT record.</summary>
         public string? TlsRptRecord { get; private set; }
+        /// <summary>DNS configuration used when following CNAMEs to locate the policy TXT.</summary>
+        public DnsConfiguration DnsConfiguration { get; set; } = new DnsConfiguration();
 
         /// <summary>Indicates whether a TLSRPT record exists.</summary>
         public bool TlsRptRecordExists { get; private set; }
@@ -26,6 +28,10 @@ public class TLSRPTAnalysis : IHasAssessments {
 
         /// <summary>Indicates whether the record starts with v=TLSRPTv1.</summary>
         public bool StartsCorrectly { get; private set; }
+        /// <summary>TTL values observed for TLSRPT TXT answers.</summary>
+        public IReadOnlyList<int> DnsRecordTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>Minimum TTL across TLSRPT answers.</summary>
+        public int? DnsRecordTtl => (DnsRecordTtls?.Count ?? 0) > 0 ? DnsRecordTtls.Min() : null;
 
         /// <summary>True when at least one RUA destination is defined.</summary>
         public bool RuaDefined { get; private set; }
@@ -67,6 +73,7 @@ public class TLSRPTAnalysis : IHasAssessments {
             InvalidRua = new List<string>();
             UnknownTags = new List<string>();
             RuaHttpStatus = new Dictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+            DnsRecordTtls = Array.Empty<int>();
 
             if (dnsResults == null) {
                 logger?.WriteVerbose("DNS query returned no results.");
@@ -74,8 +81,31 @@ public class TLSRPTAnalysis : IHasAssessments {
             }
 
             var recordList = dnsResults
-                .Where(r => r.Type != DnsRecordType.CNAME)
+                .Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=TLSRPTv1", StringComparison.OrdinalIgnoreCase) >= 0)
                 .ToList();
+            var cnameTargets = dnsResults
+                .Where(r => r.Type == DnsRecordType.CNAME && !string.IsNullOrWhiteSpace(r.Data))
+                .Select(r => r.Data!.Trim('.'))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (recordList.Count == 0 || cnameTargets.Length > 0)
+            {
+                foreach (var target in cnameTargets)
+                {
+                    try
+                    {
+                        var follow = await DnsConfiguration.QueryDNS(target, DnsRecordType.TXT, cancellationToken: cancellationToken);
+                        var followTxt = follow.Where(r => r.Type == DnsRecordType.TXT && (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=TLSRPTv1", StringComparison.OrdinalIgnoreCase) >= 0).ToList();
+                        if (followTxt.Count > 0)
+                        {
+                            recordList = followTxt;
+                            break;
+                        }
+                    }
+                    catch { }
+                }
+            }
+            DnsRecordTtls = recordList.Select(r => r.TTL).ToArray();
             TlsRptRecordExists = recordList.Any();
             MultipleRecords = recordList.Count > 1;
             if (!TlsRptRecordExists) {

--- a/DomainDetective/Views/Converters.Dkim.cs
+++ b/DomainDetective/Views/Converters.Dkim.cs
@@ -15,6 +15,9 @@ public static partial class Converters
             var recs = RecommendationEngine.FromProblems(a);
             Summarize(a, out var warnCount, out var errCount, out var status);
             var narrative = DomainDetective.Narratives.DkimNarrative.Build(result, kvp.Key, a);
+            var ttlSource = (result.AuthoritativeTtls != null && result.AuthoritativeTtls.Count > 0)
+                ? result.AuthoritativeTtls
+                : (result.Ttls ?? Array.Empty<int>());
             yield return new DkimRecordInfo
             {
                 Check = HealthCheckType.DKIM,
@@ -23,6 +26,8 @@ public static partial class Converters
                 Selector = kvp.Key,
                 Name = result.Name,
                 DkimRecord = result.DkimRecord,
+                DnsRecordTtl = ttlSource.Count > 0 ? ttlSource.Min() : (int?)null,
+                DnsRecordTtls = ttlSource,
                 DkimRecordExists = result.DkimRecordExists,
                 StartsCorrectly = result.StartsCorrectly,
                 PublicKeyExists = result.PublicKeyExists,
@@ -76,6 +81,9 @@ public class DkimRecordInfo
     public string Selector { get; set; } = string.Empty;
     /// <summary>DNS name queried (selector._domainkey.domain).</summary>
     public string Name { get; set; } = string.Empty;
+    /// <summary>Minimum TTL observed for the selector TXT.</summary>
+    public int? DnsRecordTtl { get; set; }
+    public IReadOnlyList<int> DnsRecordTtls { get; set; } = System.Array.Empty<int>();
     /// <summary>Raw DKIM TXT record.</summary>
     public string DkimRecord { get; set; } = string.Empty;
     public bool DkimRecordExists { get; set; }

--- a/DomainDetective/Views/Converters.Dmarc.cs
+++ b/DomainDetective/Views/Converters.Dmarc.cs
@@ -16,6 +16,8 @@ public static partial class Converters
             Area = AreaForKind(HealthCheckType.DMARC),
             Subject = analysis.Subject,
             DmarcRecord = analysis.DmarcRecord,
+            DnsRecordTtl = analysis.DnsRecordTtl,
+            DnsRecordTtls = analysis.DnsRecordTtls,
             DmarcRecordExists = analysis.DmarcRecordExists,
             StartsCorrectly = analysis.StartsCorrectly,
             IsPolicyValid = analysis.IsPolicyValid,
@@ -64,6 +66,9 @@ public class DmarcRecordInfo
     public string Subject { get; set; } = string.Empty;
     /// <summary>Raw DMARC TXT record.</summary>
     public string DmarcRecord { get; set; } = string.Empty;
+    /// <summary>Minimum TTL across DMARC TXT answers.</summary>
+    public int? DnsRecordTtl { get; set; }
+    public IReadOnlyList<int> DnsRecordTtls { get; set; } = System.Array.Empty<int>();
     public bool DmarcRecordExists { get; set; }
     public bool StartsCorrectly { get; set; }
     public bool IsPolicyValid { get; set; }

--- a/DomainDetective/Views/Converters.Mtasts.cs
+++ b/DomainDetective/Views/Converters.Mtasts.cs
@@ -17,6 +17,8 @@ public static partial class Converters
             Subject = analysis.Domain,
             DnsRecordPresent = analysis.DnsRecordPresent,
             DnsRecordValid = analysis.DnsRecordValid,
+            DnsRecordTtl = analysis.DnsRecordTtl,
+            DnsRecordTtls = analysis.DnsRecordTtls,
             PolicyPresent = analysis.PolicyPresent,
             PolicyValid = analysis.PolicyValid,
             Mode = analysis.Mode,
@@ -44,6 +46,8 @@ public class MtastsInfo
     public string Subject { get; set; }
     public bool DnsRecordPresent { get; set; }
     public bool DnsRecordValid { get; set; }
+    public int? DnsRecordTtl { get; set; }
+    public IReadOnlyList<int> DnsRecordTtls { get; set; } = System.Array.Empty<int>();
     public bool PolicyPresent { get; set; }
     public bool PolicyValid { get; set; }
     public string Mode { get; set; }

--- a/DomainDetective/Views/Converters.Mx.cs
+++ b/DomainDetective/Views/Converters.Mx.cs
@@ -107,13 +107,15 @@ public static partial class Converters
             PointsToLocalhost = analysis.PointsToLocalhost,
             Ipv6Supported = analysis.Ipv6Supported,
             MxTtlUniform = analysis.MxTtlUniform,
+            MxRecordTtl = analysis.MinMxTtl,
+            MxRecordTtls = analysis.MxRecordTtls,
             MxRrsetConsistentAcrossNs = analysis.MxRrsetConsistentAcrossNs,
             TargetAddressConsistentAcrossNs = analysis.TargetAddressConsistentAcrossNs,
             Assessments = analysis is IHasAssessments h ? h.Assessments : new List<Assessment>(),
             Status = status,
             WarningCount = warnCount,
             ErrorCount = errCount,
-            Summary = $"{analysis.MxRecords?.Count ?? 0} MX; backup {(analysis.HasBackupServers ? "yes" : "no")}\u002c TTL {(analysis.MxTtlUniform ? "uniform" : "mixed")}\u002c NS {(analysis.MxRrsetConsistentAcrossNs ? "consistent" : "differs")}",
+            Summary = $"{analysis.MxRecords?.Count ?? 0} MX; backup {(analysis.HasBackupServers ? "yes" : "no")}\u002c TTL {(analysis.MinMxTtl.HasValue ? analysis.MinMxTtl.Value.ToString() : "-")}s {(analysis.MxTtlUniform ? "uniform" : "mixed")}\u002c NS {(analysis.MxRrsetConsistentAcrossNs ? "consistent" : "differs")}",
             Recommendations = recs,
             Positives = positives,
             References = new [] { "https://www.rfc-editor.org/rfc/rfc5321" },
@@ -169,6 +171,8 @@ public class MxInfo
     public bool PointsToLocalhost { get; set; }
     public bool Ipv6Supported { get; set; }
     public bool MxTtlUniform { get; set; }
+    public int? MxRecordTtl { get; set; }
+    public IReadOnlyList<int> MxRecordTtls { get; set; } = System.Array.Empty<int>();
     public bool MxRrsetConsistentAcrossNs { get; set; }
     public bool TargetAddressConsistentAcrossNs { get; set; }
     public IReadOnlyList<Assessment> Assessments { get; set; } = System.Array.Empty<Assessment>();

--- a/DomainDetective/Views/Converters.Spf.cs
+++ b/DomainDetective/Views/Converters.Spf.cs
@@ -98,6 +98,8 @@ public static partial class Converters
             Area = AreaForKind(HealthCheckType.SPF),
             Subject = analysis.Subject,
             SpfRecord = analysis.SpfRecord,
+            DnsRecordTtl = analysis.DnsRecordTtl,
+            DnsRecordTtls = analysis.DnsRecordTtls,
             RecordLength = analysis?.SpfRecord?.Length ?? 0,
             SpfRecordExists = analysis.SpfRecordExists,
             StartsCorrectly = analysis.StartsCorrectly,
@@ -155,6 +157,8 @@ public class SpfRecordInfo
     public AnalysisArea Area { get; set; }
     public string Subject { get; set; } = string.Empty;
     public string SpfRecord { get; set; } = string.Empty;
+    public int? DnsRecordTtl { get; set; }
+    public IReadOnlyList<int> DnsRecordTtls { get; set; } = System.Array.Empty<int>();
     public int RecordLength { get; set; }
     public bool SpfRecordExists { get; set; }
     public bool StartsCorrectly { get; set; }

--- a/DomainDetective/Views/Converters.TlsRpt.cs
+++ b/DomainDetective/Views/Converters.TlsRpt.cs
@@ -16,6 +16,8 @@ public static partial class Converters
             Area = AreaForKind(HealthCheckType.TLSRPT),
             Subject = analysis.Subject,
             TlsRptRecord = analysis.TlsRptRecord,
+            DnsRecordTtl = analysis.DnsRecordTtl,
+            DnsRecordTtls = analysis.DnsRecordTtls,
             TlsRptRecordExists = analysis.TlsRptRecordExists,
             MultipleRecords = analysis.MultipleRecords,
             StartsCorrectly = analysis.StartsCorrectly,
@@ -44,6 +46,8 @@ public class TlsRptInfo
     public AnalysisArea Area { get; set; }
     public string Subject { get; set; }
     public string TlsRptRecord { get; set; }
+    public int? DnsRecordTtl { get; set; }
+    public IReadOnlyList<int> DnsRecordTtls { get; set; } = System.Array.Empty<int>();
     public bool TlsRptRecordExists { get; set; }
     public bool MultipleRecords { get; set; }
     public bool StartsCorrectly { get; set; }

--- a/DomainDetective/Views/Converters.Ttl.cs
+++ b/DomainDetective/Views/Converters.Ttl.cs
@@ -7,28 +7,62 @@ public static partial class Converters
 {
     public static TtlInfo Convert(DnsTtlAnalysis analysis)
     {
+        static IReadOnlyList<int> PreferAuthoritative(IReadOnlyList<int> authoritative, IReadOnlyList<int> observed) =>
+            authoritative != null && authoritative.Count > 0 ? authoritative : observed ?? System.Array.Empty<int>();
+        static Dictionary<string, IReadOnlyList<int>> PreferAuthoritativeMap(Dictionary<string, IReadOnlyList<int>> authoritative, Dictionary<string, IReadOnlyList<int>> observed)
+        {
+            if (authoritative != null && authoritative.Count > 0)
+            {
+                return authoritative;
+            }
+
+            return observed ?? new Dictionary<string, IReadOnlyList<int>>();
+        }
+
         Summarize(analysis.Assessments, out var warnCount, out var errCount, out var status);
         var recs = RecommendationEngine.FromProblems(analysis.Assessments);
         var positives = RecommendationEngine.FromPositives(analysis.Assessments);
+        var aTtls = PreferAuthoritative(analysis.AuthoritativeATtls, analysis.ATtls);
+        var aaaaTtls = PreferAuthoritative(analysis.AuthoritativeAaaaTtls, analysis.AaaaTtls);
+        var mxTtls = PreferAuthoritative(analysis.AuthoritativeMxTtls, analysis.MxTtls);
+        var nsTtls = PreferAuthoritative(analysis.AuthoritativeNsTtls, analysis.NsTtls);
+        var spfTtls = PreferAuthoritative(analysis.AuthoritativeSpfTxtTtls, analysis.SpfTxtTtls);
+        var dmarcTtls = PreferAuthoritative(analysis.AuthoritativeDmarcTxtTtls, analysis.DmarcTxtTtls);
+        var mtastsTtls = PreferAuthoritative(analysis.AuthoritativeMtastsTxtTtls, analysis.MtastsTxtTtls);
+        var tlsRptTtls = PreferAuthoritative(analysis.AuthoritativeTlsRptTxtTtls, analysis.TlsRptTxtTtls);
+        var dkimMap = PreferAuthoritativeMap(analysis.AuthoritativeDkimTxtTtls, analysis.DkimTxtTtls);
+        var soaEffective = analysis.AuthoritativeSoaTtl ?? analysis.SoaTtl;
         return new TtlInfo
         {
             Check = HealthCheckType.TTL,
             Area = AreaForKind(HealthCheckType.TTL),
             Subject = analysis.Subject,
             DnssecSigned = analysis.DnsSecSigned,
-            ATtls = analysis.ATtls,
-            AaaaTtls = analysis.AaaaTtls,
-            MxTtls = analysis.MxTtls,
-            NsTtls = analysis.NsTtls,
-            SoaTtl = analysis.SoaTtl,
-            SpfTxtTtls = analysis.SpfTxtTtls,
-            DmarcTxtTtls = analysis.DmarcTxtTtls,
-            DkimTxtTtls = analysis.DkimTxtTtls,
+            ATtls = aTtls,
+            AuthoritativeATtls = analysis.AuthoritativeATtls,
+            AaaaTtls = aaaaTtls,
+            AuthoritativeAaaaTtls = analysis.AuthoritativeAaaaTtls,
+            MxTtls = mxTtls,
+            AuthoritativeMxTtls = analysis.AuthoritativeMxTtls,
+            NsTtls = nsTtls,
+            AuthoritativeNsTtls = analysis.AuthoritativeNsTtls,
+            SoaTtl = soaEffective,
+            AuthoritativeSoaTtl = analysis.AuthoritativeSoaTtl,
+            SpfTxtTtls = spfTtls,
+            AuthoritativeSpfTxtTtls = analysis.AuthoritativeSpfTxtTtls,
+            DmarcTxtTtls = dmarcTtls,
+            AuthoritativeDmarcTxtTtls = analysis.AuthoritativeDmarcTxtTtls,
+            MtastsTxtTtls = mtastsTtls,
+            AuthoritativeMtastsTxtTtls = analysis.AuthoritativeMtastsTxtTtls,
+            TlsRptTxtTtls = tlsRptTtls,
+            AuthoritativeTlsRptTxtTtls = analysis.AuthoritativeTlsRptTxtTtls,
+            DkimTxtTtls = dkimMap,
+            AuthoritativeDkimTxtTtls = analysis.AuthoritativeDkimTxtTtls,
             Assessments = analysis.Assessments,
             Status = status,
             WarningCount = warnCount,
             ErrorCount = errCount,
-            Summary = $"SOA {analysis.SoaTtl}s; A min/max {(analysis.ATtls?.Count>0?System.Math.Min(int.MaxValue, analysis.ATtls.Min()).ToString():"-")}/{(analysis.ATtls?.Count>0?analysis.ATtls.Max().ToString():"-")}",
+            Summary = $"SOA {soaEffective}s; A min/max {(aTtls?.Count>0?System.Math.Min(int.MaxValue, aTtls.Min()).ToString():"-")}/{(aTtls?.Count>0?aTtls.Max().ToString():"-")}",
             Recommendations = recs,
             Positives = positives,
             References = new [] { "https://www.rfc-editor.org/rfc/rfc1035" },
@@ -43,21 +77,33 @@ public class TtlInfo
     public AnalysisArea Area { get; set; }
     public string Subject { get; set; }
     public bool DnssecSigned { get; set; }
-    public IReadOnlyList<int> ATtls { get; set; }
-    public IReadOnlyList<int> AaaaTtls { get; set; }
-    public IReadOnlyList<int> MxTtls { get; set; }
-    public IReadOnlyList<int> NsTtls { get; set; }
+    public IReadOnlyList<int> ATtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeATtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AaaaTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeAaaaTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> MxTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeMxTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> NsTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeNsTtls { get; set; } = System.Array.Empty<int>();
     public int SoaTtl { get; set; }
-    public IReadOnlyList<int> SpfTxtTtls { get; set; }
-    public IReadOnlyList<int> DmarcTxtTtls { get; set; }
-    public Dictionary<string, IReadOnlyList<int>> DkimTxtTtls { get; set; }
-    public IReadOnlyList<Assessment> Assessments { get; set; }
-    public string Status { get; set; }
+    public int? AuthoritativeSoaTtl { get; set; }
+    public IReadOnlyList<int> SpfTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeSpfTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> DmarcTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeDmarcTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> MtastsTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeMtastsTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> TlsRptTxtTtls { get; set; } = System.Array.Empty<int>();
+    public IReadOnlyList<int> AuthoritativeTlsRptTxtTtls { get; set; } = System.Array.Empty<int>();
+    public Dictionary<string, IReadOnlyList<int>> DkimTxtTtls { get; set; } = new();
+    public Dictionary<string, IReadOnlyList<int>> AuthoritativeDkimTxtTtls { get; set; } = new();
+    public IReadOnlyList<Assessment> Assessments { get; set; } = System.Array.Empty<Assessment>();
+    public string Status { get; set; } = string.Empty;
     public int WarningCount { get; set; }
     public int ErrorCount { get; set; }
-    public string Summary { get; set; }
-    public IReadOnlyList<RecommendationAdvice> Recommendations { get; set; }
-    public IReadOnlyList<RecommendationAdvice> Positives { get; set; }
-    public IReadOnlyList<string> References { get; set; }
-    public DnsTtlAnalysis Raw { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public IReadOnlyList<RecommendationAdvice> Recommendations { get; set; } = System.Array.Empty<RecommendationAdvice>();
+    public IReadOnlyList<RecommendationAdvice> Positives { get; set; } = System.Array.Empty<RecommendationAdvice>();
+    public IReadOnlyList<string> References { get; set; } = System.Array.Empty<string>();
+    public DnsTtlAnalysis Raw { get; set; } = new DnsTtlAnalysis();
 }

--- a/README.MD
+++ b/README.MD
@@ -382,6 +382,8 @@ Analyze TTL values:
 ```powershell
 Test-DnsTtl -DomainName "example.com"
 ```
+Set `CollectAuthoritativeTtls` on the health check to gather authoritative TTLs from NS hosts alongside observed resolver TTLs when you need configured values. Default is `false`.
+Mail-focused runs of `Test-DDDomainOverallHealth` now include DNS TTLs for SPF, DMARC, DKIM selectors, MX, MTA-STS, and TLS-RPT records without adding `-HealthCheckType TTL`.
 
 Get concise summaries (Area/Check/Status/Summary) for views returned by cmdlets:
 


### PR DESCRIPTION
## Summary / Issue
Addresses issue #989.

DomainDetective previously sampled resolver-observed TTLs for SPF/DMARC/DKIM/MX but:
- TTLs were not surfaced via Test-DDDomainOverallHealth unless HealthCheckType.TTL was requested.
- MTA-STS (`_mta-sts.<domain>` TXT) and TLS-RPT (`_smtp._tls.<domain>` TXT) DNS TTLs were not sampled.
- DKIM selector TTLs and per-MX TTLs were not consistently available for automation/reporting.

This PR implements opt-in authoritative TTL collection and surfaces TTLs through analysis models and views so mail-focused runs include TTL metrics by default (without requiring HealthCheckType.TTL).

## What changed
- DomainDetective/DnsTtlAnalysis.cs
  - New Authoritative* TTL properties for A/AAAA/MX/NS/SOA and TXT records (DKIM/DMARC/MTA-STS/TLS-RPT).
  - Logic to optionally query authoritative name servers (non-recursive) and fall back to resolver-observed TTLs.
- DomainDetective/Protocols/*.cs (SPF, DMARC, DKIM, MTASTS, TLSRPT, MX)
  - Persist DNS record TTLs on protocol analyses:
    - SpfAnalysis.DnsRecordTtl
    - DmarcAnalysis.DnsRecordTtl
    - MTASTSAnalysis.DnsRecordTtl (DNS TTL for `_mta-sts`, distinct from policy max_age)
    - TLSRPTAnalysis.DnsRecordTtl (DNS TTL for `_smtp._tls`)
    - DkimAnalysis: TTL per selector
    - MxAnalysis.MinMxTtl / per-MX TTLs
- DomainDetective.Reports/Composition/SectionProjectors.cs
  - Prefer authoritative DKIM TXT TTL map when available when building report rows.
- DomainDetective.CLI/Wizard/DomainWizard.cs
  - Prefer authoritative DKIM TTLs in TTL concatenation logic used by CLI views.
- DomainDetective.PowerShell/CmdletTestDomainHealth.cs
  - New `CollectAuthoritativeTtls` SwitchParameter; wired to DomainHealthCheck.CollectAuthoritativeTtls.
- DomainDetective.Tests/TestTtlFields.cs (new)
  - Unit tests validating TTL capture for DMARC, SPF, DKIM, MTA-STS, TLS-RPT and MX, including CNAME-cascade behavior and authoritative-vs-resolver precedence.
- README.MD
  - Documented the new opt-in `CollectAuthoritativeTtls` behavior and mail-focused runs now surface TTLs for the mail bundle.

## How this addresses issue #989 (proposal → implementation)
1) Persist TTL metadata on protocol analyses
   - Each protocol analysis now captures and exposes its DNS record TTL(s) so downstream consumers can read TTLs without re-querying DNS.

2) Extend DnsTtlAnalysis coverage for MTA-STS and TLS-RPT
   - _mta-sts and _smtp._tls TXT DNS TTLs are sampled and exposed via MtastsTxtTtls / TlsRptTxtTtls.

3) Bubble TTL data through views
   - Views / Raw output from Test-DDDomainOverallHealth include the new TTL fields; mail-focused runs (SPF/DMARC/DKIM/MX/MTASTS/TLSRPT) surface TTL metrics without adding HealthCheckType.TTL.

## Testing
- Unit tests:
```bash
dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj
```
- PowerShell module tests:
```powershell
pwsh ./Module/DomainDetective.Tests.ps1
```
- Manual:
```powershell
# Opt-in authoritative TTL collection
Test-DDDomainOverallHealth -DomainName "example.com" -CollectAuthoritativeTtls
# Mail bundle (TTL metrics included without -HealthCheckType TTL)
Test-DDDomainOverallHealth -DomainName "example.com" -HealthCheckType SPF,DMARC,DKIM,MX,MTASTS,TLSRPT
```

## Backwards compatibility & risk
- Opt-in: authoritative collection is disabled by default (no breaking changes).
- Additional authoritative queries may increase run time and DNS traffic when enabled — documented and opt-in.

## Suggested merge commit message
```
feat(ttl): ✨ Collect authoritative DNS TTLs and prefer them in views

- Add Authoritative* TTL properties to DnsTtlAnalysis
- Persist per-protocol DNS record TTLs (SPF/DMARC/DKIM/MTA-STS/TLS-RPT/MX)
- Wire CollectAuthoritativeTtls switch into PowerShell cmdlet
- Prefer authoritative DKIM TTLs in reports and CLI
- Add unit tests validating TTL capture and precedence
```

## Commands to prepare PR (Windows / PowerShell)
```powershell
git fetch origin
git checkout continue-989
git rebase origin/continue
git push --force-with-lease origin continue-989
gh pr create --base continue --head continue-989 --title "feat(ttl): ✨ Collect authoritative DNS TTLs and prefer them in views" --body-file PRs/feat-collect-authoritative-ttls.md
```

## Checklist (acceptance criteria from #989)
- [x] Existing consumers remain compatible (opt-in behavior)
- [x] Mail-focused runs include TTL metrics for SPF/DMARC/DKIM/MX/MTA-STS/TLS-RPT without adding HealthCheckType.TTL
- [x] DNS TTL for `_mta-sts` and `_smtp._tls` available via analysis objects and views (DNS TTL, not policy max_age)
- [x] DKIM selector TTLs exposed per selector
- [x] MX records expose TTL across MX records
- [x] README/CHANGELOG updated to call out new TTL visibility
