### PR TITLE
Preserve certificate inventory CT baseline

### DIFF
--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -2195,6 +2195,20 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public void BuildPassiveCtMetadataSourceRequests_PrefersCertSpotterWildcardAwareExactHostQuery() {
+        IReadOnlyList<PassiveCtSourceClient.SourceRequest> requests =
+            CertificateInventoryCapture.BuildPassiveCtMetadataSourceRequests("access.tchibo.com");
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal("certspotter", requests[0].SourceName);
+        Assert.Contains("domain=access.tchibo.com", requests[0].Url, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("match_wildcards=true", requests[0].Url, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("include_subdomains=true", requests[0].Url, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("crt.sh", requests[1].SourceName);
+        Assert.Contains("q=access.tchibo.com", requests[1].Url, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task TryHydrateExactCtMetadataThumbprintFromCrtShCertificateAsync_AcceptsWildcardSubjectAlternativeNames() {
         const string hostName = "mail.emmasguesthouse.co.za";
         using RSA rsa = RSA.Create(2048);

--- a/DomainDetective.Tests/TestSubdomainsAnalysis.cs
+++ b/DomainDetective.Tests/TestSubdomainsAnalysis.cs
@@ -387,6 +387,109 @@ public class TestSubdomainsAnalysis
     }
 
     [Fact]
+    public async Task PassiveCtClient_DoesNotCooldownSourceAfterPerHostTimeout()
+    {
+        var requestSequence = 0;
+        var server = new TcpListenerFixture((listener, token) => Task.Run(async () =>
+        {
+            var handlers = new List<Task>();
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var clientTask = listener.AcceptTcpClientAsync();
+                    var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                    if (completed != clientTask)
+                    {
+                        break;
+                    }
+
+                    handlers.Add(Task.Run(async () =>
+                    {
+                        using var client = await clientTask;
+                        int currentRequest = Interlocked.Increment(ref requestSequence);
+                        using NetworkStream stream = client.GetStream();
+                        using var reader = new StreamReader(stream);
+                        using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                        string? line;
+                        do
+                        {
+                            line = await reader.ReadLineAsync();
+                        } while (!string.IsNullOrEmpty(line));
+
+                        if (currentRequest == 1)
+                        {
+                            await Task.Delay(TimeSpan.FromMilliseconds(250), token);
+                            return;
+                        }
+
+                        const string payload = @"[{ ""dns_names"": [""api.example.com""] }]";
+                        await writer.WriteLineAsync("HTTP/1.1 200 OK");
+                        await writer.WriteLineAsync("Content-Type: application/json");
+                        await writer.WriteLineAsync($"Content-Length: {payload.Length}");
+                        await writer.WriteLineAsync();
+                        await writer.WriteAsync(payload);
+                    }, token));
+                }
+            }
+            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (token.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                await Task.WhenAll(handlers).ConfigureAwait(false);
+            }
+        }, token));
+        await server.InitializeAsync();
+
+        try
+        {
+            var client = new PassiveCtSourceClient();
+            var requests = new[]
+            {
+                new PassiveCtSourceClient.SourceRequest
+                {
+                    SourceName = "crt.sh",
+                    Url = $"http://127.0.0.1:{server.Port}/"
+                }
+            };
+            var options = new PassiveCtSourceClient.QueryOptions
+            {
+                RequestTimeout = TimeSpan.FromMilliseconds(100),
+                RetryCount = 0,
+                SourceCooldown = TimeSpan.FromSeconds(30)
+            };
+
+            PassiveCtSourceClient.QueryResult first = await client.QueryAsync(
+                requests,
+                options,
+                null,
+                new InternalLogger(),
+                CancellationToken.None);
+            await Task.Delay(TimeSpan.FromMilliseconds(300));
+            PassiveCtSourceClient.QueryResult second = await client.QueryAsync(
+                requests,
+                options,
+                null,
+                new InternalLogger(),
+                CancellationToken.None);
+
+            Assert.True(first.RetrySuggested);
+            Assert.DoesNotContain(first.Warnings, warning => warning.Contains("Next retry after", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(first.Diagnostics, diagnostic => diagnostic.CooldownUntilUtc.HasValue);
+            Assert.DoesNotContain(second.Warnings, warning => warning.Contains("cooling down", StringComparison.OrdinalIgnoreCase));
+            Assert.DoesNotContain(second.Diagnostics, diagnostic => string.Equals(diagnostic.State, "CoolingDown", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            await server.DisposeAsync();
+        }
+    }
+
+    [Fact]
     public async Task PassiveCtClient_DoesNotRetryOrCooldownSourceAfterHttp404()
     {
         var requestCount = 0;
@@ -468,6 +571,193 @@ public class TestSubdomainsAnalysis
             Assert.DoesNotContain(first.Diagnostics, diagnostic => diagnostic.CooldownUntilUtc.HasValue);
             Assert.DoesNotContain(second.Diagnostics, diagnostic => string.Equals(diagnostic.State, "CoolingDown", StringComparison.OrdinalIgnoreCase));
             Assert.Equal(2, requestCount);
+        }
+        finally
+        {
+            await server.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task PassiveCtClient_RespectsConfiguredPerSourceMinimumSpacing()
+    {
+        var requestOffsets = new List<long>();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var server = new TcpListenerFixture((listener, token) => Task.Run(async () =>
+        {
+            var handlers = new List<Task>();
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var clientTask = listener.AcceptTcpClientAsync();
+                    var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                    if (completed != clientTask)
+                    {
+                        break;
+                    }
+
+                    handlers.Add(Task.Run(async () =>
+                    {
+                        using var client = await clientTask;
+                        lock (requestOffsets)
+                        {
+                            requestOffsets.Add(stopwatch.ElapsedMilliseconds);
+                        }
+
+                        using NetworkStream stream = client.GetStream();
+                        using var reader = new StreamReader(stream);
+                        using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                        string? line;
+                        do
+                        {
+                            line = await reader.ReadLineAsync();
+                        } while (!string.IsNullOrEmpty(line));
+
+                        const string payload = @"[{ ""name_value"": ""api.example.com"" }]";
+                        await writer.WriteLineAsync("HTTP/1.1 200 OK");
+                        await writer.WriteLineAsync("Content-Type: application/json");
+                        await writer.WriteLineAsync($"Content-Length: {payload.Length}");
+                        await writer.WriteLineAsync();
+                        await writer.WriteAsync(payload);
+                    }, token));
+                }
+            }
+            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (token.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                await Task.WhenAll(handlers).ConfigureAwait(false);
+            }
+        }, token));
+        await server.InitializeAsync();
+
+        try
+        {
+            var client = new PassiveCtSourceClient();
+            var requests = new[]
+            {
+                new PassiveCtSourceClient.SourceRequest
+                {
+                    SourceName = "crt.sh",
+                    Url = $"http://127.0.0.1:{server.Port}/"
+                }
+            };
+            var options = new PassiveCtSourceClient.QueryOptions
+            {
+                RetryCount = 0,
+                CrtShMinimumSpacing = TimeSpan.FromMilliseconds(150)
+            };
+
+            PassiveCtSourceClient.QueryResult first = await client.QueryAsync(
+                requests,
+                options,
+                null,
+                new InternalLogger(),
+                CancellationToken.None);
+            PassiveCtSourceClient.QueryResult second = await client.QueryAsync(
+                requests,
+                options,
+                null,
+                new InternalLogger(),
+                CancellationToken.None);
+
+            Assert.False(first.RetrySuggested);
+            Assert.False(second.RetrySuggested);
+            Assert.Equal(2, requestOffsets.Count);
+            Assert.True(requestOffsets[1] - requestOffsets[0] >= 125);
+        }
+        finally
+        {
+            await server.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task PassiveCtClient_StopsUsingSourceAfterConfiguredPerRunBudget()
+    {
+        var requestCount = 0;
+        var server = new TcpListenerFixture((listener, token) => Task.Run(async () =>
+        {
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var clientTask = listener.AcceptTcpClientAsync();
+                    var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                    if (completed != clientTask)
+                    {
+                        break;
+                    }
+
+                    using var client = await clientTask;
+                    Interlocked.Increment(ref requestCount);
+                    using NetworkStream stream = client.GetStream();
+                    using var reader = new StreamReader(stream);
+                    using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                    string? line;
+                    do
+                    {
+                        line = await reader.ReadLineAsync();
+                    } while (!string.IsNullOrEmpty(line));
+
+                    const string payload = @"[{ ""name_value"": ""api.example.com"" }]";
+                    await writer.WriteLineAsync("HTTP/1.1 200 OK");
+                    await writer.WriteLineAsync("Content-Type: application/json");
+                    await writer.WriteLineAsync($"Content-Length: {payload.Length}");
+                    await writer.WriteLineAsync();
+                    await writer.WriteAsync(payload);
+                }
+            }
+            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (token.IsCancellationRequested)
+            {
+            }
+        }, token));
+        await server.InitializeAsync();
+
+        try
+        {
+            var client = new PassiveCtSourceClient();
+            var requests = new[]
+            {
+                new PassiveCtSourceClient.SourceRequest
+                {
+                    SourceName = "certspotter",
+                    Url = $"http://127.0.0.1:{server.Port}/"
+                }
+            };
+            var options = new PassiveCtSourceClient.QueryOptions
+            {
+                RetryCount = 0,
+                SourceCooldown = TimeSpan.FromSeconds(30),
+                CertSpotterMaximumRequestsPerRun = 1
+            };
+
+            PassiveCtSourceClient.QueryResult first = await client.QueryAsync(
+                requests,
+                options,
+                null,
+                new InternalLogger(),
+                CancellationToken.None);
+            PassiveCtSourceClient.QueryResult second = await client.QueryAsync(
+                requests,
+                options,
+                null,
+                new InternalLogger(),
+                CancellationToken.None);
+
+            Assert.Single(first.Payloads);
+            Assert.Empty(second.Payloads);
+            Assert.Contains(second.Warnings, warning => warning.Contains("request budget for this run", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(second.Diagnostics, diagnostic => string.Equals(diagnostic.State, "BudgetExhausted", StringComparison.OrdinalIgnoreCase));
+            Assert.Equal(1, requestCount);
         }
         finally
         {

--- a/DomainDetective/CertificateInventoryCapture.CtDiscovery.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtDiscovery.cs
@@ -830,6 +830,7 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         return string.Equals(diagnostic.State, "CoolingDown", StringComparison.OrdinalIgnoreCase) ||
+               string.Equals(diagnostic.State, "BudgetExhausted", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(diagnostic.State, "RateLimited", StringComparison.OrdinalIgnoreCase) ||
                string.Equals(diagnostic.State, "TemporarilyUnavailable", StringComparison.OrdinalIgnoreCase);
     }
@@ -840,6 +841,9 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         string state = string.IsNullOrWhiteSpace(diagnostic.State) ? "unavailable" : diagnostic.State;
+        if (string.Equals(state, "BudgetExhausted", StringComparison.OrdinalIgnoreCase)) {
+            return "request budget is exhausted for this run";
+        }
         if (diagnostic.CooldownUntilUtc.HasValue) {
             return "is " +
                    state +

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -758,9 +758,29 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         string? thumbprint = null;
+        bool? isSelfSigned = null;
+        bool? weakKey = null;
+        bool? sha1Signature = null;
+        bool? hasServerAuthentication = null;
+        bool? hasClientAuthentication = null;
+        bool? hasSecureEmail = null;
+        string? authenticationProfile = null;
         if (selectedRow.CertificateDer != null && selectedRow.CertificateDer.Length > 0) {
             using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(selectedRow.CertificateDer);
             thumbprint = NormalizeCtMetadataThumbprint(certificate.Thumbprint);
+            CertificateExtendedKeyUsageInfo eku = CertificateExtendedKeyUsageAnalyzer.Analyze(certificate);
+            string? signatureOid = certificate.SignatureAlgorithm?.Value;
+            int keySize = GetPublicKeySize(certificate);
+
+            isSelfSigned = IsSelfSigned(certificate);
+            weakKey = keySize > 0 && keySize < 2048;
+            sha1Signature = IsSha1Signature(signatureOid);
+            hasServerAuthentication = eku.AllowsServerAuthentication;
+            hasClientAuthentication = eku.AllowsClientAuthentication;
+            hasSecureEmail = eku.AllowsSecureEmail;
+            authenticationProfile = string.IsNullOrWhiteSpace(eku.AuthenticationProfile)
+                ? CertificateAuthenticationProfileClassifier.Classify(eku)
+                : eku.AuthenticationProfile;
         }
 
         return new SubdomainDiscoveryEntry {
@@ -775,6 +795,13 @@ public sealed partial class CertificateInventoryCapture {
             LatestCertificateNotBeforeUtc = selectedRow.NotBeforeUtc,
             LatestCertificateNotAfterUtc = selectedRow.NotAfterUtc,
             LatestCertificateSubjectAlternativeNames = selectedRow.CandidateNames,
+            LatestCertificateIsSelfSigned = isSelfSigned,
+            LatestCertificateWeakKey = weakKey,
+            LatestCertificateSha1Signature = sha1Signature,
+            LatestCertificateHasServerAuthentication = hasServerAuthentication,
+            LatestCertificateHasClientAuthentication = hasClientAuthentication,
+            LatestCertificateHasSecureEmail = hasSecureEmail,
+            LatestCertificateAuthenticationProfile = authenticationProfile,
             CtSources = new[] { "crt.sh-db" },
             CertificateObservationCount = rows.Count,
             ResolutionStatus = SubdomainResolutionStatus.Unknown
@@ -822,6 +849,12 @@ public sealed partial class CertificateInventoryCapture {
                 ? parsed
                 : (DateTimeOffset?)null
         };
+    }
+
+    private static bool IsSha1Signature(string? oid) {
+        return oid == "1.2.840.113549.1.1.5" ||
+               oid == "1.2.840.10040.4.3" ||
+               oid == "1.3.14.3.2.29";
     }
 
     internal static int ResolveExactPassiveCtMetadataBackfillParallelism(
@@ -892,6 +925,10 @@ public sealed partial class CertificateInventoryCapture {
                     RetryBaseDelay = options.PassiveCtRetryBaseDelay,
                     RetryMaxDelay = options.PassiveCtRetryMaxDelay,
                     SourceCooldown = options.PassiveCtSourceCooldown,
+                    CrtShMinimumSpacing = options.PassiveCtCrtShMinimumSpacing,
+                    CertSpotterMinimumSpacing = options.PassiveCtCertSpotterMinimumSpacing,
+                    CrtShMaximumRequestsPerRun = options.PassiveCtCrtShMaximumRequestsPerRun,
+                    CertSpotterMaximumRequestsPerRun = options.PassiveCtCertSpotterMaximumRequestsPerRun,
                     QueryAllSources = false,
                     PayloadValidator = ValidatePassiveCtMetadataArrayPayload
                 },
@@ -1300,15 +1337,15 @@ public sealed partial class CertificateInventoryCapture {
             : value!.Trim();
     }
 
-    private static IReadOnlyList<PassiveCtSourceClient.SourceRequest> BuildPassiveCtMetadataSourceRequests(string normalizedHost) {
+    internal static IReadOnlyList<PassiveCtSourceClient.SourceRequest> BuildPassiveCtMetadataSourceRequests(string normalizedHost) {
         var requests = new List<PassiveCtSourceClient.SourceRequest>(2);
+        requests.Add(new PassiveCtSourceClient.SourceRequest {
+            SourceName = "certspotter",
+            Url = "https://api.certspotter.com/v1/issuances?domain=" + Uri.EscapeDataString(normalizedHost) + "&match_wildcards=true&expand=dns_names"
+        });
         requests.Add(new PassiveCtSourceClient.SourceRequest {
             SourceName = "crt.sh",
             Url = "https://crt.sh/?q=" + Uri.EscapeDataString(normalizedHost) + "&output=json"
-        });
-        requests.Add(new PassiveCtSourceClient.SourceRequest {
-            SourceName = "certspotter",
-            Url = "https://api.certspotter.com/v1/issuances?domain=" + Uri.EscapeDataString(normalizedHost) + "&include_subdomains=true&expand=dns_names"
         });
         return requests;
     }

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -136,6 +136,30 @@ public sealed class CertificateInventoryCaptureOptions {
     public TimeSpan PassiveCtSourceCooldown { get; set; } = TimeSpan.FromSeconds(60);
 
     /// <summary>
+    /// Minimum spacing between public crt.sh requests when passive/public CT fallback is active.
+    /// This helps exact-host rescue and fallback discovery stay within respectful shared-source pacing.
+    /// </summary>
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.
+    /// This is anti-burst pacing only; the main safety rail is the run-local request budget below.
+    /// </summary>
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Maximum number of public crt.sh exact-host metadata requests issued during a single passive CT run.
+    /// Zero means uncapped.
+    /// </summary>
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 8;
+
+    /// <summary>
+    /// Maximum number of Cert Spotter exact-host metadata requests issued during a single passive CT run.
+    /// Zero means uncapped. The default stays conservative for unauthenticated public-plan access.
+    /// </summary>
+    public int PassiveCtCertSpotterMaximumRequestsPerRun { get; set; } = 1;
+
+    /// <summary>
     /// Maximum number of concurrent passive/public CT network queries issued at once.
     /// This is intentionally separate from <see cref="DiscoveryParallelism"/> so DNS/native CT work
     /// can remain wide while rate-limited passive CT providers are queried more gently.
@@ -689,6 +713,18 @@ public sealed partial class CertificateInventoryCapture {
         }
         if (options.PassiveCtSourceCooldown < TimeSpan.Zero) {
             throw new ArgumentOutOfRangeException(nameof(options.PassiveCtSourceCooldown), "PassiveCtSourceCooldown must be non-negative.");
+        }
+        if (options.PassiveCtCrtShMinimumSpacing < TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(options.PassiveCtCrtShMinimumSpacing), "PassiveCtCrtShMinimumSpacing must be non-negative.");
+        }
+        if (options.PassiveCtCertSpotterMinimumSpacing < TimeSpan.Zero) {
+            throw new ArgumentOutOfRangeException(nameof(options.PassiveCtCertSpotterMinimumSpacing), "PassiveCtCertSpotterMinimumSpacing must be non-negative.");
+        }
+        if (options.PassiveCtCrtShMaximumRequestsPerRun < 0) {
+            throw new ArgumentOutOfRangeException(nameof(options.PassiveCtCrtShMaximumRequestsPerRun), "PassiveCtCrtShMaximumRequestsPerRun must be non-negative.");
+        }
+        if (options.PassiveCtCertSpotterMaximumRequestsPerRun < 0) {
+            throw new ArgumentOutOfRangeException(nameof(options.PassiveCtCertSpotterMaximumRequestsPerRun), "PassiveCtCertSpotterMaximumRequestsPerRun must be non-negative.");
         }
         if (options.PassiveCtParallelism < 1) {
             throw new ArgumentOutOfRangeException(nameof(options.PassiveCtParallelism), "PassiveCtParallelism must be at least 1.");

--- a/DomainDetective/PassiveCtSourceClient.cs
+++ b/DomainDetective/PassiveCtSourceClient.cs
@@ -17,6 +17,7 @@ internal sealed class PassiveCtSourceClient
         public int ConsecutiveFailures { get; set; }
         public DateTimeOffset LastSuccessUtc { get; set; }
         public DateTimeOffset LastCooldownAnnouncementUtc { get; set; }
+        public DateTimeOffset NextEligibleRequestStartUtc { get; set; }
     }
 
     internal readonly record struct SourceHealthSnapshot(
@@ -52,6 +53,10 @@ internal sealed class PassiveCtSourceClient
         public TimeSpan RetryBaseDelay { get; init; } = TimeSpan.FromMilliseconds(750);
         public TimeSpan RetryMaxDelay { get; init; } = TimeSpan.FromSeconds(15);
         public TimeSpan SourceCooldown { get; init; } = TimeSpan.FromSeconds(60);
+        public TimeSpan CrtShMinimumSpacing { get; init; } = TimeSpan.Zero;
+        public TimeSpan CertSpotterMinimumSpacing { get; init; } = TimeSpan.Zero;
+        public int CrtShMaximumRequestsPerRun { get; init; }
+        public int CertSpotterMaximumRequestsPerRun { get; init; }
         public bool QueryAllSources { get; init; }
         public bool PreserveRequestOrder { get; init; } = true;
         public Func<string, string?>? PayloadValidator { get; init; }
@@ -63,11 +68,14 @@ internal sealed class PassiveCtSourceClient
         public string? Failure { get; init; }
         public bool RetrySuggested { get; init; }
         public TimeSpan? RetryAfter { get; init; }
+        public bool ApplySharedCooldown { get; init; }
     }
 
     private static readonly ConcurrentDictionary<string, SourceState> SharedSourceStates = new(StringComparer.OrdinalIgnoreCase);
     private static readonly ConcurrentDictionary<string, SemaphoreSlim> SharedSourceGates = new(StringComparer.OrdinalIgnoreCase);
     private static int _rotationCursor = -1;
+    private readonly object _querySessionBudgetLock = new();
+    private readonly Dictionary<string, int> _querySessionRequestCounts = new(StringComparer.OrdinalIgnoreCase);
 
     public async Task<QueryResult> QueryAsync(
         IReadOnlyList<SourceRequest> requests,
@@ -130,6 +138,42 @@ internal sealed class PassiveCtSourceClient
                     {
                         logger?.WriteVerbose("{0}", cooldownMessage);
                     }
+                    continue;
+                }
+
+                if (useSharedSourceState)
+                {
+                    await WaitForMinimumSpacingAsync(
+                            request.SourceName,
+                            effectiveOptions,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                if (!TryReserveQuerySessionBudget(
+                        request.SourceName,
+                        effectiveOptions,
+                        out int configuredBudget,
+                        out int consumedRequests))
+                {
+                    result.RetrySuggested = true;
+                    string budgetMessage =
+                        "Passive CT source '" +
+                        request.SourceName +
+                        "' exhausted its request budget for this run (" +
+                        configuredBudget.ToString() +
+                        "); let the next monitoring cycle retry.";
+                    result.Warnings.Add(budgetMessage);
+                    result.Diagnostics.Add(new PassiveCtDiagnosticEntry
+                    {
+                        SourceName = request.SourceName,
+                        RequestUrl = request.Url,
+                        State = "BudgetExhausted",
+                        RetrySuggested = true,
+                        RetryAfterSeconds = null,
+                        Failure = "Per-run request budget exhausted after " + consumedRequests.ToString() + " request(s)."
+                    });
+                    logger?.WriteVerbose("{0}", budgetMessage);
                     continue;
                 }
 
@@ -204,7 +248,7 @@ internal sealed class PassiveCtSourceClient
                         warning += ": " + outcome.Failure;
                     }
 
-                    if (useSharedSourceState)
+                    if (useSharedSourceState && outcome.ApplySharedCooldown)
                     {
                         DateTimeOffset retryUtc = MarkTransientFailure(request.SourceName, cooldown);
                         warning += ". Next retry after " + retryUtc.ToString("u") + ".";
@@ -251,7 +295,7 @@ internal sealed class PassiveCtSourceClient
 
         if (result.Payloads.Count == 0 && result.RetrySuggested)
         {
-            result.Warnings.Add("Passive CT sources were temporarily unavailable or rate-limited; check later or let the next monitoring cycle retry.");
+            result.Warnings.Add("Passive CT sources were temporarily unavailable, rate-limited, or exhausted for this run; check later or let the next monitoring cycle retry.");
         }
 
         return result;
@@ -288,6 +332,18 @@ internal sealed class PassiveCtSourceClient
             sourceCooldown = TimeSpan.Zero;
         }
 
+        TimeSpan crtShMinimumSpacing = options?.CrtShMinimumSpacing ?? TimeSpan.Zero;
+        if (crtShMinimumSpacing < TimeSpan.Zero)
+        {
+            crtShMinimumSpacing = TimeSpan.Zero;
+        }
+
+        TimeSpan certSpotterMinimumSpacing = options?.CertSpotterMinimumSpacing ?? TimeSpan.Zero;
+        if (certSpotterMinimumSpacing < TimeSpan.Zero)
+        {
+            certSpotterMinimumSpacing = TimeSpan.Zero;
+        }
+
         return new QueryOptions
         {
             RequestTimeout = requestTimeout,
@@ -295,6 +351,10 @@ internal sealed class PassiveCtSourceClient
             RetryBaseDelay = retryBaseDelay,
             RetryMaxDelay = retryMaxDelay,
             SourceCooldown = sourceCooldown,
+            CrtShMinimumSpacing = crtShMinimumSpacing,
+            CertSpotterMinimumSpacing = certSpotterMinimumSpacing,
+            CrtShMaximumRequestsPerRun = Math.Max(0, options?.CrtShMaximumRequestsPerRun ?? 0),
+            CertSpotterMaximumRequestsPerRun = Math.Max(0, options?.CertSpotterMaximumRequestsPerRun ?? 0),
             QueryAllSources = options?.QueryAllSources ?? false,
             PreserveRequestOrder = options?.PreserveRequestOrder ?? true,
             PayloadValidator = options?.PayloadValidator
@@ -358,6 +418,94 @@ internal sealed class PassiveCtSourceClient
     private static DateTimeOffset? TryGetSourceCooldownUtc(string sourceName)
     {
         return TryGetCooldown(sourceName, out DateTimeOffset cooldownUntilUtc) ? cooldownUntilUtc : null;
+    }
+
+    private static async Task WaitForMinimumSpacingAsync(
+        string sourceName,
+        QueryOptions options,
+        CancellationToken cancellationToken)
+    {
+        TimeSpan minimumSpacing = ResolveMinimumSpacing(sourceName, options);
+        if (minimumSpacing <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        SourceState state = SharedSourceStates.GetOrAdd(sourceName, static _ => new SourceState());
+        TimeSpan delay = TimeSpan.Zero;
+        lock (state)
+        {
+            DateTimeOffset nowUtc = DateTimeOffset.UtcNow;
+            if (state.NextEligibleRequestStartUtc > nowUtc)
+            {
+                delay = state.NextEligibleRequestStartUtc - nowUtc;
+                nowUtc = state.NextEligibleRequestStartUtc;
+            }
+
+            state.NextEligibleRequestStartUtc = nowUtc + minimumSpacing;
+        }
+
+        if (delay > TimeSpan.Zero)
+        {
+            await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static TimeSpan ResolveMinimumSpacing(string sourceName, QueryOptions options)
+    {
+        if (string.Equals(sourceName, "crt.sh", StringComparison.OrdinalIgnoreCase))
+        {
+            return options.CrtShMinimumSpacing;
+        }
+
+        if (string.Equals(sourceName, "certspotter", StringComparison.OrdinalIgnoreCase))
+        {
+            return options.CertSpotterMinimumSpacing;
+        }
+
+        return TimeSpan.Zero;
+    }
+
+    private int ResolveMaximumRequestsPerRun(string sourceName, QueryOptions options)
+    {
+        if (string.Equals(sourceName, "crt.sh", StringComparison.OrdinalIgnoreCase))
+        {
+            return options.CrtShMaximumRequestsPerRun;
+        }
+
+        if (string.Equals(sourceName, "certspotter", StringComparison.OrdinalIgnoreCase))
+        {
+            return options.CertSpotterMaximumRequestsPerRun;
+        }
+
+        return 0;
+    }
+
+    private bool TryReserveQuerySessionBudget(
+        string sourceName,
+        QueryOptions options,
+        out int configuredBudget,
+        out int consumedRequests)
+    {
+        configuredBudget = ResolveMaximumRequestsPerRun(sourceName, options);
+        consumedRequests = 0;
+        if (configuredBudget <= 0)
+        {
+            return true;
+        }
+
+        lock (_querySessionBudgetLock)
+        {
+            _querySessionRequestCounts.TryGetValue(sourceName, out consumedRequests);
+            if (consumedRequests >= configuredBudget)
+            {
+                return false;
+            }
+
+            consumedRequests++;
+            _querySessionRequestCounts[sourceName] = consumedRequests;
+            return true;
+        }
     }
 
     private static bool IsRateLimitedFailure(string? failure, TimeSpan? retryAfter)
@@ -608,7 +756,8 @@ internal sealed class PassiveCtSourceClient
                     {
                         Failure = ex.Message,
                         RetrySuggested = true,
-                        RetryAfter = retryAfter
+                        RetryAfter = retryAfter,
+                        ApplySharedCooldown = ShouldApplySharedCooldown(ex, retryAfter)
                     };
                 }
 
@@ -712,6 +861,32 @@ internal sealed class PassiveCtSourceClient
             }
 
             return false;
+        }
+
+        return false;
+    }
+
+    private static bool ShouldApplySharedCooldown(Exception ex, TimeSpan? retryAfter)
+    {
+        if (retryAfter.HasValue && retryAfter.Value > TimeSpan.Zero)
+        {
+            return true;
+        }
+
+        if (ex is HttpRequestException httpEx)
+        {
+            int? statusCode = TryGetHttpStatusCode(httpEx);
+            if (!statusCode.HasValue)
+            {
+                return false;
+            }
+
+            if ((HttpStatusCode)statusCode.Value == HttpStatusCode.RequestTimeout)
+            {
+                return false;
+            }
+
+            return ShouldRetryStatusCode((HttpStatusCode)statusCode.Value);
         }
 
         return false;


### PR DESCRIPTION
## Summary
- preserve the current certificate inventory CT/runtime baseline as a focused branch
- keep the CT discovery, metadata backfill, and passive source handling changes together with their tests
- intentionally leave website and tools work out of this PR because that now lives in #1166

## Why
- we need a clean merge point before simplifying the DD/DDPlus certificate-monitoring path
- the current state contains useful CT/runtime work that should not remain only in a dirty checkout