### PR TITLE
Add explicit CT capture profiles

### DIFF
--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3804,6 +3804,109 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task BackfillMissingCtCertificateMetadataAsync_RetainsExactPassiveFallbackWhenDomainPostgreSqlLookupFails()
+    {
+        var verboseMessages = new List<string>();
+        var overrideBatches = new List<IReadOnlyList<string>>();
+        var capture = new CertificateInventoryCapture
+        {
+            CtPassiveMetadataBackfillOverride = (hosts, _, _, _) =>
+            {
+                overrideBatches.Add(hosts.ToList());
+
+                if (hosts.Count == 1 &&
+                    string.Equals(hosts[0], "api.example.com", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult<IReadOnlyList<SubdomainDiscoveryEntry>>(
+                    [
+                        new SubdomainDiscoveryEntry
+                        {
+                            Name = "api.example.com",
+                            LatestCertificateThumbprint = "EXACT-FALLBACK-THUMBPRINT-001",
+                            LatestCertificateSubjectAlternativeNames = new[] { "api.example.com" },
+                            CtSources = new[] { "crt.sh" }
+                        }
+                    ]);
+                }
+
+                return Task.FromResult<IReadOnlyList<SubdomainDiscoveryEntry>>(Array.Empty<SubdomainDiscoveryEntry>());
+            },
+            CtExactMetadataPostgreSqlOverride = static (_, _, _, _) =>
+                Task.FromResult<SubdomainDiscoveryEntry?>(null)
+        };
+
+        var method = typeof(CertificateInventoryCapture).GetMethod(
+            "BackfillMissingCtCertificateMetadataAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(method);
+
+        var warnings = new List<string>();
+        var options = new CertificateInventoryCaptureOptions
+        {
+            EnablePassiveCtFallback = true,
+            EnablePassiveCtMetadataFallback = true,
+            EnableCrtShPostgreSqlMetadataFallback = true,
+            CrtShPostgreSqlConnectionString = "Host=127.0.0.1;Port=1;Database=certwatch;Username=guest;SSL Mode=Disable;Timeout=1;Command Timeout=1",
+            CrtShPostgreSqlCommandTimeoutSeconds = 1,
+            CrtShPostgreSqlMaximumConcurrentRequests = 1
+        };
+        options.ExactHostSeedCtMetadataSuppressedHosts.Add("api.example.com");
+
+        var logger = new InternalLogger(false);
+        logger.OnVerboseMessage += (_, args) =>
+        {
+            if (!string.IsNullOrWhiteSpace(args.Message))
+            {
+                verboseMessages.Add(args.Message);
+            }
+        };
+
+        Task<IReadOnlyList<SubdomainDiscoveryEntry>> task =
+            (Task<IReadOnlyList<SubdomainDiscoveryEntry>>)method!.Invoke(
+                capture,
+                new object[]
+                {
+                    new[] { "example.com" },
+                    new[]
+                    {
+                        new SubdomainDiscoveryEntry
+                        {
+                            Name = "api.example.com"
+                        }
+                    },
+                    options,
+                    warnings,
+                    new List<PassiveCtDiagnosticEntry>(),
+                    logger,
+                    CancellationToken.None
+                })!;
+
+        IReadOnlyList<SubdomainDiscoveryEntry> result = await task;
+
+        SubdomainDiscoveryEntry entry = Assert.Single(result);
+        Assert.Equal("api.example.com", entry.Name);
+        Assert.Equal("EXACT-FALLBACK-THUMBPRINT-001", entry.LatestCertificateThumbprint);
+        Assert.Contains(
+            warnings,
+            warning => warning.Contains("domain PostgreSQL lookup failed", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            overrideBatches,
+            hosts => hosts.Count == 1 &&
+                     string.Equals(hosts[0], "example.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            overrideBatches,
+            hosts => hosts.Count == 1 &&
+                     string.Equals(hosts[0], "api.example.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            verboseMessages,
+            message => message.Contains("retaining 1 remaining host(s) for exact passive CT metadata", StringComparison.OrdinalIgnoreCase));
+        Assert.DoesNotContain(
+            verboseMessages,
+            message => message.Contains("skipping exact passive CT metadata", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public async Task CaptureAsync_DoesNotAnnounceExactPassiveMetadataQueryWhenSharedCooldownAlreadyBlocksRun()
     {
         PassiveCtSourceClient.ResetSharedStateForTesting();

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3905,6 +3905,7 @@ public class TestCertificateInventoryCapture {
             IncludeCtDiscoveredSubdomains = true,
             EnableNativeCtLogSubdomainSource = true,
             EnablePassiveCtFallback = true,
+            EnablePassiveCtMetadataFallback = false,
             NativeCtLogOnly = true,
             VerifyCtDiscoveredSubdomains = true,
             BackfillMissingCtCertificateMetadata = false,
@@ -3925,6 +3926,7 @@ public class TestCertificateInventoryCapture {
         Assert.False(options.IncludeCtDiscoveredSubdomains);
         Assert.False(options.EnableNativeCtLogSubdomainSource);
         Assert.False(options.EnablePassiveCtFallback);
+        Assert.True(options.EnablePassiveCtMetadataFallback);
         Assert.False(options.NativeCtLogOnly);
         Assert.False(options.VerifyCtDiscoveredSubdomains);
         Assert.True(options.BackfillMissingCtCertificateMetadata);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -2057,6 +2057,12 @@ public class TestCertificateInventoryCapture {
             HashAlgorithmName.SHA256,
             RSASignaturePadding.Pkcs1);
         request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection {
+                    new(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid)
+                },
+                critical: false));
+        request.CertificateExtensions.Add(
             new X509BasicConstraintsExtension(false, false, 0, false));
         request.CertificateExtensions.Add(
             new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
@@ -2103,6 +2109,10 @@ public class TestCertificateInventoryCapture {
             cancellationToken: CancellationToken.None);
 
         Assert.Equal(certificate.Thumbprint, hydrated.LatestCertificateThumbprint);
+        Assert.True(hydrated.LatestCertificateHasServerAuthentication);
+        Assert.False(hydrated.LatestCertificateHasClientAuthentication);
+        Assert.False(hydrated.LatestCertificateHasSecureEmail);
+        Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, hydrated.LatestCertificateAuthenticationProfile);
     }
 
     [Fact]
@@ -2834,6 +2844,7 @@ public class TestCertificateInventoryCapture {
         var notBefore = new DateTimeOffset(2022, 7, 11, 0, 0, 0, TimeSpan.Zero);
         var notAfter = new DateTimeOffset(2023, 8, 11, 23, 59, 59, TimeSpan.Zero);
         var passiveQueries = new List<string>();
+        const string thumbprint = "AA11BB22CC33DD44EE55FF6677889900AA11BB22";
 
         var capture = new CertificateInventoryCapture {
             CtSubdomainEntryDiscoveryOverride = (domains, options, logger, cancellationToken) => {
@@ -2852,18 +2863,23 @@ public class TestCertificateInventoryCapture {
             CtPassiveMetadataBackfillOverride = (domains, options, logger, cancellationToken) => {
                 string target = Assert.Single(domains);
                 passiveQueries.Add(target);
-                IReadOnlyList<SubdomainDiscoveryEntry> discovered = string.Equals(target, "airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase)
+                IReadOnlyList<SubdomainDiscoveryEntry> discovered = string.Equals(target, "eurofins.com", StringComparison.OrdinalIgnoreCase)
                     ? new[] {
                         new SubdomainDiscoveryEntry {
                             Name = "airtoxics.eurofins.com",
                             FirstSeenUtc = passiveCtEntryTimestamp,
                             LastSeenUtc = passiveCtEntryTimestamp,
                             LatestCertificateCtEntryTimestampUtc = passiveCtEntryTimestamp,
+                            LatestCertificateThumbprint = thumbprint,
                             LatestCertificateSubject = "CN=airtoxics.eurofins.com",
                             LatestCertificateIssuer = "CN=Sectigo RSA Domain Validation Secure Server CA, O=Sectigo Limited, C=GB",
                             LatestCertificateSerialNumber = "0CE4A3C00C1DD4890B9EBA4223FE917F",
                             LatestCertificateNotBeforeUtc = notBefore,
                             LatestCertificateNotAfterUtc = notAfter,
+                            LatestCertificateHasServerAuthentication = true,
+                            LatestCertificateHasClientAuthentication = false,
+                            LatestCertificateHasSecureEmail = false,
+                            LatestCertificateAuthenticationProfile = CertificateAuthenticationProfileClassifier.ServerAuthOnly,
                             CtSources = new[] { "crt.sh" },
                             CertificateObservationCount = 1,
                             ResolutionStatus = SubdomainResolutionStatus.Resolves
@@ -2916,7 +2932,7 @@ public class TestCertificateInventoryCapture {
 
         var result = await capture.CaptureAsync(new[] { "eurofins.com", "airtoxics.eurofins.com" }, options, cancellationToken: CancellationToken.None);
 
-        Assert.Equal(new[] { "airtoxics.eurofins.com" }, passiveQueries);
+        Assert.Equal(new[] { "eurofins.com" }, passiveQueries);
         Assert.Equal(1, result.CtDiscoveredSubdomainCount);
         Assert.Equal(0, result.CtPromotedHttpsCount);
         Assert.Equal(1, result.CtSkippedHttpsPromotionCount);
@@ -2929,6 +2945,189 @@ public class TestCertificateInventoryCapture {
         Assert.Equal("live-probe", endpoint.CaptureDisposition);
         Assert.Equal("CN=airtoxics.eurofins.com", endpoint.CertificateSubject);
         Assert.Equal(passiveCtEntryTimestamp, endpoint.CtLatestCertificateEntryTimestampUtc);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_ExactHostPassiveBackfillRunsWhenCtDiscoveryOnlyHasIdentityMetadata() {
+        var ctFirstSeen = new DateTimeOffset(2026, 3, 5, 10, 21, 27, TimeSpan.Zero);
+        var ctLastSeen = new DateTimeOffset(2026, 3, 5, 15, 42, 37, TimeSpan.Zero);
+        var passiveCtEntryTimestamp = new DateTimeOffset(2022, 7, 11, 15, 36, 47, TimeSpan.Zero);
+        var notBefore = new DateTimeOffset(2022, 7, 11, 0, 0, 0, TimeSpan.Zero);
+        var notAfter = new DateTimeOffset(2023, 8, 11, 23, 59, 59, TimeSpan.Zero);
+        var passiveQueries = new List<string>();
+        const string thumbprint = "AA11BB22CC33DD44EE55FF6677889900AA11BB22";
+
+        var capture = new CertificateInventoryCapture {
+            CtSubdomainEntryDiscoveryOverride = (domains, options, logger, cancellationToken) => {
+                IReadOnlyList<SubdomainDiscoveryEntry> discovered = new[] {
+                    new SubdomainDiscoveryEntry {
+                        Name = "airtoxics.eurofins.com",
+                        FirstSeenUtc = ctFirstSeen,
+                        LastSeenUtc = ctLastSeen,
+                        LatestCertificateCtEntryTimestampUtc = passiveCtEntryTimestamp,
+                        LatestCertificateSubject = "CN=airtoxics.eurofins.com",
+                        LatestCertificateIssuer = "CN=Identity Only Issuer",
+                        LatestCertificateSerialNumber = "IDENTITY-ONLY-123",
+                        LatestCertificateNotBeforeUtc = notBefore,
+                        LatestCertificateNotAfterUtc = notAfter,
+                        CtSources = new[] { "native-ct" },
+                        CertificateObservationCount = 2,
+                        ResolutionStatus = SubdomainResolutionStatus.Resolves
+                    }
+                };
+                return Task.FromResult(discovered);
+            },
+            CtPassiveMetadataBackfillOverride = (domains, options, logger, cancellationToken) => {
+                string target = Assert.Single(domains);
+                passiveQueries.Add(target);
+                IReadOnlyList<SubdomainDiscoveryEntry> discovered = string.Equals(target, "airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase)
+                    ? new[] {
+                        new SubdomainDiscoveryEntry {
+                            Name = "airtoxics.eurofins.com",
+                            FirstSeenUtc = passiveCtEntryTimestamp,
+                            LastSeenUtc = passiveCtEntryTimestamp,
+                            LatestCertificateCtEntryTimestampUtc = passiveCtEntryTimestamp,
+                            LatestCertificateThumbprint = thumbprint,
+                            LatestCertificateSubject = "CN=airtoxics.eurofins.com",
+                            LatestCertificateIssuer = "CN=Sectigo RSA Domain Validation Secure Server CA, O=Sectigo Limited, C=GB",
+                            LatestCertificateSerialNumber = "0CE4A3C00C1DD4890B9EBA4223FE917F",
+                            LatestCertificateNotBeforeUtc = notBefore,
+                            LatestCertificateNotAfterUtc = notAfter,
+                            LatestCertificateHasServerAuthentication = true,
+                            LatestCertificateHasClientAuthentication = false,
+                            LatestCertificateHasSecureEmail = false,
+                            LatestCertificateAuthenticationProfile = CertificateAuthenticationProfileClassifier.ServerAuthOnly,
+                            CtSources = new[] { "crt.sh" },
+                            CertificateObservationCount = 1,
+                            ResolutionStatus = SubdomainResolutionStatus.Resolves
+                        }
+                    }
+                    : Array.Empty<SubdomainDiscoveryEntry>();
+                return Task.FromResult(discovered);
+            },
+            HttpsProbeOverride = (httpsTargets, options, logger, cancellationToken) => {
+                var entries = new List<CertificateMonitor.Entry>();
+                foreach (var target in httpsTargets) {
+                    var uri = new Uri(target);
+                    entries.Add(new CertificateMonitor.Entry {
+                        Host = uri.Host,
+                        ResolvedHost = uri.Host,
+                        Url = target,
+                        Scheme = uri.Scheme,
+                        Port = uri.Port,
+                        Service = "HTTPS",
+                        Valid = false,
+                        Expired = false,
+                        ChainComplete = false,
+                        Protocol = SslProtocols.None,
+                        Analysis = new CertificateAnalysis {
+                            Url = target,
+                            IsReachable = false
+                        }
+                    });
+                }
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            }
+        };
+
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = true,
+            IncludeWwwHttps = false,
+            IncludeCtDiscoveredSubdomains = true,
+            VerifyCtDiscoveredSubdomains = false,
+            EnablePassiveCtFallback = true,
+            EnablePassiveCtMetadataFallback = true,
+            IncludeMxHosts = false,
+            IncludeMxHttps = false,
+            IncludeSmtpStartTls = false,
+            IncludeSubmissionStartTls = false,
+            IncludeImapTls = false,
+            IncludePop3Tls = false,
+            BackfillMissingCtCertificateMetadata = true,
+            PersistSnapshot = false
+        };
+
+        var result = await capture.CaptureAsync(new[] { "eurofins.com", "airtoxics.eurofins.com" }, options, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(new[] { "eurofins.com", "airtoxics.eurofins.com" }, passiveQueries);
+        var discovered = Assert.Single(result.CtDiscoveredSubdomainEntries, entry => entry.Name.Equals("airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(thumbprint, discovered.LatestCertificateThumbprint);
+        Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, discovered.LatestCertificateAuthenticationProfile);
+        var endpoint = Assert.Single(result.Snapshot.Entries, entry => entry.Host.Equals("airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(thumbprint, endpoint.CertificateThumbprint);
+        Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, endpoint.AuthenticationProfile);
+    }
+
+    [IntegrationFact]
+    public async Task CaptureAsync_CtEvidenceRefreshProfile_HydratesExactHostFromLiveCtSources() {
+        const string hostName = "api.github.com";
+
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (httpsTargets, options, logger, cancellationToken) => {
+                var entries = new List<CertificateMonitor.Entry>();
+                foreach (var target in httpsTargets) {
+                    var uri = new Uri(target);
+                    entries.Add(new CertificateMonitor.Entry {
+                        Host = uri.Host,
+                        ResolvedHost = uri.Host,
+                        Url = target,
+                        Scheme = uri.Scheme,
+                        Port = uri.Port,
+                        Service = "HTTPS",
+                        Valid = false,
+                        Expired = false,
+                        ChainComplete = false,
+                        Protocol = SslProtocols.None,
+                        Analysis = new CertificateAnalysis {
+                            Url = target,
+                            IsReachable = false
+                        }
+                    });
+                }
+
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            }
+        };
+
+        var options = new CertificateInventoryCaptureOptions {
+            EnablePassiveCtMetadataFallback = true,
+            EnableCrtShPostgreSqlMetadataFallback = true,
+            BackfillMissingCtCertificateMetadata = true,
+            PersistSnapshot = false,
+            CrtShPostgreSqlCommandTimeoutSeconds = 20,
+            PassiveCtRequestTimeout = TimeSpan.FromSeconds(20)
+        }.ApplyCtEvidenceRefreshProfile();
+
+        var result = await capture.CaptureAsync(new[] { hostName }, options, cancellationToken: CancellationToken.None);
+
+        var endpoint = Assert.Single(result.Snapshot.Entries, entry => entry.Host.Equals(hostName, StringComparison.OrdinalIgnoreCase));
+        Assert.False(endpoint.IsReachable);
+        Assert.True(endpoint.PresentInCtLogs);
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateThumbprint));
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateSubject));
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateIssuer));
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateSerialNumber));
+        Assert.True(endpoint.NotBeforeUtc.HasValue);
+        Assert.True(endpoint.NotAfterUtc.HasValue);
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.AuthenticationProfile));
+        Assert.Contains(
+            endpoint.CtDiscoverySources,
+            source => source.Equals("crt.sh", StringComparison.OrdinalIgnoreCase) ||
+                      source.Equals("crt.sh-db", StringComparison.OrdinalIgnoreCase) ||
+                      source.Equals("certspotter", StringComparison.OrdinalIgnoreCase));
+
+        Console.WriteLine($"Host={endpoint.Host}");
+        Console.WriteLine($"Reachable={endpoint.IsReachable}");
+        Console.WriteLine($"PresentInCtLogs={endpoint.PresentInCtLogs}");
+        Console.WriteLine($"Thumbprint={endpoint.CertificateThumbprint}");
+        Console.WriteLine($"Subject={endpoint.CertificateSubject}");
+        Console.WriteLine($"Issuer={endpoint.CertificateIssuer}");
+        Console.WriteLine($"Serial={endpoint.CertificateSerialNumber}");
+        Console.WriteLine($"NotBeforeUtc={endpoint.NotBeforeUtc:O}");
+        Console.WriteLine($"NotAfterUtc={endpoint.NotAfterUtc:O}");
+        Console.WriteLine($"AuthenticationProfile={endpoint.AuthenticationProfile}");
+        Console.WriteLine($"AllowsServerAuthentication={endpoint.AllowsServerAuthentication}");
+        Console.WriteLine($"CtSources={string.Join(", ", endpoint.CtDiscoverySources)}");
     }
 
     [Fact]
@@ -3266,14 +3465,17 @@ public class TestCertificateInventoryCapture {
     }
 
     [Theory]
-    [InlineData(16, 4, 40, true, 4)]
-    [InlineData(3, 8, 40, true, 3)]
-    [InlineData(16, 4, 5, true, 4)]
-    [InlineData(16, 4, 3, true, 3)]
-    [InlineData(16, 4, 40, false, 16)]
+    [InlineData(16, 4, 2, 40, true, 4)]
+    [InlineData(3, 8, 2, 40, true, 3)]
+    [InlineData(16, 4, 2, 5, true, 4)]
+    [InlineData(16, 4, 2, 3, true, 3)]
+    [InlineData(16, 4, 2, 40, false, 2)]
+    [InlineData(16, 4, 5, 40, false, 5)]
+    [InlineData(3, 8, 2, 40, false, 2)]
     public void ResolveExactPassiveCtMetadataBackfillParallelism_UsesBoundedConcurrency(
         int configuredDiscoveryParallelism,
         int configuredPassiveCtParallelism,
+        int configuredCrtShPostgreSqlMaximumConcurrentRequests,
         int hostCount,
         bool usePassiveNetworkQueries,
         int expected)
@@ -3281,6 +3483,7 @@ public class TestCertificateInventoryCapture {
         int result = CertificateInventoryCapture.ResolveExactPassiveCtMetadataBackfillParallelism(
             configuredDiscoveryParallelism,
             configuredPassiveCtParallelism,
+            configuredCrtShPostgreSqlMaximumConcurrentRequests,
             hostCount,
             usePassiveNetworkQueries);
 

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3903,6 +3903,9 @@ public class TestCertificateInventoryCapture {
             IncludeApexHttps = false,
             IncludeWwwHttps = true,
             IncludeCtDiscoveredSubdomains = true,
+            EnableNativeCtLogSubdomainSource = true,
+            EnablePassiveCtFallback = true,
+            NativeCtLogOnly = true,
             VerifyCtDiscoveredSubdomains = true,
             BackfillMissingCtCertificateMetadata = false,
             PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
@@ -3920,6 +3923,9 @@ public class TestCertificateInventoryCapture {
         Assert.True(options.IncludeApexHttps);
         Assert.False(options.IncludeWwwHttps);
         Assert.False(options.IncludeCtDiscoveredSubdomains);
+        Assert.False(options.EnableNativeCtLogSubdomainSource);
+        Assert.False(options.EnablePassiveCtFallback);
+        Assert.False(options.NativeCtLogOnly);
         Assert.False(options.VerifyCtDiscoveredSubdomains);
         Assert.True(options.BackfillMissingCtCertificateMetadata);
         Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3861,6 +3861,11 @@ public class TestCertificateInventoryCapture {
             IncludeApexHttps = true,
             IncludeWwwHttps = true,
             IncludeCtDiscoveredSubdomains = false,
+            EnableNativeCtLogSubdomainSource = false,
+            EnablePassiveCtFallback = false,
+            NativeCtLogOnly = true,
+            VerifyCtDiscoveredSubdomains = true,
+            BackfillMissingCtCertificateMetadata = false,
             PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
             IncludeMxHosts = true,
             IncludeMxHttps = true,
@@ -3876,7 +3881,11 @@ public class TestCertificateInventoryCapture {
         Assert.False(options.IncludeApexHttps);
         Assert.False(options.IncludeWwwHttps);
         Assert.True(options.IncludeCtDiscoveredSubdomains);
+        Assert.True(options.EnableNativeCtLogSubdomainSource);
+        Assert.True(options.EnablePassiveCtFallback);
+        Assert.False(options.NativeCtLogOnly);
         Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.True(options.BackfillMissingCtCertificateMetadata);
         Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
         Assert.False(options.IncludeMxHosts);
         Assert.False(options.IncludeMxHttps);
@@ -3895,6 +3904,7 @@ public class TestCertificateInventoryCapture {
             IncludeWwwHttps = true,
             IncludeCtDiscoveredSubdomains = true,
             VerifyCtDiscoveredSubdomains = true,
+            BackfillMissingCtCertificateMetadata = false,
             PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
             IncludeMxHosts = true,
             IncludeMxHttps = true,
@@ -3911,6 +3921,7 @@ public class TestCertificateInventoryCapture {
         Assert.False(options.IncludeWwwHttps);
         Assert.False(options.IncludeCtDiscoveredSubdomains);
         Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.True(options.BackfillMissingCtCertificateMetadata);
         Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
         Assert.False(options.IncludeMxHosts);
         Assert.False(options.IncludeMxHttps);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -670,6 +670,49 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task CaptureAsync_PrefersHttpsOverMail_WhenOnlyOneTargetIsAllowed() {
+        using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
+        var observedHttpsTargets = new List<string>();
+        var capture = new CertificateInventoryCapture {
+            MxLookupOverride = (domain, dnsConfiguration, maxMxHostsPerDomain, cancellationToken) =>
+                Task.FromResult<IReadOnlyList<string>>(new[] { "mx.invalid" }),
+            HttpsProbeOverride = (httpsTargets, options, logger, cancellationToken) => {
+                observedHttpsTargets.AddRange(httpsTargets);
+                var entries = new List<CertificateMonitor.Entry>();
+                foreach (var target in httpsTargets) {
+                    entries.Add(CreateHttpsEntry(target, certificate));
+                }
+
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            }
+        };
+
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = true,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = true,
+            IncludeMxHttps = false,
+            IncludeSmtpStartTls = true,
+            IncludeSubmissionStartTls = false,
+            IncludeImapTls = false,
+            IncludePop3Tls = false,
+            MaxTargets = 1,
+            PersistSnapshot = false
+        };
+
+        var result = await capture.CaptureAsync(new[] { "example.com" }, options, cancellationToken: CancellationToken.None);
+
+        Assert.Single(observedHttpsTargets);
+        Assert.Contains(observedHttpsTargets, target => target.Contains("example.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(1, result.HttpsEndpointCount);
+        Assert.Equal(0, result.MailEndpointCount);
+        Assert.Equal(1, result.HttpsTargetCountBeforeLimit);
+        Assert.Equal(1, result.MailTargetCountBeforeLimit);
+        Assert.Equal(0, result.HttpsTargetCountDroppedByLimit);
+        Assert.Equal(1, result.MailTargetCountDroppedByLimit);
+    }
+
+    [Fact]
     public async Task CaptureAsync_ReusesRecentStableFailureSnapshotEntries_WhenEnabled() {
         var cacheDirectory = Path.Combine(Path.GetTempPath(), "dd-ci-cache-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(cacheDirectory);
@@ -2201,6 +2244,17 @@ public class TestCertificateInventoryCapture {
         Assert.Contains("identities(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("x509_altnames(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("encode(x509_serialNumber(c.certificate), 'hex')", query, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("certificate_identity", query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildCrtShPostgreSqlDomainMetadataQuery_UsesHostArraysAndWildcardAwareMatching() {
+        string query = CertificateInventoryCapture.BuildCrtShPostgreSqlDomainMetadataQuery();
+
+        Assert.Contains("identities(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("candidate_name = ANY(@hosts)", query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("candidate_name = ANY(@wildcardHosts)", query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("LIMIT @limit", query, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("certificate_identity", query, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3853,6 +3853,73 @@ public class TestCertificateInventoryCapture {
             message => message.Contains("skipping exact passive CT metadata", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void ApplyCtDiscoveryOnlyProfile_DisablesProbeExpansionAndKeepsCtDiscoveryEnabled()
+    {
+        var options = new CertificateInventoryCaptureOptions
+        {
+            IncludeApexHttps = true,
+            IncludeWwwHttps = true,
+            IncludeCtDiscoveredSubdomains = false,
+            PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
+            IncludeMxHosts = true,
+            IncludeMxHttps = true,
+            IncludeSmtpStartTls = true,
+            IncludeSubmissionStartTls = true,
+            IncludeImapTls = true,
+            IncludePop3Tls = true
+        };
+
+        CertificateInventoryCaptureOptions returned = options.ApplyCtDiscoveryOnlyProfile();
+
+        Assert.Same(options, returned);
+        Assert.False(options.IncludeApexHttps);
+        Assert.False(options.IncludeWwwHttps);
+        Assert.True(options.IncludeCtDiscoveredSubdomains);
+        Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
+        Assert.False(options.IncludeMxHosts);
+        Assert.False(options.IncludeMxHttps);
+        Assert.False(options.IncludeSmtpStartTls);
+        Assert.False(options.IncludeSubmissionStartTls);
+        Assert.False(options.IncludeImapTls);
+        Assert.False(options.IncludePop3Tls);
+    }
+
+    [Fact]
+    public void ApplyCtEvidenceRefreshProfile_DisablesCtDiscoveryAndMailExpansion()
+    {
+        var options = new CertificateInventoryCaptureOptions
+        {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = true,
+            IncludeCtDiscoveredSubdomains = true,
+            VerifyCtDiscoveredSubdomains = true,
+            PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
+            IncludeMxHosts = true,
+            IncludeMxHttps = true,
+            IncludeSmtpStartTls = true,
+            IncludeSubmissionStartTls = true,
+            IncludeImapTls = true,
+            IncludePop3Tls = true
+        };
+
+        CertificateInventoryCaptureOptions returned = options.ApplyCtEvidenceRefreshProfile();
+
+        Assert.Same(options, returned);
+        Assert.True(options.IncludeApexHttps);
+        Assert.False(options.IncludeWwwHttps);
+        Assert.False(options.IncludeCtDiscoveredSubdomains);
+        Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
+        Assert.False(options.IncludeMxHosts);
+        Assert.False(options.IncludeMxHttps);
+        Assert.False(options.IncludeSmtpStartTls);
+        Assert.False(options.IncludeSubmissionStartTls);
+        Assert.False(options.IncludeImapTls);
+        Assert.False(options.IncludePop3Tls);
+    }
+
     private static CertificateMonitor.Entry CreateHttpsEntry(string url, X509Certificate2 certificate) {
         var uri = new Uri(url);
         var analysis = new CertificateAnalysis {

--- a/DomainDetective.Tests/TestSubdomainsAnalysis.cs
+++ b/DomainDetective.Tests/TestSubdomainsAnalysis.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Tests.Fixtures;
@@ -670,6 +671,92 @@ public class TestSubdomainsAnalysis
             Assert.False(second.RetrySuggested);
             Assert.Equal(2, requestOffsets.Count);
             Assert.True(requestOffsets[1] - requestOffsets[0] >= 125);
+        }
+        finally
+        {
+            await server.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_UsesConfiguredPassiveCtSourceSpacingForWildcardDiscovery()
+    {
+        var requestOffsets = new List<long>();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var server = new TcpListenerFixture((listener, token) => Task.Run(async () =>
+        {
+            var handlers = new List<Task>();
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var clientTask = listener.AcceptTcpClientAsync();
+                    var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                    if (completed != clientTask)
+                    {
+                        break;
+                    }
+
+                    handlers.Add(Task.Run(async () =>
+                    {
+                        using var client = await clientTask;
+                        lock (requestOffsets)
+                        {
+                            requestOffsets.Add(stopwatch.ElapsedMilliseconds);
+                        }
+
+                        using NetworkStream stream = client.GetStream();
+                        using var reader = new StreamReader(stream);
+                        using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                        string? line;
+                        do
+                        {
+                            line = await reader.ReadLineAsync();
+                        } while (!string.IsNullOrEmpty(line));
+
+                        const string payload = @"[{ ""name_value"": ""api.example.com"" }]";
+                        await writer.WriteLineAsync("HTTP/1.1 200 OK");
+                        await writer.WriteLineAsync("Content-Type: application/json");
+                        await writer.WriteLineAsync($"Content-Length: {payload.Length}");
+                        await writer.WriteLineAsync();
+                        await writer.WriteAsync(payload);
+                    }, token));
+                }
+            }
+            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (token.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                await Task.WhenAll(handlers).ConfigureAwait(false);
+            }
+        }, token));
+        await server.InitializeAsync();
+
+        try
+        {
+            var analysis = new SubdomainsAnalysis
+            {
+                VerifyStillResolves = false,
+                UseCertSpotterFallback = false,
+                CrtShUrlTemplate = $"http://127.0.0.1:{server.Port}/?q=%25.{{0}}&output=json",
+                PassiveCtRetryCount = 0,
+                PassiveCtCrtShMinimumSpacing = TimeSpan.FromMilliseconds(300)
+            };
+
+            await analysis.AnalyzeAsync("example.com", new InternalLogger(), CancellationToken.None);
+            await analysis.AnalyzeAsync("example.net", new InternalLogger(), CancellationToken.None);
+
+            Assert.Equal(2, requestOffsets.Count);
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            Assert.True(requestOffsets[1] - requestOffsets[0] >= 225);
         }
         finally
         {

--- a/DomainDetective/CertificateInventoryCapture.CtDiscovery.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtDiscovery.cs
@@ -120,6 +120,10 @@ public sealed partial class CertificateInventoryCapture {
                         PassiveCtRetryBaseDelay = options.PassiveCtRetryBaseDelay,
                         PassiveCtRetryMaxDelay = options.PassiveCtRetryMaxDelay,
                         PassiveCtSourceCooldown = options.PassiveCtSourceCooldown,
+                        PassiveCtCrtShMinimumSpacing = options.PassiveCtCrtShMinimumSpacing,
+                        PassiveCtCertSpotterMinimumSpacing = options.PassiveCtCertSpotterMinimumSpacing,
+                        PassiveCtCrtShMaximumRequestsPerRun = options.PassiveCtCrtShMaximumRequestsPerRun,
+                        PassiveCtCertSpotterMaximumRequestsPerRun = options.PassiveCtCertSpotterMaximumRequestsPerRun,
                         EnableNativeCtLogSource = options.EnableNativeCtLogSubdomainSource,
                         NativeCtLogOnly = options.NativeCtLogOnly || !allowPassiveCtFallback,
                         NativeCtLogListUrl = options.NativeCtLogListUrl,
@@ -487,6 +491,10 @@ public sealed partial class CertificateInventoryCapture {
                         PassiveCtRetryBaseDelay = options.PassiveCtRetryBaseDelay,
                         PassiveCtRetryMaxDelay = options.PassiveCtRetryMaxDelay,
                         PassiveCtSourceCooldown = options.PassiveCtSourceCooldown,
+                        PassiveCtCrtShMinimumSpacing = options.PassiveCtCrtShMinimumSpacing,
+                        PassiveCtCertSpotterMinimumSpacing = options.PassiveCtCertSpotterMinimumSpacing,
+                        PassiveCtCrtShMaximumRequestsPerRun = options.PassiveCtCrtShMaximumRequestsPerRun,
+                        PassiveCtCertSpotterMaximumRequestsPerRun = options.PassiveCtCertSpotterMaximumRequestsPerRun,
                         EnableNativeCtLogSource = false,
                         NativeCtLogOnly = false
                     };

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Helpers;
 using Npgsql;
+using NpgsqlTypes;
 
 namespace DomainDetective;
 
@@ -131,6 +132,50 @@ public sealed partial class CertificateInventoryCapture {
                         hydrated != null &&
                         !IsCtCertificateMetadataMissing(hydrated)) {
                         targetNames.Remove(normalizedName);
+                    }
+                }
+            }
+        }
+
+        if (ShouldUseCrtShPostgreSqlMetadataFallback(options)) {
+            logger.WriteVerbose(
+                "CT metadata backfill: querying domain-batched crt.sh PostgreSQL metadata for {0} domain(s) covering {1} remaining subdomain(s).",
+                missingByDomain.Count(static pair => pair.Value.Count > 0),
+                missingByDomain.Sum(static pair => pair.Value.Count));
+
+            foreach (KeyValuePair<string, HashSet<string>> pair in missingByDomain
+                         .Where(static pair => pair.Value.Count > 0)
+                         .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Dictionary<string, SubdomainDiscoveryEntry> domainHydrated;
+                try {
+                    domainHydrated =
+                        await QueryCrtShPostgreSqlMetadataByDomainAsync(
+                                pair.Key,
+                                pair.Value,
+                                options,
+                                logger,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup timed out for {pair.Key}.";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                } catch (Exception ex) {
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                }
+
+                foreach (KeyValuePair<string, SubdomainDiscoveryEntry> hydratedPair in domainHydrated) {
+                    MergeCtSubdomainEntry(merged, hydratedPair.Value);
+                    if (merged.TryGetValue(hydratedPair.Key, out SubdomainDiscoveryEntry? hydrated) &&
+                        hydrated != null &&
+                        !IsCtCertificateMetadataMissing(hydrated)) {
+                        pair.Value.Remove(hydratedPair.Key);
                     }
                 }
             }
@@ -694,6 +739,87 @@ public sealed partial class CertificateInventoryCapture {
         return entry;
     }
 
+    private async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlMetadataByDomainAsync(
+        string domain,
+        IReadOnlyCollection<string> hostNames,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger logger,
+        CancellationToken cancellationToken) {
+        var results = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(domain) || hostNames == null || hostNames.Count == 0 || options == null) {
+            return results;
+        }
+
+        List<string> normalizedHosts = hostNames
+            .Where(static host => !string.IsNullOrWhiteSpace(host))
+            .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (normalizedHosts.Count == 0) {
+            return results;
+        }
+
+        string normalizedDomain = domain.Trim().TrimEnd('.').ToLowerInvariant();
+        string connectionString = BuildCrtShPostgreSqlConnectionString(options);
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandTimeout = Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds);
+        command.CommandText = BuildCrtShPostgreSqlDomainMetadataQuery();
+        command.Parameters.AddWithValue("domain", normalizedDomain);
+        command.Parameters.Add(new NpgsqlParameter<string[]>("hosts", NpgsqlDbType.Array | NpgsqlDbType.Text)
+        {
+            TypedValue = normalizedHosts.ToArray()
+        });
+        command.Parameters.Add(new NpgsqlParameter<string[]>("wildcardHosts", NpgsqlDbType.Array | NpgsqlDbType.Text)
+        {
+            TypedValue = normalizedHosts.Select(BuildWildcardCandidateHost).ToArray()
+        });
+        command.Parameters.AddWithValue("limit", Math.Max(32, normalizedHosts.Count * 8));
+
+        var rows = new List<CrtShPostgreSqlExactMetadataRow>();
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false)) {
+            rows.Add(new CrtShPostgreSqlExactMetadataRow
+            {
+                CertificateDer = reader.IsDBNull(0) ? null : (byte[])reader.GetValue(0),
+                EntryTimestampUtc = reader.IsDBNull(1) ? null : ReadDateTimeOffset(reader.GetValue(1)),
+                CommonName = reader.IsDBNull(2) ? null : reader.GetString(2),
+                IssuerName = reader.IsDBNull(3) ? null : reader.GetString(3),
+                SerialNumber = reader.IsDBNull(4) ? null : reader.GetString(4),
+                NotBeforeUtc = reader.IsDBNull(5) ? null : ReadDateTimeOffset(reader.GetValue(5)),
+                NotAfterUtc = reader.IsDBNull(6) ? null : ReadDateTimeOffset(reader.GetValue(6)),
+                CandidateNames = reader.IsDBNull(7)
+                    ? Array.Empty<string>()
+                    : ((string[])reader.GetValue(7))
+                        .Select(static name => NormalizeCtMetadataCandidate(name, preserveWildcard: true))
+                        .Where(static name => !string.IsNullOrWhiteSpace(name))
+                        .Select(static name => name!)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList()
+            });
+        }
+
+        foreach (string normalizedHost in normalizedHosts) {
+            SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(normalizedHost, rows);
+            if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
+                continue;
+            }
+
+            results[normalizedHost] = entry;
+        }
+
+        if (results.Count > 0) {
+            logger.WriteVerbose(
+                "CT metadata backfill domain PostgreSQL lookup matched {0} host(s) for {1} from {2} candidate certificate row(s).",
+                results.Count,
+                normalizedDomain,
+                rows.Count);
+        }
+
+        return results;
+    }
+
     internal static string BuildCrtShPostgreSqlExactMetadataQuery() {
         return
             """
@@ -741,6 +867,54 @@ public sealed partial class CertificateInventoryCapture {
             ORDER BY entry_timestamp DESC NULLS LAST,
                      x509_notBefore(c.certificate) DESC NULLS LAST
             LIMIT 16;
+            """;
+    }
+
+    internal static string BuildCrtShPostgreSqlDomainMetadataQuery() {
+        return
+            """
+            SELECT
+                c.certificate,
+                COALESCE(
+                    (
+                        SELECT MAX(ctle.entry_timestamp)
+                        FROM ct_log_entry ctle
+                        WHERE ctle.certificate_id = c.id
+                    ),
+                    NULL
+                ) AS entry_timestamp,
+                x509_commonName(c.certificate) AS common_name,
+                x509_issuerName(c.certificate) AS issuer_name,
+                encode(x509_serialNumber(c.certificate), 'hex') AS serial_number,
+                x509_notBefore(c.certificate) AS not_before,
+                x509_notAfter(c.certificate) AS not_after,
+                ARRAY(
+                    SELECT candidate_name
+                    FROM (
+                        SELECT x509_commonName(c.certificate) AS candidate_name
+                        UNION
+                        SELECT alt_name
+                        FROM x509_altnames(c.certificate) AS alt_name
+                    ) AS candidate_names
+                    WHERE candidate_name IS NOT NULL
+                    ORDER BY lower(candidate_name)
+                ) AS dns_names
+            FROM certificate c
+            WHERE identities(c.certificate) @@ plainto_tsquery('simple', @domain)
+              AND EXISTS (
+                    SELECT 1
+                    FROM (
+                        SELECT lower(COALESCE(x509_commonName(c.certificate), '')) AS candidate_name
+                        UNION
+                        SELECT lower(alt_name)
+                        FROM x509_altnames(c.certificate) AS alt_name
+                    ) AS candidate_names
+                    WHERE candidate_name = ANY(@hosts)
+                       OR candidate_name = ANY(@wildcardHosts)
+                )
+            ORDER BY entry_timestamp DESC NULLS LAST,
+                     x509_notBefore(c.certificate) DESC NULLS LAST
+            LIMIT @limit;
             """;
     }
 

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -381,11 +381,13 @@ public sealed partial class CertificateInventoryCapture {
             return true;
         }
 
-        return string.IsNullOrWhiteSpace(entry.LatestCertificateSubject) &&
-               string.IsNullOrWhiteSpace(entry.LatestCertificateIssuer) &&
-               string.IsNullOrWhiteSpace(entry.LatestCertificateSerialNumber) &&
-               !entry.LatestCertificateNotBeforeUtc.HasValue &&
-               !entry.LatestCertificateNotAfterUtc.HasValue;
+        return string.IsNullOrWhiteSpace(entry.LatestCertificateSubject) ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateIssuer) ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateSerialNumber) ||
+               !entry.LatestCertificateNotBeforeUtc.HasValue ||
+               !entry.LatestCertificateNotAfterUtc.HasValue ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateThumbprint) ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateAuthenticationProfile);
     }
 
     private static bool HasCtCertificateMetadata(
@@ -472,6 +474,7 @@ public sealed partial class CertificateInventoryCapture {
             int exactNetworkParallelism = ResolveExactPassiveCtMetadataBackfillParallelism(
                 options.DiscoveryParallelism,
                 options.PassiveCtParallelism,
+                options.CrtShPostgreSqlMaximumConcurrentRequests,
                 remainingHostNames.Count,
                 usePassiveNetworkQueries: true);
             int scheduledHosts = 0;
@@ -603,6 +606,7 @@ public sealed partial class CertificateInventoryCapture {
         int exactParallelism = ResolveExactPassiveCtMetadataBackfillParallelism(
             options.DiscoveryParallelism,
             options.PassiveCtParallelism,
+            options.CrtShPostgreSqlMaximumConcurrentRequests,
             hostNames.Count,
             usePassiveNetworkQueries: false);
         using var gate = new SemaphoreSlim(exactParallelism, exactParallelism);
@@ -860,6 +864,7 @@ public sealed partial class CertificateInventoryCapture {
     internal static int ResolveExactPassiveCtMetadataBackfillParallelism(
         int configuredDiscoveryParallelism,
         int configuredPassiveCtParallelism,
+        int configuredCrtShPostgreSqlMaximumConcurrentRequests,
         int hostCount,
         bool usePassiveNetworkQueries) {
         int configuredParallelism = Math.Max(1, configuredDiscoveryParallelism);
@@ -867,7 +872,9 @@ public sealed partial class CertificateInventoryCapture {
             ? Math.Min(
                 Math.Min(configuredParallelism, Math.Max(1, configuredPassiveCtParallelism)),
                 4)
-            : configuredParallelism;
+            : Math.Min(
+                configuredParallelism,
+                Math.Max(1, configuredCrtShPostgreSqlMaximumConcurrentRequests));
         return Math.Min(Math.Max(1, hostCount), effectiveParallelism);
     }
 
@@ -1013,6 +1020,19 @@ public sealed partial class CertificateInventoryCapture {
             return entry;
         }
 
+        CertificateExtendedKeyUsageInfo eku = CertificateExtendedKeyUsageAnalyzer.Analyze(certificate);
+        string? signatureOid = certificate.SignatureAlgorithm?.Value;
+        int keySize = GetPublicKeySize(certificate);
+        bool isSelfSigned = IsSelfSigned(certificate);
+        bool weakKey = keySize > 0 && keySize < 2048;
+        bool sha1Signature = IsSha1Signature(signatureOid);
+        bool hasServerAuthentication = eku.AllowsServerAuthentication;
+        bool hasClientAuthentication = eku.AllowsClientAuthentication;
+        bool hasSecureEmail = eku.AllowsSecureEmail;
+        string authenticationProfile = string.IsNullOrWhiteSpace(eku.AuthenticationProfile)
+            ? CertificateAuthenticationProfileClassifier.Classify(eku)
+            : eku.AuthenticationProfile;
+
         SubdomainDiscoveryEntry hydratedEntry = CloneSubdomainEntry(entry);
         hydratedEntry = new SubdomainDiscoveryEntry {
             Name = hydratedEntry.Name,
@@ -1026,13 +1046,15 @@ public sealed partial class CertificateInventoryCapture {
             LatestCertificateNotBeforeUtc = hydratedEntry.LatestCertificateNotBeforeUtc ?? new DateTimeOffset(certificate.NotBefore.ToUniversalTime()),
             LatestCertificateNotAfterUtc = hydratedEntry.LatestCertificateNotAfterUtc ?? new DateTimeOffset(certificate.NotAfter.ToUniversalTime()),
             LatestCertificateSubjectAlternativeNames = hydratedEntry.LatestCertificateSubjectAlternativeNames == null ? Array.Empty<string>() : hydratedEntry.LatestCertificateSubjectAlternativeNames.ToList(),
-            LatestCertificateIsSelfSigned = hydratedEntry.LatestCertificateIsSelfSigned,
-            LatestCertificateWeakKey = hydratedEntry.LatestCertificateWeakKey,
-            LatestCertificateSha1Signature = hydratedEntry.LatestCertificateSha1Signature,
-            LatestCertificateHasServerAuthentication = hydratedEntry.LatestCertificateHasServerAuthentication,
-            LatestCertificateHasClientAuthentication = hydratedEntry.LatestCertificateHasClientAuthentication,
-            LatestCertificateHasSecureEmail = hydratedEntry.LatestCertificateHasSecureEmail,
-            LatestCertificateAuthenticationProfile = hydratedEntry.LatestCertificateAuthenticationProfile,
+            LatestCertificateIsSelfSigned = hydratedEntry.LatestCertificateIsSelfSigned ?? isSelfSigned,
+            LatestCertificateWeakKey = hydratedEntry.LatestCertificateWeakKey ?? weakKey,
+            LatestCertificateSha1Signature = hydratedEntry.LatestCertificateSha1Signature ?? sha1Signature,
+            LatestCertificateHasServerAuthentication = hydratedEntry.LatestCertificateHasServerAuthentication ?? hasServerAuthentication,
+            LatestCertificateHasClientAuthentication = hydratedEntry.LatestCertificateHasClientAuthentication ?? hasClientAuthentication,
+            LatestCertificateHasSecureEmail = hydratedEntry.LatestCertificateHasSecureEmail ?? hasSecureEmail,
+            LatestCertificateAuthenticationProfile = string.IsNullOrWhiteSpace(hydratedEntry.LatestCertificateAuthenticationProfile)
+                ? authenticationProfile
+                : hydratedEntry.LatestCertificateAuthenticationProfile,
             CtSources = hydratedEntry.CtSources == null ? Array.Empty<string>() : hydratedEntry.CtSources.ToList(),
             CertificateObservationCount = hydratedEntry.CertificateObservationCount,
             ResolutionStatus = hydratedEntry.ResolutionStatus,

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -137,6 +137,7 @@ public sealed partial class CertificateInventoryCapture {
             }
         }
 
+        bool domainPostgreSqlLookupFailed = false;
         if (ShouldUseCrtShPostgreSqlMetadataFallback(options)) {
             logger.WriteVerbose(
                 "CT metadata backfill: querying domain-batched crt.sh PostgreSQL metadata for {0} domain(s) covering {1} remaining subdomain(s).",
@@ -159,11 +160,13 @@ public sealed partial class CertificateInventoryCapture {
                                 cancellationToken)
                             .ConfigureAwait(false);
                 } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+                    domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup timed out for {pair.Key}.";
                     warnings.Add(warning);
                     logger.WriteVerbose(warning);
                     continue;
                 } catch (Exception ex) {
+                    domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
                     warnings.Add(warning);
                     logger.WriteVerbose(warning);
@@ -193,14 +196,18 @@ public sealed partial class CertificateInventoryCapture {
             .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         if (remainingMissingNames.Count > 0 && suppressedHosts.Count > 0) {
-            int originalCount = remainingMissingNames.Count;
-            remainingMissingNames = remainingMissingNames
-                .Where(name => !suppressedHosts.Contains(name!.Trim().TrimEnd('.').ToLowerInvariant()))
-                .ToList();
-            int suppressedCount = originalCount - remainingMissingNames.Count;
-            if (suppressedCount > 0) {
+            int suppressedCount = remainingMissingNames.Count(name =>
+                suppressedHosts.Contains(name!.Trim().TrimEnd('.').ToLowerInvariant()));
+            if (suppressedCount > 0 && !domainPostgreSqlLookupFailed) {
+                remainingMissingNames = remainingMissingNames
+                    .Where(name => !suppressedHosts.Contains(name!.Trim().TrimEnd('.').ToLowerInvariant()))
+                    .ToList();
                 logger.WriteVerbose(
                     "CT metadata backfill: skipping exact passive CT metadata for {0} remaining host(s) because the caller already supplied suppression state.",
+                    suppressedCount);
+            } else if (suppressedCount > 0) {
+                logger.WriteVerbose(
+                    "CT metadata backfill: retaining {0} remaining host(s) for exact passive CT metadata because domain-batched crt.sh PostgreSQL lookup failed in this pass.",
                     suppressedCount);
             }
         }

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataEnrichment.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataEnrichment.cs
@@ -179,7 +179,7 @@ public sealed partial class CertificateInventoryCapture {
             entry.NotAfterUtc = discoveredEntry.LatestCertificateNotAfterUtc;
             updated = true;
         }
-        if (string.IsNullOrWhiteSpace(entry.AuthenticationProfile) &&
+        if ((string.IsNullOrWhiteSpace(entry.AuthenticationProfile) || hadNoPrimaryCertificateEvidence) &&
             !string.IsNullOrWhiteSpace(discoveredEntry.LatestCertificateAuthenticationProfile)) {
             entry.AuthenticationProfile = discoveredEntry.LatestCertificateAuthenticationProfile!;
             updated = true;

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -662,6 +662,15 @@ public sealed partial class CertificateInventoryCapture {
             return;
         }
 
+        // When a run is only allowed to probe one endpoint, prefer the direct HTTPS
+        // target over auxiliary mail expansion. This keeps apex/root website checks
+        // from being starved by MX-derived targets during tightly bounded passes.
+        if (maxTargets == 1) {
+            allowedHttps = 1;
+            allowedMail = 0;
+            return;
+        }
+
         var total = normalizedHttps + normalizedMail;
         var desiredHttps = (int)Math.Round(
             maxTargets * (double)normalizedHttps / total,

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -390,7 +390,8 @@ public sealed class CertificateInventoryCaptureOptions {
     /// Configures the capture for exact-host CT evidence refresh.
     /// This keeps the run focused on apex or explicit host probes plus CT metadata hydration,
     /// without reopening broader CT discovery or MX/mail expansion. CT metadata hydration stays
-    /// enabled for exact-host seeds and explicit CT metadata targets rather than discovered-host expansion.
+    /// enabled for exact-host seeds and explicit CT metadata targets via passive metadata fallback
+    /// rather than discovered-host expansion.
     /// </summary>
     public CertificateInventoryCaptureOptions ApplyCtEvidenceRefreshProfile() {
         IncludeApexHttps = true;
@@ -398,6 +399,7 @@ public sealed class CertificateInventoryCaptureOptions {
         IncludeCtDiscoveredSubdomains = false;
         EnableNativeCtLogSubdomainSource = false;
         EnablePassiveCtFallback = false;
+        EnablePassiveCtMetadataFallback = true;
         NativeCtLogOnly = false;
         VerifyCtDiscoveredSubdomains = false;
         BackfillMissingCtCertificateMetadata = true;

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -120,6 +120,13 @@ public sealed class CertificateInventoryCaptureOptions {
     /// </summary>
     public int CrtShPostgreSqlCommandTimeoutSeconds { get; set; } = 15;
 
+    /// <summary>
+    /// Maximum number of concurrent exact-host crt.sh PostgreSQL metadata rescue queries.
+    /// Keep this conservative for the public guest replica to avoid exhausting shared
+    /// connection budgets during large capture runs.
+    /// </summary>
+    public int CrtShPostgreSqlMaximumConcurrentRequests { get; set; } = 2;
+
     /// <summary>Per-request timeout for passive/public CT HTTP calls.</summary>
     public TimeSpan PassiveCtRequestTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
@@ -139,19 +146,19 @@ public sealed class CertificateInventoryCaptureOptions {
     /// Minimum spacing between public crt.sh requests when passive/public CT fallback is active.
     /// This helps exact-host rescue and fallback discovery stay within respectful shared-source pacing.
     /// </summary>
-    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.
     /// This is anti-burst pacing only; the main safety rail is the run-local request budget below.
     /// </summary>
-    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Maximum number of public crt.sh exact-host metadata requests issued during a single passive CT run.
     /// Zero means uncapped.
     /// </summary>
-    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 8;
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 5;
 
     /// <summary>
     /// Maximum number of Cert Spotter exact-host metadata requests issued during a single passive CT run.
@@ -818,7 +825,11 @@ public sealed partial class CertificateInventoryCapture {
         var normalizedDomains = NormalizeDomains(domains, warnings);
         var seeds = BuildSeeds(normalizedDomains);
         var normalizedCtDiscoveryDomains = options.CtDiscoveryDomains.Count == 0
-            ? normalizedDomains
+            ? seeds
+                .Where(static seed => seed != null && !seed.IsExactHostSeed && !string.IsNullOrWhiteSpace(seed.Name))
+                .Select(static seed => seed.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList()
             : NormalizeDomains(options.CtDiscoveryDomains, warnings);
         var ctDiscoverySeeds = BuildSeeds(normalizedCtDiscoveryDomains);
         logger.WriteVerbose("Certificate inventory capture started for {0} normalized domain(s).", normalizedDomains.Count);

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -370,8 +370,13 @@ public sealed class CertificateInventoryCaptureOptions {
         IncludeApexHttps = false;
         IncludeWwwHttps = false;
         IncludeCtDiscoveredSubdomains = true;
+        EnableNativeCtLogSubdomainSource = true;
+        EnablePassiveCtFallback = true;
+        NativeCtLogOnly = false;
         VerifyCtDiscoveredSubdomains = false;
+        BackfillMissingCtCertificateMetadata = true;
         PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        // Disable all non-CT probe expansion in the discovery-only lane.
         IncludeMxHosts = false;
         IncludeMxHttps = false;
         IncludeSmtpStartTls = false;
@@ -384,14 +389,17 @@ public sealed class CertificateInventoryCaptureOptions {
     /// <summary>
     /// Configures the capture for exact-host CT evidence refresh.
     /// This keeps the run focused on apex or explicit host probes plus CT metadata hydration,
-    /// without reopening broader CT discovery or MX/mail expansion.
+    /// without reopening broader CT discovery or MX/mail expansion. CT metadata hydration stays
+    /// enabled for exact-host seeds and explicit CT metadata targets rather than discovered-host expansion.
     /// </summary>
     public CertificateInventoryCaptureOptions ApplyCtEvidenceRefreshProfile() {
         IncludeApexHttps = true;
         IncludeWwwHttps = false;
         IncludeCtDiscoveredSubdomains = false;
         VerifyCtDiscoveredSubdomains = false;
+        BackfillMissingCtCertificateMetadata = true;
         PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        // Disable all non-CT probe expansion in the evidence-refresh lane.
         IncludeMxHosts = false;
         IncludeMxHttps = false;
         IncludeSmtpStartTls = false;

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -362,6 +362,46 @@ public sealed class CertificateInventoryCaptureOptions {
     public bool PersistSnapshot { get; set; } = true;
 
     /// <summary>
+    /// Configures the capture for CT discovery only.
+    /// This keeps the run focused on discovering names and CT-backed metadata without
+    /// widening into HTTPS, MX, or mail probing in the same pass.
+    /// </summary>
+    public CertificateInventoryCaptureOptions ApplyCtDiscoveryOnlyProfile() {
+        IncludeApexHttps = false;
+        IncludeWwwHttps = false;
+        IncludeCtDiscoveredSubdomains = true;
+        VerifyCtDiscoveredSubdomains = false;
+        PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        IncludeMxHosts = false;
+        IncludeMxHttps = false;
+        IncludeSmtpStartTls = false;
+        IncludeSubmissionStartTls = false;
+        IncludeImapTls = false;
+        IncludePop3Tls = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the capture for exact-host CT evidence refresh.
+    /// This keeps the run focused on apex or explicit host probes plus CT metadata hydration,
+    /// without reopening broader CT discovery or MX/mail expansion.
+    /// </summary>
+    public CertificateInventoryCaptureOptions ApplyCtEvidenceRefreshProfile() {
+        IncludeApexHttps = true;
+        IncludeWwwHttps = false;
+        IncludeCtDiscoveredSubdomains = false;
+        VerifyCtDiscoveredSubdomains = false;
+        PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        IncludeMxHosts = false;
+        IncludeMxHttps = false;
+        IncludeSmtpStartTls = false;
+        IncludeSubmissionStartTls = false;
+        IncludeImapTls = false;
+        IncludePop3Tls = false;
+        return this;
+    }
+
+    /// <summary>
     /// Additional endpoints to probe.
     /// Supported forms:
     /// - https://host[:port], http://host[:port]

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -396,6 +396,9 @@ public sealed class CertificateInventoryCaptureOptions {
         IncludeApexHttps = true;
         IncludeWwwHttps = false;
         IncludeCtDiscoveredSubdomains = false;
+        EnableNativeCtLogSubdomainSource = false;
+        EnablePassiveCtFallback = false;
+        NativeCtLogOnly = false;
         VerifyCtDiscoveredSubdomains = false;
         BackfillMissingCtCertificateMetadata = true;
         PromoteCtDiscoveredSubdomainsToHttpsProbes = false;

--- a/DomainDetective/Protocols/SubdomainEnumeration.cs
+++ b/DomainDetective/Protocols/SubdomainEnumeration.cs
@@ -51,6 +51,18 @@ public class SubdomainEnumeration
     /// <summary>Cooldown applied to passive/public CT sources after transient failures or rate limits.</summary>
     public TimeSpan PassiveCtSourceCooldown { get; set; } = TimeSpan.FromSeconds(60);
 
+    /// <summary>Minimum spacing between public crt.sh requests when passive/public CT fallback is active.</summary>
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.</summary>
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>Maximum number of public crt.sh requests issued during one passive enumeration run.</summary>
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 5;
+
+    /// <summary>Maximum number of Cert Spotter requests issued during one passive enumeration run.</summary>
+    public int PassiveCtCertSpotterMaximumRequestsPerRun { get; set; } = 1;
+
     /// <summary>List of subdomains discovered via brute force.</summary>
     public List<string> BruteForceResults { get; private set; } = new();
 
@@ -102,6 +114,10 @@ public class SubdomainEnumeration
                 RetryBaseDelay = PassiveCtRetryBaseDelay,
                 RetryMaxDelay = PassiveCtRetryMaxDelay,
                 SourceCooldown = PassiveCtSourceCooldown,
+                CrtShMinimumSpacing = PassiveCtCrtShMinimumSpacing,
+                CertSpotterMinimumSpacing = PassiveCtCertSpotterMinimumSpacing,
+                CrtShMaximumRequestsPerRun = PassiveCtCrtShMaximumRequestsPerRun,
+                CertSpotterMaximumRequestsPerRun = PassiveCtCertSpotterMaximumRequestsPerRun,
                 PayloadValidator = ValidatePassiveCtArrayPayload
             },
             PassiveHttpGetOverride,

--- a/DomainDetective/Protocols/SubdomainsAnalysis.CtAndResolutionHelpers.cs
+++ b/DomainDetective/Protocols/SubdomainsAnalysis.CtAndResolutionHelpers.cs
@@ -134,6 +134,10 @@ public sealed partial class SubdomainsAnalysis : IHasAssessments
                 RetryBaseDelay = PassiveCtRetryBaseDelay,
                 RetryMaxDelay = PassiveCtRetryMaxDelay,
                 SourceCooldown = PassiveCtSourceCooldown,
+                CrtShMinimumSpacing = PassiveCtCrtShMinimumSpacing,
+                CertSpotterMinimumSpacing = PassiveCtCertSpotterMinimumSpacing,
+                CrtShMaximumRequestsPerRun = PassiveCtCrtShMaximumRequestsPerRun,
+                CertSpotterMaximumRequestsPerRun = PassiveCtCertSpotterMaximumRequestsPerRun,
                 PayloadValidator = ValidatePassiveCtArrayPayload
             },
             QueryOverride,

--- a/DomainDetective/Protocols/SubdomainsAnalysis.cs
+++ b/DomainDetective/Protocols/SubdomainsAnalysis.cs
@@ -51,6 +51,29 @@ public sealed partial class SubdomainsAnalysis : IHasAssessments
     /// <summary>Cooldown applied to passive/public CT sources after transient failures or rate limits.</summary>
     public TimeSpan PassiveCtSourceCooldown { get; set; } = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// Minimum spacing between public crt.sh requests when passive/public CT fallback is active.
+    /// crt.sh publishes conservative shared limits, so the default stays intentionally gentle.
+    /// </summary>
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.
+    /// </summary>
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Maximum number of public crt.sh requests issued during one passive CT run.
+    /// Zero means uncapped.
+    /// </summary>
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum number of Cert Spotter requests issued during one passive CT run.
+    /// Zero means uncapped.
+    /// </summary>
+    public int PassiveCtCertSpotterMaximumRequestsPerRun { get; set; } = 1;
+
     /// <summary>When true, uses direct RFC6962 CT log polling as primary subdomain discovery source.</summary>
     public bool EnableNativeCtLogSource { get; set; }
 

--- a/Website/content/docs/configuration.md
+++ b/Website/content/docs/configuration.md
@@ -24,6 +24,10 @@ Available endpoints:
 - `DnsEndpoint.Cloudflare` - Cloudflare DoH (JSON)
 - `DnsEndpoint.Google` - Google Public DNS
 - `DnsEndpoint.Quad9` - Quad9 DNS
+- `DnsEndpoint.Quad9Http3` - Quad9 DoH3 on .NET 8+
+- `DnsEndpoint.Quad9Quic` - Quad9 DoQ on .NET 8+ when QUIC is supported
+
+For browser-hosted DomainDetective pages, keep using browser-safe DoH resolver choices. The broader transport list applies to local DnsClientX usage in PowerShell, CLI, and C#.
 
 ### Multiple Resolvers
 

--- a/Website/content/docs/dns-examples.md
+++ b/Website/content/docs/dns-examples.md
@@ -57,6 +57,14 @@ Test-DnsBenchmark -Name 'contoso.com' -DnsProvider Cloudflare, Google, Quad9 -At
     Sort-Object Rank | Format-Table Target, SuccessPercent, AverageMs, Rank, IsRecommended
 ```
 
+Use modern explicit endpoints on .NET 8+:
+
+```powershell
+Resolve-Dns -Name 'contoso.com' -Type A `
+    -ResolverEndpoint 'doq@dns.quad9.net:853','doh3@https://dns.quad9.net/dns-query' `
+    -ResolverStrategy FirstSuccess | Format-Table
+```
+
 ## C# Examples
 
 Install the package:
@@ -90,6 +98,20 @@ foreach (var recordType in recordTypes) {
 }
 ```
 
+Query through a modern explicit endpoint set on .NET 8+:
+
+```csharp
+using DnsClientX;
+
+var responses = await ClientX.QueryDns(
+    new ResolveDnsRequest {
+        Names = new[] { "contoso.com" },
+        RecordTypes = new[] { DnsRecordType.A, DnsRecordType.AAAA },
+        ResolverEndpoints = new[] { "doh3@https://dns.quad9.net/dns-query", "doq@dns.quad9.net:853" },
+        ResolverStrategy = MultiResolverStrategy.FirstSuccess
+    });
+```
+
 Use the DomainDetective DNS inventory:
 
 ```csharp
@@ -115,7 +137,7 @@ domaindetective check contoso.com --checks DNSINVENTORY
 ## When To Use Which Path
 
 - Use [DNS Lookup](/tools/dns-lookup/) for a quick browser-safe answer view
-- Use DnsClientX PowerShell or C# when you need specific hostnames, typed records, or repeatable DNS automation
+- Use DnsClientX PowerShell or C# when you need specific hostnames, typed records, repeatable DNS automation, or modern local transports
 - Use the wider DomainDetective API or CLI when you want DNS as part of full domain posture analysis
 
 ## Related Reading

--- a/Website/content/docs/dns-resolvers.md
+++ b/Website/content/docs/dns-resolvers.md
@@ -22,6 +22,13 @@ DomainDetective uses the [DnsClientX](https://github.com/EvotecIT/DnsClientX) li
 
 By default, DomainDetective uses the system DNS resolver. For browser-based tools, it uses browser-safe DNS-over-HTTPS resolver paths instead of raw UDP or TCP DNS.
 
+For local DnsClientX usage, the transport surface is broader:
+
+- `System` and `SystemTcp` cover classic resolver paths.
+- DoH, DoT, and explicit endpoint strings are available locally.
+- On .NET 8 and later, DoH3 and DoQ stay in the core package with no extra transport package required.
+- The browser workspace still stays on DoH because browsers do not expose raw UDP, TCP, DoT, or DoQ sockets to the site.
+
 ## Configuring a Single Resolver
 
 ```csharp
@@ -31,15 +38,30 @@ healthCheck.DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
 
 ## Available Resolvers
 
-| Endpoint | Protocol | Provider |
-|----------|----------|----------|
-| `System` | UDP/TCP | OS default |
-| `SystemTcp` | TCP | OS default |
-| `CloudflareWireFormat` | DoH (wire) | Cloudflare |
-| `Cloudflare` | DoH (JSON) | Cloudflare |
-| `Google` | DoH | Google |
-| `Quad9` | DoH | Quad9 |
+| Endpoint | Protocol | Local | Browser workspace |
+|----------|----------|-------|-------------------|
+| `System` | UDP/TCP fallback | Yes | No |
+| `SystemTcp` | TCP | Yes | No |
+| `CloudflareWireFormat` | DoH (wire) | Yes | No |
+| `Cloudflare` | DoH (JSON) | Yes | Yes |
+| `Google` | DoH | Yes | Yes |
+| `Quad9` | DoH | Yes | No |
+| `CloudflareQuic` | DoQ | Yes on .NET 8+ | No |
+| `GoogleQuic` | DoQ | Yes on .NET 8+ | No |
+| `Quad9Http3` | DoH3 | Yes on .NET 8+ | No |
+| `Quad9Quic` | DoQ | Yes on .NET 8+ | No |
+
+## Explicit Endpoint Syntax
+
+Local DnsClientX workflows also accept explicit endpoint strings:
+
+- `udp@1.1.1.1:53`
+- `tcp@9.9.9.9:53`
+- `dot@dns.quad9.net:853`
+- `doh@https://dns.google/dns-query`
+- `doh3@https://dns.quad9.net/dns-query`
+- `doq@dns.quad9.net:853`
 
 ## Browser Compatibility
 
-When running in a browser (Blazor WASM), only DNS-over-HTTPS endpoints work because browsers cannot make raw UDP/TCP DNS queries. The DomainDetective website currently keeps the browser-safe DNS workspace focused on `Google DNS` and `Cloudflare DNS`, while fuller resolver choice stays in the local DnsClientX workflows.
+When running in a browser (Blazor WASM), only DNS-over-HTTPS endpoints work because browsers cannot make raw UDP, TCP, DoT, or DoQ DNS queries. The DomainDetective website currently keeps the browser-safe DNS workspace focused on `Google DNS` and `Cloudflare DNS`, while fuller resolver choice stays in the local DnsClientX workflows.

--- a/Website/content/docs/dns-workspace.md
+++ b/Website/content/docs/dns-workspace.md
@@ -70,6 +70,18 @@ Switch to DnsClientX locally when you want:
 - Batch DNS workflows
 - Benchmarking multiple resolvers
 - System DNS, DoH, DoT, or other provider choices
+- DoH3 or DoQ on .NET 8 and later
+- Explicit resolver endpoint strings such as `doq@dns.quad9.net:853`
+
+## Transport Boundaries
+
+The browser workspace is intentionally narrower than the local library:
+
+- Browser: browser-safe DoH resolvers only
+- Local DnsClientX: UDP, TCP, DoH, DoT, and built-in resolver families
+- Local DnsClientX on .NET 8+: DoH3 and DoQ in the core package
+
+That split keeps the site behavior honest while preserving the fuller transport surface in PowerShell, CLI, and C#.
 
 ## C# Quick Start
 

--- a/Website/content/docs/dnsclientx.md
+++ b/Website/content/docs/dnsclientx.md
@@ -25,6 +25,15 @@ This page is the DNS landing area when you want to move between:
 - direct C# DNS queries
 - resolver and benchmarking guidance
 
+## Support Snapshot
+
+The browser workspace and the local library do not expose the same transport surface:
+
+- The browser workspace stays on browser-safe DNS-over-HTTPS resolver paths.
+- Local DnsClientX workflows can use system DNS, UDP, TCP, DoT, and DoH.
+- On .NET 8 and later, local DnsClientX workflows can also use DoH3 and DoQ without adding extra transport packages.
+- Older targets keep the same API surface, but modern transports are reported as unsupported at runtime.
+
 ## Start In The Browser
 
 Use [`/tools/dns-lookup/`](/tools/dns-lookup/) when you want:
@@ -35,6 +44,8 @@ Use [`/tools/dns-lookup/`](/tools/dns-lookup/) when you want:
 - a focused export you can paste into notes or tickets
 
 That workspace is documented in the [DnsClientX DNS Workspace](/docs/dns-workspace/) guide.
+
+It is intentionally not a full transport matrix for DnsClientX. If you want DoT, DoH3, DoQ, explicit endpoint strings, benchmarking, or saved resolver selection reuse, move to the local PowerShell, CLI, or C# paths.
 
 ## Move To PowerShell
 
@@ -62,6 +73,14 @@ Benchmark resolvers:
 ```powershell
 Test-DnsBenchmark -Name 'contoso.com' -DnsProvider Cloudflare, Google, Quad9 -Attempts 3 |
     Sort-Object Rank | Format-Table Target, SuccessPercent, AverageMs, Rank, IsRecommended
+```
+
+Use modern explicit endpoints on .NET 8+:
+
+```powershell
+Resolve-Dns -Name 'contoso.com' -Type A `
+    -ResolverEndpoint 'doq@dns.quad9.net:853','doh3@https://dns.quad9.net/dns-query' `
+    -ResolverStrategy FirstSuccess | Format-Table
 ```
 
 ## Move To C#
@@ -93,6 +112,20 @@ var responses = await client.Resolve("contoso.com", new[] { DnsRecordType.A, Dns
 responses.DisplayTable();
 ```
 
+Use a modern explicit endpoint on .NET 8+:
+
+```csharp
+using DnsClientX;
+
+var response = await ClientX.QueryDns(
+    new ResolveDnsRequest {
+        Names = new[] { "contoso.com" },
+        RecordTypes = new[] { DnsRecordType.A },
+        ResolverEndpoints = new[] { "doh3@https://dns.quad9.net/dns-query", "doq@dns.quad9.net:853" },
+        ResolverStrategy = MultiResolverStrategy.FirstSuccess
+    });
+```
+
 ## Today vs Later
 
 Today, the DomainDetective website uses DnsClientX as the DNS engine behind the browser workspace and the local workflow guidance.
@@ -102,6 +135,7 @@ Later, this documentation lane can expand into a fuller DNS area with:
 - more DnsClientX-focused examples
 - direct DNS API documentation links
 - deeper resolver and benchmarking guides
+- clearer transport-by-runtime support notes
 
 ## Related Reading
 


### PR DESCRIPTION
## Summary
- add explicit reusable CT discovery-only and CT evidence-refresh capture profiles
- cover the new profile helpers with focused tests

## Why
- DDPlus and future callers need named reusable capture intents instead of rebuilding these option combinations by hand
- the product goal is simpler when CT discovery and CT evidence refresh are explicit library-side concepts