### PR TITLE
Add TTL collection for MTA-STS and TLS-RPT TXT records

### DIFF
--- a/DomainDetective/DnsTtlAnalysis.cs
+++ b/DomainDetective/DnsTtlAnalysis.cs
@@ -37,6 +37,10 @@ namespace DomainDetective {
         public IReadOnlyList<int> SpfTxtTtls { get; private set; } = Array.Empty<int>();
         /// <summary>TTL values for _dmarc TXT.</summary>
         public IReadOnlyList<int> DmarcTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>TTL values for _mta-sts TXT.</summary>
+        public IReadOnlyList<int> MtaStsTxtTtls { get; private set; } = Array.Empty<int>();
+        /// <summary>TTL values for _smtp._tls TXT.</summary>
+        public IReadOnlyList<int> TlsRptTxtTtls { get; private set; } = Array.Empty<int>();
         /// <summary>TTL values for DKIM selector TXT records, keyed by FQDN (selector._domainkey.domain).</summary>
         public Dictionary<string, IReadOnlyList<int>> DkimTxtTtls { get; private set; } = new();
         /// <summary>Collection of warning messages produced during analysis.</summary>
@@ -56,6 +60,10 @@ namespace DomainDetective {
         public int MinTtlDmarcSeconds { get; set; } = 3600;
         /// <summary>Minimum TTL for DKIM selector TXT records (seconds).</summary>
         public int MinTtlDkimSelectorSeconds { get; set; } = 3600;
+        /// <summary>Minimum TTL for MTA-STS TXT records (seconds).</summary>
+        public int MinTtlMtaStsSeconds { get; set; } = 3600;
+        /// <summary>Minimum TTL for TLS-RPT TXT records (seconds).</summary>
+        public int MinTtlTlsRptSeconds { get; set; } = 3600;
 
         // Per-authoritative-server TTL uniformity results
         public Dictionary<string, int?> ServerTtlA { get; private set; } = new();
@@ -181,6 +189,8 @@ namespace DomainDetective {
             SoaTtl = 0;
             SpfTxtTtls = Array.Empty<int>();
             DmarcTxtTtls = Array.Empty<int>();
+            MtaStsTxtTtls = Array.Empty<int>();
+            TlsRptTxtTtls = Array.Empty<int>();
             DkimTxtTtls = new Dictionary<string, IReadOnlyList<int>>();
 
             var aRecords = await QueryDns(domainName, DnsRecordType.A);
@@ -191,6 +201,8 @@ namespace DomainDetective {
             var dsRecords = await QueryDns(domainName, DnsRecordType.DS);
             var txtApex = await QueryDns(domainName, DnsRecordType.TXT);
             var txtDmarc = await QueryDns($"_dmarc.{domainName}", DnsRecordType.TXT);
+            var txtMtaSts = await QueryDns($"_mta-sts.{domainName}", DnsRecordType.TXT);
+            var txtTlsRpt = await QueryDns($"_smtp._tls.{domainName}", DnsRecordType.TXT);
 
             DnsSecSigned = dsRecords.Length > 0;
 
@@ -208,6 +220,14 @@ namespace DomainDetective {
             // Only treat TXT at _dmarc as DMARC when it actually contains a DMARC record
             DmarcTxtTtls = txtDmarc
                 .Where(r => (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=DMARC1", StringComparison.OrdinalIgnoreCase) >= 0)
+                .Select(r => r.TTL)
+                .ToArray();
+            MtaStsTxtTtls = txtMtaSts
+                .Where(r => (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=STSv1", StringComparison.OrdinalIgnoreCase) >= 0)
+                .Select(r => r.TTL)
+                .ToArray();
+            TlsRptTxtTtls = txtTlsRpt
+                .Where(r => (r.Data ?? r.DataRaw ?? string.Empty).IndexOf("v=TLSRPTv1", StringComparison.OrdinalIgnoreCase) >= 0)
                 .Select(r => r.TTL)
                 .ToArray();
 
@@ -233,8 +253,18 @@ namespace DomainDetective {
             }
 
             // Evaluate TXT categories with specific minima
-            if (SpfTxtTtls.Any()) Evaluate("SPF TXT", SpfTxtTtls, MinTtlSpfSeconds, 86400, false, logger);
-            if (DmarcTxtTtls.Any()) Evaluate("DMARC TXT", DmarcTxtTtls, MinTtlDmarcSeconds, 86400, false, logger);
+            if (SpfTxtTtls.Any()) {
+                Evaluate("SPF TXT", SpfTxtTtls, MinTtlSpfSeconds, 86400, false, logger);
+            }
+            if (DmarcTxtTtls.Any()) {
+                Evaluate("DMARC TXT", DmarcTxtTtls, MinTtlDmarcSeconds, 86400, false, logger);
+            }
+            if (MtaStsTxtTtls.Any()) {
+                Evaluate("MTA-STS TXT", MtaStsTxtTtls, MinTtlMtaStsSeconds, 604800, false, logger);
+            }
+            if (TlsRptTxtTtls.Any()) {
+                Evaluate("TLS-RPT TXT", TlsRptTxtTtls, MinTtlTlsRptSeconds, 604800, false, logger);
+            }
         }
 
         /// <summary>

--- a/DomainDetective/Views/Converters.Ttl.cs
+++ b/DomainDetective/Views/Converters.Ttl.cs
@@ -23,6 +23,8 @@ public static partial class Converters
             SoaTtl = analysis.SoaTtl,
             SpfTxtTtls = analysis.SpfTxtTtls,
             DmarcTxtTtls = analysis.DmarcTxtTtls,
+            MtaStsTxtTtls = analysis.MtaStsTxtTtls,
+            TlsRptTxtTtls = analysis.TlsRptTxtTtls,
             DkimTxtTtls = analysis.DkimTxtTtls,
             Assessments = analysis.Assessments,
             Status = status,
@@ -50,6 +52,8 @@ public class TtlInfo
     public int SoaTtl { get; set; }
     public IReadOnlyList<int> SpfTxtTtls { get; set; }
     public IReadOnlyList<int> DmarcTxtTtls { get; set; }
+    public IReadOnlyList<int> MtaStsTxtTtls { get; set; }
+    public IReadOnlyList<int> TlsRptTxtTtls { get; set; }
     public Dictionary<string, IReadOnlyList<int>> DkimTxtTtls { get; set; }
     public IReadOnlyList<Assessment> Assessments { get; set; }
     public string Status { get; set; }


### PR DESCRIPTION
## Summary

  - Fixes #993: collect and filter TTLs for `_mta-sts (v=STSv1)` and `_smtp._tls (v=TLSRPTv1)` TXT records in `DnsTtlAnalysis`, matching SPF/DMARC handling.
  - Expose the new TTL lists via `TtlInfo` so reports/exports can surface them; evaluate with configurable minima (default 3600s, max 604800s).
  - Preserve existing SPF/DMARC/DKIM behaviors and align TXT evaluation patterns.

  ## Testing

  - `dotnet test DomainDetective.Tests/DomainDetective.Tests.csproj --filter FullyQualifiedName~DnsTtlAnalysis`