### PR TITLE
fix(caa, dane, smimea): 🐛 Update methods to return Task.CompletedTask…

### DIFF
--- a/DomainDetective/Protocols/CAAAnalysis.cs
+++ b/DomainDetective/Protocols/CAAAnalysis.cs
@@ -86,7 +86,7 @@ As an illustration, a CAA record that is set on example.com is also applicable t
         /// </summary>
         /// <param name="dnsResults">DNS query results containing CAA records.</param>
         /// <param name="logger">Logger used for warnings and errors.</param>
-        public async Task AnalyzeCAARecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        public Task AnalyzeCAARecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "CAA", target: Subject ?? DomainName);
             // reset all properties so repeated calls don't accumulate data
             DomainName = null;
@@ -105,14 +105,14 @@ As an illustration, a CAA record that is set on example.com is also applicable t
 
             if (dnsResults == null) {
                 logger.WriteVerbose("DNS query returned no results.");
-                return;
+                return Task.CompletedTask;
             }
 
             var caaRecordList = dnsResults.ToList();
 
             if (!caaRecordList.Any()) {
                 logger.WriteVerbose("No CAA record found.");
-                return;
+                return Task.CompletedTask;
             }
 
             DomainName = caaRecordList.First().Name;
@@ -274,6 +274,7 @@ As an illustration, a CAA record that is set on example.com is also applicable t
 
             CheckForConflicts();
             GenerateLists(logger);
+            return Task.CompletedTask;
         }
         /// <summary>
         /// Builds summary lists of issuers and contact addresses from <see cref="AnalysisResults"/>.

--- a/DomainDetective/Protocols/DANEAnalysis.cs
+++ b/DomainDetective/Protocols/DANEAnalysis.cs
@@ -56,7 +56,7 @@ namespace DomainDetective {
         }
 
 
-        public async Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger, CancellationToken cancellationToken = default) {
+        public Task AnalyzeDANERecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger, CancellationToken cancellationToken = default) {
             using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "DANE");
             Reset();
 
@@ -64,7 +64,7 @@ namespace DomainDetective {
 
             if (dnsResults == null) {
                 logger.WriteVerbose("DNS query returned no results.");
-                return;
+                return Task.CompletedTask;
             }
 
             var daneRecordList = dnsResults.ToList();
@@ -201,6 +201,7 @@ namespace DomainDetective {
 
             cancellationToken.ThrowIfCancellationRequested();
             HasInvalidRecords = AnalysisResults.Any(x => !x.ValidDANERecord);
+            return Task.CompletedTask;
         }
 
         private bool ValidateUsage(int usageValue) {

--- a/DomainDetective/Protocols/SMIMEAAnalysis.cs
+++ b/DomainDetective/Protocols/SMIMEAAnalysis.cs
@@ -31,12 +31,12 @@ namespace DomainDetective {
         /// <summary>Actionable recommendations derived from assessments.</summary>
         public IReadOnlyList<RecommendationAdvice> Recommendations => RecommendationEngine.From(Assessments);
 
-        public async Task AnalyzeSMIMEARecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
+        public Task AnalyzeSMIMEARecords(IEnumerable<DnsAnswer> dnsResults, InternalLogger logger) {
             using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "SMIMEA");
             Reset();
             if (dnsResults == null) {
                 logger?.WriteVerbose("DNS query returned no results.");
-                return;
+                return Task.CompletedTask;
             }
             var records = dnsResults.ToList();
             var duplicate = records.GroupBy(x => x.Data).Where(g => g.Count() > 1).ToList();
@@ -120,6 +120,8 @@ namespace DomainDetective {
             if (AnalysisResults.Any(x => x.ValidSMIMEARecord)) {
                 logger?.WriteInformationCode(SmimeaCodes.CertificateValid, "Valid SMIMEA certificate association");
             }
+
+            return Task.CompletedTask;
         }
 
         private bool ValidateUsage(int usage) => usage switch { 0 or 1 or 2 or 3 => true, _ => false };


### PR DESCRIPTION
… instead of void

* Changed `AnalyzeCAARecords`, `AnalyzeDANERecords`, and `AnalyzeSMIMEARecords` methods to return `Task.CompletedTask` for better async handling.
* This change improves consistency across the analysis methods and prepares for potential future asynchronous operations.