### PR TITLE
Refine CT discovery pacing and wildcard capture flow

### DIFF
--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -1430,6 +1430,7 @@ public class TestCertificateInventoryCapture {
             IncludeCtDiscoveredSubdomains = true,
             VerifyCtDiscoveredSubdomains = false,
             EnablePassiveCtFallback = true,
+            BackfillMissingCtCertificateMetadata = false,
             IncludeMxHosts = false,
             IncludeMxHttps = false,
             IncludeSmtpStartTls = false,
@@ -2573,6 +2574,7 @@ public class TestCertificateInventoryCapture {
             ReuseRecentSnapshotEntries = true,
             RecentSnapshotTtl = TimeSpan.FromDays(365),
             BackfillMissingCtCertificateMetadata = true,
+            CtDiscoveryDomains = { "eurofins.com" },
             PersistSnapshot = false
         };
 

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -2057,6 +2057,12 @@ public class TestCertificateInventoryCapture {
             HashAlgorithmName.SHA256,
             RSASignaturePadding.Pkcs1);
         request.CertificateExtensions.Add(
+            new X509EnhancedKeyUsageExtension(
+                new OidCollection {
+                    new(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid)
+                },
+                critical: false));
+        request.CertificateExtensions.Add(
             new X509BasicConstraintsExtension(false, false, 0, false));
         request.CertificateExtensions.Add(
             new X509SubjectKeyIdentifierExtension(request.PublicKey, false));
@@ -2103,6 +2109,10 @@ public class TestCertificateInventoryCapture {
             cancellationToken: CancellationToken.None);
 
         Assert.Equal(certificate.Thumbprint, hydrated.LatestCertificateThumbprint);
+        Assert.True(hydrated.LatestCertificateHasServerAuthentication);
+        Assert.False(hydrated.LatestCertificateHasClientAuthentication);
+        Assert.False(hydrated.LatestCertificateHasSecureEmail);
+        Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, hydrated.LatestCertificateAuthenticationProfile);
     }
 
     [Fact]
@@ -2834,6 +2844,7 @@ public class TestCertificateInventoryCapture {
         var notBefore = new DateTimeOffset(2022, 7, 11, 0, 0, 0, TimeSpan.Zero);
         var notAfter = new DateTimeOffset(2023, 8, 11, 23, 59, 59, TimeSpan.Zero);
         var passiveQueries = new List<string>();
+        const string thumbprint = "AA11BB22CC33DD44EE55FF6677889900AA11BB22";
 
         var capture = new CertificateInventoryCapture {
             CtSubdomainEntryDiscoveryOverride = (domains, options, logger, cancellationToken) => {
@@ -2852,18 +2863,23 @@ public class TestCertificateInventoryCapture {
             CtPassiveMetadataBackfillOverride = (domains, options, logger, cancellationToken) => {
                 string target = Assert.Single(domains);
                 passiveQueries.Add(target);
-                IReadOnlyList<SubdomainDiscoveryEntry> discovered = string.Equals(target, "airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase)
+                IReadOnlyList<SubdomainDiscoveryEntry> discovered = string.Equals(target, "eurofins.com", StringComparison.OrdinalIgnoreCase)
                     ? new[] {
                         new SubdomainDiscoveryEntry {
                             Name = "airtoxics.eurofins.com",
                             FirstSeenUtc = passiveCtEntryTimestamp,
                             LastSeenUtc = passiveCtEntryTimestamp,
                             LatestCertificateCtEntryTimestampUtc = passiveCtEntryTimestamp,
+                            LatestCertificateThumbprint = thumbprint,
                             LatestCertificateSubject = "CN=airtoxics.eurofins.com",
                             LatestCertificateIssuer = "CN=Sectigo RSA Domain Validation Secure Server CA, O=Sectigo Limited, C=GB",
                             LatestCertificateSerialNumber = "0CE4A3C00C1DD4890B9EBA4223FE917F",
                             LatestCertificateNotBeforeUtc = notBefore,
                             LatestCertificateNotAfterUtc = notAfter,
+                            LatestCertificateHasServerAuthentication = true,
+                            LatestCertificateHasClientAuthentication = false,
+                            LatestCertificateHasSecureEmail = false,
+                            LatestCertificateAuthenticationProfile = CertificateAuthenticationProfileClassifier.ServerAuthOnly,
                             CtSources = new[] { "crt.sh" },
                             CertificateObservationCount = 1,
                             ResolutionStatus = SubdomainResolutionStatus.Resolves
@@ -2916,7 +2932,7 @@ public class TestCertificateInventoryCapture {
 
         var result = await capture.CaptureAsync(new[] { "eurofins.com", "airtoxics.eurofins.com" }, options, cancellationToken: CancellationToken.None);
 
-        Assert.Equal(new[] { "airtoxics.eurofins.com" }, passiveQueries);
+        Assert.Equal(new[] { "eurofins.com" }, passiveQueries);
         Assert.Equal(1, result.CtDiscoveredSubdomainCount);
         Assert.Equal(0, result.CtPromotedHttpsCount);
         Assert.Equal(1, result.CtSkippedHttpsPromotionCount);
@@ -2929,6 +2945,189 @@ public class TestCertificateInventoryCapture {
         Assert.Equal("live-probe", endpoint.CaptureDisposition);
         Assert.Equal("CN=airtoxics.eurofins.com", endpoint.CertificateSubject);
         Assert.Equal(passiveCtEntryTimestamp, endpoint.CtLatestCertificateEntryTimestampUtc);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_ExactHostPassiveBackfillRunsWhenCtDiscoveryOnlyHasIdentityMetadata() {
+        var ctFirstSeen = new DateTimeOffset(2026, 3, 5, 10, 21, 27, TimeSpan.Zero);
+        var ctLastSeen = new DateTimeOffset(2026, 3, 5, 15, 42, 37, TimeSpan.Zero);
+        var passiveCtEntryTimestamp = new DateTimeOffset(2022, 7, 11, 15, 36, 47, TimeSpan.Zero);
+        var notBefore = new DateTimeOffset(2022, 7, 11, 0, 0, 0, TimeSpan.Zero);
+        var notAfter = new DateTimeOffset(2023, 8, 11, 23, 59, 59, TimeSpan.Zero);
+        var passiveQueries = new List<string>();
+        const string thumbprint = "AA11BB22CC33DD44EE55FF6677889900AA11BB22";
+
+        var capture = new CertificateInventoryCapture {
+            CtSubdomainEntryDiscoveryOverride = (domains, options, logger, cancellationToken) => {
+                IReadOnlyList<SubdomainDiscoveryEntry> discovered = new[] {
+                    new SubdomainDiscoveryEntry {
+                        Name = "airtoxics.eurofins.com",
+                        FirstSeenUtc = ctFirstSeen,
+                        LastSeenUtc = ctLastSeen,
+                        LatestCertificateCtEntryTimestampUtc = passiveCtEntryTimestamp,
+                        LatestCertificateSubject = "CN=airtoxics.eurofins.com",
+                        LatestCertificateIssuer = "CN=Identity Only Issuer",
+                        LatestCertificateSerialNumber = "IDENTITY-ONLY-123",
+                        LatestCertificateNotBeforeUtc = notBefore,
+                        LatestCertificateNotAfterUtc = notAfter,
+                        CtSources = new[] { "native-ct" },
+                        CertificateObservationCount = 2,
+                        ResolutionStatus = SubdomainResolutionStatus.Resolves
+                    }
+                };
+                return Task.FromResult(discovered);
+            },
+            CtPassiveMetadataBackfillOverride = (domains, options, logger, cancellationToken) => {
+                string target = Assert.Single(domains);
+                passiveQueries.Add(target);
+                IReadOnlyList<SubdomainDiscoveryEntry> discovered = string.Equals(target, "airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase)
+                    ? new[] {
+                        new SubdomainDiscoveryEntry {
+                            Name = "airtoxics.eurofins.com",
+                            FirstSeenUtc = passiveCtEntryTimestamp,
+                            LastSeenUtc = passiveCtEntryTimestamp,
+                            LatestCertificateCtEntryTimestampUtc = passiveCtEntryTimestamp,
+                            LatestCertificateThumbprint = thumbprint,
+                            LatestCertificateSubject = "CN=airtoxics.eurofins.com",
+                            LatestCertificateIssuer = "CN=Sectigo RSA Domain Validation Secure Server CA, O=Sectigo Limited, C=GB",
+                            LatestCertificateSerialNumber = "0CE4A3C00C1DD4890B9EBA4223FE917F",
+                            LatestCertificateNotBeforeUtc = notBefore,
+                            LatestCertificateNotAfterUtc = notAfter,
+                            LatestCertificateHasServerAuthentication = true,
+                            LatestCertificateHasClientAuthentication = false,
+                            LatestCertificateHasSecureEmail = false,
+                            LatestCertificateAuthenticationProfile = CertificateAuthenticationProfileClassifier.ServerAuthOnly,
+                            CtSources = new[] { "crt.sh" },
+                            CertificateObservationCount = 1,
+                            ResolutionStatus = SubdomainResolutionStatus.Resolves
+                        }
+                    }
+                    : Array.Empty<SubdomainDiscoveryEntry>();
+                return Task.FromResult(discovered);
+            },
+            HttpsProbeOverride = (httpsTargets, options, logger, cancellationToken) => {
+                var entries = new List<CertificateMonitor.Entry>();
+                foreach (var target in httpsTargets) {
+                    var uri = new Uri(target);
+                    entries.Add(new CertificateMonitor.Entry {
+                        Host = uri.Host,
+                        ResolvedHost = uri.Host,
+                        Url = target,
+                        Scheme = uri.Scheme,
+                        Port = uri.Port,
+                        Service = "HTTPS",
+                        Valid = false,
+                        Expired = false,
+                        ChainComplete = false,
+                        Protocol = SslProtocols.None,
+                        Analysis = new CertificateAnalysis {
+                            Url = target,
+                            IsReachable = false
+                        }
+                    });
+                }
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            }
+        };
+
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = true,
+            IncludeWwwHttps = false,
+            IncludeCtDiscoveredSubdomains = true,
+            VerifyCtDiscoveredSubdomains = false,
+            EnablePassiveCtFallback = true,
+            EnablePassiveCtMetadataFallback = true,
+            IncludeMxHosts = false,
+            IncludeMxHttps = false,
+            IncludeSmtpStartTls = false,
+            IncludeSubmissionStartTls = false,
+            IncludeImapTls = false,
+            IncludePop3Tls = false,
+            BackfillMissingCtCertificateMetadata = true,
+            PersistSnapshot = false
+        };
+
+        var result = await capture.CaptureAsync(new[] { "eurofins.com", "airtoxics.eurofins.com" }, options, cancellationToken: CancellationToken.None);
+
+        Assert.Equal(new[] { "eurofins.com", "airtoxics.eurofins.com" }, passiveQueries);
+        var discovered = Assert.Single(result.CtDiscoveredSubdomainEntries, entry => entry.Name.Equals("airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(thumbprint, discovered.LatestCertificateThumbprint);
+        Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, discovered.LatestCertificateAuthenticationProfile);
+        var endpoint = Assert.Single(result.Snapshot.Entries, entry => entry.Host.Equals("airtoxics.eurofins.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(thumbprint, endpoint.CertificateThumbprint);
+        Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, endpoint.AuthenticationProfile);
+    }
+
+    [IntegrationFact]
+    public async Task CaptureAsync_CtEvidenceRefreshProfile_HydratesExactHostFromLiveCtSources() {
+        const string hostName = "api.github.com";
+
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (httpsTargets, options, logger, cancellationToken) => {
+                var entries = new List<CertificateMonitor.Entry>();
+                foreach (var target in httpsTargets) {
+                    var uri = new Uri(target);
+                    entries.Add(new CertificateMonitor.Entry {
+                        Host = uri.Host,
+                        ResolvedHost = uri.Host,
+                        Url = target,
+                        Scheme = uri.Scheme,
+                        Port = uri.Port,
+                        Service = "HTTPS",
+                        Valid = false,
+                        Expired = false,
+                        ChainComplete = false,
+                        Protocol = SslProtocols.None,
+                        Analysis = new CertificateAnalysis {
+                            Url = target,
+                            IsReachable = false
+                        }
+                    });
+                }
+
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            }
+        };
+
+        var options = new CertificateInventoryCaptureOptions {
+            EnablePassiveCtMetadataFallback = true,
+            EnableCrtShPostgreSqlMetadataFallback = true,
+            BackfillMissingCtCertificateMetadata = true,
+            PersistSnapshot = false,
+            CrtShPostgreSqlCommandTimeoutSeconds = 20,
+            PassiveCtRequestTimeout = TimeSpan.FromSeconds(20)
+        }.ApplyCtEvidenceRefreshProfile();
+
+        var result = await capture.CaptureAsync(new[] { hostName }, options, cancellationToken: CancellationToken.None);
+
+        var endpoint = Assert.Single(result.Snapshot.Entries, entry => entry.Host.Equals(hostName, StringComparison.OrdinalIgnoreCase));
+        Assert.False(endpoint.IsReachable);
+        Assert.True(endpoint.PresentInCtLogs);
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateThumbprint));
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateSubject));
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateIssuer));
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.CertificateSerialNumber));
+        Assert.True(endpoint.NotBeforeUtc.HasValue);
+        Assert.True(endpoint.NotAfterUtc.HasValue);
+        Assert.False(string.IsNullOrWhiteSpace(endpoint.AuthenticationProfile));
+        Assert.Contains(
+            endpoint.CtDiscoverySources,
+            source => source.Equals("crt.sh", StringComparison.OrdinalIgnoreCase) ||
+                      source.Equals("crt.sh-db", StringComparison.OrdinalIgnoreCase) ||
+                      source.Equals("certspotter", StringComparison.OrdinalIgnoreCase));
+
+        Console.WriteLine($"Host={endpoint.Host}");
+        Console.WriteLine($"Reachable={endpoint.IsReachable}");
+        Console.WriteLine($"PresentInCtLogs={endpoint.PresentInCtLogs}");
+        Console.WriteLine($"Thumbprint={endpoint.CertificateThumbprint}");
+        Console.WriteLine($"Subject={endpoint.CertificateSubject}");
+        Console.WriteLine($"Issuer={endpoint.CertificateIssuer}");
+        Console.WriteLine($"Serial={endpoint.CertificateSerialNumber}");
+        Console.WriteLine($"NotBeforeUtc={endpoint.NotBeforeUtc:O}");
+        Console.WriteLine($"NotAfterUtc={endpoint.NotAfterUtc:O}");
+        Console.WriteLine($"AuthenticationProfile={endpoint.AuthenticationProfile}");
+        Console.WriteLine($"AllowsServerAuthentication={endpoint.AllowsServerAuthentication}");
+        Console.WriteLine($"CtSources={string.Join(", ", endpoint.CtDiscoverySources)}");
     }
 
     [Fact]
@@ -3266,14 +3465,17 @@ public class TestCertificateInventoryCapture {
     }
 
     [Theory]
-    [InlineData(16, 4, 40, true, 4)]
-    [InlineData(3, 8, 40, true, 3)]
-    [InlineData(16, 4, 5, true, 4)]
-    [InlineData(16, 4, 3, true, 3)]
-    [InlineData(16, 4, 40, false, 16)]
+    [InlineData(16, 4, 2, 40, true, 4)]
+    [InlineData(3, 8, 2, 40, true, 3)]
+    [InlineData(16, 4, 2, 5, true, 4)]
+    [InlineData(16, 4, 2, 3, true, 3)]
+    [InlineData(16, 4, 2, 40, false, 2)]
+    [InlineData(16, 4, 5, 40, false, 5)]
+    [InlineData(3, 8, 2, 40, false, 2)]
     public void ResolveExactPassiveCtMetadataBackfillParallelism_UsesBoundedConcurrency(
         int configuredDiscoveryParallelism,
         int configuredPassiveCtParallelism,
+        int configuredCrtShPostgreSqlMaximumConcurrentRequests,
         int hostCount,
         bool usePassiveNetworkQueries,
         int expected)
@@ -3281,6 +3483,7 @@ public class TestCertificateInventoryCapture {
         int result = CertificateInventoryCapture.ResolveExactPassiveCtMetadataBackfillParallelism(
             configuredDiscoveryParallelism,
             configuredPassiveCtParallelism,
+            configuredCrtShPostgreSqlMaximumConcurrentRequests,
             hostCount,
             usePassiveNetworkQueries);
 
@@ -3861,6 +4064,11 @@ public class TestCertificateInventoryCapture {
             IncludeApexHttps = true,
             IncludeWwwHttps = true,
             IncludeCtDiscoveredSubdomains = false,
+            EnableNativeCtLogSubdomainSource = false,
+            EnablePassiveCtFallback = false,
+            NativeCtLogOnly = true,
+            VerifyCtDiscoveredSubdomains = true,
+            BackfillMissingCtCertificateMetadata = false,
             PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
             IncludeMxHosts = true,
             IncludeMxHttps = true,
@@ -3876,7 +4084,11 @@ public class TestCertificateInventoryCapture {
         Assert.False(options.IncludeApexHttps);
         Assert.False(options.IncludeWwwHttps);
         Assert.True(options.IncludeCtDiscoveredSubdomains);
+        Assert.True(options.EnableNativeCtLogSubdomainSource);
+        Assert.True(options.EnablePassiveCtFallback);
+        Assert.False(options.NativeCtLogOnly);
         Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.True(options.BackfillMissingCtCertificateMetadata);
         Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
         Assert.False(options.IncludeMxHosts);
         Assert.False(options.IncludeMxHttps);
@@ -3895,6 +4107,7 @@ public class TestCertificateInventoryCapture {
             IncludeWwwHttps = true,
             IncludeCtDiscoveredSubdomains = true,
             VerifyCtDiscoveredSubdomains = true,
+            BackfillMissingCtCertificateMetadata = false,
             PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
             IncludeMxHosts = true,
             IncludeMxHttps = true,
@@ -3911,6 +4124,7 @@ public class TestCertificateInventoryCapture {
         Assert.False(options.IncludeWwwHttps);
         Assert.False(options.IncludeCtDiscoveredSubdomains);
         Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.True(options.BackfillMissingCtCertificateMetadata);
         Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
         Assert.False(options.IncludeMxHosts);
         Assert.False(options.IncludeMxHttps);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -2199,6 +2199,66 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public void TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows_PrefersTargetThumbprintOverNewerHostCertificate() {
+        const string hostName = "mail.emmasguesthouse.co.za";
+
+        using RSA olderKey = RSA.Create(2048);
+        var olderRequest = new CertificateRequest(
+            $"CN={hostName}",
+            olderKey,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        olderRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        olderRequest.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(olderRequest.PublicKey, false));
+        using X509Certificate2 olderCertificate = olderRequest.CreateSelfSigned(
+            new DateTimeOffset(2026, 3, 20, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 6, 20, 0, 0, 0, TimeSpan.Zero));
+
+        using RSA newerKey = RSA.Create(2048);
+        var newerRequest = new CertificateRequest(
+            $"CN={hostName}",
+            newerKey,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        newerRequest.CertificateExtensions.Add(new X509BasicConstraintsExtension(false, false, 0, false));
+        newerRequest.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(newerRequest.PublicKey, false));
+        using X509Certificate2 newerCertificate = newerRequest.CreateSelfSigned(
+            new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero),
+            new DateTimeOffset(2026, 7, 1, 0, 0, 0, TimeSpan.Zero));
+
+        SubdomainDiscoveryEntry? entry = CertificateInventoryCapture.TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
+            hostName,
+            new[] {
+                new CertificateInventoryCapture.CrtShPostgreSqlExactMetadataRow {
+                    CertificateDer = newerCertificate.Export(X509ContentType.Cert),
+                    EntryTimestampUtc = new DateTimeOffset(2026, 4, 1, 12, 0, 0, TimeSpan.Zero),
+                    CommonName = hostName,
+                    IssuerName = newerCertificate.Issuer,
+                    SerialNumber = newerCertificate.SerialNumber,
+                    NotBeforeUtc = new DateTimeOffset(newerCertificate.NotBefore.ToUniversalTime()),
+                    NotAfterUtc = new DateTimeOffset(newerCertificate.NotAfter.ToUniversalTime()),
+                    CandidateNames = new[] { hostName }
+                },
+                new CertificateInventoryCapture.CrtShPostgreSqlExactMetadataRow {
+                    CertificateDer = olderCertificate.Export(X509ContentType.Cert),
+                    EntryTimestampUtc = new DateTimeOffset(2026, 3, 20, 12, 0, 0, TimeSpan.Zero),
+                    CommonName = hostName,
+                    IssuerName = olderCertificate.Issuer,
+                    SerialNumber = olderCertificate.SerialNumber,
+                    NotBeforeUtc = new DateTimeOffset(olderCertificate.NotBefore.ToUniversalTime()),
+                    NotAfterUtc = new DateTimeOffset(olderCertificate.NotAfter.ToUniversalTime()),
+                    CandidateNames = new[] { hostName }
+                }
+            },
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase) { olderCertificate.Thumbprint });
+
+        Assert.NotNull(entry);
+        Assert.Equal(olderCertificate.Thumbprint, entry!.LatestCertificateThumbprint);
+        Assert.Equal(olderCertificate.SerialNumber, entry.LatestCertificateSerialNumber);
+        Assert.Contains("crt.sh-db", entry.CtSources, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows_AcceptsWildcardSubjectAlternativeNames() {
         const string hostName = "mail.emmasguesthouse.co.za";
         using RSA rsa = RSA.Create(2048);
@@ -2244,7 +2304,16 @@ public class TestCertificateInventoryCapture {
         Assert.Contains("identities(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("x509_altnames(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("encode(x509_serialNumber(c.certificate), 'hex')", query, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("@wildcardHost", query, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("certificate_identity", query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildWildcardCandidateHost_DoesNotBroadenRegistrableRootsToTopLevelWildcards() {
+        Assert.Equal("abclabs.com", CertificateInventoryCapture.BuildWildcardCandidateHost("abclabs.com"));
+        Assert.Equal("eurofins.pl", CertificateInventoryCapture.BuildWildcardCandidateHost("eurofins.pl"));
+        Assert.Equal("*.example.com", CertificateInventoryCapture.BuildWildcardCandidateHost("mail.example.com"));
+        Assert.Equal("*.emmasguesthouse.co.za", CertificateInventoryCapture.BuildWildcardCandidateHost("mail.emmasguesthouse.co.za"));
     }
 
     [Fact]
@@ -3474,6 +3543,61 @@ public class TestCertificateInventoryCapture {
         Assert.DoesNotContain(
             warnings,
             warning => warning.Contains("Passive CT exact metadata backfill skipped", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ExactCtMetadataBackfill_UsesDirectPostgreSqlMetadataWhenPassiveFallbackIsDisabled() {
+        var passiveFallbackCalled = false;
+        var capture = new CertificateInventoryCapture
+        {
+            CtExactMetadataPostgreSqlOverride = (host, options, logger, cancellationToken) =>
+                Task.FromResult<SubdomainDiscoveryEntry?>(new SubdomainDiscoveryEntry
+                {
+                    Name = host,
+                    LatestCertificateThumbprint = "DBONLY11223344556677889900AABBCCDDEEFF",
+                    LatestCertificateSubject = "CN=api.example.com",
+                    LatestCertificateIssuer = "CN=crt.sh-db",
+                    CtSources = new[] { "crt.sh-db" },
+                    CertificateObservationCount = 1
+                }),
+            CtPassiveMetadataBackfillOverride = (_, _, _, _) =>
+            {
+                passiveFallbackCalled = true;
+                return Task.FromResult<IReadOnlyList<SubdomainDiscoveryEntry>>(Array.Empty<SubdomainDiscoveryEntry>());
+            }
+        };
+        var method = typeof(CertificateInventoryCapture).GetMethod(
+            "BackfillMissingCtCertificateMetadataExactAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(method);
+
+        var options = new CertificateInventoryCaptureOptions
+        {
+            EnablePassiveCtFallback = false,
+            EnablePassiveCtMetadataFallback = false,
+            EnableCrtShPostgreSqlMetadataFallback = true
+        };
+
+        Task<IReadOnlyList<SubdomainDiscoveryEntry>> task =
+            (Task<IReadOnlyList<SubdomainDiscoveryEntry>>)method!.Invoke(
+                capture,
+                new object[]
+                {
+                    new[] { "api.example.com" },
+                    options,
+                    new List<string>(),
+                    new List<PassiveCtDiagnosticEntry>(),
+                    new InternalLogger(false),
+                    CancellationToken.None
+                })!;
+
+        IReadOnlyList<SubdomainDiscoveryEntry> result = await task;
+
+        SubdomainDiscoveryEntry entry = Assert.Single(result);
+        Assert.Equal("api.example.com", entry.Name);
+        Assert.Equal("DBONLY11223344556677889900AABBCCDDEEFF", entry.LatestCertificateThumbprint);
+        Assert.False(passiveFallbackCalled);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -670,6 +670,49 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task CaptureAsync_PrefersHttpsOverMail_WhenOnlyOneTargetIsAllowed() {
+        using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
+        var observedHttpsTargets = new List<string>();
+        var capture = new CertificateInventoryCapture {
+            MxLookupOverride = (domain, dnsConfiguration, maxMxHostsPerDomain, cancellationToken) =>
+                Task.FromResult<IReadOnlyList<string>>(new[] { "mx.invalid" }),
+            HttpsProbeOverride = (httpsTargets, options, logger, cancellationToken) => {
+                observedHttpsTargets.AddRange(httpsTargets);
+                var entries = new List<CertificateMonitor.Entry>();
+                foreach (var target in httpsTargets) {
+                    entries.Add(CreateHttpsEntry(target, certificate));
+                }
+
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            }
+        };
+
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = true,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = true,
+            IncludeMxHttps = false,
+            IncludeSmtpStartTls = true,
+            IncludeSubmissionStartTls = false,
+            IncludeImapTls = false,
+            IncludePop3Tls = false,
+            MaxTargets = 1,
+            PersistSnapshot = false
+        };
+
+        var result = await capture.CaptureAsync(new[] { "example.com" }, options, cancellationToken: CancellationToken.None);
+
+        Assert.Single(observedHttpsTargets);
+        Assert.Contains(observedHttpsTargets, target => target.Contains("example.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Equal(1, result.HttpsEndpointCount);
+        Assert.Equal(0, result.MailEndpointCount);
+        Assert.Equal(1, result.HttpsTargetCountBeforeLimit);
+        Assert.Equal(1, result.MailTargetCountBeforeLimit);
+        Assert.Equal(0, result.HttpsTargetCountDroppedByLimit);
+        Assert.Equal(1, result.MailTargetCountDroppedByLimit);
+    }
+
+    [Fact]
     public async Task CaptureAsync_ReusesRecentStableFailureSnapshotEntries_WhenEnabled() {
         var cacheDirectory = Path.Combine(Path.GetTempPath(), "dd-ci-cache-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(cacheDirectory);
@@ -2201,6 +2244,17 @@ public class TestCertificateInventoryCapture {
         Assert.Contains("identities(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("x509_altnames(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("encode(x509_serialNumber(c.certificate), 'hex')", query, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("certificate_identity", query, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void BuildCrtShPostgreSqlDomainMetadataQuery_UsesHostArraysAndWildcardAwareMatching() {
+        string query = CertificateInventoryCapture.BuildCrtShPostgreSqlDomainMetadataQuery();
+
+        Assert.Contains("identities(c.certificate)", query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("candidate_name = ANY(@hosts)", query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("candidate_name = ANY(@wildcardHosts)", query, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("LIMIT @limit", query, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("certificate_identity", query, StringComparison.OrdinalIgnoreCase);
     }
 

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3853,6 +3853,73 @@ public class TestCertificateInventoryCapture {
             message => message.Contains("skipping exact passive CT metadata", StringComparison.OrdinalIgnoreCase));
     }
 
+    [Fact]
+    public void ApplyCtDiscoveryOnlyProfile_DisablesProbeExpansionAndKeepsCtDiscoveryEnabled()
+    {
+        var options = new CertificateInventoryCaptureOptions
+        {
+            IncludeApexHttps = true,
+            IncludeWwwHttps = true,
+            IncludeCtDiscoveredSubdomains = false,
+            PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
+            IncludeMxHosts = true,
+            IncludeMxHttps = true,
+            IncludeSmtpStartTls = true,
+            IncludeSubmissionStartTls = true,
+            IncludeImapTls = true,
+            IncludePop3Tls = true
+        };
+
+        CertificateInventoryCaptureOptions returned = options.ApplyCtDiscoveryOnlyProfile();
+
+        Assert.Same(options, returned);
+        Assert.False(options.IncludeApexHttps);
+        Assert.False(options.IncludeWwwHttps);
+        Assert.True(options.IncludeCtDiscoveredSubdomains);
+        Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
+        Assert.False(options.IncludeMxHosts);
+        Assert.False(options.IncludeMxHttps);
+        Assert.False(options.IncludeSmtpStartTls);
+        Assert.False(options.IncludeSubmissionStartTls);
+        Assert.False(options.IncludeImapTls);
+        Assert.False(options.IncludePop3Tls);
+    }
+
+    [Fact]
+    public void ApplyCtEvidenceRefreshProfile_DisablesCtDiscoveryAndMailExpansion()
+    {
+        var options = new CertificateInventoryCaptureOptions
+        {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = true,
+            IncludeCtDiscoveredSubdomains = true,
+            VerifyCtDiscoveredSubdomains = true,
+            PromoteCtDiscoveredSubdomainsToHttpsProbes = true,
+            IncludeMxHosts = true,
+            IncludeMxHttps = true,
+            IncludeSmtpStartTls = true,
+            IncludeSubmissionStartTls = true,
+            IncludeImapTls = true,
+            IncludePop3Tls = true
+        };
+
+        CertificateInventoryCaptureOptions returned = options.ApplyCtEvidenceRefreshProfile();
+
+        Assert.Same(options, returned);
+        Assert.True(options.IncludeApexHttps);
+        Assert.False(options.IncludeWwwHttps);
+        Assert.False(options.IncludeCtDiscoveredSubdomains);
+        Assert.False(options.VerifyCtDiscoveredSubdomains);
+        Assert.False(options.PromoteCtDiscoveredSubdomainsToHttpsProbes);
+        Assert.False(options.IncludeMxHosts);
+        Assert.False(options.IncludeMxHttps);
+        Assert.False(options.IncludeSmtpStartTls);
+        Assert.False(options.IncludeSubmissionStartTls);
+        Assert.False(options.IncludeImapTls);
+        Assert.False(options.IncludePop3Tls);
+    }
+
     private static CertificateMonitor.Entry CreateHttpsEntry(string url, X509Certificate2 certificate) {
         var uri = new Uri(url);
         var analysis = new CertificateAnalysis {

--- a/DomainDetective.Tests/TestMtaStsNarrative.cs
+++ b/DomainDetective.Tests/TestMtaStsNarrative.cs
@@ -8,6 +8,7 @@ using Xunit;
 
 namespace DomainDetective.Tests;
 
+[Collection("HttpListener")]
 public class TestMtaStsNarrative
 {
     [Fact]
@@ -16,7 +17,7 @@ public class TestMtaStsNarrative
         Skip.If(!HttpListener.IsSupported, "HttpListener not supported");
         using var listener = new HttpListener();
         var port = PortHelper.GetFreePort();
-        var prefix = $"http://localhost:{port}/";
+        var prefix = $"http://127.0.0.1:{port}/";
         listener.Prefixes.Add(prefix);
         listener.Start();
         const string policy = "version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 86400";

--- a/DomainDetective.Tests/TestSubdomainsAnalysis.cs
+++ b/DomainDetective.Tests/TestSubdomainsAnalysis.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Tests.Fixtures;
@@ -670,6 +671,92 @@ public class TestSubdomainsAnalysis
             Assert.False(second.RetrySuggested);
             Assert.Equal(2, requestOffsets.Count);
             Assert.True(requestOffsets[1] - requestOffsets[0] >= 125);
+        }
+        finally
+        {
+            await server.DisposeAsync();
+        }
+    }
+
+    [Fact]
+    public async Task AnalyzeAsync_UsesConfiguredPassiveCtSourceSpacingForWildcardDiscovery()
+    {
+        var requestOffsets = new List<long>();
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        var server = new TcpListenerFixture((listener, token) => Task.Run(async () =>
+        {
+            var handlers = new List<Task>();
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    var clientTask = listener.AcceptTcpClientAsync();
+                    var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                    if (completed != clientTask)
+                    {
+                        break;
+                    }
+
+                    handlers.Add(Task.Run(async () =>
+                    {
+                        using var client = await clientTask;
+                        lock (requestOffsets)
+                        {
+                            requestOffsets.Add(stopwatch.ElapsedMilliseconds);
+                        }
+
+                        using NetworkStream stream = client.GetStream();
+                        using var reader = new StreamReader(stream);
+                        using var writer = new StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                        string? line;
+                        do
+                        {
+                            line = await reader.ReadLineAsync();
+                        } while (!string.IsNullOrEmpty(line));
+
+                        const string payload = @"[{ ""name_value"": ""api.example.com"" }]";
+                        await writer.WriteLineAsync("HTTP/1.1 200 OK");
+                        await writer.WriteLineAsync("Content-Type: application/json");
+                        await writer.WriteLineAsync($"Content-Length: {payload.Length}");
+                        await writer.WriteLineAsync();
+                        await writer.WriteAsync(payload);
+                    }, token));
+                }
+            }
+            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (token.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                await Task.WhenAll(handlers).ConfigureAwait(false);
+            }
+        }, token));
+        await server.InitializeAsync();
+
+        try
+        {
+            var analysis = new SubdomainsAnalysis
+            {
+                VerifyStillResolves = false,
+                UseCertSpotterFallback = false,
+                CrtShUrlTemplate = $"http://127.0.0.1:{server.Port}/?q=%25.{{0}}&output=json",
+                PassiveCtRetryCount = 0,
+                PassiveCtCrtShMinimumSpacing = TimeSpan.FromMilliseconds(300)
+            };
+
+            await analysis.AnalyzeAsync("example.com", new InternalLogger(), CancellationToken.None);
+            await analysis.AnalyzeAsync("example.net", new InternalLogger(), CancellationToken.None);
+
+            Assert.Equal(2, requestOffsets.Count);
+            if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            Assert.True(requestOffsets[1] - requestOffsets[0] >= 225);
         }
         finally
         {

--- a/DomainDetective.Tests/TestSubdomainsAnalysis.cs
+++ b/DomainDetective.Tests/TestSubdomainsAnalysis.cs
@@ -21,6 +21,11 @@ public class TestSubdomainsAnalysis
         PassiveCtSourceClient.ResetSharedStateForTesting();
     }
 
+    private static void AssertExpectedListenerCancellation(Exception exception, CancellationToken token)
+    {
+        Assert.True(token.IsCancellationRequested, exception.Message);
+    }
+
     [Fact]
     public async Task ParsesCtAndAggregatesSubdomains()
     {
@@ -274,11 +279,13 @@ public class TestSubdomainsAnalysis
                     await writer.WriteAsync("{}");
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
         }, token));
         await server.InitializeAsync();
@@ -433,11 +440,13 @@ public class TestSubdomainsAnalysis
                     }, token));
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
             finally
             {
@@ -624,11 +633,13 @@ public class TestSubdomainsAnalysis
                     }, token));
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
             finally
             {
@@ -723,11 +734,13 @@ public class TestSubdomainsAnalysis
                     }, token));
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
             finally
             {

--- a/DomainDetective.Tests/TestSubdomainsAnalysis.cs
+++ b/DomainDetective.Tests/TestSubdomainsAnalysis.cs
@@ -251,11 +251,13 @@ public class TestSubdomainsAnalysis
                         {
                             await clientTask;
                         }
-                        catch (ObjectDisposedException) when (token.IsCancellationRequested)
+                        catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
                         {
+                            AssertExpectedListenerCancellation(ex, token);
                         }
-                        catch (SocketException) when (token.IsCancellationRequested)
+                        catch (SocketException ex) when (token.IsCancellationRequested)
                         {
+                            AssertExpectedListenerCancellation(ex, token);
                         }
 
                         break;
@@ -343,11 +345,13 @@ public class TestSubdomainsAnalysis
                     Interlocked.Increment(ref requestCount);
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
         }, token));
         await server.InitializeAsync();
@@ -532,11 +536,13 @@ public class TestSubdomainsAnalysis
                     await writer.WriteLineAsync();
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
         }, token));
         await server.InitializeAsync();
@@ -813,11 +819,13 @@ public class TestSubdomainsAnalysis
                     await writer.WriteAsync(payload);
                 }
             }
-            catch (ObjectDisposedException) when (token.IsCancellationRequested)
+            catch (ObjectDisposedException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
-            catch (SocketException) when (token.IsCancellationRequested)
+            catch (SocketException ex) when (token.IsCancellationRequested)
             {
+                AssertExpectedListenerCancellation(ex, token);
             }
         }, token));
         await server.InitializeAsync();

--- a/DomainDetective/CertificateInventoryCapture.CtDiscovery.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtDiscovery.cs
@@ -120,6 +120,10 @@ public sealed partial class CertificateInventoryCapture {
                         PassiveCtRetryBaseDelay = options.PassiveCtRetryBaseDelay,
                         PassiveCtRetryMaxDelay = options.PassiveCtRetryMaxDelay,
                         PassiveCtSourceCooldown = options.PassiveCtSourceCooldown,
+                        PassiveCtCrtShMinimumSpacing = options.PassiveCtCrtShMinimumSpacing,
+                        PassiveCtCertSpotterMinimumSpacing = options.PassiveCtCertSpotterMinimumSpacing,
+                        PassiveCtCrtShMaximumRequestsPerRun = options.PassiveCtCrtShMaximumRequestsPerRun,
+                        PassiveCtCertSpotterMaximumRequestsPerRun = options.PassiveCtCertSpotterMaximumRequestsPerRun,
                         EnableNativeCtLogSource = options.EnableNativeCtLogSubdomainSource,
                         NativeCtLogOnly = options.NativeCtLogOnly || !allowPassiveCtFallback,
                         NativeCtLogListUrl = options.NativeCtLogListUrl,
@@ -487,6 +491,10 @@ public sealed partial class CertificateInventoryCapture {
                         PassiveCtRetryBaseDelay = options.PassiveCtRetryBaseDelay,
                         PassiveCtRetryMaxDelay = options.PassiveCtRetryMaxDelay,
                         PassiveCtSourceCooldown = options.PassiveCtSourceCooldown,
+                        PassiveCtCrtShMinimumSpacing = options.PassiveCtCrtShMinimumSpacing,
+                        PassiveCtCertSpotterMinimumSpacing = options.PassiveCtCertSpotterMinimumSpacing,
+                        PassiveCtCrtShMaximumRequestsPerRun = options.PassiveCtCrtShMaximumRequestsPerRun,
+                        PassiveCtCertSpotterMaximumRequestsPerRun = options.PassiveCtCertSpotterMaximumRequestsPerRun,
                         EnableNativeCtLogSource = false,
                         NativeCtLogOnly = false
                     };

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Helpers;
 using Npgsql;
+using NpgsqlTypes;
 
 namespace DomainDetective;
 
@@ -131,6 +132,50 @@ public sealed partial class CertificateInventoryCapture {
                         hydrated != null &&
                         !IsCtCertificateMetadataMissing(hydrated)) {
                         targetNames.Remove(normalizedName);
+                    }
+                }
+            }
+        }
+
+        if (ShouldUseCrtShPostgreSqlMetadataFallback(options)) {
+            logger.WriteVerbose(
+                "CT metadata backfill: querying domain-batched crt.sh PostgreSQL metadata for {0} domain(s) covering {1} remaining subdomain(s).",
+                missingByDomain.Count(static pair => pair.Value.Count > 0),
+                missingByDomain.Sum(static pair => pair.Value.Count));
+
+            foreach (KeyValuePair<string, HashSet<string>> pair in missingByDomain
+                         .Where(static pair => pair.Value.Count > 0)
+                         .OrderBy(static pair => pair.Key, StringComparer.OrdinalIgnoreCase)) {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                Dictionary<string, SubdomainDiscoveryEntry> domainHydrated;
+                try {
+                    domainHydrated =
+                        await QueryCrtShPostgreSqlMetadataByDomainAsync(
+                                pair.Key,
+                                pair.Value,
+                                options,
+                                logger,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup timed out for {pair.Key}.";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                } catch (Exception ex) {
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                }
+
+                foreach (KeyValuePair<string, SubdomainDiscoveryEntry> hydratedPair in domainHydrated) {
+                    MergeCtSubdomainEntry(merged, hydratedPair.Value);
+                    if (merged.TryGetValue(hydratedPair.Key, out SubdomainDiscoveryEntry? hydrated) &&
+                        hydrated != null &&
+                        !IsCtCertificateMetadataMissing(hydrated)) {
+                        pair.Value.Remove(hydratedPair.Key);
                     }
                 }
             }
@@ -694,6 +739,87 @@ public sealed partial class CertificateInventoryCapture {
         return entry;
     }
 
+    private async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlMetadataByDomainAsync(
+        string domain,
+        IReadOnlyCollection<string> hostNames,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger logger,
+        CancellationToken cancellationToken) {
+        var results = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(domain) || hostNames == null || hostNames.Count == 0 || options == null) {
+            return results;
+        }
+
+        List<string> normalizedHosts = hostNames
+            .Where(static host => !string.IsNullOrWhiteSpace(host))
+            .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (normalizedHosts.Count == 0) {
+            return results;
+        }
+
+        string normalizedDomain = domain.Trim().TrimEnd('.').ToLowerInvariant();
+        string connectionString = BuildCrtShPostgreSqlConnectionString(options);
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandTimeout = Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds);
+        command.CommandText = BuildCrtShPostgreSqlDomainMetadataQuery();
+        command.Parameters.AddWithValue("domain", normalizedDomain);
+        command.Parameters.Add(new NpgsqlParameter<string[]>("hosts", NpgsqlDbType.Array | NpgsqlDbType.Text)
+        {
+            TypedValue = normalizedHosts.ToArray()
+        });
+        command.Parameters.Add(new NpgsqlParameter<string[]>("wildcardHosts", NpgsqlDbType.Array | NpgsqlDbType.Text)
+        {
+            TypedValue = normalizedHosts.Select(BuildWildcardCandidateHost).ToArray()
+        });
+        command.Parameters.AddWithValue("limit", Math.Max(32, normalizedHosts.Count * 8));
+
+        var rows = new List<CrtShPostgreSqlExactMetadataRow>();
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false)) {
+            rows.Add(new CrtShPostgreSqlExactMetadataRow
+            {
+                CertificateDer = reader.IsDBNull(0) ? null : (byte[])reader.GetValue(0),
+                EntryTimestampUtc = reader.IsDBNull(1) ? null : ReadDateTimeOffset(reader.GetValue(1)),
+                CommonName = reader.IsDBNull(2) ? null : reader.GetString(2),
+                IssuerName = reader.IsDBNull(3) ? null : reader.GetString(3),
+                SerialNumber = reader.IsDBNull(4) ? null : reader.GetString(4),
+                NotBeforeUtc = reader.IsDBNull(5) ? null : ReadDateTimeOffset(reader.GetValue(5)),
+                NotAfterUtc = reader.IsDBNull(6) ? null : ReadDateTimeOffset(reader.GetValue(6)),
+                CandidateNames = reader.IsDBNull(7)
+                    ? Array.Empty<string>()
+                    : ((string[])reader.GetValue(7))
+                        .Select(static name => NormalizeCtMetadataCandidate(name, preserveWildcard: true))
+                        .Where(static name => !string.IsNullOrWhiteSpace(name))
+                        .Select(static name => name!)
+                        .Distinct(StringComparer.OrdinalIgnoreCase)
+                        .ToList()
+            });
+        }
+
+        foreach (string normalizedHost in normalizedHosts) {
+            SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(normalizedHost, rows);
+            if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
+                continue;
+            }
+
+            results[normalizedHost] = entry;
+        }
+
+        if (results.Count > 0) {
+            logger.WriteVerbose(
+                "CT metadata backfill domain PostgreSQL lookup matched {0} host(s) for {1} from {2} candidate certificate row(s).",
+                results.Count,
+                normalizedDomain,
+                rows.Count);
+        }
+
+        return results;
+    }
+
     internal static string BuildCrtShPostgreSqlExactMetadataQuery() {
         return
             """
@@ -741,6 +867,54 @@ public sealed partial class CertificateInventoryCapture {
             ORDER BY entry_timestamp DESC NULLS LAST,
                      x509_notBefore(c.certificate) DESC NULLS LAST
             LIMIT 16;
+            """;
+    }
+
+    internal static string BuildCrtShPostgreSqlDomainMetadataQuery() {
+        return
+            """
+            SELECT
+                c.certificate,
+                COALESCE(
+                    (
+                        SELECT MAX(ctle.entry_timestamp)
+                        FROM ct_log_entry ctle
+                        WHERE ctle.certificate_id = c.id
+                    ),
+                    NULL
+                ) AS entry_timestamp,
+                x509_commonName(c.certificate) AS common_name,
+                x509_issuerName(c.certificate) AS issuer_name,
+                encode(x509_serialNumber(c.certificate), 'hex') AS serial_number,
+                x509_notBefore(c.certificate) AS not_before,
+                x509_notAfter(c.certificate) AS not_after,
+                ARRAY(
+                    SELECT candidate_name
+                    FROM (
+                        SELECT x509_commonName(c.certificate) AS candidate_name
+                        UNION
+                        SELECT alt_name
+                        FROM x509_altnames(c.certificate) AS alt_name
+                    ) AS candidate_names
+                    WHERE candidate_name IS NOT NULL
+                    ORDER BY lower(candidate_name)
+                ) AS dns_names
+            FROM certificate c
+            WHERE identities(c.certificate) @@ plainto_tsquery('simple', @domain)
+              AND EXISTS (
+                    SELECT 1
+                    FROM (
+                        SELECT lower(COALESCE(x509_commonName(c.certificate), '')) AS candidate_name
+                        UNION
+                        SELECT lower(alt_name)
+                        FROM x509_altnames(c.certificate) AS alt_name
+                    ) AS candidate_names
+                    WHERE candidate_name = ANY(@hosts)
+                       OR candidate_name = ANY(@wildcardHosts)
+                )
+            ORDER BY entry_timestamp DESC NULLS LAST,
+                     x509_notBefore(c.certificate) DESC NULLS LAST
+            LIMIT @limit;
             """;
     }
 

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -52,7 +52,8 @@ public sealed partial class CertificateInventoryCapture {
 
         bool allowPassiveMetadataFallback = options.EnablePassiveCtFallback ||
                                             options.EnablePassiveCtMetadataFallback;
-        if (!allowPassiveMetadataFallback) {
+        bool allowPostgreSqlMetadataFallback = ShouldUseCrtShPostgreSqlMetadataFallback(options);
+        if (!allowPassiveMetadataFallback && !allowPostgreSqlMetadataFallback) {
             return discoveredEntries;
         }
 
@@ -137,7 +138,8 @@ public sealed partial class CertificateInventoryCapture {
             }
         }
 
-        if (ShouldUseCrtShPostgreSqlMetadataFallback(options)) {
+        bool domainPostgreSqlLookupFailed = false;
+        if (allowPostgreSqlMetadataFallback) {
             logger.WriteVerbose(
                 "CT metadata backfill: querying domain-batched crt.sh PostgreSQL metadata for {0} domain(s) covering {1} remaining subdomain(s).",
                 missingByDomain.Count(static pair => pair.Value.Count > 0),
@@ -159,11 +161,13 @@ public sealed partial class CertificateInventoryCapture {
                                 cancellationToken)
                             .ConfigureAwait(false);
                 } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+                    domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup timed out for {pair.Key}.";
                     warnings.Add(warning);
                     logger.WriteVerbose(warning);
                     continue;
                 } catch (Exception ex) {
+                    domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
                     warnings.Add(warning);
                     logger.WriteVerbose(warning);
@@ -193,14 +197,18 @@ public sealed partial class CertificateInventoryCapture {
             .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         if (remainingMissingNames.Count > 0 && suppressedHosts.Count > 0) {
-            int originalCount = remainingMissingNames.Count;
-            remainingMissingNames = remainingMissingNames
-                .Where(name => !suppressedHosts.Contains(name!.Trim().TrimEnd('.').ToLowerInvariant()))
-                .ToList();
-            int suppressedCount = originalCount - remainingMissingNames.Count;
-            if (suppressedCount > 0) {
+            int suppressedCount = remainingMissingNames.Count(name =>
+                suppressedHosts.Contains(name!.Trim().TrimEnd('.').ToLowerInvariant()));
+            if (suppressedCount > 0 && !domainPostgreSqlLookupFailed) {
+                remainingMissingNames = remainingMissingNames
+                    .Where(name => !suppressedHosts.Contains(name!.Trim().TrimEnd('.').ToLowerInvariant()))
+                    .ToList();
                 logger.WriteVerbose(
                     "CT metadata backfill: skipping exact passive CT metadata for {0} remaining host(s) because the caller already supplied suppression state.",
+                    suppressedCount);
+            } else if (suppressedCount > 0) {
+                logger.WriteVerbose(
+                    "CT metadata backfill: retaining {0} remaining host(s) for exact passive CT metadata because domain-batched crt.sh PostgreSQL lookup failed in this pass.",
                     suppressedCount);
             }
         }
@@ -254,7 +262,9 @@ public sealed partial class CertificateInventoryCapture {
 
         if (options.NativeCtLogOnly ||
             !options.BackfillMissingCtCertificateMetadata ||
-            (!options.EnablePassiveCtFallback && !options.EnablePassiveCtMetadataFallback)) {
+            (!options.EnablePassiveCtFallback &&
+             !options.EnablePassiveCtMetadataFallback &&
+             !ShouldUseCrtShPostgreSqlMetadataFallback(options))) {
             return Array.Empty<SubdomainDiscoveryEntry>();
         }
 
@@ -462,7 +472,9 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         var results = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
-        bool usePassiveNetworkQueries = CtPassiveMetadataBackfillOverride == null;
+        bool allowPassiveMetadataFallback = options.EnablePassiveCtFallback ||
+                                            options.EnablePassiveCtMetadataFallback;
+        bool usePassiveNetworkQueries = allowPassiveMetadataFallback && CtPassiveMetadataBackfillOverride == null;
         List<string> normalizedHostNames = hostNames
             .Where(static hostName => !string.IsNullOrWhiteSpace(hostName))
             .Select(static hostName => hostName.Trim())
@@ -499,6 +511,12 @@ public sealed partial class CertificateInventoryCapture {
                     .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
                     .ToList();
             }
+        }
+
+        if (!allowPassiveMetadataFallback) {
+            return results.Values
+                .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                .ToList();
         }
 
         if (TryBuildPassiveCtRunSuppressionReason(passiveCtDiagnosticEntries, out string suppressionReason)) {
@@ -648,6 +666,14 @@ public sealed partial class CertificateInventoryCapture {
             return results;
         }
 
+        if (CtExactMetadataPostgreSqlOverride == null) {
+            return await QueryCrtShPostgreSqlMetadataExactSequentialAsync(
+                hostNames,
+                options,
+                logger,
+                cancellationToken).ConfigureAwait(false);
+        }
+
         int exactParallelism = ResolveExactPassiveCtMetadataBackfillParallelism(
             options.DiscoveryParallelism,
             options.PassiveCtParallelism,
@@ -687,6 +713,78 @@ public sealed partial class CertificateInventoryCapture {
         return results;
     }
 
+    private static async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlMetadataExactSequentialAsync(
+        IReadOnlyList<string> hostNames,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        CancellationToken cancellationToken) {
+        var results = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
+        if (hostNames == null || hostNames.Count == 0 || options == null) {
+            return results;
+        }
+
+        List<string> normalizedHosts = hostNames
+            .Where(static host => !string.IsNullOrWhiteSpace(host))
+            .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (normalizedHosts.Count == 0) {
+            return results;
+        }
+
+        string connectionString = BuildCrtShPostgreSqlConnectionString(options);
+        HashSet<string> targetedThumbprints = BuildTargetedCtMetadataThumbprintSet(options);
+        await using var connection = new NpgsqlConnection(connectionString);
+        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        foreach (string normalizedHost in normalizedHosts) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                SubdomainDiscoveryEntry? entry = await QueryCrtShPostgreSqlMetadataExactAsync(
+                    connection,
+                    normalizedHost,
+                    options,
+                    logger,
+                    targetedThumbprints,
+                    cancellationToken).ConfigureAwait(false);
+                if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
+                    continue;
+                }
+
+                MergeCtSubdomainEntry(results, entry);
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
+            } catch (Exception ex) {
+                logger?.WriteVerbose(
+                    "CT metadata backfill exact PostgreSQL lookup failed for {0}: {1}",
+                    normalizedHost,
+                    ex.Message);
+                if (connection.FullState == System.Data.ConnectionState.Broken ||
+                    connection.FullState == System.Data.ConnectionState.Closed) {
+                    break;
+                }
+            }
+        }
+
+        return results;
+    }
+
+    private static HashSet<string> BuildTargetedCtMetadataThumbprintSet(CertificateInventoryCaptureOptions? options) {
+        if (options == null || options.CtMetadataTargetThumbprints.Count == 0) {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var thumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string rawThumbprint in options.CtMetadataTargetThumbprints) {
+            string? normalizedThumbprint = NormalizeCtMetadataThumbprint(rawThumbprint);
+            if (!string.IsNullOrWhiteSpace(normalizedThumbprint)) {
+                thumbprints.Add(normalizedThumbprint!);
+            }
+        }
+
+        return thumbprints;
+    }
+
     private static async Task<SubdomainDiscoveryEntry?> QueryCrtShPostgreSqlMetadataExactAsync(
         string hostName,
         CertificateInventoryCaptureOptions options,
@@ -700,11 +798,32 @@ public sealed partial class CertificateInventoryCapture {
         string connectionString = BuildCrtShPostgreSqlConnectionString(options);
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        return await QueryCrtShPostgreSqlMetadataExactAsync(
+            connection,
+            normalizedHost,
+            options,
+            logger,
+            BuildTargetedCtMetadataThumbprintSet(options),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<SubdomainDiscoveryEntry?> QueryCrtShPostgreSqlMetadataExactAsync(
+        NpgsqlConnection connection,
+        string normalizedHost,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken) {
+        if (connection == null ||
+            string.IsNullOrWhiteSpace(normalizedHost) ||
+            options == null) {
+            return null;
+        }
+
         using var command = connection.CreateCommand();
         command.CommandTimeout = Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds);
         command.CommandText = BuildCrtShPostgreSqlExactMetadataQuery();
         command.Parameters.AddWithValue("host", normalizedHost);
-        command.Parameters.AddWithValue("wildcardHost", BuildWildcardCandidateHost(normalizedHost));
 
         var rows = new List<CrtShPostgreSqlExactMetadataRow>();
         await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -728,7 +847,10 @@ public sealed partial class CertificateInventoryCapture {
             });
         }
 
-        SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(normalizedHost, rows);
+        SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
+            normalizedHost,
+            rows,
+            targetedThumbprints);
         if (entry != null) {
             logger?.WriteVerbose(
                 "CT metadata backfill exact PostgreSQL lookup matched {0} row(s) for {1}.",
@@ -760,6 +882,7 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         string normalizedDomain = domain.Trim().TrimEnd('.').ToLowerInvariant();
+        HashSet<string> targetedThumbprints = BuildTargetedCtMetadataThumbprintSet(options);
         string connectionString = BuildCrtShPostgreSqlConnectionString(options);
         await using var connection = new NpgsqlConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
@@ -801,7 +924,10 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         foreach (string normalizedHost in normalizedHosts) {
-            SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(normalizedHost, rows);
+            SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
+                normalizedHost,
+                rows,
+                targetedThumbprints);
             if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
                 continue;
             }
@@ -850,18 +976,13 @@ public sealed partial class CertificateInventoryCapture {
                     ORDER BY lower(candidate_name)
                 ) AS dns_names
             FROM certificate c
-            WHERE (
-                    identities(c.certificate) @@ plainto_tsquery('simple', @host)
-                 OR identities(c.certificate) @@ plainto_tsquery('simple', @wildcardHost)
-                  )
+            WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)
               AND (
                     lower(COALESCE(x509_commonName(c.certificate), '')) = lower(@host)
-                 OR lower(COALESCE(x509_commonName(c.certificate), '')) = lower(@wildcardHost)
                  OR EXISTS (
                         SELECT 1
                         FROM x509_altnames(c.certificate) AS alt_name
                         WHERE lower(alt_name) = lower(@host)
-                           OR lower(alt_name) = lower(@wildcardHost)
                     )
                   )
             ORDER BY entry_timestamp DESC NULLS LAST,
@@ -920,14 +1041,41 @@ public sealed partial class CertificateInventoryCapture {
 
     internal static SubdomainDiscoveryEntry? TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
         string normalizedHost,
-        IReadOnlyList<CrtShPostgreSqlExactMetadataRow>? rows) {
+        IReadOnlyList<CrtShPostgreSqlExactMetadataRow>? rows,
+        ISet<string>? targetedThumbprints = null) {
         if (string.IsNullOrWhiteSpace(normalizedHost) || rows == null || rows.Count == 0) {
             return null;
         }
 
-        CrtShPostgreSqlExactMetadataRow? selectedRow = rows
+        List<CrtShPostgreSqlExactMetadataRow> matchingRows = rows
             .Where(row => row != null &&
                           row.CandidateNames.Any(candidate => CtMetadataCandidateMatchesHost(normalizedHost, candidate)))
+            .ToList();
+        if (matchingRows.Count == 0) {
+            return null;
+        }
+
+        var normalizedTargetedThumbprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (targetedThumbprints != null && targetedThumbprints.Count > 0) {
+            foreach (string rawThumbprint in targetedThumbprints) {
+                string? normalizedThumbprint = NormalizeCtMetadataThumbprint(rawThumbprint);
+                if (!string.IsNullOrWhiteSpace(normalizedThumbprint)) {
+                    normalizedTargetedThumbprints.Add(normalizedThumbprint!);
+                }
+            }
+        }
+
+        IEnumerable<CrtShPostgreSqlExactMetadataRow> candidateRows = matchingRows;
+        if (normalizedTargetedThumbprints.Count > 0) {
+            List<CrtShPostgreSqlExactMetadataRow> targetedRows = matchingRows
+                .Where(row => DoesCrtShPostgreSqlRowMatchTargetThumbprint(row, normalizedTargetedThumbprints))
+                .ToList();
+            if (targetedRows.Count > 0) {
+                candidateRows = targetedRows;
+            }
+        }
+
+        CrtShPostgreSqlExactMetadataRow? selectedRow = candidateRows
             .OrderByDescending(static row => row.EntryTimestampUtc ?? DateTimeOffset.MinValue)
             .ThenByDescending(static row => row.NotBeforeUtc ?? DateTimeOffset.MinValue)
             .FirstOrDefault();
@@ -986,13 +1134,30 @@ public sealed partial class CertificateInventoryCapture {
         };
     }
 
+    private static bool DoesCrtShPostgreSqlRowMatchTargetThumbprint(
+        CrtShPostgreSqlExactMetadataRow? row,
+        ISet<string>? targetedThumbprints) {
+        if (row == null ||
+            targetedThumbprints == null ||
+            targetedThumbprints.Count == 0 ||
+            row.CertificateDer == null ||
+            row.CertificateDer.Length == 0) {
+            return false;
+        }
+
+        using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(row.CertificateDer);
+        string? thumbprint = NormalizeCtMetadataThumbprint(certificate.Thumbprint);
+        return !string.IsNullOrWhiteSpace(thumbprint) &&
+               targetedThumbprints.Contains(thumbprint!);
+    }
+
     private static string BuildCrtShPostgreSqlConnectionString(CertificateInventoryCaptureOptions options) {
         if (!string.IsNullOrWhiteSpace(options?.CrtShPostgreSqlConnectionString)) {
             return options!.CrtShPostgreSqlConnectionString!;
         }
 
         var builder = new NpgsqlConnectionStringBuilder {
-            Host = "crt.sh",
+            Host = "91.199.212.73",
             Port = 5432,
             Database = "certwatch",
             Username = "guest",
@@ -1003,13 +1168,16 @@ public sealed partial class CertificateInventoryCapture {
         return builder.ConnectionString;
     }
 
-    private static string BuildWildcardCandidateHost(string normalizedHost) {
+    internal static string BuildWildcardCandidateHost(string normalizedHost) {
         if (string.IsNullOrWhiteSpace(normalizedHost)) {
             return normalizedHost ?? string.Empty;
         }
 
         int firstDotIndex = normalizedHost.IndexOf('.');
-        return firstDotIndex <= 0 || firstDotIndex >= normalizedHost.Length - 1
+        int lastDotIndex = normalizedHost.LastIndexOf('.');
+        return firstDotIndex <= 0 ||
+               firstDotIndex >= normalizedHost.Length - 1 ||
+               firstDotIndex == lastDotIndex
             ? normalizedHost
             : "*." + normalizedHost.Substring(firstDotIndex + 1);
     }

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -381,11 +381,13 @@ public sealed partial class CertificateInventoryCapture {
             return true;
         }
 
-        return string.IsNullOrWhiteSpace(entry.LatestCertificateSubject) &&
-               string.IsNullOrWhiteSpace(entry.LatestCertificateIssuer) &&
-               string.IsNullOrWhiteSpace(entry.LatestCertificateSerialNumber) &&
-               !entry.LatestCertificateNotBeforeUtc.HasValue &&
-               !entry.LatestCertificateNotAfterUtc.HasValue;
+        return string.IsNullOrWhiteSpace(entry.LatestCertificateSubject) ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateIssuer) ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateSerialNumber) ||
+               !entry.LatestCertificateNotBeforeUtc.HasValue ||
+               !entry.LatestCertificateNotAfterUtc.HasValue ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateThumbprint) ||
+               string.IsNullOrWhiteSpace(entry.LatestCertificateAuthenticationProfile);
     }
 
     private static bool HasCtCertificateMetadata(
@@ -472,6 +474,7 @@ public sealed partial class CertificateInventoryCapture {
             int exactNetworkParallelism = ResolveExactPassiveCtMetadataBackfillParallelism(
                 options.DiscoveryParallelism,
                 options.PassiveCtParallelism,
+                options.CrtShPostgreSqlMaximumConcurrentRequests,
                 remainingHostNames.Count,
                 usePassiveNetworkQueries: true);
             int scheduledHosts = 0;
@@ -603,6 +606,7 @@ public sealed partial class CertificateInventoryCapture {
         int exactParallelism = ResolveExactPassiveCtMetadataBackfillParallelism(
             options.DiscoveryParallelism,
             options.PassiveCtParallelism,
+            options.CrtShPostgreSqlMaximumConcurrentRequests,
             hostNames.Count,
             usePassiveNetworkQueries: false);
         using var gate = new SemaphoreSlim(exactParallelism, exactParallelism);
@@ -860,6 +864,7 @@ public sealed partial class CertificateInventoryCapture {
     internal static int ResolveExactPassiveCtMetadataBackfillParallelism(
         int configuredDiscoveryParallelism,
         int configuredPassiveCtParallelism,
+        int configuredCrtShPostgreSqlMaximumConcurrentRequests,
         int hostCount,
         bool usePassiveNetworkQueries) {
         int configuredParallelism = Math.Max(1, configuredDiscoveryParallelism);
@@ -867,7 +872,9 @@ public sealed partial class CertificateInventoryCapture {
             ? Math.Min(
                 Math.Min(configuredParallelism, Math.Max(1, configuredPassiveCtParallelism)),
                 4)
-            : configuredParallelism;
+            : Math.Min(
+                configuredParallelism,
+                Math.Max(1, configuredCrtShPostgreSqlMaximumConcurrentRequests));
         return Math.Min(Math.Max(1, hostCount), effectiveParallelism);
     }
 
@@ -1013,6 +1020,19 @@ public sealed partial class CertificateInventoryCapture {
             return entry;
         }
 
+        CertificateExtendedKeyUsageInfo eku = CertificateExtendedKeyUsageAnalyzer.Analyze(certificate);
+        string? signatureOid = certificate.SignatureAlgorithm?.Value;
+        int keySize = GetPublicKeySize(certificate);
+        bool isSelfSigned = IsSelfSigned(certificate);
+        bool weakKey = keySize > 0 && keySize < 2048;
+        bool sha1Signature = IsSha1Signature(signatureOid);
+        bool hasServerAuthentication = eku.AllowsServerAuthentication;
+        bool hasClientAuthentication = eku.AllowsClientAuthentication;
+        bool hasSecureEmail = eku.AllowsSecureEmail;
+        string authenticationProfile = string.IsNullOrWhiteSpace(eku.AuthenticationProfile)
+            ? CertificateAuthenticationProfileClassifier.Classify(eku)
+            : eku.AuthenticationProfile;
+
         SubdomainDiscoveryEntry hydratedEntry = CloneSubdomainEntry(entry);
         hydratedEntry = new SubdomainDiscoveryEntry {
             Name = hydratedEntry.Name,
@@ -1026,13 +1046,15 @@ public sealed partial class CertificateInventoryCapture {
             LatestCertificateNotBeforeUtc = hydratedEntry.LatestCertificateNotBeforeUtc ?? new DateTimeOffset(certificate.NotBefore.ToUniversalTime()),
             LatestCertificateNotAfterUtc = hydratedEntry.LatestCertificateNotAfterUtc ?? new DateTimeOffset(certificate.NotAfter.ToUniversalTime()),
             LatestCertificateSubjectAlternativeNames = hydratedEntry.LatestCertificateSubjectAlternativeNames == null ? Array.Empty<string>() : hydratedEntry.LatestCertificateSubjectAlternativeNames.ToList(),
-            LatestCertificateIsSelfSigned = hydratedEntry.LatestCertificateIsSelfSigned,
-            LatestCertificateWeakKey = hydratedEntry.LatestCertificateWeakKey,
-            LatestCertificateSha1Signature = hydratedEntry.LatestCertificateSha1Signature,
-            LatestCertificateHasServerAuthentication = hydratedEntry.LatestCertificateHasServerAuthentication,
-            LatestCertificateHasClientAuthentication = hydratedEntry.LatestCertificateHasClientAuthentication,
-            LatestCertificateHasSecureEmail = hydratedEntry.LatestCertificateHasSecureEmail,
-            LatestCertificateAuthenticationProfile = hydratedEntry.LatestCertificateAuthenticationProfile,
+            LatestCertificateIsSelfSigned = hydratedEntry.LatestCertificateIsSelfSigned ?? isSelfSigned,
+            LatestCertificateWeakKey = hydratedEntry.LatestCertificateWeakKey ?? weakKey,
+            LatestCertificateSha1Signature = hydratedEntry.LatestCertificateSha1Signature ?? sha1Signature,
+            LatestCertificateHasServerAuthentication = hydratedEntry.LatestCertificateHasServerAuthentication ?? hasServerAuthentication,
+            LatestCertificateHasClientAuthentication = hydratedEntry.LatestCertificateHasClientAuthentication ?? hasClientAuthentication,
+            LatestCertificateHasSecureEmail = hydratedEntry.LatestCertificateHasSecureEmail ?? hasSecureEmail,
+            LatestCertificateAuthenticationProfile = string.IsNullOrWhiteSpace(hydratedEntry.LatestCertificateAuthenticationProfile)
+                ? authenticationProfile
+                : hydratedEntry.LatestCertificateAuthenticationProfile,
             CtSources = hydratedEntry.CtSources == null ? Array.Empty<string>() : hydratedEntry.CtSources.ToList(),
             CertificateObservationCount = hydratedEntry.CertificateObservationCount,
             ResolutionStatus = hydratedEntry.ResolutionStatus,

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Threading;
@@ -166,7 +168,31 @@ public sealed partial class CertificateInventoryCapture {
                     warnings.Add(warning);
                     logger.WriteVerbose(warning);
                     continue;
-                } catch (Exception ex) {
+                } catch (NpgsqlException ex) {
+                    domainPostgreSqlLookupFailed = true;
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                } catch (TimeoutException ex) {
+                    domainPostgreSqlLookupFailed = true;
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                } catch (InvalidOperationException ex) {
+                    domainPostgreSqlLookupFailed = true;
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                } catch (IOException ex) {
+                    domainPostgreSqlLookupFailed = true;
+                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
+                    warnings.Add(warning);
+                    logger.WriteVerbose(warning);
+                    continue;
+                } catch (CryptographicException ex) {
                     domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
                     warnings.Add(warning);
@@ -754,11 +780,38 @@ public sealed partial class CertificateInventoryCapture {
                 MergeCtSubdomainEntry(results, entry);
             } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                 throw;
-            } catch (Exception ex) {
-                logger?.WriteVerbose(
-                    "CT metadata backfill exact PostgreSQL lookup failed for {0}: {1}",
-                    normalizedHost,
-                    ex.Message);
+            } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
+                if (connection.FullState == System.Data.ConnectionState.Broken ||
+                    connection.FullState == System.Data.ConnectionState.Closed) {
+                    break;
+                }
+            } catch (NpgsqlException ex) {
+                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
+                if (connection.FullState == System.Data.ConnectionState.Broken ||
+                    connection.FullState == System.Data.ConnectionState.Closed) {
+                    break;
+                }
+            } catch (TimeoutException ex) {
+                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
+                if (connection.FullState == System.Data.ConnectionState.Broken ||
+                    connection.FullState == System.Data.ConnectionState.Closed) {
+                    break;
+                }
+            } catch (InvalidOperationException ex) {
+                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
+                if (connection.FullState == System.Data.ConnectionState.Broken ||
+                    connection.FullState == System.Data.ConnectionState.Closed) {
+                    break;
+                }
+            } catch (IOException ex) {
+                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
+                if (connection.FullState == System.Data.ConnectionState.Broken ||
+                    connection.FullState == System.Data.ConnectionState.Closed) {
+                    break;
+                }
+            } catch (CryptographicException ex) {
+                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
                 if (connection.FullState == System.Data.ConnectionState.Broken ||
                     connection.FullState == System.Data.ConnectionState.Closed) {
                     break;
@@ -767,6 +820,16 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         return results;
+    }
+
+    private static void LogCrtShPostgreSqlExactMetadataSequentialFailure(
+        InternalLogger? logger,
+        string normalizedHost,
+        Exception ex) {
+        logger?.WriteVerbose(
+            "CT metadata backfill exact PostgreSQL lookup failed for {0}: {1}",
+            normalizedHost,
+            ex.Message);
     }
 
     private static HashSet<string> BuildTargetedCtMetadataThumbprintSet(CertificateInventoryCaptureOptions? options) {

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataEnrichment.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataEnrichment.cs
@@ -179,7 +179,7 @@ public sealed partial class CertificateInventoryCapture {
             entry.NotAfterUtc = discoveredEntry.LatestCertificateNotAfterUtc;
             updated = true;
         }
-        if (string.IsNullOrWhiteSpace(entry.AuthenticationProfile) &&
+        if ((string.IsNullOrWhiteSpace(entry.AuthenticationProfile) || hadNoPrimaryCertificateEvidence) &&
             !string.IsNullOrWhiteSpace(discoveredEntry.LatestCertificateAuthenticationProfile)) {
             entry.AuthenticationProfile = discoveredEntry.LatestCertificateAuthenticationProfile!;
             updated = true;

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -662,6 +662,15 @@ public sealed partial class CertificateInventoryCapture {
             return;
         }
 
+        // When a run is only allowed to probe one endpoint, prefer the direct HTTPS
+        // target over auxiliary mail expansion. This keeps apex/root website checks
+        // from being starved by MX-derived targets during tightly bounded passes.
+        if (maxTargets == 1) {
+            allowedHttps = 1;
+            allowedMail = 0;
+            return;
+        }
+
         var total = normalizedHttps + normalizedMail;
         var desiredHttps = (int)Math.Round(
             maxTargets * (double)normalizedHttps / total,

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -72,6 +72,13 @@ public sealed class CertificateInventoryCaptureOptions {
     /// </summary>
     public List<string> ExactPassiveCtMetadataTargetHosts { get; } = new();
 
+    /// <summary>
+    /// Optional normalized certificate thumbprints that should be preferred when passive CT metadata
+    /// rescue needs provenance for already-identified certificates rather than the newest certificate
+    /// currently associated with a host.
+    /// </summary>
+    public List<string> CtMetadataTargetThumbprints { get; } = new();
+
     /// <summary>When true, uses native RFC6962 CT log polling for subdomain discovery.</summary>
     public bool EnableNativeCtLogSubdomainSource { get; set; }
 

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -120,6 +120,13 @@ public sealed class CertificateInventoryCaptureOptions {
     /// </summary>
     public int CrtShPostgreSqlCommandTimeoutSeconds { get; set; } = 15;
 
+    /// <summary>
+    /// Maximum number of concurrent exact-host crt.sh PostgreSQL metadata rescue queries.
+    /// Keep this conservative for the public guest replica to avoid exhausting shared
+    /// connection budgets during large capture runs.
+    /// </summary>
+    public int CrtShPostgreSqlMaximumConcurrentRequests { get; set; } = 2;
+
     /// <summary>Per-request timeout for passive/public CT HTTP calls.</summary>
     public TimeSpan PassiveCtRequestTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
@@ -139,19 +146,19 @@ public sealed class CertificateInventoryCaptureOptions {
     /// Minimum spacing between public crt.sh requests when passive/public CT fallback is active.
     /// This helps exact-host rescue and fallback discovery stay within respectful shared-source pacing.
     /// </summary>
-    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.
     /// This is anti-burst pacing only; the main safety rail is the run-local request budget below.
     /// </summary>
-    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
 
     /// <summary>
     /// Maximum number of public crt.sh exact-host metadata requests issued during a single passive CT run.
     /// Zero means uncapped.
     /// </summary>
-    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 8;
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 5;
 
     /// <summary>
     /// Maximum number of Cert Spotter exact-host metadata requests issued during a single passive CT run.
@@ -370,8 +377,13 @@ public sealed class CertificateInventoryCaptureOptions {
         IncludeApexHttps = false;
         IncludeWwwHttps = false;
         IncludeCtDiscoveredSubdomains = true;
+        EnableNativeCtLogSubdomainSource = true;
+        EnablePassiveCtFallback = true;
+        NativeCtLogOnly = false;
         VerifyCtDiscoveredSubdomains = false;
+        BackfillMissingCtCertificateMetadata = true;
         PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        // Disable all non-CT probe expansion in the discovery-only lane.
         IncludeMxHosts = false;
         IncludeMxHttps = false;
         IncludeSmtpStartTls = false;
@@ -384,14 +396,17 @@ public sealed class CertificateInventoryCaptureOptions {
     /// <summary>
     /// Configures the capture for exact-host CT evidence refresh.
     /// This keeps the run focused on apex or explicit host probes plus CT metadata hydration,
-    /// without reopening broader CT discovery or MX/mail expansion.
+    /// without reopening broader CT discovery or MX/mail expansion. CT metadata hydration stays
+    /// enabled for exact-host seeds and explicit CT metadata targets rather than discovered-host expansion.
     /// </summary>
     public CertificateInventoryCaptureOptions ApplyCtEvidenceRefreshProfile() {
         IncludeApexHttps = true;
         IncludeWwwHttps = false;
         IncludeCtDiscoveredSubdomains = false;
         VerifyCtDiscoveredSubdomains = false;
+        BackfillMissingCtCertificateMetadata = true;
         PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        // Disable all non-CT probe expansion in the evidence-refresh lane.
         IncludeMxHosts = false;
         IncludeMxHttps = false;
         IncludeSmtpStartTls = false;
@@ -805,7 +820,11 @@ public sealed partial class CertificateInventoryCapture {
         var normalizedDomains = NormalizeDomains(domains, warnings);
         var seeds = BuildSeeds(normalizedDomains);
         var normalizedCtDiscoveryDomains = options.CtDiscoveryDomains.Count == 0
-            ? normalizedDomains
+            ? seeds
+                .Where(static seed => seed != null && !seed.IsExactHostSeed && !string.IsNullOrWhiteSpace(seed.Name))
+                .Select(static seed => seed.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList()
             : NormalizeDomains(options.CtDiscoveryDomains, warnings);
         var ctDiscoverySeeds = BuildSeeds(normalizedCtDiscoveryDomains);
         logger.WriteVerbose("Certificate inventory capture started for {0} normalized domain(s).", normalizedDomains.Count);

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -362,6 +362,46 @@ public sealed class CertificateInventoryCaptureOptions {
     public bool PersistSnapshot { get; set; } = true;
 
     /// <summary>
+    /// Configures the capture for CT discovery only.
+    /// This keeps the run focused on discovering names and CT-backed metadata without
+    /// widening into HTTPS, MX, or mail probing in the same pass.
+    /// </summary>
+    public CertificateInventoryCaptureOptions ApplyCtDiscoveryOnlyProfile() {
+        IncludeApexHttps = false;
+        IncludeWwwHttps = false;
+        IncludeCtDiscoveredSubdomains = true;
+        VerifyCtDiscoveredSubdomains = false;
+        PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        IncludeMxHosts = false;
+        IncludeMxHttps = false;
+        IncludeSmtpStartTls = false;
+        IncludeSubmissionStartTls = false;
+        IncludeImapTls = false;
+        IncludePop3Tls = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the capture for exact-host CT evidence refresh.
+    /// This keeps the run focused on apex or explicit host probes plus CT metadata hydration,
+    /// without reopening broader CT discovery or MX/mail expansion.
+    /// </summary>
+    public CertificateInventoryCaptureOptions ApplyCtEvidenceRefreshProfile() {
+        IncludeApexHttps = true;
+        IncludeWwwHttps = false;
+        IncludeCtDiscoveredSubdomains = false;
+        VerifyCtDiscoveredSubdomains = false;
+        PromoteCtDiscoveredSubdomainsToHttpsProbes = false;
+        IncludeMxHosts = false;
+        IncludeMxHttps = false;
+        IncludeSmtpStartTls = false;
+        IncludeSubmissionStartTls = false;
+        IncludeImapTls = false;
+        IncludePop3Tls = false;
+        return this;
+    }
+
+    /// <summary>
     /// Additional endpoints to probe.
     /// Supported forms:
     /// - https://host[:port], http://host[:port]

--- a/DomainDetective/Protocols/SubdomainEnumeration.cs
+++ b/DomainDetective/Protocols/SubdomainEnumeration.cs
@@ -51,6 +51,18 @@ public class SubdomainEnumeration
     /// <summary>Cooldown applied to passive/public CT sources after transient failures or rate limits.</summary>
     public TimeSpan PassiveCtSourceCooldown { get; set; } = TimeSpan.FromSeconds(60);
 
+    /// <summary>Minimum spacing between public crt.sh requests when passive/public CT fallback is active.</summary>
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.</summary>
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>Maximum number of public crt.sh requests issued during one passive enumeration run.</summary>
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 5;
+
+    /// <summary>Maximum number of Cert Spotter requests issued during one passive enumeration run.</summary>
+    public int PassiveCtCertSpotterMaximumRequestsPerRun { get; set; } = 1;
+
     /// <summary>List of subdomains discovered via brute force.</summary>
     public List<string> BruteForceResults { get; private set; } = new();
 
@@ -102,6 +114,10 @@ public class SubdomainEnumeration
                 RetryBaseDelay = PassiveCtRetryBaseDelay,
                 RetryMaxDelay = PassiveCtRetryMaxDelay,
                 SourceCooldown = PassiveCtSourceCooldown,
+                CrtShMinimumSpacing = PassiveCtCrtShMinimumSpacing,
+                CertSpotterMinimumSpacing = PassiveCtCertSpotterMinimumSpacing,
+                CrtShMaximumRequestsPerRun = PassiveCtCrtShMaximumRequestsPerRun,
+                CertSpotterMaximumRequestsPerRun = PassiveCtCertSpotterMaximumRequestsPerRun,
                 PayloadValidator = ValidatePassiveCtArrayPayload
             },
             PassiveHttpGetOverride,

--- a/DomainDetective/Protocols/SubdomainsAnalysis.CtAndResolutionHelpers.cs
+++ b/DomainDetective/Protocols/SubdomainsAnalysis.CtAndResolutionHelpers.cs
@@ -134,6 +134,10 @@ public sealed partial class SubdomainsAnalysis : IHasAssessments
                 RetryBaseDelay = PassiveCtRetryBaseDelay,
                 RetryMaxDelay = PassiveCtRetryMaxDelay,
                 SourceCooldown = PassiveCtSourceCooldown,
+                CrtShMinimumSpacing = PassiveCtCrtShMinimumSpacing,
+                CertSpotterMinimumSpacing = PassiveCtCertSpotterMinimumSpacing,
+                CrtShMaximumRequestsPerRun = PassiveCtCrtShMaximumRequestsPerRun,
+                CertSpotterMaximumRequestsPerRun = PassiveCtCertSpotterMaximumRequestsPerRun,
                 PayloadValidator = ValidatePassiveCtArrayPayload
             },
             QueryOverride,

--- a/DomainDetective/Protocols/SubdomainsAnalysis.cs
+++ b/DomainDetective/Protocols/SubdomainsAnalysis.cs
@@ -51,6 +51,29 @@ public sealed partial class SubdomainsAnalysis : IHasAssessments
     /// <summary>Cooldown applied to passive/public CT sources after transient failures or rate limits.</summary>
     public TimeSpan PassiveCtSourceCooldown { get; set; } = TimeSpan.FromSeconds(60);
 
+    /// <summary>
+    /// Minimum spacing between public crt.sh requests when passive/public CT fallback is active.
+    /// crt.sh publishes conservative shared limits, so the default stays intentionally gentle.
+    /// </summary>
+    public TimeSpan PassiveCtCrtShMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Minimum spacing between Cert Spotter requests when passive/public CT fallback is active.
+    /// </summary>
+    public TimeSpan PassiveCtCertSpotterMinimumSpacing { get; set; } = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Maximum number of public crt.sh requests issued during one passive CT run.
+    /// Zero means uncapped.
+    /// </summary>
+    public int PassiveCtCrtShMaximumRequestsPerRun { get; set; } = 5;
+
+    /// <summary>
+    /// Maximum number of Cert Spotter requests issued during one passive CT run.
+    /// Zero means uncapped.
+    /// </summary>
+    public int PassiveCtCertSpotterMaximumRequestsPerRun { get; set; } = 1;
+
     /// <summary>When true, uses direct RFC6962 CT log polling as primary subdomain discovery source.</summary>
     public bool EnableNativeCtLogSource { get; set; }
 


### PR DESCRIPTION
## Summary
- refine wildcard CT discovery so passive provider pacing and run budgets apply consistently across broad discovery and targeted metadata rescue
- add explicit CT capture profile handling for certificate inventory flows
- expand regression coverage around CT discovery, enrichment, and pacing behavior

## Validation
- focused DomainDetective test coverage for certificate inventory and subdomain CT analysis