### PR TITLE
Declutter website tools UX and fix shipped usage guidance

### DIFF
--- a/DomainDetective.Toolbox/Components/Shared/HostedFeaturePreview.razor
+++ b/DomainDetective.Toolbox/Components/Shared/HostedFeaturePreview.razor
@@ -1,20 +1,15 @@
 @using DomainDetective.Toolbox.Models
 
 <div class="tool-not-available">
-    <div class="tool-not-available-eyebrow">Advanced online tool</div>
+    <div class="tool-not-available-eyebrow">Run locally</div>
     <h3>@Tool.Name</h3>
     <p class="tool-not-available-copy">
         @GetIntro(Tool)
     </p>
 
-    <div class="tool-share-metrics">
-        <span class="tool-share-pill tool-share-pill-unavailable">Advanced online</span>
-        <span class="tool-share-pill tool-share-pill-fresh">Web edition guidance included</span>
-    </div>
-
     <div class="tool-summary-grid tool-summary-grid-compact">
         <div class="tool-summary-card">
-            <span class="tool-summary-label">What it covers</span>
+            <span class="tool-summary-label">What it checks</span>
             <ul class="tool-bullet-list">
                 @foreach (var item in GetCoverage(Tool)) {
                     <li>@item</li>
@@ -22,18 +17,12 @@
             </ul>
         </div>
         <div class="tool-summary-card">
-            <span class="tool-summary-label">In this web edition</span>
-            <p class="tool-summary-note">@GetStaticEditionNote(Tool)</p>
-        </div>
-        <div class="tool-summary-card">
-            <span class="tool-summary-label">What you can use now</span>
-            <ul class="tool-bullet-list">
-                @foreach (var item in GetWebEditionHighlights(Tool)) {
-                    <li>@item</li>
-                }
-            </ul>
+            <span class="tool-summary-label">How to run it</span>
+            <p class="tool-summary-note">Install the CLI or PowerShell module to run this check locally with the same analysis engine.</p>
         </div>
     </div>
+
+    <ToolUsageExamples Definition="Tool" StartOpen="true" />
 
     @if (GetRelatedLinks(Tool).Count > 0) {
         <div class="tool-link-row">
@@ -49,12 +38,12 @@
 
     private static string GetIntro(ToolDefinition tool) {
         return tool.Slug switch {
-            "http-headers" => "This check inspects live web responses, header behavior, redirects, and security policy details in the advanced online experience.",
-            "security-txt" => "This check retrieves and validates the published security.txt file, including disclosure fields, canonical location, expiry, and signing details.",
-            "rdap" => "This check analyzes live domain registration records, registrar details, status flags, and expiry data.",
-            "cert-check" => "This check inspects the live TLS handshake, certificate chain, protocol posture, and revocation details.",
-            "ct-subdomains" => "This check expands attack-surface discovery using historical certificate transparency evidence and related DD correlation.",
-            _ => $"{tool.Name} is available in the advanced online experience."
+            "http-headers" => "Inspects live web responses, header behavior, redirects, and security policy details.",
+            "security-txt" => "Retrieves and validates the published security.txt file, including disclosure fields, canonical location, expiry, and signing details.",
+            "rdap" => "Analyzes live domain registration records, registrar details, status flags, and expiry data.",
+            "cert-check" => "Inspects the live TLS handshake, certificate chain, protocol posture, and revocation details.",
+            "ct-subdomains" => "Discovers subdomains using historical certificate transparency evidence.",
+            _ => tool.Description
         };
     }
 
@@ -63,7 +52,7 @@
             "http-headers" => new[] {
                 "Response headers and redirect behavior",
                 "CSP, HSTS, framing, and mixed-header posture",
-                "DD guidance and policy follow-up"
+                "Security policy guidance"
             },
             "security-txt" => new[] {
                 "Published disclosure file retrieval",
@@ -73,7 +62,7 @@
             "rdap" => new[] {
                 "Registrar and registration status",
                 "Expiry and lifecycle posture",
-                "DD-backed registration guidance"
+                "Registration guidance"
             },
             "cert-check" => new[] {
                 "Certificate chain and issuer identity",
@@ -83,55 +72,9 @@
             "ct-subdomains" => new[] {
                 "Historical subdomain discovery",
                 "CT-backed hostname evidence",
-                "Exposure-oriented review points"
+                "Exposure-oriented review"
             },
-            _ => new[] {
-                tool.Description
-            }
-        };
-    }
-
-    private static string GetStaticEditionNote(ToolDefinition tool) {
-        return tool.Slug switch {
-            "http-headers" => "Use the web edition DNS, mail, and overview tools here. This deeper web-response analysis is part of the advanced online experience.",
-            "security-txt" => "The web edition keeps the DNS and overview tools live. Security.txt retrieval itself is part of the advanced online experience.",
-            "rdap" => "The web edition focuses on DNS and mail posture. Registration lookups remain part of the advanced online experience.",
-            "cert-check" => "The web edition keeps certificate-adjacent DNS controls like CAA and DANE live. Full TLS certificate inspection stays in the advanced online experience.",
-            "ct-subdomains" => "The web edition keeps overview and DNS tools live. Historical CT discovery remains part of the advanced online experience.",
-            _ => "This check is currently part of the advanced online experience."
-        };
-    }
-
-    private static IReadOnlyList<string> GetWebEditionHighlights(ToolDefinition tool) {
-        return tool.Slug switch {
-            "http-headers" => new[] {
-                "Use Domain Overview for broader web-edition posture",
-                "Validate DNS controls like CAA, DANE, and DNSSEC right now",
-                "Keep MX, SPF, DKIM, and DMARC checks live from the same tools catalog"
-            },
-            "security-txt" => new[] {
-                "Review mail and DNS posture with the live overview tools",
-                "Confirm contact-supporting DNS signals like MX, SPF, and DMARC",
-                "Use DNS Lookup when you need direct web-edition record inspection"
-            },
-            "rdap" => new[] {
-                "Use Domain Overview for a web-edition registration-adjacent posture snapshot",
-                "Inspect delegation with NS and SOA right now",
-                "Cross-check security controls with DNSSEC, CAA, and DANE"
-            },
-            "cert-check" => new[] {
-                "Validate certificate-adjacent DNS controls with CAA and DANE",
-                "Check name-server and DNSSEC posture before deeper TLS analysis",
-                "Use Domain Overview for a broader web-edition posture summary"
-            },
-            "ct-subdomains" => new[] {
-                "Use Domain Overview for a lighter attack-surface snapshot",
-                "Run DNS Propagation and Dangling CNAME in the web edition",
-                "Inspect mail and DNS controls for the main domain right now"
-            },
-            _ => new[] {
-                "Use the live DNS, mail, and overview tools available in this web edition"
-            }
+            _ => new[] { tool.Description }
         };
     }
 

--- a/DomainDetective.Toolbox/Components/Shared/ToolCategoryGrid.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolCategoryGrid.razor
@@ -12,23 +12,12 @@
             </div>
             <div class="category-tools">
                 @foreach (var tool in categoryTools) {
-                    @if (EnableLinks) {
-                        <a href="@($"/tools/{tool.Slug}/")" class="category-tool-link">
-                            <span class="category-tool-name">@tool.Name</span>
-                            @if (TryGetToolBadge(tool) is { } badge) {
-                                <span class="@badge.CssClass">@badge.Text</span>
-                            }
-                        </a>
-                    } else {
-                        <div class="category-tool-static">
-                            <span class="category-tool-name">@tool.Name</span>
-                            @if (TryGetToolBadge(tool) is { } badge) {
-                                <span class="@badge.CssClass">@badge.Text</span>
-                            } else if (!string.IsNullOrWhiteSpace(ToolBadgeText)) {
-                                <span class="category-tool-badge category-tool-badge-hosted">@ToolBadgeText</span>
-                            }
-                        </div>
-                    }
+                    <a href="@($"/tools/{tool.Slug}/")" class="category-tool-link">
+                        @if (DeploymentMode == ToolsDeploymentMode.StaticOnly) {
+                            <span class="tool-availability-dot @GetDotClass(tool)"></span>
+                        }
+                        <span class="category-tool-name">@tool.Name</span>
+                    </a>
                 }
             </div>
         </div>
@@ -37,30 +26,14 @@
 
 @code {
     [Parameter] public required IReadOnlyList<ToolDefinition> Tools { get; set; }
-    [Parameter] public bool EnableLinks { get; set; } = true;
-    [Parameter] public string? ToolBadgeText { get; set; }
     [Parameter] public ToolsDeploymentMode? DeploymentMode { get; set; }
 
     private IEnumerable<ToolCategory> GetCategories() =>
         Tools.Select(t => t.Category).Distinct().OrderBy(c => c);
 
-    private ToolBadge? TryGetToolBadge(ToolDefinition tool) {
-        if (!DeploymentMode.HasValue || DeploymentMode != ToolsDeploymentMode.StaticOnly) {
-            return null;
-        }
-
-        if (!EnableLinks) {
-            return !string.IsNullOrWhiteSpace(ToolBadgeText)
-                ? new ToolBadge(ToolBadgeText!, "category-tool-badge category-tool-badge-hosted")
-                : null;
-        }
-
-        if (tool.HostedCompatible && !tool.BrowserCompatible) {
-            return new ToolBadge("Adaptive", "category-tool-badge category-tool-badge-partial");
-        }
-
-        return new ToolBadge("Available", "category-tool-badge category-tool-badge-available");
+    private static string GetDotClass(ToolDefinition tool) {
+        if (tool.BrowserCompatible) return "tool-availability-dot-browser";
+        if (tool.LiteCompatible) return "tool-availability-dot-partial";
+        return "tool-availability-dot-local";
     }
-
-    private sealed record ToolBadge(string Text, string CssClass);
 }

--- a/DomainDetective.Toolbox/Components/Shared/ToolNotAvailable.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolNotAvailable.razor
@@ -1,41 +1,14 @@
+@using DomainDetective.Toolbox.Models
+
 <div class="tool-not-available">
-    <div class="tool-not-available-eyebrow">Desktop workflow</div>
-    <h3>@(string.IsNullOrWhiteSpace(ToolName) ? "Desktop Only" : $"{ToolName} works best outside the browser")</h3>
+    <div class="tool-not-available-eyebrow">Run locally</div>
+    <h3>@Tool.Name</h3>
     <p class="tool-not-available-copy">
-        @if (!string.IsNullOrWhiteSpace(Description)) {
-            <span>@Description</span>
-            <span> </span>
-        }
-        <span>This check relies on network capabilities that browser sandboxing can limit, so the full experience lives in the CLI and PowerShell module.</span>
+        @Tool.Description.
+        This check relies on network capabilities that browser sandboxing limits. Use the CLI or PowerShell module for the full experience.
     </p>
 
-    <div class="tool-summary-grid tool-summary-grid-compact">
-        <div class="tool-summary-card">
-            <span class="tool-summary-label">Best runtime</span>
-            <strong class="tool-summary-value">CLI + PowerShell</strong>
-            <p class="tool-summary-note">Direct DNS, certificate, and protocol checks without browser restrictions.</p>
-        </div>
-        <div class="tool-summary-card">
-            <span class="tool-summary-label">Install once</span>
-            <strong class="tool-summary-value">Same engine</strong>
-            <p class="tool-summary-note">You get the exact same analysis core that powers the docs, reports, and automation flows.</p>
-        </div>
-    </div>
-
-    <div class="desktop-command-grid">
-        @if (!string.IsNullOrEmpty(CliCommand)) {
-            <div class="desktop-command-card">
-                <div class="desktop-command-label">CLI</div>
-                <div class="result-record desktop-command-text">$ domaindetective @CliCommand example.com</div>
-            </div>
-        }
-        @if (!string.IsNullOrEmpty(PowerShellCommand)) {
-            <div class="desktop-command-card">
-                <div class="desktop-command-label">PowerShell</div>
-                <div class="result-record desktop-command-text">PS&gt; @PowerShellCommand</div>
-            </div>
-        }
-    </div>
+    <ToolUsageExamples Definition="Tool" StartOpen="true" />
 
     <div class="tool-link-row">
         <a href="/docs/quickstart/" class="tool-inline-link">Install Domain Detective</a>
@@ -45,8 +18,5 @@
 </div>
 
 @code {
-    [Parameter] public string? ToolName { get; set; }
-    [Parameter] public string? Description { get; set; }
-    [Parameter] public string? CliCommand { get; set; }
-    [Parameter] public string? PowerShellCommand { get; set; }
+    [Parameter] public required ToolDefinition Tool { get; set; }
 }

--- a/DomainDetective.Toolbox/Components/Shared/ToolPage.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolPage.razor
@@ -21,10 +21,7 @@
     </div>
 
     @if (!CanRunOnline(Definition)) {
-        <ToolNotAvailable ToolName="@Definition.Name"
-                          Description="@Definition.Description"
-                          CliCommand="@Definition.Slug"
-                          PowerShellCommand="@GetPowerShellCommand()" />
+        <ToolNotAvailable Tool="Definition" />
     } else {
         @if (Availability.IsStaticOnly && SupportsLiteTool(Definition)) {
             <div class="tool-callout tool-callout-inline">
@@ -190,6 +187,8 @@
             }
         }
     }
+
+    <ToolUsageExamples Definition="Definition" />
 </div>
 
 @code {
@@ -749,12 +748,6 @@
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
     }
-
-    private string GetPowerShellCommand() => Definition.Slug switch {
-        "cert-check" => "Get-DomainCertificate -Domain example.com",
-        "dane" => "Get-DomainDANE -Domain example.com",
-        _ => $"Get-DomainHealthCheck -Domain example.com"
-    };
 
     private static string FormatTimestamp(DateTimeOffset? timestamp) {
         return timestamp.HasValue ? timestamp.Value.ToString("HH:mm:ss") : "pending";

--- a/DomainDetective.Toolbox/Components/Shared/ToolUsageExamples.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolUsageExamples.razor
@@ -3,21 +3,21 @@
 @inject IJSRuntime JS
 
 @if (HasAnyExample()) {
-    <details class="tool-usage-examples" open="@StartOpen">
+    <details class="tool-usage-examples" open="@StartOpen" @ref="_examplesElement">
         <summary>Run with CLI, PowerShell, or C#</summary>
         <div class="tool-usage-tabs">
             <div class="tool-usage-tab-bar">
                 @if (Definition.CliExample is not null) {
                     <button type="button" class="tool-usage-tab-btn @(_activeTab == "cli" ? "active" : "")"
-                            @onclick="@(() => _activeTab = "cli")">CLI</button>
+                            @onclick="@(() => SelectTab("cli"))">CLI</button>
                 }
                 @if (Definition.PowerShellExample is not null) {
                     <button type="button" class="tool-usage-tab-btn @(_activeTab == "ps" ? "active" : "")"
-                            @onclick="@(() => _activeTab = "ps")">PowerShell</button>
+                            @onclick="@(() => SelectTab("ps"))">PowerShell</button>
                 }
                 @if (Definition.CSharpExample is not null) {
                     <button type="button" class="tool-usage-tab-btn @(_activeTab == "cs" ? "active" : "")"
-                            @onclick="@(() => _activeTab = "cs")">C#</button>
+                            @onclick="@(() => SelectTab("cs"))">C#</button>
                 }
             </div>
 
@@ -29,7 +29,7 @@
                             @(_copied ? "Copied" : "Copy")
                         </button>
                     </div>
-                    <pre class="tool-usage-code"><code>$ dotnet tool install -g DomainDetective.CLI
+                    <pre class="tool-usage-code language-bash"><code class="language-bash">$ dotnet tool install -g DomainDetective.CLI
 $ @Definition.CliExample</code></pre>
                 </div>
             }
@@ -42,7 +42,7 @@ $ @Definition.CliExample</code></pre>
                             @(_copied ? "Copied" : "Copy")
                         </button>
                     </div>
-                    <pre class="tool-usage-code"><code>PS&gt; Install-Module DomainDetective -Scope CurrentUser
+                    <pre class="tool-usage-code language-powershell"><code class="language-powershell">PS&gt; Install-Module DomainDetective -Scope CurrentUser
 PS&gt; Import-Module DomainDetective
 PS&gt; @Definition.PowerShellExample</code></pre>
                 </div>
@@ -56,7 +56,7 @@ PS&gt; @Definition.PowerShellExample</code></pre>
                             @(_copied ? "Copied" : "Copy")
                         </button>
                     </div>
-                    <pre class="tool-usage-code"><code>using DomainDetective;
+                    <pre class="tool-usage-code language-csharp"><code class="language-csharp">using DomainDetective;
 
 @Definition.CSharpExample</code></pre>
                 </div>
@@ -71,17 +71,56 @@ PS&gt; @Definition.PowerShellExample</code></pre>
 
     private string _activeTab = "cli";
     private bool _copied;
+    private bool _shouldHighlightCode;
+    private ElementReference _examplesElement;
 
     protected override void OnParametersSet() {
-        if (Definition.CliExample is not null) _activeTab = "cli";
-        else if (Definition.PowerShellExample is not null) _activeTab = "ps";
-        else if (Definition.CSharpExample is not null) _activeTab = "cs";
+        if (!IsTabAvailable(_activeTab)) {
+            if (Definition.CliExample is not null) _activeTab = "cli";
+            else if (Definition.PowerShellExample is not null) _activeTab = "ps";
+            else if (Definition.CSharpExample is not null) _activeTab = "cs";
+        }
+
+        _shouldHighlightCode = HasAnyExample();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender) {
+        if (!_shouldHighlightCode) {
+            return;
+        }
+
+        _shouldHighlightCode = false;
+
+        try {
+            await JS.InvokeVoidAsync("domainDetectiveTools.highlightCodeBlocks", _examplesElement);
+        } catch {
+            // Syntax highlighting is an enhancement and should not break the page.
+        }
     }
 
     private bool HasAnyExample() =>
         Definition.CliExample is not null ||
         Definition.PowerShellExample is not null ||
         Definition.CSharpExample is not null;
+
+    private bool IsTabAvailable(string tab) {
+        return tab switch {
+            "cli" => Definition.CliExample is not null,
+            "ps" => Definition.PowerShellExample is not null,
+            "cs" => Definition.CSharpExample is not null,
+            _ => false
+        };
+    }
+
+    private void SelectTab(string tab) {
+        if (!IsTabAvailable(tab) || string.Equals(_activeTab, tab, StringComparison.Ordinal)) {
+            return;
+        }
+
+        _activeTab = tab;
+        _copied = false;
+        _shouldHighlightCode = true;
+    }
 
     private async Task CopyAsync(string text) {
         try {

--- a/DomainDetective.Toolbox/Components/Shared/ToolUsageExamples.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolUsageExamples.razor
@@ -1,0 +1,98 @@
+@using DomainDetective.Toolbox.Models
+@using Microsoft.JSInterop
+@inject IJSRuntime JS
+
+@if (HasAnyExample()) {
+    <details class="tool-usage-examples" open="@StartOpen">
+        <summary>Run with CLI, PowerShell, or C#</summary>
+        <div class="tool-usage-tabs">
+            <div class="tool-usage-tab-bar">
+                @if (Definition.CliExample is not null) {
+                    <button type="button" class="tool-usage-tab-btn @(_activeTab == "cli" ? "active" : "")"
+                            @onclick="@(() => _activeTab = "cli")">CLI</button>
+                }
+                @if (Definition.PowerShellExample is not null) {
+                    <button type="button" class="tool-usage-tab-btn @(_activeTab == "ps" ? "active" : "")"
+                            @onclick="@(() => _activeTab = "ps")">PowerShell</button>
+                }
+                @if (Definition.CSharpExample is not null) {
+                    <button type="button" class="tool-usage-tab-btn @(_activeTab == "cs" ? "active" : "")"
+                            @onclick="@(() => _activeTab = "cs")">C#</button>
+                }
+            </div>
+
+            @if (_activeTab == "cli" && Definition.CliExample is not null) {
+                <div class="tool-usage-panel">
+                    <div class="tool-usage-panel-header">
+                        <span class="tool-usage-panel-label">Install &amp; run</span>
+                        <button type="button" class="tool-usage-copy-btn" @onclick="@(() => CopyAsync($"dotnet tool install -g DomainDetective.CLI\n{Definition.CliExample}"))">
+                            @(_copied ? "Copied" : "Copy")
+                        </button>
+                    </div>
+                    <pre class="tool-usage-code"><code>$ dotnet tool install -g DomainDetective.CLI
+$ @Definition.CliExample</code></pre>
+                </div>
+            }
+
+            @if (_activeTab == "ps" && Definition.PowerShellExample is not null) {
+                <div class="tool-usage-panel">
+                    <div class="tool-usage-panel-header">
+                        <span class="tool-usage-panel-label">Install module &amp; run</span>
+                        <button type="button" class="tool-usage-copy-btn" @onclick="@(() => CopyAsync($"Install-Module DomainDetective -Scope CurrentUser\nImport-Module DomainDetective\n{Definition.PowerShellExample}"))">
+                            @(_copied ? "Copied" : "Copy")
+                        </button>
+                    </div>
+                    <pre class="tool-usage-code"><code>PS&gt; Install-Module DomainDetective -Scope CurrentUser
+PS&gt; Import-Module DomainDetective
+PS&gt; @Definition.PowerShellExample</code></pre>
+                </div>
+            }
+
+            @if (_activeTab == "cs" && Definition.CSharpExample is not null) {
+                <div class="tool-usage-panel">
+                    <div class="tool-usage-panel-header">
+                        <span class="tool-usage-panel-label">NuGet package</span>
+                        <button type="button" class="tool-usage-copy-btn" @onclick="@(() => CopyAsync(Definition.CSharpExample))">
+                            @(_copied ? "Copied" : "Copy")
+                        </button>
+                    </div>
+                    <pre class="tool-usage-code"><code>using DomainDetective;
+
+@Definition.CSharpExample</code></pre>
+                </div>
+            }
+        </div>
+    </details>
+}
+
+@code {
+    [Parameter] public required ToolDefinition Definition { get; set; }
+    [Parameter] public bool StartOpen { get; set; }
+
+    private string _activeTab = "cli";
+    private bool _copied;
+
+    protected override void OnParametersSet() {
+        if (Definition.CliExample is not null) _activeTab = "cli";
+        else if (Definition.PowerShellExample is not null) _activeTab = "ps";
+        else if (Definition.CSharpExample is not null) _activeTab = "cs";
+    }
+
+    private bool HasAnyExample() =>
+        Definition.CliExample is not null ||
+        Definition.PowerShellExample is not null ||
+        Definition.CSharpExample is not null;
+
+    private async Task CopyAsync(string text) {
+        try {
+            await JS.InvokeVoidAsync("domainDetectiveTools.copyText", text);
+            _copied = true;
+            StateHasChanged();
+            await Task.Delay(1400);
+            _copied = false;
+            StateHasChanged();
+        } catch {
+            // clipboard API may not be available
+        }
+    }
+}

--- a/DomainDetective.Toolbox/Components/Tools/Overview/DomainOverviewPresentation.cs
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/DomainOverviewPresentation.cs
@@ -64,7 +64,7 @@ internal static class DomainOverviewPresentation
 
         if (lines.Count < 5)
         {
-            lines.AddRange(info.Summary.Hints.Take(5 - lines.Count));
+            if (info.Summary?.Hints != null) lines.AddRange(info.Summary.Hints.Take(5 - lines.Count));
         }
 
         return lines
@@ -171,7 +171,7 @@ internal static class DomainOverviewPresentation
 
     private static DomainOverviewDetailCardView BuildExposureSnapshotCard(DomainOverviewInfo info)
     {
-        var samples = info.SubdomainSample
+        var samples = (info.SubdomainSample ?? Array.Empty<string>())
             .Take(3)
             .ToArray();
 
@@ -197,7 +197,7 @@ internal static class DomainOverviewPresentation
             samples.Add("Registrar: " + info.Rdap.Registrar);
         }
 
-        samples.AddRange(info.Summary.Hints.Take(2));
+        if (info.Summary?.Hints != null) samples.AddRange(info.Summary.Hints.Take(2));
 
         return new DomainOverviewDetailCardView
         {
@@ -206,7 +206,7 @@ internal static class DomainOverviewPresentation
             Summary = "Registration timing, registrar context, and DD hinting combine here to summarize the registration and lifecycle posture.",
             Tags = new[]
             {
-                "Hints: " + info.Summary.Hints.Count,
+                "Hints: " + (info.Summary?.Hints?.Count ?? 0),
                 info.DaysUntilExpiration.HasValue ? "Days remaining: " + info.DaysUntilExpiration.Value : "Expiry not observed"
             },
             Samples = samples.Where(static item => !string.IsNullOrWhiteSpace(item)).Distinct(StringComparer.OrdinalIgnoreCase).Take(3).ToArray()
@@ -314,7 +314,7 @@ internal static class DomainOverviewPresentation
             samples.Add("Web posture: grade " + info.HttpGrade);
         }
 
-        samples.AddRange(info.Summary.Hints.Take(3));
+        if (info.Summary?.Hints != null) samples.AddRange(info.Summary.Hints.Take(3));
 
         if (info.Rdap != null && !string.IsNullOrWhiteSpace(info.Rdap.Registrar))
         {
@@ -352,10 +352,10 @@ internal static class DomainOverviewPresentation
         var samples = new List<string>();
         if (subdomains != null)
         {
-            samples.AddRange(subdomains.Highlights.Take(3));
+            if (subdomains.Highlights != null) samples.AddRange(subdomains.Highlights.Take(3));
         }
 
-        if (samples.Count < 4)
+        if (samples.Count < 4 && info.SubdomainSample != null)
         {
             samples.AddRange(info.SubdomainSample.Take(4 - samples.Count));
         }
@@ -453,8 +453,8 @@ internal static class DomainOverviewPresentation
             samples.Add(Truncate(info.SpfRecord, 120));
         }
 
-        samples.AddRange(info.Highlights.Take(2));
-        if (samples.Count < 3)
+        if (info.Highlights != null) samples.AddRange(info.Highlights.Take(2));
+        if (samples.Count < 3 && info.ResolvedIncludeRecords != null)
         {
             samples.AddRange(info.ResolvedIncludeRecords.Take(2).Select(static value => "Include: " + value));
         }
@@ -529,8 +529,8 @@ internal static class DomainOverviewPresentation
             samples.Add(Truncate(info.DmarcRecord, 120));
         }
 
-        samples.AddRange(info.Highlights.Take(2));
-        samples.AddRange(info.MailtoRua.Take(2).Select(static value => "rua: " + value));
+        if (info.Highlights != null) samples.AddRange(info.Highlights.Take(2));
+        if (info.MailtoRua != null) samples.AddRange(info.MailtoRua.Take(2).Select(static value => "rua: " + value));
 
         return new DomainOverviewDetailCardView
         {
@@ -969,12 +969,15 @@ internal static class DomainOverviewPresentation
     private static DomainOverviewDetailCardView BuildRegistrationEvidenceCard(RdapInfo info)
     {
         var samples = new List<string>();
-        samples.AddRange(info.NameServers.Take(3).Select(static value => "NS: " + value));
-        samples.AddRange(info.StatusValues.Take(2).Select(static value => "Status: " + value));
-        samples.AddRange(info.EventSummaries
-            .Where(static item => !string.IsNullOrWhiteSpace(item.Action) && !string.IsNullOrWhiteSpace(item.Date))
-            .Take(2)
-            .Select(static item => item.Action + ": " + item.Date));
+        if (info.NameServers != null)
+            samples.AddRange(info.NameServers.Take(3).Select(static value => "NS: " + value));
+        if (info.StatusValues != null)
+            samples.AddRange(info.StatusValues.Take(2).Select(static value => "Status: " + value));
+        if (info.EventSummaries != null)
+            samples.AddRange(info.EventSummaries
+                .Where(static item => !string.IsNullOrWhiteSpace(item.Action) && !string.IsNullOrWhiteSpace(item.Date))
+                .Take(2)
+                .Select(static item => item.Action + ": " + item.Date));
 
         return new DomainOverviewDetailCardView
         {
@@ -1055,9 +1058,10 @@ internal static class DomainOverviewPresentation
         tags.Add(info.HstsPresent ? "HSTS on" : "HSTS missing");
         tags.Add(info.Http2Supported ? "HTTP/2" : "No HTTP/2");
 
-        if (info.MissingSecurityHeaders.Count > 0)
+        var missingCount = info.MissingSecurityHeaders?.Count ?? 0;
+        if (missingCount > 0)
         {
-            tags.Add(info.MissingSecurityHeaders.Count + " missing headers");
+            tags.Add(missingCount + " missing headers");
         }
 
         var samples = new List<string>();
@@ -1071,8 +1075,9 @@ internal static class DomainOverviewPresentation
             samples.Add("Referrer-Policy: " + info.ReferrerPolicy);
         }
 
-        samples.AddRange(info.Highlights.Take(2));
-        if (samples.Count == 0)
+        if (info.Highlights != null)
+            samples.AddRange(info.Highlights.Take(2));
+        if (samples.Count == 0 && info.Details != null)
         {
             samples.AddRange(info.Details.Take(2));
         }
@@ -1082,7 +1087,7 @@ internal static class DomainOverviewPresentation
             Title = "HTTP headers",
             ValueLabel = info.IsReachable ? "Grade " + info.Grade : "Offline",
             Summary = info.IsReachable
-                ? $"Reachable over {(string.IsNullOrWhiteSpace(info.ProtocolVersion) ? "HTTP" : info.ProtocolVersion)} with {(info.HstsPresent ? "HSTS enabled" : "no HSTS")} and {info.MissingSecurityHeaders.Count} missing security header(s)."
+                ? $"Reachable over {(string.IsNullOrWhiteSpace(info.ProtocolVersion) ? "HTTP" : info.ProtocolVersion)} with {(info.HstsPresent ? "HSTS enabled" : "no HSTS")} and {missingCount} missing security header(s)."
                 : (string.IsNullOrWhiteSpace(info.FailureReason) ? "HTTP endpoint was not reachable during the DD run." : info.FailureReason),
             Tags = tags,
             Samples = samples.Where(static item => !string.IsNullOrWhiteSpace(item)).Distinct(StringComparer.OrdinalIgnoreCase).Take(4).ToArray()
@@ -1128,7 +1133,8 @@ internal static class DomainOverviewPresentation
             samples.Add("Subject: " + info.CertificateSubject);
         }
 
-        samples.AddRange(info.Highlights.Take(2));
+        if (info.Highlights != null)
+            samples.AddRange(info.Highlights.Take(2));
 
         return new DomainOverviewDetailCardView
         {
@@ -1165,16 +1171,20 @@ internal static class DomainOverviewPresentation
         }
 
         var samples = new List<string>();
-        samples.AddRange(info.ContactEmail.Take(2).Select(static value => "Contact email: " + value));
-        samples.AddRange(info.ContactWebsite.Take(1).Select(static value => "Contact URL: " + value));
-        samples.AddRange(info.Highlights.Take(2));
+        if (info.ContactEmail != null)
+            samples.AddRange(info.ContactEmail.Take(2).Select(static value => "Contact email: " + value));
+        if (info.ContactWebsite != null)
+            samples.AddRange(info.ContactWebsite.Take(1).Select(static value => "Contact URL: " + value));
+        if (info.Highlights != null)
+            samples.AddRange(info.Highlights.Take(2));
 
+        var contactCount = (info.ContactEmail?.Count ?? 0) + (info.ContactWebsite?.Count ?? 0);
         return new DomainOverviewDetailCardView
         {
             Title = "Security.txt",
             ValueLabel = info.RecordPresent ? "Published" : "Missing",
             Summary = info.RecordPresent
-                ? $"Disclosure file is {(info.RecordValid ? "valid" : "present but needs attention")} with {info.ContactEmail.Count + info.ContactWebsite.Count} contact route(s)."
+                ? $"Disclosure file is {(info.RecordValid ? "valid" : "present but needs attention")} with {contactCount} contact route(s)."
                 : "No security.txt disclosure policy was found.",
             Tags = tags,
             Samples = samples.Where(static item => !string.IsNullOrWhiteSpace(item)).Distinct(StringComparer.OrdinalIgnoreCase).Take(4).ToArray()
@@ -1199,27 +1209,30 @@ internal static class DomainOverviewPresentation
             tags.Add("Contact entity");
         }
 
-        if (info.NameServers.Count > 0)
+        var nsCount = info.NameServers?.Count ?? 0;
+        if (nsCount > 0)
         {
-            tags.Add(info.NameServers.Count + " NS");
+            tags.Add(nsCount + " NS");
         }
 
         var samples = new List<string>();
-        samples.AddRange(info.EventSummaries
-            .Where(static item => !string.IsNullOrWhiteSpace(item.Action) && !string.IsNullOrWhiteSpace(item.Date))
-            .Take(2)
-            .Select(static item => item.Action + ": " + item.Date));
-        samples.AddRange(info.EntitySummaries
-            .Where(static item => !string.IsNullOrWhiteSpace(item.Handle))
-            .Take(2)
-            .Select(static item => "Entity: " + item.Handle));
+        if (info.EventSummaries != null)
+            samples.AddRange(info.EventSummaries
+                .Where(static item => !string.IsNullOrWhiteSpace(item.Action) && !string.IsNullOrWhiteSpace(item.Date))
+                .Take(2)
+                .Select(static item => item.Action + ": " + item.Date));
+        if (info.EntitySummaries != null)
+            samples.AddRange(info.EntitySummaries
+                .Where(static item => !string.IsNullOrWhiteSpace(item.Handle))
+                .Take(2)
+                .Select(static item => "Entity: " + item.Handle));
 
         return new DomainOverviewDetailCardView
         {
             Title = "Registration",
             ValueLabel = info.RecordAvailable ? FormatDays(info.DaysUntilExpiration, "Available") : "Unavailable",
             Summary = info.RecordAvailable
-                ? $"Registration data is available from {(string.IsNullOrWhiteSpace(info.Registrar) ? "the registrar" : info.Registrar)} with {info.StatusValues.Count} status value(s)."
+                ? $"Registration data is available from {(string.IsNullOrWhiteSpace(info.Registrar) ? "the registrar" : info.Registrar)} with {(info.StatusValues?.Count ?? 0)} status value(s)."
                 : "Registration data was not available during the DD run.",
             Tags = tags,
             Samples = samples.Where(static item => !string.IsNullOrWhiteSpace(item)).Distinct(StringComparer.OrdinalIgnoreCase).Take(4).ToArray()
@@ -1230,8 +1243,8 @@ internal static class DomainOverviewPresentation
     {
         var tags = new List<string>
         {
-            info.Pathways.Count + " pathway(s)",
-            info.Targets.Count + " target(s)"
+            (info.Pathways?.Count ?? 0) + " pathway(s)",
+            (info.Targets?.Count ?? 0) + " target(s)"
         };
 
         if (info.ProvidersWithListings > 0)
@@ -1240,8 +1253,9 @@ internal static class DomainOverviewPresentation
         }
 
         var samples = new List<string>();
-        samples.AddRange(info.Listings.Take(3).Select(static item => item.Target + " via " + item.Provider));
-        if (samples.Count == 0)
+        if (info.Listings != null)
+            samples.AddRange(info.Listings.Take(3).Select(static item => item.Target + " via " + item.Provider));
+        if (samples.Count == 0 && info.Pathways != null)
         {
             samples.AddRange(info.Pathways.Take(2).Select(static item => item.Label + ": " + item.TargetsChecked + " checked"));
         }

--- a/DomainDetective.Toolbox/Components/Tools/Overview/DomainOverviewTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/DomainOverviewTool.razor
@@ -220,16 +220,9 @@
 <ResultCard Title="Mail and DNS security" Status="ResultCard.ResultStatus.Info">
     <div class="overview-status-strip">
         @foreach (var card in mailControlCards) {
-            <OverviewControlCard Card="card" CalloutClass="@($"tool-callout tool-callout-control {card.StateClass}")" Compact="true" />
+            <OverviewPairedCard Control="card" Detail="FindMatchingDetail(card, mailCards)" />
         }
     </div>
-    @if (mailCards.Count > 0) {
-        <div class="tool-section-grid mt-3">
-            @foreach (var card in mailCards) {
-                <OverviewDetailCard Card="card" />
-            }
-        </div>
-    }
 </ResultCard>
 }
 </div>
@@ -630,6 +623,12 @@
         }
 
         return $"{(int)age.TotalDays}d ago";
+    }
+
+    private static DomainOverviewDetailCardView? FindMatchingDetail(OverviewControlCardView control, IReadOnlyList<DomainOverviewDetailCardView> details) {
+        var title = control.Title.Trim().ToLowerInvariant();
+        return details.FirstOrDefault(d => d.Title.ToLowerInvariant().Contains(title)) ??
+               details.FirstOrDefault(d => title.Contains(d.Title.Split(' ')[0].ToLowerInvariant()));
     }
 
     private static bool IsSectionPending(DomainOverviewInfo info, string section) {

--- a/DomainDetective.Toolbox/Components/Tools/Overview/M365OverviewTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/M365OverviewTool.razor
@@ -299,16 +299,9 @@
 <ResultCard Title="Mail and DNS controls" Status="ResultCard.ResultStatus.Info">
     <div class="overview-status-strip">
         @foreach (var card in mailControlCards) {
-            <OverviewControlCard Card="card" CalloutClass="@($"tool-callout tool-callout-control {card.StateClass}")" Compact="true" />
+            <OverviewPairedCard Control="card" Detail="FindMatchingDetail(card, mailCards)" />
         }
     </div>
-    @if (mailCards.Count > 0) {
-        <div class="tool-section-grid mt-3">
-            @foreach (var card in mailCards) {
-                <OverviewDetailCard Card="card" />
-            }
-        </div>
-    }
 </ResultCard>
 }
 </div>
@@ -683,6 +676,12 @@
         }
 
         return string.Join(", ", values);
+    }
+
+    private static DomainOverviewDetailCardView? FindMatchingDetail(OverviewControlCardView control, IReadOnlyList<DomainOverviewDetailCardView> details) {
+        var title = control.Title.Trim().ToLowerInvariant();
+        return details.FirstOrDefault(d => d.Title.ToLowerInvariant().Contains(title)) ??
+               details.FirstOrDefault(d => title.Contains(d.Title.Split(' ')[0].ToLowerInvariant()));
     }
 
     private static bool IsSectionPending(Microsoft365OverviewInfo info, string section) {

--- a/DomainDetective.Toolbox/Components/Tools/Overview/OverviewPairedCard.razor
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/OverviewPairedCard.razor
@@ -1,0 +1,48 @@
+@* Renders a control card with its matching detail card as an expandable section *@
+
+<div class="overview-paired-card @Control.StateClass">
+    <div class="overview-paired-header">
+        <div class="overview-paired-title">
+            <strong>@Control.Title</strong>
+            <span class="overview-paired-value">@Control.ValueLabel</span>
+        </div>
+        <div class="tool-chip-list">
+            @foreach (var tag in Control.Tags) {
+                <span class="tool-chip">@tag</span>
+            }
+        </div>
+        @if (Control.Samples.Count > 0) {
+            <p class="overview-paired-sample">@Control.Samples[0]</p>
+        }
+    </div>
+
+    @if (Detail is not null) {
+        <details class="overview-paired-detail">
+            <summary class="overview-paired-detail-toggle">
+                @Detail.Title: @Detail.ValueLabel
+            </summary>
+            <div class="overview-paired-detail-body">
+                <p class="tool-summary-note">@Detail.Summary</p>
+                @if (Detail.Tags.Count > 0) {
+                    <div class="tool-chip-list">
+                        @foreach (var tag in Detail.Tags) {
+                            <span class="tool-chip">@tag</span>
+                        }
+                    </div>
+                }
+                @if (Detail.Samples.Count > 0) {
+                    <ul class="tool-bullet-list mt-2">
+                        @foreach (var sample in Detail.Samples) {
+                            <li>@sample</li>
+                        }
+                    </ul>
+                }
+            </div>
+        </details>
+    }
+</div>
+
+@code {
+    [Parameter] public required OverviewControlCardView Control { get; set; }
+    [Parameter] public DomainOverviewDetailCardView? Detail { get; set; }
+}

--- a/DomainDetective.Toolbox/Models/ToolDefinition.cs
+++ b/DomainDetective.Toolbox/Models/ToolDefinition.cs
@@ -21,4 +21,7 @@ public sealed class ToolDefinition {
     public string? InputPlaceholder { get; init; }
     public string? SecondaryInputLabel { get; init; }
     public string? SecondaryInputPlaceholder { get; init; }
+    public string? CliExample { get; init; }
+    public string? PowerShellExample { get; init; }
+    public string? CSharpExample { get; init; }
 }

--- a/DomainDetective.Toolbox/Services/ToolRegistry.cs
+++ b/DomainDetective.Toolbox/Services/ToolRegistry.cs
@@ -13,7 +13,10 @@ public sealed class ToolRegistry {
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
             HostedCompatible = true,
-            LiteCompatible = true
+            LiteCompatible = true,
+            CliExample = "domaindetective check 'example.com'",
+            PowerShellExample = "Test-DomainHealth -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.Verify(\"example.com\");"
         },
         new ToolDefinition {
             Name = "Domain Overview",
@@ -24,7 +27,10 @@ public sealed class ToolRegistry {
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
             HostedCompatible = true,
-            LiteCompatible = true
+            LiteCompatible = true,
+            CliExample = "domaindetective check 'example.com'",
+            PowerShellExample = "Test-DomainHealth -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.Verify(\"example.com\");"
         },
 
         // Email Security
@@ -34,7 +40,10 @@ public sealed class ToolRegistry {
             Description = "Validate SPF records and check for misconfigurations",
             Category = ToolCategory.EmailSecurity,
             Icon = "shield-check",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks SPF",
+            PowerShellExample = "Test-DDEmailSpfRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifySPF(\"example.com\");"
         },
         new ToolDefinition {
             Name = "DKIM Lookup",
@@ -44,7 +53,10 @@ public sealed class ToolRegistry {
             Icon = "key",
             InputPlaceholder = "example.com",
             SecondaryInputLabel = "Selector (optional)",
-            SecondaryInputPlaceholder = "Leave blank to auto-detect"
+            SecondaryInputPlaceholder = "Leave blank to auto-detect",
+            CliExample = "domaindetective check 'example.com' --checks DKIM",
+            PowerShellExample = "Test-DDEmailDkimRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDKIM(\"example.com\", new[] { \"selector1\" });"
         },
         new ToolDefinition {
             Name = "DMARC Lookup",
@@ -52,7 +64,10 @@ public sealed class ToolRegistry {
             Description = "Analyze DMARC policy and reporting configuration",
             Category = ToolCategory.EmailSecurity,
             Icon = "shield",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks DMARC",
+            PowerShellExample = "Test-DDEmailDmarcRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDMARC(\"example.com\");"
         },
         new ToolDefinition {
             Name = "MX Lookup",
@@ -60,7 +75,10 @@ public sealed class ToolRegistry {
             Description = "Check mail exchanger records and priorities",
             Category = ToolCategory.EmailSecurity,
             Icon = "mail",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks MX",
+            PowerShellExample = "Test-DDDnsMxRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyMX(\"example.com\");"
         },
         new ToolDefinition {
             Name = "MTA-STS Check",
@@ -71,7 +89,10 @@ public sealed class ToolRegistry {
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
             HostedCompatible = true,
-            LiteCompatible = true
+            LiteCompatible = true,
+            CliExample = "domaindetective check 'example.com' --checks MTASTS",
+            PowerShellExample = "Test-DDEmailMtaSts -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyMTASTS(\"example.com\");"
         },
         new ToolDefinition {
             Name = "TLS-RPT Check",
@@ -79,7 +100,10 @@ public sealed class ToolRegistry {
             Description = "Check TLS reporting DNS record configuration",
             Category = ToolCategory.EmailSecurity,
             Icon = "file-text",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks TLSRPT",
+            PowerShellExample = "Test-DDEmailTlsRptRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyTLSRPT(\"example.com\");"
         },
         new ToolDefinition {
             Name = "BIMI Lookup",
@@ -87,7 +111,10 @@ public sealed class ToolRegistry {
             Description = "Validate BIMI record and brand indicator",
             Category = ToolCategory.EmailSecurity,
             Icon = "image",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks BIMI",
+            PowerShellExample = "Test-DDEmailBimiRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyBIMI(\"example.com\");"
         },
 
         // DNS
@@ -97,7 +124,10 @@ public sealed class ToolRegistry {
             Description = "Query DNS records of any type (A, AAAA, CNAME, TXT, etc.)",
             Category = ToolCategory.Dns,
             Icon = "search",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks DNSINVENTORY",
+            PowerShellExample = "Test-DomainHealth -DomainName 'example.com' -HealthCheckType DNSINVENTORY",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDnsInventoryAsync(\"example.com\");"
         },
         new ToolDefinition {
             Name = "DNSSEC Check",
@@ -105,7 +135,10 @@ public sealed class ToolRegistry {
             Description = "Validate DNSSEC chain of trust",
             Category = ToolCategory.Dns,
             Icon = "shield",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks DNSSEC",
+            PowerShellExample = "Test-DDDnsSecStatus -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDNSSEC(\"example.com\");"
         },
         new ToolDefinition {
             Name = "SOA Lookup",
@@ -113,7 +146,10 @@ public sealed class ToolRegistry {
             Description = "Check SOA record and zone authority",
             Category = ToolCategory.Dns,
             Icon = "server",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks SOA",
+            PowerShellExample = "Test-DDDnsSoaRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifySOA(\"example.com\");"
         },
         new ToolDefinition {
             Name = "NS Lookup",
@@ -121,7 +157,10 @@ public sealed class ToolRegistry {
             Description = "List authoritative nameservers",
             Category = ToolCategory.Dns,
             Icon = "globe",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks NS",
+            PowerShellExample = "Test-DDDnsNsRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyNS(\"example.com\");"
         },
         new ToolDefinition {
             Name = "DNS Propagation",
@@ -132,7 +171,10 @@ public sealed class ToolRegistry {
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
             HostedCompatible = true,
-            LiteCompatible = true
+            LiteCompatible = true,
+            CliExample = "domaindetective DnsPropagation --domain 'example.com' --record-type A",
+            PowerShellExample = "Test-DDDnsPropagation -DomainName 'example.com' -RecordType A",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDnsPropagationAsync(\"example.com\");"
         },
 
         // TLS & Certificates
@@ -144,7 +186,10 @@ public sealed class ToolRegistry {
             Icon = "award",
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
-            HostedCompatible = true
+            HostedCompatible = true,
+            CliExample = "domaindetective check 'example.com' --checks CERT",
+            PowerShellExample = "Test-DDDomainCertificate -Url 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyWebsiteCertificate(\"example.com\");"
         },
         new ToolDefinition {
             Name = "CAA Lookup",
@@ -152,7 +197,10 @@ public sealed class ToolRegistry {
             Description = "Check Certificate Authority Authorization records",
             Category = ToolCategory.TlsCert,
             Icon = "check-square",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks CAA",
+            PowerShellExample = "Test-DDDnsCaaRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyCAA(\"example.com\");"
         },
         new ToolDefinition {
             Name = "DANE Check",
@@ -160,7 +208,10 @@ public sealed class ToolRegistry {
             Description = "Validate DANE/TLSA records",
             Category = ToolCategory.TlsCert,
             Icon = "link",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks DANE",
+            PowerShellExample = "Test-DDTlsDaneRecord -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDANE(\"example.com\", new[] { 443 });"
         },
 
         // Web Security
@@ -172,7 +223,10 @@ public sealed class ToolRegistry {
             Icon = "code",
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
-            HostedCompatible = true
+            HostedCompatible = true,
+            CliExample = "domaindetective check 'example.com' --checks WEBSITE",
+            PowerShellExample = "Test-DDWebsiteSecurity -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyWebsiteHttps(\"example.com\");"
         },
         new ToolDefinition {
             Name = "Security.txt",
@@ -182,7 +236,10 @@ public sealed class ToolRegistry {
             Icon = "file-text",
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
-            HostedCompatible = true
+            HostedCompatible = true,
+            CliExample = "domaindetective check 'example.com' --checks SECURITYTXT",
+            PowerShellExample = "Test-DDDomainSecurityTxt -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifySecurityTxt(\"example.com\");"
         },
 
         // Registration
@@ -194,7 +251,10 @@ public sealed class ToolRegistry {
             Icon = "database",
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
-            HostedCompatible = true
+            HostedCompatible = true,
+            CliExample = "domaindetective TestRDAP 'example.com'",
+            PowerShellExample = "Get-DDRdap -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.QueryRDAP(\"example.com\");"
         },
 
         // Threat Intel
@@ -204,7 +264,10 @@ public sealed class ToolRegistry {
             Description = "Check domain/IP against DNS blacklists",
             Category = ToolCategory.ThreatIntel,
             Icon = "alert-triangle",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks DNSBL",
+            PowerShellExample = "Test-DDDnsBlacklist -NameOrIpAddress 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDNSBL(\"example.com\");"
         },
         new ToolDefinition {
             Name = "Dangling CNAME",
@@ -212,7 +275,10 @@ public sealed class ToolRegistry {
             Description = "Detect dangling CNAME records vulnerable to takeover",
             Category = ToolCategory.ThreatIntel,
             Icon = "alert-circle",
-            InputPlaceholder = "example.com"
+            InputPlaceholder = "example.com",
+            CliExample = "domaindetective check 'example.com' --checks DANGLINGCNAME",
+            PowerShellExample = "Test-DDDnsDanglingCname -DomainName 'example.com'",
+            CSharpExample = "var hc = new DomainHealthCheck();\nawait hc.VerifyDanglingCname(\"example.com\");"
         },
 
         // Subdomain
@@ -224,7 +290,10 @@ public sealed class ToolRegistry {
             Icon = "layers",
             InputPlaceholder = "example.com",
             BrowserCompatible = false,
-            HostedCompatible = true
+            HostedCompatible = true,
+            CliExample = "domaindetective cert-inventory-capture 'example.com' --include-ct-subdomains",
+            PowerShellExample = "Invoke-DDCertificateInventory -DomainName 'example.com' -IncludeCtSubdomains",
+            CSharpExample = "var capture = new CertificateInventoryCapture();\nvar options = new CertificateInventoryCaptureOptions { IncludeCtDiscoveredSubdomains = true };\nawait capture.CaptureAsync(new[] { \"example.com\" }, options);"
         }
     };
 

--- a/DomainDetective.Website/DomainDetective.Website.csproj
+++ b/DomainDetective.Website/DomainDetective.Website.csproj
@@ -16,4 +16,9 @@
         <ProjectReference Include="..\DomainDetective.Toolbox\DomainDetective.Toolbox.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <Content Include="..\Website\static\css\prism-theme.css" Link="wwwroot\css\prism-theme.css" CopyToOutputDirectory="PreserveNewest" />
+        <Content Include="..\Website\static\assets\prism\**\*" Link="wwwroot\assets\prism\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
+
 </Project>

--- a/DomainDetective.Website/Pages/Tools.razor
+++ b/DomainDetective.Website/Pages/Tools.razor
@@ -21,76 +21,23 @@
         </div>
 
         @if (Availability.IsStaticOnly) {
-            <div class="tools-edition-guide">
-                <div class="tools-edition-guide-header">
-                    <h2>What works in this web version</h2>
-                    <p>
-                        The web edition keeps the DNS, mail, and lightweight overview tools live in the browser.
-                        Deeper web-response, certificate, registration, and larger discovery checks stay visible here as advanced online features,
-                        and the same tool pages unlock automatically when the full online experience is enabled.
-                    </p>
-                </div>
-
-                <div class="tools-edition-guide-grid">
-                    <article class="tools-edition-guide-card tools-edition-guide-card-available">
-                        <span class="tools-edition-guide-kicker">Available now</span>
-                        <strong>@GetAvailableNowCount() live tools</strong>
-                        <p>Runs fully in this web edition using live DD checks that work directly in the browser.</p>
-                    </article>
-
-                    <article class="tools-edition-guide-card tools-edition-guide-card-partial">
-                        <span class="tools-edition-guide-kicker">Adaptive web mode</span>
-                        <strong>@GetBrowserSafePartialCount() adaptive tools</strong>
-                        <p>Same tool page, with web-ready sections live and deeper sections clearly marked.</p>
-                    </article>
-
-                    <article class="tools-edition-guide-card tools-edition-guide-card-hosted">
-                        <span class="tools-edition-guide-kicker">Advanced online tools</span>
-                        <strong>@_hostedPreviewTools.Count deeper tools</strong>
-                        <p>Kept visible for discovery, with feature previews and related live tools instead of broken pages.</p>
-                    </article>
-                </div>
-            </div>
-
-            <div class="tools-edition-summary">
-                <span class="tools-edition-pill">Available now: @GetAvailableNowCount()</span>
-                <span class="tools-edition-pill">Adaptive web tools: @GetBrowserSafePartialCount()</span>
-                <span class="tools-edition-pill">Advanced online tools: @_hostedPreviewTools.Count</span>
+            <div class="tools-availability-legend">
+                <span class="legend-item"><span class="legend-dot legend-dot-browser"></span> Runs in browser</span>
+                <span class="legend-item"><span class="legend-dot legend-dot-partial"></span> Partial browser support</span>
+                <span class="legend-item"><span class="legend-dot legend-dot-local"></span> Run locally (CLI / PowerShell)</span>
             </div>
         }
 
         @if (!string.IsNullOrEmpty(_searchQuery)) {
-            if (_filteredTools is not null && _filteredTools.Count > 0) {
-                <ToolCategoryGrid Tools="_filteredTools" DeploymentMode="Availability.Mode" />
-            }
-
-            @if (Availability.IsStaticOnly && _filteredHostedPreviewTools.Count > 0) {
-                <div class="tools-edition-panel">
-                    <div class="tools-edition-header">
-                        <h2>Advanced Online Matches</h2>
-                        <p>These matches belong to the advanced online tools. They stay visible here so people can discover them without hitting a broken result.</p>
-                    </div>
-                    <ToolCategoryGrid Tools="_filteredHostedPreviewTools" EnableLinks="false" ToolBadgeText="Advanced" DeploymentMode="Availability.Mode" />
-                </div>
-            }
-
-            @if ((_filteredTools is null || _filteredTools.Count == 0) && _filteredHostedPreviewTools.Count == 0) {
+            @if (_filteredAllTools.Count > 0) {
+                <ToolCategoryGrid Tools="_filteredAllTools" DeploymentMode="Availability.Mode" />
+            } else {
                 <div class="tools-empty">
                     <p>No tools match "<strong>@_searchQuery</strong>"</p>
                 </div>
             }
         } else {
-            <ToolCategoryGrid Tools="_availableTools" DeploymentMode="Availability.Mode" />
-
-            @if (Availability.IsStaticOnly && _hostedPreviewTools.Count > 0) {
-                <div class="tools-edition-panel">
-                    <div class="tools-edition-header">
-                        <h2>Advanced Online Tools</h2>
-                        <p>These deeper checks are part of the advanced online experience. The web edition keeps the web-ready tools live and leaves the heavier checks here as product previews.</p>
-                    </div>
-                    <ToolCategoryGrid Tools="_hostedPreviewTools" EnableLinks="false" ToolBadgeText="Advanced" DeploymentMode="Availability.Mode" />
-                </div>
-            }
+            <ToolCategoryGrid Tools="_allTools" DeploymentMode="Availability.Mode" />
         }
     </div>
 } else {
@@ -100,7 +47,7 @@
             <h2>Tool not found</h2>
             <p>No tool matches "<strong>@ToolSlug</strong>". <a href="/tools/">Browse all tools</a></p>
         </div>
-    } else if (Availability.IsStaticOnly && tool.HostedCompatible && !Availability.CanRun(tool)) {
+    } else if (Availability.IsStaticOnly && tool.HostedCompatible && !tool.BrowserCompatible && !tool.LiteCompatible) {
         <div class="tool-page">
             <div class="tool-breadcrumb">
                 <a href="/tools/">Tools</a> / @ToolRegistry.GetCategoryDisplayName(tool.Category) / @tool.Name
@@ -114,9 +61,17 @@
             <HostedFeaturePreview Tool="tool" />
         </div>
     } else if (!Availability.CanRun(tool)) {
-        <div class="tool-not-found">
-            <h2>Tool not available online</h2>
-            <p>@Availability.GetUnavailableMessage(tool) <a href="/tools/">Browse available tools</a></p>
+        <div class="tool-page">
+            <div class="tool-breadcrumb">
+                <a href="/tools/">Tools</a> / @ToolRegistry.GetCategoryDisplayName(tool.Category) / @tool.Name
+            </div>
+
+            <div class="tool-page-header">
+                <h1>@tool.Name</h1>
+                <p>@tool.Description</p>
+            </div>
+
+            <ToolNotAvailable Tool="tool" />
         </div>
     } else {
         <ToolPage Definition="tool" />
@@ -128,71 +83,28 @@
 
     private bool _isReady;
     private string? _searchQuery;
-    private IReadOnlyList<ToolDefinition> _availableTools = Array.Empty<ToolDefinition>();
-    private IReadOnlyList<ToolDefinition> _hostedPreviewTools = Array.Empty<ToolDefinition>();
-    private IReadOnlyList<ToolDefinition>? _filteredTools;
-    private IReadOnlyList<ToolDefinition> _filteredHostedPreviewTools = Array.Empty<ToolDefinition>();
+    private IReadOnlyList<ToolDefinition> _allTools = Array.Empty<ToolDefinition>();
+    private IReadOnlyList<ToolDefinition> _filteredAllTools = Array.Empty<ToolDefinition>();
 
     protected override async Task OnParametersSetAsync() {
         await Availability.InitializeAsync();
-        _availableTools = Availability.FilterVisible(Registry.GetAll());
-        _hostedPreviewTools = Availability.IsStaticOnly
-            ? Registry.GetAll()
-                .Where(static tool => tool.HostedCompatible && !tool.BrowserCompatible)
-                .Where(tool => !_availableTools.Any(available => string.Equals(available.Slug, tool.Slug, StringComparison.OrdinalIgnoreCase)))
-                .ToList()
-            : Array.Empty<ToolDefinition>();
-        if (string.IsNullOrWhiteSpace(_searchQuery)) {
-            _filteredTools = null;
-            _filteredHostedPreviewTools = Array.Empty<ToolDefinition>();
-        } else {
-            var matches = Registry.Search(_searchQuery);
-            _filteredTools = Availability.FilterVisible(matches);
-            _filteredHostedPreviewTools = Availability.IsStaticOnly
-                ? matches
-                    .Where(static tool => tool.HostedCompatible && !tool.BrowserCompatible)
-                    .Where(tool => !_availableTools.Any(available => string.Equals(available.Slug, tool.Slug, StringComparison.OrdinalIgnoreCase)))
-                    .ToList()
-                : Array.Empty<ToolDefinition>();
+        _allTools = Registry.GetAll();
+        if (!string.IsNullOrWhiteSpace(_searchQuery)) {
+            _filteredAllTools = Registry.Search(_searchQuery);
         }
-
         _isReady = true;
     }
 
     private void HandleSearch(string query) {
         _searchQuery = query;
-        if (string.IsNullOrWhiteSpace(query)) {
-            _filteredTools = null;
-            _filteredHostedPreviewTools = Array.Empty<ToolDefinition>();
-            return;
-        }
-
-        var matches = Registry.Search(query);
-        _filteredTools = Availability.FilterVisible(matches);
-        _filteredHostedPreviewTools = Availability.IsStaticOnly
-            ? matches
-                .Where(static tool => tool.HostedCompatible && !tool.BrowserCompatible)
-                .Where(tool => !_availableTools.Any(available => string.Equals(available.Slug, tool.Slug, StringComparison.OrdinalIgnoreCase)))
-                .ToList()
-            : Array.Empty<ToolDefinition>();
-    }
-
-    private int GetBrowserSafePartialCount() {
-        return _availableTools.Count(static tool => tool.HostedCompatible && !tool.BrowserCompatible);
-    }
-
-    private int GetAvailableNowCount() {
-        return _availableTools.Count(static tool => tool.BrowserCompatible);
+        _filteredAllTools = string.IsNullOrWhiteSpace(query)
+            ? Array.Empty<ToolDefinition>()
+            : Registry.Search(query);
     }
 
     private string GetPageTitle() {
-        if (!_isReady) return "Tools | Domain Detective";
-        if (string.IsNullOrEmpty(ToolSlug)) return "Tools | Domain Detective";
+        if (!_isReady || string.IsNullOrEmpty(ToolSlug)) return "Tools | Domain Detective";
         var tool = Registry.GetBySlug(ToolSlug);
-        if (tool is null || !Availability.CanRun(tool)) {
-            return tool is not null ? $"{tool.Name} | Domain Detective" : "Tool Not Available | Domain Detective";
-        }
-
-        return $"{tool.Name} | Domain Detective";
+        return tool is not null ? $"{tool.Name} | Domain Detective" : "Tool Not Available | Domain Detective";
     }
 }

--- a/DomainDetective.Website/Pages/Tools.razor
+++ b/DomainDetective.Website/Pages/Tools.razor
@@ -2,6 +2,7 @@
 @page "/{ToolSlug}"
 @inject ToolRegistry Registry
 @inject ToolAvailabilityService Availability
+@inject NavigationManager Navigation
 
 <PageTitle>@GetPageTitle()</PageTitle>
 
@@ -80,6 +81,7 @@
 
 @code {
     [Parameter] public string? ToolSlug { get; set; }
+    [SupplyParameterFromQuery(Name = "domain")] public string? DomainQuery { get; set; }
 
     private bool _isReady;
     private string? _searchQuery;
@@ -87,6 +89,12 @@
     private IReadOnlyList<ToolDefinition> _filteredAllTools = Array.Empty<ToolDefinition>();
 
     protected override async Task OnParametersSetAsync() {
+        if (string.IsNullOrEmpty(ToolSlug) && !string.IsNullOrWhiteSpace(DomainQuery)) {
+            var target = "/tools/domain-overview/?q=" + Uri.EscapeDataString(DomainQuery.Trim());
+            Navigation.NavigateTo(target, replace: true);
+            return;
+        }
+
         await Availability.InitializeAsync();
         _allTools = Registry.GetAll();
         if (!string.IsNullOrWhiteSpace(_searchQuery)) {

--- a/DomainDetective.Website/wwwroot/css/app.css
+++ b/DomainDetective.Website/wwwroot/css/app.css
@@ -231,12 +231,16 @@ a:hover { color: var(--dd-accent-light); }
 }
 
 .dd-nav-link {
+    display: inline-flex;
+    align-items: center;
     position: relative;
     color: var(--dd-muted);
     font-size: 0.875rem;
     font-weight: 500;
+    line-height: 1.4;
     transition: color 0.2s, background 0.2s;
     padding: 0.5rem 0.75rem;
+    min-height: 2.4rem;
     border-radius: var(--dd-radius-sm);
     white-space: nowrap;
 }
@@ -274,10 +278,12 @@ a:hover { color: var(--dd-accent-light); }
 }
 
 .dd-nav-dropdown-trigger {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     gap: 0.25rem;
     padding: 0.5rem 0.75rem;
+    min-height: 2.4rem;
+    line-height: 1.4;
     font-size: 0.875rem;
     font-weight: 500;
     color: var(--dd-muted);
@@ -882,7 +888,9 @@ a:hover { color: var(--dd-accent-light); }
 }
 
 .tool-input-secondary {
-    max-width: 200px;
+    flex: 0 1 17rem;
+    min-width: 17rem;
+    max-width: 20rem;
 }
 
 .tool-run-btn {
@@ -2347,7 +2355,12 @@ a:hover { color: var(--dd-accent-light); }
     .desktop-command-grid {
         grid-template-columns: 1fr;
     }
-    .tool-input-secondary { max-width: none; }
+    .tool-input-secondary {
+        flex: 1 1 auto;
+        min-width: 0;
+        max-width: none;
+        width: 100%;
+    }
     .dd-nav-toggle { display: inline-flex; }
     .dd-nav {
         position: fixed;

--- a/DomainDetective.Website/wwwroot/css/app.css
+++ b/DomainDetective.Website/wwwroot/css/app.css
@@ -746,7 +746,6 @@ a:hover { color: var(--dd-accent-light); }
 .category-tool-link {
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 0.5rem;
     padding: 0.375rem 0.5rem;
     border-radius: var(--dd-radius-sm);
@@ -760,237 +759,8 @@ a:hover { color: var(--dd-accent-light); }
     padding-left: 0.75rem;
 }
 
-.category-tool-static {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.5rem 0.6rem;
-    border-radius: var(--dd-radius-sm);
-    background: rgba(13, 21, 48, 0.28);
-    color: var(--dd-ink);
-    font-size: 0.9rem;
-}
-
 .category-tool-name {
     min-width: 0;
-}
-
-.category-tool-badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.24rem 0.55rem;
-    border-radius: 999px;
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-    white-space: nowrap;
-}
-
-.category-tool-badge-available {
-    border: 1px solid rgba(34, 197, 94, 0.18);
-    background: rgba(20, 83, 45, 0.24);
-    color: #bbf7d0;
-}
-
-.category-tool-badge-partial {
-    border: 1px solid rgba(6, 182, 212, 0.18);
-    background: rgba(8, 47, 73, 0.26);
-    color: #a5f3fc;
-}
-
-.category-tool-badge-hosted {
-    border: 1px solid rgba(251, 191, 36, 0.18);
-    background: rgba(120, 53, 15, 0.24);
-    color: #fde68a;
-}
-
-.tools-edition-panel {
-    margin-top: 2.5rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.tools-edition-summary {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.75rem;
-    margin-bottom: 1.5rem;
-}
-
-.tools-edition-guide {
-    display: grid;
-    gap: 1.2rem;
-    margin: 0 auto 1.75rem;
-    padding: 1.35rem;
-    border: 1px solid rgba(0, 217, 255, 0.08);
-    border-radius: var(--dd-radius);
-    background:
-        linear-gradient(180deg, rgba(13, 21, 48, 0.76), rgba(13, 21, 48, 0.4));
-    box-shadow: var(--dd-shadow-card);
-}
-
-.tools-edition-guide-header {
-    display: grid;
-    gap: 0.45rem;
-}
-
-.tools-edition-guide-header h2 {
-    margin: 0;
-    font-family: var(--dd-font-display);
-    font-size: 1.35rem;
-    font-weight: 700;
-    color: var(--dd-ink-strong);
-}
-
-.tools-edition-guide-header p {
-    margin: 0;
-    max-width: 72ch;
-    color: var(--dd-muted);
-    line-height: 1.7;
-}
-
-.tools-edition-guide-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
-}
-
-.tools-edition-guide-card {
-    display: grid;
-    gap: 0.45rem;
-    padding: 1rem;
-    border-radius: var(--dd-radius-sm);
-    border: 1px solid rgba(0, 217, 255, 0.08);
-    background: rgba(13, 21, 48, 0.46);
-}
-
-.tools-edition-guide-kicker {
-    color: var(--dd-muted);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-}
-
-.tools-edition-guide-card strong {
-    color: var(--dd-ink-strong);
-    font-family: var(--dd-font-display);
-    font-size: 1.05rem;
-    line-height: 1.3;
-}
-
-.tools-edition-guide-card p {
-    margin: 0;
-    color: var(--dd-muted);
-    font-size: 0.9rem;
-    line-height: 1.6;
-}
-
-.tools-edition-guide-card-available {
-    box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.15);
-}
-
-.tools-edition-guide-card-partial {
-    box-shadow: inset 0 0 0 1px rgba(6, 182, 212, 0.15);
-}
-
-.tools-edition-guide-card-hosted {
-    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.14);
-}
-
-.tools-edition-pill {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.45rem 0.8rem;
-    border-radius: 999px;
-    border: 1px solid rgba(0, 217, 255, 0.12);
-    background: rgba(13, 21, 48, 0.42);
-    color: var(--dd-ink);
-    font-size: 0.82rem;
-    font-weight: 600;
-    line-height: 1.3;
-}
-
-.tools-edition-pill-live {
-    border-color: rgba(34, 197, 94, 0.2);
-    background: rgba(20, 83, 45, 0.24);
-    color: #bbf7d0;
-}
-
-.tools-edition-header h2 {
-    margin: 0 0 0.5rem;
-    font-family: var(--dd-font-display);
-    font-size: 1.35rem;
-    font-weight: 700;
-    color: var(--dd-ink-strong);
-}
-
-.tools-edition-header p {
-    margin: 0;
-    max-width: 70ch;
-    color: var(--dd-muted);
-    line-height: 1.65;
-}
-
-[data-theme="light"] .category-tool-static {
-    background: rgba(244, 249, 255, 0.9);
-    color: var(--dd-ink-strong);
-}
-
-[data-theme="light"] .category-tool-badge-available {
-    border-color: rgba(34, 197, 94, 0.18);
-    background: rgba(240, 253, 244, 0.96);
-    color: #166534;
-}
-
-[data-theme="light"] .category-tool-badge-partial {
-    border-color: rgba(8, 145, 178, 0.18);
-    background: rgba(236, 254, 255, 0.96);
-    color: #0f766e;
-}
-
-[data-theme="light"] .tools-edition-pill {
-    border-color: rgba(15, 143, 176, 0.14);
-    background: rgba(244, 249, 255, 0.96);
-    color: var(--dd-ink-strong);
-}
-
-[data-theme="light"] .tools-edition-guide {
-    border-color: rgba(15, 143, 176, 0.14);
-    background:
-        linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(244, 249, 255, 0.92));
-}
-
-[data-theme="light"] .tools-edition-guide-card {
-    border-color: rgba(15, 143, 176, 0.12);
-    background: rgba(250, 252, 255, 0.98);
-}
-
-[data-theme="light"] .tools-edition-guide-card-available {
-    box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.14);
-}
-
-[data-theme="light"] .tools-edition-guide-card-partial {
-    box-shadow: inset 0 0 0 1px rgba(8, 145, 178, 0.14);
-}
-
-[data-theme="light"] .tools-edition-guide-card-hosted {
-    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.14);
-}
-
-[data-theme="light"] .category-tool-badge-hosted {
-    border-color: rgba(245, 158, 11, 0.18);
-    background: rgba(255, 251, 235, 0.96);
-    color: #b45309;
-}
-
-[data-theme="light"] .tools-edition-pill-live {
-    border-color: rgba(34, 197, 94, 0.18);
-    background: rgba(240, 253, 244, 0.96);
-    color: #166534;
 }
 
 /* ── Tool Page ──────────────────────────────────────────────────── */
@@ -1004,6 +774,23 @@ a:hover { color: var(--dd-accent-light); }
 .tool-page-overview {
     max-width: 1180px;
     padding-top: 0.55rem;
+}
+.tool-page-overview .result-card {
+    margin-bottom: 1.75rem;
+    padding: 1.75rem;
+}
+.tool-page-overview .result-card-title {
+    font-size: 1.2rem;
+}
+.tool-page-overview .tool-summary-grid {
+    gap: 1.1rem;
+}
+.tool-page-overview .tool-callout-grid {
+    gap: 1.1rem;
+}
+.tool-page-overview .overview-section-state {
+    margin-bottom: 1.25rem;
+    padding: 0.5rem 0;
 }
 
 .tool-page-header {
@@ -1213,12 +1000,15 @@ a:hover { color: var(--dd-accent-light); }
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 1rem;
+    margin-bottom: 1.25rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid var(--dd-border);
     position: relative;
 }
 .result-card-title {
     font-family: var(--dd-font-display);
     font-weight: 700;
+    font-size: 1.15rem;
     color: var(--dd-ink-strong);
 }
 
@@ -1519,19 +1309,52 @@ a:hover { color: var(--dd-accent-light); }
 }
 
 .tool-callout-pass {
+    border-color: rgba(34, 197, 94, 0.35);
     box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.18);
+}
+.tool-callout-pass .tool-summary-label {
+    color: #4ade80;
+}
+.tool-callout-pass .tool-summary-value {
+    color: #bbf7d0;
 }
 
 .tool-callout-warning {
+    border-color: rgba(245, 158, 11, 0.35);
     box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.18);
+}
+.tool-callout-warning .tool-summary-label {
+    color: #fbbf24;
+}
+.tool-callout-warning .tool-summary-value {
+    color: #fde68a;
 }
 
 .tool-callout-fail {
-    box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.18);
+    border-color: rgba(239, 68, 68, 0.4);
+    box-shadow: inset 0 0 0 1px rgba(239, 68, 68, 0.22);
+    background: linear-gradient(180deg, rgba(40, 12, 12, 0.6), rgba(30, 10, 10, 0.4));
+}
+.tool-callout-fail .tool-summary-label {
+    color: #f87171;
+}
+.tool-callout-fail .tool-summary-value {
+    color: #fecaca;
 }
 
 .tool-callout-info {
+    border-color: rgba(59, 130, 246, 0.3);
     box-shadow: inset 0 0 0 1px rgba(59, 130, 246, 0.16);
+}
+
+.tool-callout-pass::before {
+    background: linear-gradient(90deg, rgba(34, 197, 94, 0.9), rgba(34, 197, 94, 0.4)) !important;
+}
+.tool-callout-warning::before {
+    background: linear-gradient(90deg, rgba(245, 158, 11, 0.9), rgba(245, 158, 11, 0.4)) !important;
+}
+.tool-callout-fail::before {
+    background: linear-gradient(90deg, rgba(239, 68, 68, 0.9), rgba(239, 68, 68, 0.4)) !important;
 }
 
 .tool-callout-soft {
@@ -1553,6 +1376,7 @@ a:hover { color: var(--dd-accent-light); }
     position: absolute;
     top: 0;
     left: 0;
+    right: 0;
     right: 0;
     height: 2px;
     background: linear-gradient(90deg, rgba(0, 217, 255, 0.95), rgba(91, 140, 255, 0.9));
@@ -1836,9 +1660,10 @@ a:hover { color: var(--dd-accent-light); }
 
 .tool-section-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
     gap: 1.1rem;
     align-items: start;
+    max-width: 100%;
 }
 
 .tool-section-grid > * {
@@ -1973,9 +1798,13 @@ a:hover { color: var(--dd-accent-light); }
 .overview-section-state {
     display: flex;
     flex-wrap: wrap;
-    align-items: flex-start;
-    gap: 0.6rem;
-    margin: 0 0 0.95rem;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 1.25rem;
+    padding: 0.65rem 0.85rem;
+    border-radius: var(--dd-radius-sm);
+    background: rgba(13, 21, 48, 0.4);
+    border: 1px solid var(--dd-border);
 }
 
 .overview-section-state-text {
@@ -2276,8 +2105,13 @@ a:hover { color: var(--dd-accent-light); }
 
 .overview-status-strip {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 0.9rem;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+@media (max-width: 768px) {
+    .overview-status-strip {
+        grid-template-columns: 1fr;
+    }
 }
 
 .overview-status-card {
@@ -2417,7 +2251,6 @@ a:hover { color: var(--dd-accent-light); }
     border: 1px solid var(--dd-border);
     border-radius: var(--dd-radius);
     padding: 2rem;
-    text-align: center;
     box-shadow: var(--dd-shadow-card);
 }
 
@@ -2428,19 +2261,22 @@ a:hover { color: var(--dd-accent-light); }
     text-transform: uppercase;
     letter-spacing: 0.12em;
     margin-bottom: 0.6rem;
+    text-align: center;
 }
 
 .tool-not-available h3 {
-    color: var(--dd-warning);
+    color: var(--dd-accent);
     margin-bottom: 0.75rem;
     font-family: var(--dd-font-display);
     font-size: 1.5rem;
+    text-align: center;
 }
 
 .tool-not-available-copy {
     max-width: 52rem;
-    margin: 0 auto;
+    margin: 0 auto 1.25rem;
     color: var(--dd-muted);
+    text-align: center;
 }
 
 .desktop-command-grid {
@@ -2570,3 +2406,294 @@ a:hover { color: var(--dd-accent-light); }
     .tools-hero p { font-size: 0.95rem; }
     .tool-page-header h1 { font-size: 1.4rem; }
 }
+
+/* ── Tool Usage Examples ── */
+.tool-usage-examples {
+    margin-top: 2rem;
+    border: 1px solid var(--dd-border);
+    border-radius: var(--dd-radius);
+    background: var(--dd-panel);
+    text-align: left;
+}
+.tool-usage-examples > summary {
+    padding: 0.875rem 1.25rem;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--dd-text);
+    list-style: none;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.tool-usage-examples > summary::after {
+    content: "+";
+    font-size: 1.2rem;
+    color: var(--dd-muted);
+    transition: transform 0.2s;
+}
+.tool-usage-examples[open] > summary::after {
+    content: "\2212";
+}
+.tool-usage-examples > summary::-webkit-details-marker { display: none; }
+.tool-usage-tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 1px solid var(--dd-border);
+    padding: 0 1.25rem;
+}
+.tool-usage-tab-btn {
+    background: none;
+    border: none;
+    padding: 0.625rem 1rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--dd-muted);
+    cursor: pointer;
+    border-bottom: 2px solid transparent;
+    transition: color 0.15s, border-color 0.15s;
+}
+.tool-usage-tab-btn:hover {
+    color: var(--dd-text);
+}
+.tool-usage-tab-btn.active {
+    color: var(--dd-accent);
+    border-bottom-color: var(--dd-accent);
+}
+.tool-usage-panel {
+    padding: 1rem 1.25rem 1.25rem;
+}
+.tool-usage-panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+.tool-usage-panel-label {
+    font-size: 0.8rem;
+    color: var(--dd-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+}
+.tool-usage-copy-btn {
+    background: var(--dd-card);
+    border: 1px solid var(--dd-border);
+    border-radius: var(--dd-radius-sm);
+    padding: 0.3rem 0.75rem;
+    font-size: 0.8rem;
+    color: var(--dd-accent);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+.tool-usage-copy-btn:hover {
+    background: var(--dd-border);
+}
+.tool-usage-code {
+    background: var(--dd-bg);
+    border: 1px solid var(--dd-border);
+    border-radius: var(--dd-radius-sm);
+    padding: 1rem 1.25rem;
+    margin: 0;
+    overflow-x: auto;
+    font-family: var(--dd-font-mono);
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: var(--dd-text);
+}
+.tool-usage-code code {
+    background: none;
+    padding: 0;
+    font-size: inherit;
+    color: inherit;
+}
+
+/* ── Tools Availability Legend ── */
+.tools-availability-legend {
+    display: flex;
+    gap: 1.5rem;
+    justify-content: center;
+    padding: 0.75rem 0;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--dd-muted);
+}
+.legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+}
+.legend-dot-browser { background: var(--dd-success, #22c55e); }
+.legend-dot-partial { background: var(--dd-warning, #f59e0b); }
+.legend-dot-local { background: var(--dd-accent2, #5b8cff); }
+
+/* Tool availability dot indicator in category grid */
+/* ── Overview Paired Cards ── */
+.overview-paired-card {
+    position: relative;
+    border: 1px solid var(--dd-border);
+    border-radius: var(--dd-radius-sm);
+    background: linear-gradient(180deg, rgba(13, 21, 48, 0.94), rgba(13, 21, 48, 0.86));
+    overflow: hidden;
+}
+.overview-paired-card::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, rgba(0, 217, 255, 0.95), rgba(91, 140, 255, 0.9));
+    opacity: 0.7;
+}
+.overview-paired-card.tool-callout-pass { border-color: rgba(34, 197, 94, 0.35); }
+.overview-paired-card.tool-callout-pass::before { background: linear-gradient(90deg, rgba(34, 197, 94, 0.9), rgba(34, 197, 94, 0.4)); }
+.overview-paired-card.tool-callout-warning { border-color: rgba(245, 158, 11, 0.35); }
+.overview-paired-card.tool-callout-warning::before { background: linear-gradient(90deg, rgba(245, 158, 11, 0.9), rgba(245, 158, 11, 0.4)); }
+.overview-paired-card.tool-callout-fail { border-color: rgba(239, 68, 68, 0.4); }
+.overview-paired-card.tool-callout-fail::before { background: linear-gradient(90deg, rgba(239, 68, 68, 0.9), rgba(239, 68, 68, 0.4)); }
+.overview-paired-card.tool-callout-fail { background: linear-gradient(180deg, rgba(40, 12, 12, 0.5), rgba(13, 21, 48, 0.86)); }
+
+.overview-paired-header {
+    padding: 1rem 1.1rem;
+    display: grid;
+    gap: 0.5rem;
+}
+.overview-paired-title {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+}
+.overview-paired-title strong {
+    font-size: 1.05rem;
+    color: var(--dd-ink-strong);
+}
+.overview-paired-value {
+    font-family: var(--dd-font-display);
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--dd-accent);
+}
+.overview-paired-card.tool-callout-pass .overview-paired-value { color: #4ade80; }
+.overview-paired-card.tool-callout-warning .overview-paired-value { color: #fbbf24; }
+.overview-paired-card.tool-callout-fail .overview-paired-value { color: #f87171; }
+
+.overview-paired-sample {
+    margin: 0;
+    color: var(--dd-muted);
+    font-size: 0.85rem;
+}
+
+.overview-paired-detail {
+    border-top: 1px solid var(--dd-border);
+}
+.overview-paired-detail-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0.65rem 1.1rem;
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--dd-muted);
+    list-style: none;
+    transition: color 0.15s, background 0.15s;
+}
+.overview-paired-detail-toggle:hover {
+    color: var(--dd-text);
+    background: rgba(0, 217, 255, 0.04);
+}
+.overview-paired-detail-toggle::after {
+    content: "+";
+    font-size: 1rem;
+    color: var(--dd-muted);
+}
+.overview-paired-detail[open] .overview-paired-detail-toggle::after {
+    content: "\2212";
+}
+.overview-paired-detail-toggle::-webkit-details-marker { display: none; }
+.overview-paired-detail-body {
+    padding: 0 1.1rem 1rem;
+    display: grid;
+    gap: 0.6rem;
+}
+
+/* ── Overview Paired Cards — Light Mode ── */
+[data-theme="light"] .overview-paired-card {
+    background: #ffffff;
+    border-color: rgba(15, 143, 176, 0.16);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+[data-theme="light"] .overview-paired-card::before {
+    opacity: 0.6;
+}
+[data-theme="light"] .overview-paired-card.tool-callout-pass {
+    border-color: rgba(34, 197, 94, 0.3);
+    background: linear-gradient(180deg, rgba(240, 253, 244, 0.8), #ffffff);
+}
+[data-theme="light"] .overview-paired-card.tool-callout-warning {
+    border-color: rgba(245, 158, 11, 0.3);
+    background: linear-gradient(180deg, rgba(255, 251, 235, 0.8), #ffffff);
+}
+[data-theme="light"] .overview-paired-card.tool-callout-fail {
+    border-color: rgba(239, 68, 68, 0.3);
+    background: linear-gradient(180deg, rgba(254, 242, 242, 0.8), #ffffff);
+}
+[data-theme="light"] .overview-paired-card.tool-callout-pass .overview-paired-value { color: #15803d; }
+[data-theme="light"] .overview-paired-card.tool-callout-warning .overview-paired-value { color: #b45309; }
+[data-theme="light"] .overview-paired-card.tool-callout-fail .overview-paired-value { color: #dc2626; }
+[data-theme="light"] .overview-paired-value { color: #0e7490; }
+[data-theme="light"] .overview-paired-detail {
+    border-top-color: rgba(15, 143, 176, 0.12);
+}
+[data-theme="light"] .overview-paired-detail-toggle:hover {
+    background: rgba(15, 143, 176, 0.04);
+}
+[data-theme="light"] .overview-paired-detail-body {
+    background: rgba(246, 250, 255, 0.5);
+}
+
+/* ── Light mode status callout fixes ── */
+[data-theme="light"] .tool-callout-pass {
+    border-color: rgba(34, 197, 94, 0.25);
+    background: linear-gradient(180deg, rgba(240, 253, 244, 0.9), rgba(255, 255, 255, 0.95));
+}
+[data-theme="light"] .tool-callout-pass .tool-summary-label { color: #15803d; }
+[data-theme="light"] .tool-callout-pass .tool-summary-value { color: #166534; }
+[data-theme="light"] .tool-callout-warning {
+    border-color: rgba(245, 158, 11, 0.25);
+    background: linear-gradient(180deg, rgba(255, 251, 235, 0.9), rgba(255, 255, 255, 0.95));
+}
+[data-theme="light"] .tool-callout-warning .tool-summary-label { color: #b45309; }
+[data-theme="light"] .tool-callout-warning .tool-summary-value { color: #92400e; }
+[data-theme="light"] .tool-callout-fail {
+    border-color: rgba(239, 68, 68, 0.25);
+    background: linear-gradient(180deg, rgba(254, 242, 242, 0.9), rgba(255, 255, 255, 0.95));
+}
+[data-theme="light"] .tool-callout-fail .tool-summary-label { color: #dc2626; }
+[data-theme="light"] .tool-callout-fail .tool-summary-value { color: #991b1b; }
+
+/* ── Light mode section state bar ── */
+[data-theme="light"] .overview-section-state {
+    background: rgba(246, 250, 255, 0.8);
+    border-color: rgba(15, 143, 176, 0.12);
+}
+
+.tool-availability-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 0.375rem;
+    flex-shrink: 0;
+}
+.tool-availability-dot-browser { background: var(--dd-success, #22c55e); }
+.tool-availability-dot-partial { background: var(--dd-warning, #f59e0b); }
+.tool-availability-dot-local { background: var(--dd-accent2, #5b8cff); }

--- a/DomainDetective.Website/wwwroot/index.html
+++ b/DomainDetective.Website/wwwroot/index.html
@@ -22,6 +22,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&display=optional" />
     <link rel="stylesheet" href="css/app.css" />
+    <link rel="stylesheet" href="css/prism-theme.css" />
     <link rel="stylesheet" href="DomainDetective.Website.styles.css" />
 </head>
 <body>

--- a/DomainDetective.Website/wwwroot/js/app.js
+++ b/DomainDetective.Website/wwwroot/js/app.js
@@ -3,6 +3,10 @@
 
     var themes = ['dark', 'light'];
     var recentRunsKey = 'dd-tool-recent-runs';
+    var prismLoadPromise = null;
+
+    window.Prism = window.Prism || {};
+    window.Prism.manual = true;
 
     function applyTheme(theme) {
         var nextTheme = theme === 'light' ? 'light' : 'dark';
@@ -30,6 +34,101 @@
         } catch (error) {
             // Ignore quota and storage errors.
         }
+    }
+
+    function hasCodeBlocks(scope) {
+        var root = scope || document;
+        return !!(root && root.querySelector && root.querySelector('pre code[class*="language-"]'));
+    }
+
+    function loadScript(src) {
+        return new Promise(function (resolve) {
+            var existing = document.querySelector('script[data-dynamic-src="' + src + '"]');
+            if (existing) {
+                if (existing.getAttribute('data-loaded') === 'true') {
+                    resolve(true);
+                    return;
+                }
+
+                existing.addEventListener('load', function () { resolve(true); }, { once: true });
+                existing.addEventListener('error', function () { resolve(false); }, { once: true });
+                return;
+            }
+
+            var script = document.createElement('script');
+            script.src = src;
+            script.async = true;
+            script.defer = true;
+            script.setAttribute('data-dynamic-src', src);
+            script.addEventListener('load', function () {
+                script.setAttribute('data-loaded', 'true');
+                resolve(true);
+            }, { once: true });
+            script.addEventListener('error', function () {
+                resolve(false);
+            }, { once: true });
+            document.head.appendChild(script);
+        });
+    }
+
+    function ensurePrismLoaded(scope) {
+        if (!hasCodeBlocks(scope)) {
+            return Promise.resolve(false);
+        }
+
+        if (window.Prism && window.Prism.plugins && window.Prism.plugins.autoloader) {
+            return Promise.resolve(true);
+        }
+
+        if (prismLoadPromise) {
+            return prismLoadPromise;
+        }
+
+        prismLoadPromise = loadScript('assets/prism/prism-core.min.js')
+            .then(function (coreLoaded) {
+                if (!coreLoaded) {
+                    return false;
+                }
+
+                return loadScript('assets/prism/prism-autoloader.min.js');
+            })
+            .then(function (autoloadLoaded) {
+                return !!autoloadLoaded;
+            })
+            .catch(function () {
+                return false;
+            });
+
+        return prismLoadPromise;
+    }
+
+    function highlightCodeBlocks(scope) {
+        var root = scope || document;
+        if (!hasCodeBlocks(root)) {
+            return Promise.resolve(false);
+        }
+
+        return ensurePrismLoaded(root).then(function (loaded) {
+            if (!loaded || !window.Prism) {
+                return false;
+            }
+
+            if (window.Prism.plugins && window.Prism.plugins.autoloader) {
+                window.Prism.plugins.autoloader.languages_path = 'assets/prism/components/';
+            }
+
+            if (root && typeof window.Prism.highlightAllUnder === 'function') {
+                window.Prism.highlightAllUnder(root);
+                return true;
+            }
+
+            if (typeof window.Prism.highlightAll === 'function') {
+                window.Prism.highlightAll();
+                return true;
+            }
+
+            return false;
+        });
     }
 
     window.domainDetectiveTools = {
@@ -129,6 +228,9 @@
             });
 
             return true;
+        },
+        highlightCodeBlocks: function (scope) {
+            return highlightCodeBlocks(scope);
         }
     };
 })();

--- a/Website/content/blog/dns-security-checklist-for-2026.md
+++ b/Website/content/blog/dns-security-checklist-for-2026.md
@@ -49,7 +49,7 @@ DNS remains a critical attack surface. From cache poisoning to subdomain takeove
 Run all these checks with a single command:
 
 ```bash
-domaindetective check example.com --all
+domaindetective check example.com --summary
 ```
 
 Or use the [online tools](/tools/) to check each item individually - all analysis runs client-side in your browser.

--- a/Website/content/blog/getting-started-with-spf-analysis.md
+++ b/Website/content/blog/getting-started-with-spf-analysis.md
@@ -36,7 +36,7 @@ Console.WriteLine($"Issues: {spf.Issues.Count}");
 ### Using PowerShell
 
 ```powershell
-$results = Get-DomainHealthCheck -Domain "example.com"
+$results = Test-DomainHealth -DomainName "example.com" -HealthCheckType SPF
 $results.SpfAnalysis | Format-List
 $results.SpfAnalysis.Issues | Format-Table
 ```

--- a/Website/content/blog/understanding-dmarc-policies.md
+++ b/Website/content/blog/understanding-dmarc-policies.md
@@ -30,7 +30,7 @@ Failed messages are rejected outright. This is the recommended end state for max
 ## Analyzing DMARC with DomainDetective
 
 ```powershell
-$results = Get-DomainHealthCheck -Domain "example.com"
+$results = Test-DomainHealth -DomainName "example.com" -HealthCheckType DMARC
 $dmarc = $results.DmarcAnalysis
 
 # Check current policy

--- a/Website/content/docs/cli-usage.md
+++ b/Website/content/docs/cli-usage.md
@@ -19,28 +19,31 @@ dotnet tool install -g DomainDetective.CLI
 domaindetective check example.com
 
 # Specific checks
-domaindetective check example.com --spf --dmarc --dkim
+domaindetective check example.com --checks SPF,DMARC,DKIM
 
-# All checks
-domaindetective check example.com --all
+# Summarize the default check set
+domaindetective check example.com --summary
+```
+
+## Focused Commands
+
+```bash
+# RDAP registration details
+domaindetective TestRDAP example.com
+
+# DNS propagation snapshot
+domaindetective DnsPropagation --domain example.com --record-type A
+
+# Certificate inventory capture
+domaindetective cert-inventory-capture example.com --include-ct-subdomains
 ```
 
 ## Output Formats
 
 ```bash
 # JSON output
-domaindetective check example.com --format json
+domaindetective check example.com --json
 
-# Table output (default)
-domaindetective check example.com --format table
-```
-
-## Batch Processing
-
-```bash
-# From a file
-domaindetective batch domains.txt --spf --dmarc
-
-# From stdin
-echo "example.com" | domaindetective batch --spf
+# Multiple domains
+domaindetective check example.com contoso.com --summary
 ```

--- a/Website/content/docs/powershell-cmdlets.md
+++ b/Website/content/docs/powershell-cmdlets.md
@@ -18,7 +18,7 @@ Install-Module DomainDetective -Scope CurrentUser
 Import-Module DomainDetective
 
 # Run a comprehensive domain health check
-$check = Get-DomainHealthCheck -Domain "example.com"
+$check = Test-DomainHealth -DomainName "example.com"
 
 # View specific results
 $check.SpfAnalysis
@@ -31,13 +31,13 @@ $check.DnsSecAnalysis
 
 ```powershell
 # SPF
-$check = Get-DomainHealthCheck -Domain "example.com" -Type SPF
+$check = Test-DomainHealth -DomainName "example.com" -HealthCheckType SPF
 
 # DKIM with selectors
-$check = Get-DomainHealthCheck -Domain "example.com" -Type DKIM -DkimSelectors "default", "selector1"
+$check = Test-DomainHealth -DomainName "example.com" -HealthCheckType DKIM -DkimSelectors "default", "selector1"
 
 # DNSSEC
-$check = Get-DomainHealthCheck -Domain "example.com" -Type DNSSEC
+$check = Test-DomainHealth -DomainName "example.com" -HealthCheckType DNSSEC
 ```
 
 ## Batch Analysis
@@ -45,7 +45,7 @@ $check = Get-DomainHealthCheck -Domain "example.com" -Type DNSSEC
 ```powershell
 $domains = "example.com", "contoso.com", "evotec.xyz"
 $results = $domains | ForEach-Object {
-    Get-DomainHealthCheck -Domain $_ -Type SPF, DMARC
+    Test-DomainHealth -DomainName $_ -HealthCheckType SPF, DMARC
 }
 $results | Format-Table Domain, SpfAnalysis, DmarcAnalysis
 ```

--- a/Website/content/docs/quickstart.md
+++ b/Website/content/docs/quickstart.md
@@ -51,7 +51,7 @@ foreach (var mx in healthCheck.MXAnalysis.MxRecords) {
 Import-Module DomainDetective
 
 # Run a comprehensive check
-$check = Get-DomainHealthCheck -Domain "example.com"
+$check = Test-DomainHealth -DomainName "example.com"
 
 # View results
 $check.SpfAnalysis

--- a/Website/data/xrefmap.json
+++ b/Website/data/xrefmap.json
@@ -1,5 +1,5 @@
 {
-  "generatedAtUtc": "2026-04-01T18:28:21.8485298Z",
+  "generatedAtUtc": "2026-04-03T21:07:40.7225403Z",
   "sourceCount": 2,
   "referenceCount": 24364,
   "duplicateCount": 0,

--- a/Website/static/css/app.css
+++ b/Website/static/css/app.css
@@ -1404,60 +1404,6 @@ pre code {
     margin-bottom: 0.75rem;
 }
 
-.tools-preview-guide {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
-    margin: 0 0 1.5rem;
-    position: relative;
-    z-index: 1;
-}
-
-.tools-preview-guide-card {
-    display: grid;
-    gap: 0.45rem;
-    padding: 1rem 1.05rem;
-    border-radius: var(--pf-radius);
-    border: 1px solid var(--pf-border);
-    background: var(--pf-card-bg);
-    backdrop-filter: blur(8px);
-    box-shadow: var(--pf-shadow-card);
-}
-
-.tools-preview-guide-kicker {
-    color: var(--pf-muted);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-}
-
-.tools-preview-guide-card strong {
-    color: var(--pf-ink-strong);
-    font-family: var(--pf-font-display);
-    font-size: 1rem;
-    line-height: 1.3;
-}
-
-.tools-preview-guide-card p {
-    margin: 0;
-    color: var(--pf-muted);
-    font-size: 0.92rem;
-    line-height: 1.6;
-}
-
-.tools-preview-guide-card-live {
-    box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.14), var(--pf-shadow-card);
-}
-
-.tools-preview-guide-card-adaptive {
-    box-shadow: inset 0 0 0 1px rgba(0, 217, 255, 0.14), var(--pf-shadow-card);
-}
-
-.tools-preview-guide-card-online {
-    box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.14), var(--pf-shadow-card);
-}
-
 .tools-grid {
     display: grid;
     grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
@@ -1475,37 +1421,6 @@ pre code {
     position: relative;
     overflow: hidden;
     backdrop-filter: blur(8px);
-}
-
-.tool-card-mode {
-    display: inline-flex;
-    align-items: center;
-    margin-bottom: 0.9rem;
-    padding: 0.28rem 0.7rem;
-    border-radius: 999px;
-    font-size: 0.74rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    line-height: 1.2;
-}
-
-.tool-card-mode-live {
-    color: #bbf7d0;
-    background: rgba(20, 83, 45, 0.24);
-    border: 1px solid rgba(34, 197, 94, 0.18);
-}
-
-.tool-card-mode-adaptive {
-    color: #a5f3fc;
-    background: rgba(8, 47, 73, 0.24);
-    border: 1px solid rgba(0, 217, 255, 0.18);
-}
-
-.tool-card-mode-online {
-    color: #fde68a;
-    background: rgba(120, 53, 15, 0.24);
-    border: 1px solid rgba(245, 158, 11, 0.18);
 }
 
 /* Glowing border + dramatic hover */

--- a/Website/themes/domaindetective/layouts/home.html
+++ b/Website/themes/domaindetective/layouts/home.html
@@ -22,12 +22,9 @@
 {{ include "header" }}
 <main>
 {{ include "sections/hero" }}
-{{ include "sections/stats" }}
 {{ include "sections/tools-preview" }}
 {{ include "sections/features" }}
-{{ include "sections/trust-banner" }}
 {{ include "sections/code-examples" }}
-{{ include "sections/faq-preview" }}
 {{ include "sections/cta" }}
 </main>
 {{ include "footer" }}

--- a/Website/themes/domaindetective/partials/api-header.html
+++ b/Website/themes/domaindetective/partials/api-header.html
@@ -15,6 +15,134 @@
     return nextTheme;
   }
 
+  function normalizePath(path) {
+    var normalized = path || '/';
+    if (normalized.charAt(0) !== '/') {
+      normalized = '/' + normalized;
+    }
+    if (!normalized.endsWith('/')) {
+      normalized += '/';
+    }
+    return normalized;
+  }
+
+  function isActivePath(currentPath, targetPath) {
+    if (!targetPath) {
+      return false;
+    }
+
+    if (targetPath === '/') {
+      return currentPath === '/';
+    }
+
+    return currentPath === targetPath || currentPath.indexOf(targetPath) === 0;
+  }
+
+  function closeDropdown(dropdown) {
+    var trigger = dropdown.querySelector('.dd-nav-dropdown-trigger, .nav-dropdown-trigger, .nav-dropdown-trigger-button');
+    dropdown.classList.remove('open');
+    if (trigger) {
+      trigger.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  function wireHeader() {
+    var currentPath = normalizePath(window.location.pathname || '/');
+    var nav = document.querySelector('.dd-nav');
+    var navToggle = document.querySelector('.dd-nav-toggle');
+
+    document.querySelectorAll('.dd-nav-links > a').forEach(function (link) {
+      link.classList.add('dd-nav-link');
+
+      var href = link.getAttribute('href');
+      if (href && isActivePath(currentPath, normalizePath(href))) {
+        link.classList.add('is-active');
+        link.setAttribute('aria-current', 'page');
+      }
+    });
+
+    document.querySelectorAll('.dd-nav .nav-dropdown').forEach(function (dropdown) {
+      dropdown.classList.add('dd-nav-dropdown');
+
+      var trigger = dropdown.querySelector('.nav-dropdown-trigger, .nav-dropdown-trigger-button, .dd-nav-dropdown-trigger');
+      if (!trigger) {
+        return;
+      }
+
+      trigger.classList.add('dd-nav-dropdown-trigger');
+      trigger.setAttribute('aria-haspopup', 'true');
+
+      var childActive = false;
+      dropdown.querySelectorAll('.nav-dropdown-menu a').forEach(function (link) {
+        var href = link.getAttribute('href');
+        if (href && isActivePath(currentPath, normalizePath(href))) {
+          link.classList.add('active');
+          childActive = true;
+        }
+      });
+
+      if (childActive || currentPath.indexOf('/api/') === 0) {
+        dropdown.classList.add('open');
+        trigger.classList.add('is-active');
+        trigger.setAttribute('aria-expanded', 'true');
+      } else {
+        trigger.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    if (navToggle && nav && navToggle.dataset.navBound !== 'true') {
+      navToggle.dataset.navBound = 'true';
+      navToggle.addEventListener('click', function () {
+        var isOpen = nav.classList.toggle('open');
+        navToggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        document.body.classList.toggle('nav-open', isOpen);
+      });
+    }
+
+    var navDropdowns = document.querySelectorAll('.dd-nav-dropdown, .nav-dropdown');
+    if (navDropdowns.length > 0) {
+      navDropdowns.forEach(function (dropdown) {
+        var trigger = dropdown.querySelector('.dd-nav-dropdown-trigger, .nav-dropdown-trigger, .nav-dropdown-trigger-button');
+        if (!trigger || trigger.dataset.dropdownBound === 'true') {
+          return;
+        }
+
+        trigger.dataset.dropdownBound = 'true';
+        trigger.addEventListener('click', function (event) {
+          if (trigger.tagName === 'BUTTON') {
+            event.preventDefault();
+          }
+
+          var willOpen = !dropdown.classList.contains('open');
+          navDropdowns.forEach(function (candidate) {
+            if (candidate !== dropdown) {
+              closeDropdown(candidate);
+            }
+          });
+
+          dropdown.classList.toggle('open', willOpen);
+          trigger.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
+        });
+      });
+
+      document.addEventListener('click', function (event) {
+        navDropdowns.forEach(function (dropdown) {
+          if (!dropdown.contains(event.target)) {
+            closeDropdown(dropdown);
+          }
+        });
+      });
+
+      document.addEventListener('keydown', function (event) {
+        if (event.key === 'Escape') {
+          navDropdowns.forEach(function (dropdown) {
+            closeDropdown(dropdown);
+          });
+        }
+      });
+    }
+  }
+
   var initialTheme = applyTheme(readTheme());
 
   document.addEventListener('DOMContentLoaded', function () {
@@ -36,122 +164,11 @@
         }
       });
     });
+
+    wireHeader();
   });
 })();
 </script>
-<style>
-.dd-nav-links {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.dd-nav-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  margin-left: 0.75rem;
-}
-
-.dd-nav-links > a,
-.dd-nav-links .nav-dropdown-trigger {
-  color: var(--pf-muted);
-  text-decoration: none;
-}
-
-.dd-nav-links > a:hover,
-.dd-nav-links .nav-dropdown-trigger:hover {
-  color: var(--pf-ink-strong);
-}
-
-.dd-nav-actions .nav-cta {
-  border: 1px solid rgba(148, 163, 184, 0.16);
-}
-
-.imo-nav__item {
-  position: relative;
-  display: flex;
-  align-items: center;
-}
-
-.imo-nav__link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  min-height: 2.5rem;
-  padding: 0.65rem 0.8rem;
-  border: none;
-  border-radius: 0.75rem;
-  background: transparent;
-  color: var(--pf-muted);
-  text-decoration: none;
-  font: inherit;
-  font-weight: 500;
-  cursor: pointer;
-  transition: color 0.2s ease, background-color 0.2s ease;
-}
-
-.imo-nav__link:hover,
-.imo-nav__link:focus-visible,
-.imo-nav__item.open > .imo-nav__link {
-  color: var(--pf-ink-strong);
-  background: rgba(0, 217, 255, 0.08);
-  outline: none;
-}
-
-.imo-chevron {
-  flex-shrink: 0;
-}
-
-.imo-dropdown {
-  position: absolute;
-  top: calc(100% + 0.45rem);
-  left: 0;
-  z-index: 120;
-  min-width: 15rem;
-  padding: 0.9rem;
-  display: none;
-  border: 1px solid var(--pf-border);
-  border-radius: 1rem;
-  background: color-mix(in srgb, var(--pf-surface) 94%, transparent);
-  box-shadow: 0 20px 38px rgba(8, 17, 31, 0.34);
-}
-
-.imo-nav__item:hover > .imo-dropdown,
-.imo-nav__item:focus-within > .imo-dropdown,
-.imo-nav__item.open > .imo-dropdown {
-  display: block;
-}
-
-.imo-dropdown__group {
-  display: grid;
-  gap: 0.55rem;
-}
-
-.imo-dropdown__title {
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.18em;
-  text-transform: uppercase;
-  color: var(--pf-muted-strong);
-}
-
-.imo-dropdown__link {
-  display: block;
-  padding: 0.55rem 0.7rem;
-  border-radius: 0.75rem;
-  color: var(--pf-ink);
-  text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease;
-}
-
-.imo-dropdown__link:hover,
-.imo-dropdown__link:focus-visible {
-  background: rgba(0, 217, 255, 0.08);
-  color: var(--pf-ink-strong);
-  outline: none;
-}
-</style>
 <header class="dd-header">
   <div class="dd-header-inner">
     <a href="/" class="dd-brand">

--- a/Website/themes/domaindetective/partials/sections/code-examples.html
+++ b/Website/themes/domaindetective/partials/sections/code-examples.html
@@ -28,10 +28,11 @@ Console.WriteLine(healthCheck.DmarcAnalysis.DmarcRecord);</code></pre>
           <div class="code-dots"><span></span><span></span><span></span></div>
           <span class="code-tab-label">check.ps1</span>
         </div>
-        <pre><code class="language-powershell">Install-Module DomainDetective
+        <pre><code class="language-powershell">Install-Module DomainDetective -Scope CurrentUser
+Import-Module DomainDetective
 
 # Quick domain check
-$results = Get-DomainHealthCheck -Domain "example.com"
+$results = Test-DomainHealth -DomainName "example.com"
 $results.SpfAnalysis | Format-Table
 $results.DmarcAnalysis | Format-Table</code></pre>
       </div>
@@ -43,8 +44,8 @@ $results.DmarcAnalysis | Format-Table</code></pre>
         <pre><code class="language-bash">dotnet tool install -g DomainDetective.CLI
 
 # Analyze a domain
-domaindetective check example.com --spf --dmarc --dkim
-domaindetective check example.com --all</code></pre>
+domaindetective check example.com --checks SPF,DMARC,DKIM
+domaindetective check example.com --summary</code></pre>
       </div>
     </div>
   </div>

--- a/Website/themes/domaindetective/partials/sections/features.html
+++ b/Website/themes/domaindetective/partials/sections/features.html
@@ -10,7 +10,7 @@
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
         </div>
         <h3>Privacy First</h3>
-        <p>DNS tools run browser-side via DNS-over-HTTPS, while advanced HTTP and TLS probes use the hosted analysis API. Analysis results are not stored.</p>
+        <p>DNS-over-HTTPS queries, no tracking, no analytics, no cookies. Analysis results are never stored. Advanced HTTP and TLS probes use the hosted analysis API.</p>
       </div>
       <div class="feature-card">
         <div class="feature-icon feature-icon-cyan">

--- a/Website/themes/domaindetective/partials/sections/hero.html
+++ b/Website/themes/domaindetective/partials/sections/hero.html
@@ -4,9 +4,9 @@
     <h1 class="hero-title">Analyze Any Domain</h1>
     <p class="hero-tagline">115+ protocol checks for DNS, email security, TLS, and web security. Open source, privacy-first, browser-native where possible.</p>
     <div class="hero-search">
-      <form action="/tools/" method="get" class="hero-search-form">
+      <form action="/tools/domain-overview/" method="get" class="hero-search-form">
         <svg class="hero-search-icon" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
-        <input type="text" name="domain" placeholder="Enter a domain to analyze (e.g. example.com)" autocomplete="off" spellcheck="false" />
+        <input type="text" name="q" placeholder="Enter a domain to analyze (e.g. example.com)" autocomplete="off" spellcheck="false" />
         <button type="submit" class="hero-search-btn">Analyze</button>
       </form>
     </div>

--- a/Website/themes/domaindetective/partials/sections/hero.html
+++ b/Website/themes/domaindetective/partials/sections/hero.html
@@ -1,9 +1,8 @@
 <section class="hero">
   <div class="hero-grid-bg"></div>
   <div class="hero-inner">
-    <div class="hero-badge"><span class="hero-dot"></span> Open Source Domain Analysis Toolkit</div>
     <h1 class="hero-title">Analyze Any Domain</h1>
-    <p class="hero-tagline">Comprehensive domain security analysis with 115+ protocol checks.<br>SPF, DKIM, DMARC, DNSSEC, TLS, HTTP headers, and more.<br>Privacy-first: browser-native where possible, with hosted probes for advanced web and TLS checks.</p>
+    <p class="hero-tagline">115+ protocol checks for DNS, email security, TLS, and web security. Open source, privacy-first, browser-native where possible.</p>
     <div class="hero-search">
       <form action="/tools/" method="get" class="hero-search-form">
         <svg class="hero-search-icon" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
@@ -11,14 +10,14 @@
         <button type="submit" class="hero-search-btn">Analyze</button>
       </form>
     </div>
-    <div class="hero-actions">
-      <a href="/tools/" class="dd-button dd-button-primary dd-button-lg">Try Online Tools</a>
-      <a href="/docs/quickstart/" class="dd-button dd-button-ghost dd-button-lg">Get Started</a>
-    </div>
     <div class="hero-links">
       <a href="/downloads/" class="hero-pill">
         <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         Downloads
+      </a>
+      <a href="/docs/quickstart/" class="hero-pill">
+        <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>
+        Get Started
       </a>
       <a href="/changelog/" class="hero-pill">
         <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>

--- a/Website/themes/domaindetective/partials/sections/tools-preview.html
+++ b/Website/themes/domaindetective/partials/sections/tools-preview.html
@@ -3,28 +3,10 @@
     <div class="section-header">
       <span class="section-eyebrow">Online Tools</span>
       <h2>Domain Analysis Tools</h2>
-      <p class="section-desc">Run web-ready DD checks directly on the web, then step into deeper online workflows when the advanced online experience is enabled.</p>
-    </div>
-    <div class="tools-preview-guide" aria-label="Tools editions overview">
-      <article class="tools-preview-guide-card tools-preview-guide-card-live">
-        <span class="tools-preview-guide-kicker">Available now</span>
-        <strong>Live web-edition checks</strong>
-        <p>DNS, mail, and core posture tools run directly in the web edition today.</p>
-      </article>
-      <article class="tools-preview-guide-card tools-preview-guide-card-adaptive">
-        <span class="tools-preview-guide-kicker">Adaptive web mode</span>
-        <strong>Same tool, lighter web mode</strong>
-        <p>Some tools keep the page live and clearly mark the deeper sections that belong to the full online experience.</p>
-      </article>
-      <article class="tools-preview-guide-card tools-preview-guide-card-online">
-        <span class="tools-preview-guide-kicker">Full online</span>
-        <strong>Deeper hosted analysis</strong>
-        <p>Web response, certificate, registration, and large discovery checks stay discoverable here without turning into broken pages.</p>
-      </article>
+      <p class="section-desc">Run checks directly in the browser or get CLI, PowerShell, and C# guidance for deeper workflows.</p>
     </div>
     <div class="tools-grid">
       <a href="/tools/spf/" class="tool-card tool-card-email">
-        <span class="tool-card-mode tool-card-mode-adaptive">Adaptive web mode</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
         </div>
@@ -40,7 +22,6 @@
         </ul>
       </a>
       <a href="/tools/dns-lookup/" class="tool-card tool-card-dns">
-        <span class="tool-card-mode tool-card-mode-adaptive">Adaptive web mode</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
         </div>
@@ -54,7 +35,6 @@
         </ul>
       </a>
       <a href="/tools/http-headers/" class="tool-card tool-card-web">
-        <span class="tool-card-mode tool-card-mode-online">Full online</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
         </div>
@@ -66,7 +46,6 @@
         </ul>
       </a>
       <a href="/tools/cert-check/" class="tool-card tool-card-tls">
-        <span class="tool-card-mode tool-card-mode-online">Full online</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
         </div>
@@ -78,7 +57,6 @@
         </ul>
       </a>
       <a href="/tools/rdap/" class="tool-card tool-card-reg">
-        <span class="tool-card-mode tool-card-mode-online">Full online</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
         </div>
@@ -88,7 +66,6 @@
         </ul>
       </a>
       <a href="/tools/dnsbl/" class="tool-card tool-card-threat">
-        <span class="tool-card-mode tool-card-mode-live">Available now</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
         </div>
@@ -99,7 +76,6 @@
         </ul>
       </a>
       <a href="/tools/ct-subdomains/" class="tool-card tool-card-subdomain">
-        <span class="tool-card-mode tool-card-mode-online">Full online</span>
         <div class="tool-card-icon">
           <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 0 1 2 2v7"/><path d="M6 9v12"/></svg>
         </div>
@@ -110,8 +86,7 @@
       </a>
     </div>
     <p class="tools-preview-cta">
-      <span class="tools-preview-cta-note">Browse the web edition now, with deeper online workflows clearly marked inside the catalog.</span>
-      <a href="/tools/" class="dd-button dd-button-ghost">View All 20+ Tools</a>
+      <a href="/tools/" class="dd-button dd-button-ghost">Explore All Tools</a>
     </p>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- declutter the website tools experience and tighten the overview presentation components
- add reusable tool usage examples and paired overview cards for the redesigned toolbox pages
- correct shipped CLI, PowerShell, and C# examples so they match the current command surface and public APIs
- refresh website docs and blog snippets that still referenced outdated commands

## Validation
- dotnet build DomainDetective.sln -c Release
- ./Website/build.ps1 -CI