### PR TITLE
Clarify DnsClientX transport support in website docs

### DIFF
--- a/Website/content/docs/configuration.md
+++ b/Website/content/docs/configuration.md
@@ -24,6 +24,10 @@ Available endpoints:
 - `DnsEndpoint.Cloudflare` - Cloudflare DoH (JSON)
 - `DnsEndpoint.Google` - Google Public DNS
 - `DnsEndpoint.Quad9` - Quad9 DNS
+- `DnsEndpoint.Quad9Http3` - Quad9 DoH3 on .NET 8+
+- `DnsEndpoint.Quad9Quic` - Quad9 DoQ on .NET 8+ when QUIC is supported
+
+For browser-hosted DomainDetective pages, keep using browser-safe DoH resolver choices. The broader transport list applies to local DnsClientX usage in PowerShell, CLI, and C#.
 
 ### Multiple Resolvers
 

--- a/Website/content/docs/dns-examples.md
+++ b/Website/content/docs/dns-examples.md
@@ -57,6 +57,14 @@ Test-DnsBenchmark -Name 'contoso.com' -DnsProvider Cloudflare, Google, Quad9 -At
     Sort-Object Rank | Format-Table Target, SuccessPercent, AverageMs, Rank, IsRecommended
 ```
 
+Use modern explicit endpoints on .NET 8+:
+
+```powershell
+Resolve-Dns -Name 'contoso.com' -Type A `
+    -ResolverEndpoint 'doq@dns.quad9.net:853','doh3@https://dns.quad9.net/dns-query' `
+    -ResolverStrategy FirstSuccess | Format-Table
+```
+
 ## C# Examples
 
 Install the package:
@@ -90,6 +98,20 @@ foreach (var recordType in recordTypes) {
 }
 ```
 
+Query through a modern explicit endpoint set on .NET 8+:
+
+```csharp
+using DnsClientX;
+
+var responses = await ClientX.QueryDns(
+    new ResolveDnsRequest {
+        Names = new[] { "contoso.com" },
+        RecordTypes = new[] { DnsRecordType.A, DnsRecordType.AAAA },
+        ResolverEndpoints = new[] { "doh3@https://dns.quad9.net/dns-query", "doq@dns.quad9.net:853" },
+        ResolverStrategy = MultiResolverStrategy.FirstSuccess
+    });
+```
+
 Use the DomainDetective DNS inventory:
 
 ```csharp
@@ -115,7 +137,7 @@ domaindetective check contoso.com --checks DNSINVENTORY
 ## When To Use Which Path
 
 - Use [DNS Lookup](/tools/dns-lookup/) for a quick browser-safe answer view
-- Use DnsClientX PowerShell or C# when you need specific hostnames, typed records, or repeatable DNS automation
+- Use DnsClientX PowerShell or C# when you need specific hostnames, typed records, repeatable DNS automation, or modern local transports
 - Use the wider DomainDetective API or CLI when you want DNS as part of full domain posture analysis
 
 ## Related Reading

--- a/Website/content/docs/dns-resolvers.md
+++ b/Website/content/docs/dns-resolvers.md
@@ -22,6 +22,13 @@ DomainDetective uses the [DnsClientX](https://github.com/EvotecIT/DnsClientX) li
 
 By default, DomainDetective uses the system DNS resolver. For browser-based tools, it uses browser-safe DNS-over-HTTPS resolver paths instead of raw UDP or TCP DNS.
 
+For local DnsClientX usage, the transport surface is broader:
+
+- `System` and `SystemTcp` cover classic resolver paths.
+- DoH, DoT, and explicit endpoint strings are available locally.
+- On .NET 8 and later, DoH3 and DoQ stay in the core package with no extra transport package required.
+- The browser workspace still stays on DoH because browsers do not expose raw UDP, TCP, DoT, or DoQ sockets to the site.
+
 ## Configuring a Single Resolver
 
 ```csharp
@@ -31,15 +38,30 @@ healthCheck.DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
 
 ## Available Resolvers
 
-| Endpoint | Protocol | Provider |
-|----------|----------|----------|
-| `System` | UDP/TCP | OS default |
-| `SystemTcp` | TCP | OS default |
-| `CloudflareWireFormat` | DoH (wire) | Cloudflare |
-| `Cloudflare` | DoH (JSON) | Cloudflare |
-| `Google` | DoH | Google |
-| `Quad9` | DoH | Quad9 |
+| Endpoint | Protocol | Local | Browser workspace |
+|----------|----------|-------|-------------------|
+| `System` | UDP/TCP fallback | Yes | No |
+| `SystemTcp` | TCP | Yes | No |
+| `CloudflareWireFormat` | DoH (wire) | Yes | No |
+| `Cloudflare` | DoH (JSON) | Yes | Yes |
+| `Google` | DoH | Yes | Yes |
+| `Quad9` | DoH | Yes | No |
+| `CloudflareQuic` | DoQ | Yes on .NET 8+ | No |
+| `GoogleQuic` | DoQ | Yes on .NET 8+ | No |
+| `Quad9Http3` | DoH3 | Yes on .NET 8+ | No |
+| `Quad9Quic` | DoQ | Yes on .NET 8+ | No |
+
+## Explicit Endpoint Syntax
+
+Local DnsClientX workflows also accept explicit endpoint strings:
+
+- `udp@1.1.1.1:53`
+- `tcp@9.9.9.9:53`
+- `dot@dns.quad9.net:853`
+- `doh@https://dns.google/dns-query`
+- `doh3@https://dns.quad9.net/dns-query`
+- `doq@dns.quad9.net:853`
 
 ## Browser Compatibility
 
-When running in a browser (Blazor WASM), only DNS-over-HTTPS endpoints work because browsers cannot make raw UDP/TCP DNS queries. The DomainDetective website currently keeps the browser-safe DNS workspace focused on `Google DNS` and `Cloudflare DNS`, while fuller resolver choice stays in the local DnsClientX workflows.
+When running in a browser (Blazor WASM), only DNS-over-HTTPS endpoints work because browsers cannot make raw UDP, TCP, DoT, or DoQ DNS queries. The DomainDetective website currently keeps the browser-safe DNS workspace focused on `Google DNS` and `Cloudflare DNS`, while fuller resolver choice stays in the local DnsClientX workflows.

--- a/Website/content/docs/dns-workspace.md
+++ b/Website/content/docs/dns-workspace.md
@@ -70,6 +70,18 @@ Switch to DnsClientX locally when you want:
 - Batch DNS workflows
 - Benchmarking multiple resolvers
 - System DNS, DoH, DoT, or other provider choices
+- DoH3 or DoQ on .NET 8 and later
+- Explicit resolver endpoint strings such as `doq@dns.quad9.net:853`
+
+## Transport Boundaries
+
+The browser workspace is intentionally narrower than the local library:
+
+- Browser: browser-safe DoH resolvers only
+- Local DnsClientX: UDP, TCP, DoH, DoT, and built-in resolver families
+- Local DnsClientX on .NET 8+: DoH3 and DoQ in the core package
+
+That split keeps the site behavior honest while preserving the fuller transport surface in PowerShell, CLI, and C#.
 
 ## C# Quick Start
 

--- a/Website/content/docs/dnsclientx.md
+++ b/Website/content/docs/dnsclientx.md
@@ -25,6 +25,15 @@ This page is the DNS landing area when you want to move between:
 - direct C# DNS queries
 - resolver and benchmarking guidance
 
+## Support Snapshot
+
+The browser workspace and the local library do not expose the same transport surface:
+
+- The browser workspace stays on browser-safe DNS-over-HTTPS resolver paths.
+- Local DnsClientX workflows can use system DNS, UDP, TCP, DoT, and DoH.
+- On .NET 8 and later, local DnsClientX workflows can also use DoH3 and DoQ without adding extra transport packages.
+- Older targets keep the same API surface, but modern transports are reported as unsupported at runtime.
+
 ## Start In The Browser
 
 Use [`/tools/dns-lookup/`](/tools/dns-lookup/) when you want:
@@ -35,6 +44,8 @@ Use [`/tools/dns-lookup/`](/tools/dns-lookup/) when you want:
 - a focused export you can paste into notes or tickets
 
 That workspace is documented in the [DnsClientX DNS Workspace](/docs/dns-workspace/) guide.
+
+It is intentionally not a full transport matrix for DnsClientX. If you want DoT, DoH3, DoQ, explicit endpoint strings, benchmarking, or saved resolver selection reuse, move to the local PowerShell, CLI, or C# paths.
 
 ## Move To PowerShell
 
@@ -62,6 +73,14 @@ Benchmark resolvers:
 ```powershell
 Test-DnsBenchmark -Name 'contoso.com' -DnsProvider Cloudflare, Google, Quad9 -Attempts 3 |
     Sort-Object Rank | Format-Table Target, SuccessPercent, AverageMs, Rank, IsRecommended
+```
+
+Use modern explicit endpoints on .NET 8+:
+
+```powershell
+Resolve-Dns -Name 'contoso.com' -Type A `
+    -ResolverEndpoint 'doq@dns.quad9.net:853','doh3@https://dns.quad9.net/dns-query' `
+    -ResolverStrategy FirstSuccess | Format-Table
 ```
 
 ## Move To C#
@@ -93,6 +112,20 @@ var responses = await client.Resolve("contoso.com", new[] { DnsRecordType.A, Dns
 responses.DisplayTable();
 ```
 
+Use a modern explicit endpoint on .NET 8+:
+
+```csharp
+using DnsClientX;
+
+var response = await ClientX.QueryDns(
+    new ResolveDnsRequest {
+        Names = new[] { "contoso.com" },
+        RecordTypes = new[] { DnsRecordType.A },
+        ResolverEndpoints = new[] { "doh3@https://dns.quad9.net/dns-query", "doq@dns.quad9.net:853" },
+        ResolverStrategy = MultiResolverStrategy.FirstSuccess
+    });
+```
+
 ## Today vs Later
 
 Today, the DomainDetective website uses DnsClientX as the DNS engine behind the browser workspace and the local workflow guidance.
@@ -102,6 +135,7 @@ Later, this documentation lane can expand into a fuller DNS area with:
 - more DnsClientX-focused examples
 - direct DNS API documentation links
 - deeper resolver and benchmarking guides
+- clearer transport-by-runtime support notes
 
 ## Related Reading
 


### PR DESCRIPTION
## Summary
- document modern transport support and runtime boundaries for DnsClientX
- clarify explicit resolver endpoint syntax for DoH3 and DoQ examples
- align resolver, workspace, configuration, and examples docs with the updated DnsClientX support story

## Testing
- .\\build.ps1 -Only build,verify -Fast -Dev