### PR TITLE
Add CT ingestion planning groundwork

### DIFF
--- a/Docs/CT_PROVIDERS.MD
+++ b/Docs/CT_PROVIDERS.MD
@@ -105,9 +105,9 @@ WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)
 
 Do not query `certificate_identity` for new code. The public crt.sh database reports that `certificate_identity` has been superseded by the full-text search index on `certificate`.
 
-DomainDetective's current crt.sh PostgreSQL metadata queries already use the supported FTS path and tests assert that `certificate_identity` is not referenced. Keep future `DomainDetective.CtSql` implementation on that path unless crt.sh publishes a new supported schema.
+DomainDetective's crt.sh PostgreSQL metadata provider uses the supported FTS path and tests assert that `certificate_identity` is not referenced. Keep future `DomainDetective.CtSql` implementation on that path unless crt.sh publishes a new supported schema.
 
-Current typed status: the in-tree fallback uses parameterized Npgsql commands, typed array parameters for domain batches, an internal `CrtShPostgreSqlExactMetadataRow` mapping type, and returns DomainDetective objects such as `SubdomainDiscoveryEntry`. It is not yet a fully typed public `DomainDetective.CtSql` provider surface: the SQL is still a handwritten string in the base package, the public `DomainDetective.CtSql` package is a registration shell, and the CT SQL provider still needs to move into that package with a typed `CtCertificateQuery` / `CtCertificateQueryResult` implementation.
+Current typed status: `DomainDetective.CtSql` registers a DbaClientX-backed crt.sh PostgreSQL provider through `DomainDetectiveCtSqlRegistration.Register()`. The base `DomainDetective` package keeps the CT capture options and SQL-shape helpers, but no longer carries the PostgreSQL dependency. The provider returns DomainDetective objects such as `SubdomainDiscoveryEntry`; the broader `CtCertificateQuery` / `CtCertificateQueryResult` provider implementation is still planned for the dedicated end-to-end CT query surface.
 
 ## DD Next Planning Notes
 

--- a/Docs/CT_PROVIDERS.MD
+++ b/Docs/CT_PROVIDERS.MD
@@ -27,7 +27,7 @@ Use native CT logs for cursor-based ingestion into a local index. Direct logs ar
 | --- | --- | --- | --- |
 | Cert Spotter | Current exact host | Yes, via `expand=cert_der` | Separate exact/full-domain budgets |
 | Cert Spotter | Subdomain expansion | Yes, if expanded | Full-domain budget is small |
-| crt.sh SQL FTS | Historical backfill | Yes, certificate table DER | Shared public DB is fragile |
+| crt.sh PostgreSQL (SQL FTS) | Historical backfill | Yes, certificate table DER | PostgreSQL interface; use certificate-table FTS query style |
 | crt.sh HTTPS | Fallback hydration | Yes, via `?d=<id>` | Slow, 503s are common |
 | Native CT logs | Local ingestion | Yes, from log entries | Needs cursors/local index |
 
@@ -37,13 +37,14 @@ These observations came from an ad-hoc live smoke test against a representative 
 
 | Path | Observed Time | Observed Result | Service Guidance |
 | --- | --- | --- | --- |
-| Live TLS probe for the apex host | 468 ms | Returned the live Amazon RSA 2048 M02 certificate, expiring 2026-06-11 | Best current-state source when the endpoint is reachable |
-| Cert Spotter exact-host DER query | 514 ms | Returned 4 rows, latest unexpired CT certificate expiring 2026-05-25 | Good for latest known public issuance when endpoint reachability is not guaranteed |
-| Cert Spotter domain expansion through DomainDetective | 2.37 s | Processed 100 CT observations and produced 397 subdomains; expansion did not include full DER because it used `expand=dns_names` | Good expansion source; follow with exact-host queries for full latest certificates |
-| crt.sh HTTPS exact query with DER hydration | 74.8 s | Eventually returned certificate material, but was much slower than Cert Spotter | Fallback/manual path only |
-| crt.sh HTTPS expansion through DomainDetective | 40 s | Failed with HTTP 503 | Do not rely on this for service-scale expansion |
-| Native CT limited tail scan | 13 s | No entries for the representative domain were found in the small scanned window | Useful only with persisted cursors/local indexing, not ad-hoc domain lookup |
-| crt.sh PostgreSQL public DB rich query | Not comparable | DomainDetective-style query was canceled by the public replica due recovery conflict; simpler FTS probes against `certificate` worked | Best-effort historical/backfill path with strict timeout and cooldown |
+| Live TLS probe for the apex host | 118 ms | Returned the live Google Trust Services WE1 certificate, expiring 2026-07-04 | Best current-state source when the endpoint is reachable |
+| Cert Spotter exact-host DER query | 1.62 s | Returned 7 rows, all with DER; latest CT certificate matched the live certificate and expired 2026-07-04 | Good for latest known public issuance when endpoint reachability is not guaranteed |
+| Cert Spotter domain expansion through DomainDetective-equivalent request | 354 ms | Processed 7 CT observations and produced 3 unique DNS names; expansion did not include full DER because it used `expand=dns_names` | Good expansion source; follow with exact-host queries for full latest certificates |
+| crt.sh HTTPS exact query with DER hydration | 3.23 s | Returned 495 JSON rows and hydrated certificate ID `25432709504`; latest certificate matched the live certificate | Works when healthy, but still treat as fallback because public rate limits and 502/503s are common |
+| crt.sh HTTPS wildcard expansion | 3.28 s | Returned 495 JSON rows and 51 unique names | Useful for manual checks, but not preferred for service-scale expansion |
+| crt.sh PostgreSQL exact FTS | 4.15 s | Returned 5 typed row mappings from the `certificate` table; first row had 932 DER bytes and matched the latest live/CT certificate | Best-effort historical/backfill path with strict timeout and cooldown |
+| crt.sh PostgreSQL domain FTS sample | 1.86 s | Returned a capped 20-name sample from certificate-table FTS | Useful for SQL-backed backfill/analysis, not a separate provider from crt.sh PostgreSQL |
+| Native CT limited tail fetch | 1.24 s | Fetched a small tail range from one Google Argon CT log; this was not a domain lookup and did not decode certificates | Useful only with persisted cursors/local indexing, not ad-hoc domain lookup |
 
 ## Cert Spotter Budgets
 
@@ -96,7 +97,7 @@ https://api.certspotter.com/v1/issuances?domain=<domain>&include_subdomains=true
 
 ## crt.sh SQL FTS
 
-crt.sh SQL FTS is the supported PostgreSQL query style against the public crt.sh database. It is still "crt.sh SQL"; the FTS part means the query searches the full-text index exposed by `identities(c.certificate)` on the `certificate` table:
+crt.sh SQL FTS is not a separate provider from crt.sh PostgreSQL. It is the supported query style to use through the public crt.sh PostgreSQL interface. The FTS part means the query searches the full-text index exposed by `identities(c.certificate)` on the `certificate` table:
 
 ```sql
 WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)

--- a/Docs/CT_PROVIDERS.MD
+++ b/Docs/CT_PROVIDERS.MD
@@ -31,18 +31,18 @@ Use native CT logs for cursor-based ingestion into a local index. Direct logs ar
 | crt.sh HTTPS | Fallback hydration | Yes, via `?d=<id>` | Slow, 503s are common |
 | Native CT logs | Local ingestion | Yes, from log entries | Needs cursors/local index |
 
-## eurofins.com Smoke-Test Observations
+## Representative Smoke-Test Observations
 
-These observations came from an ad-hoc live smoke test against `eurofins.com`. Treat them as directional evidence for service design, not as provider SLAs.
+These observations came from an ad-hoc live smoke test against a representative domain. Treat them as directional evidence for service design, not as provider SLAs.
 
 | Path | Observed Time | Observed Result | Service Guidance |
 | --- | --- | --- | --- |
-| Live TLS probe for `eurofins.com` | 468 ms | Returned the live Amazon RSA 2048 M02 certificate, expiring 2026-06-11 | Best current-state source when the endpoint is reachable |
+| Live TLS probe for the apex host | 468 ms | Returned the live Amazon RSA 2048 M02 certificate, expiring 2026-06-11 | Best current-state source when the endpoint is reachable |
 | Cert Spotter exact-host DER query | 514 ms | Returned 4 rows, latest unexpired CT certificate expiring 2026-05-25 | Good for latest known public issuance when endpoint reachability is not guaranteed |
 | Cert Spotter domain expansion through DomainDetective | 2.37 s | Processed 100 CT observations and produced 397 subdomains; expansion did not include full DER because it used `expand=dns_names` | Good expansion source; follow with exact-host queries for full latest certificates |
 | crt.sh HTTPS exact query with DER hydration | 74.8 s | Eventually returned certificate material, but was much slower than Cert Spotter | Fallback/manual path only |
 | crt.sh HTTPS expansion through DomainDetective | 40 s | Failed with HTTP 503 | Do not rely on this for service-scale expansion |
-| Native CT limited tail scan | 13 s | No `eurofins.com` entries found in the small scanned window | Useful only with persisted cursors/local indexing, not ad-hoc domain lookup |
+| Native CT limited tail scan | 13 s | No entries for the representative domain were found in the small scanned window | Useful only with persisted cursors/local indexing, not ad-hoc domain lookup |
 | crt.sh PostgreSQL public DB rich query | Not comparable | DomainDetective-style query was canceled by the public replica due recovery conflict; simpler FTS probes against `certificate` worked | Best-effort historical/backfill path with strict timeout and cooldown |
 
 ## Cert Spotter Budgets

--- a/Docs/CT_PROVIDERS.MD
+++ b/Docs/CT_PROVIDERS.MD
@@ -1,0 +1,92 @@
+# Certificate Transparency Providers
+
+DomainDetective has several CT paths. They do not have the same cost, coverage, or reliability, so services should pick a provider based on the operation instead of treating "CT" as a single generic source.
+
+## Recommended Service Usage
+
+Use Cert Spotter CT Search API for current/unexpired certificate monitoring when you have an API key and a configured budget. Use exact-host queries for monitored assets, and reserve full-domain queries for controlled subdomain expansion.
+
+Use crt.sh PostgreSQL as a best-effort historical/backfill source. The public database can return full DER certificates and historical rows, but it is a shared PostgreSQL replica and may cancel even small queries under load.
+
+Use crt.sh HTTPS only as a fallback or manual investigation path. It can hydrate a certificate by ID (`?d=`), but the public HTTPS service is slow and frequently rate-limited or unavailable.
+
+Use native CT logs for cursor-based ingestion into a local index. Direct logs are not a good ad-hoc "find everything for this domain" API because logs are append-only streams, not domain indexes.
+
+## Provider Matrix
+
+| Provider | Best For | Full Certificate Material | Notes |
+| --- | --- | --- | --- |
+| Cert Spotter | Current exact host | Yes, via `expand=cert_der` | Separate exact/full-domain budgets |
+| Cert Spotter | Subdomain expansion | Yes, if expanded | Full-domain budget is small |
+| crt.sh SQL FTS | Historical backfill | Yes, certificate table DER | Shared public DB is fragile |
+| crt.sh HTTPS | Fallback hydration | Yes, via `?d=<id>` | Slow, 503s are common |
+| Native CT logs | Local ingestion | Yes, from log entries | Needs cursors/local index |
+
+## Cert Spotter Budgets
+
+The default `CtProviderProfiles.CreateCertSpotter()` profile models the public Small CT Search API limits as separate budgets:
+
+| Budget | Default Limit |
+| --- | --- |
+| Single-hostname | 100 / hour |
+| Full-domain | 10 / hour |
+| Requests per minute | 75 / minute |
+| Requests per second | 5 / second |
+| Query timeout | 15 seconds |
+
+Single-hostname means `include_subdomains=false`. Use it for `GetLatestCertificate` on a monitored asset such as `www.example.com`.
+
+Full-domain means `include_subdomains=true`. Use it for `DiscoverSubdomains` or domain-tree refreshes such as expanding `example.com` into observed names.
+
+For exact-host full certificate queries, use:
+
+```text
+https://api.certspotter.com/v1/issuances?domain=<host>&include_subdomains=false&match_wildcards=true&expand=dns_names&expand=issuer&expand=cert_der
+```
+
+For controlled domain expansion, use:
+
+```text
+https://api.certspotter.com/v1/issuances?domain=<domain>&include_subdomains=true&expand=dns_names
+```
+
+Only add `expand=cert_der` to full-domain expansion when the caller deliberately wants to spend the full-domain budget on certificate hydration during discovery.
+
+## Query API Shape
+
+Use the `CtCertificateQuery` factories when building service workflows. They keep the service intent visible without changing provider implementations:
+
+| Service Task | Query Factory | Default Operation | Full Certificate Default |
+| --- | --- | --- | --- |
+| Latest known certificate for one monitored host | `CtCertificateQuery.ForExactHostLatest(host)` | `GetLatestCertificate` | Yes |
+| Historical certificates for one monitored host | `CtCertificateQuery.ForExactHostHistory(host)` | `GetCertificateHistory` | Yes |
+| Expand one domain into CT-observed names | `CtCertificateQuery.ForDomainExpansion(domain)` | `DiscoverSubdomains` | No |
+| Query certificate material across a domain tree | `CtCertificateQuery.ForDomainTreeCertificates(domain)` | `GetDomainTreeCertificates` | Yes |
+
+Use `ICtCertificateTransparencyProvider.QueryPagesAsync(...)` for provider calls that may return continuation tokens. The helper carries the provider runtime state forward and stops when the provider reports no more pages, returns an empty token, repeats the same token, or reaches the caller's `maxPages` safety cap.
+
+For DD Next ingestion, the safer default is a two-phase flow: run `ForDomainExpansion(domain)` to discover names, then enqueue `ForExactHostLatest(host)` for each accepted host. Only use `ForDomainTreeCertificates(domain)` when the provider is explicitly configured for broad historical collection and the caller expects the larger budget impact.
+
+## crt.sh SQL FTS
+
+crt.sh SQL FTS is the supported PostgreSQL query style against the public crt.sh database. It is still "crt.sh SQL"; the FTS part means the query searches the full-text index exposed by `identities(c.certificate)` on the `certificate` table:
+
+```sql
+WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)
+```
+
+Do not query `certificate_identity` for new code. The public crt.sh database reports that `certificate_identity` has been superseded by the full-text search index on `certificate`.
+
+DomainDetective's current crt.sh PostgreSQL metadata queries already use the supported FTS path and tests assert that `certificate_identity` is not referenced. Keep future `DomainDetective.CtSql` implementation on that path unless crt.sh publishes a new supported schema.
+
+## DD Next Planning Notes
+
+Model provider state per provider and per budget type. A Cert Spotter exact-host queue should not consume the same schedule as Cert Spotter full-domain expansion.
+
+Persist continuation tokens such as Cert Spotter `after` IDs separately from domain/subdomain records. The service should be able to resume a paged query without re-querying the first page.
+
+Store certificates by fingerprint, preferably SHA-256 DER fingerprint, and link observations from live TLS, Cert Spotter, crt.sh SQL, and native CT back to the same certificate row.
+
+Treat latest/current as a derived view, not as the only stored fact. CT latest and live TLS current can legitimately differ because live TLS requires network connectivity while CT observes public issuance.
+
+Keep crt.sh SQL behind explicit historical/backfill configuration. If PostgreSQL returns recovery-conflict, timeout, or transient-load errors, cool the provider down and continue the monitoring cycle with other providers.

--- a/Docs/CT_PROVIDERS.MD
+++ b/Docs/CT_PROVIDERS.MD
@@ -4,11 +4,20 @@ DomainDetective has several CT paths. They do not have the same cost, coverage, 
 
 ## Recommended Service Usage
 
-Use Cert Spotter CT Search API for current/unexpired certificate monitoring when you have an API key and a configured budget. Use exact-host queries for monitored assets, and reserve full-domain queries for controlled subdomain expansion.
+Use DomainDetective entry points first:
+
+| Scenario | PowerShell | CLI | C# |
+| --- | --- | --- | --- |
+| Live certificate inventory with optional CT evidence | `Invoke-DDCertificateInventory` | `DomainDetective.CLI CertificateInventoryCapture` | `CertificateInventoryCapture.CaptureAsync(...)` |
+| Add CT-observed subdomains to the monitored target set | `Invoke-DDCertificateInventory -IncludeCtSubdomains` | `CertificateInventoryCapture --include-ct-subdomains` | `CertificateInventoryCaptureOptions.IncludeCtDiscoveredSubdomains = true` |
+| Use native CT logs instead of passive public APIs | `Invoke-DDCertificateInventory -EnableNativeCtLogSubdomains -NativeCtLogOnly` | `CertificateInventoryCapture --enable-native-ct-logs --native-ct-log-only` | `CertificateInventoryCaptureOptions.EnableNativeCtLogSubdomainSource = true; NativeCtLogOnly = true` |
+| Reuse existing provider planning in a service | Use the cmdlet until a dedicated CT cmdlet exists | Use the CLI until a dedicated CT command exists | `CtIngestionPlanner`, `CtCertificateQuery`, `ICtCertificateTransparencyProvider` |
+
+Use Cert Spotter through the DomainDetective CT provider abstractions for current/unexpired certificate monitoring when you have an API key and a configured budget. Use exact-host queries for monitored assets, and reserve full-domain queries for controlled subdomain expansion.
 
 Use crt.sh PostgreSQL as a best-effort historical/backfill source. The public database can return full DER certificates and historical rows, but it is a shared PostgreSQL replica and may cancel even small queries under load.
 
-Use crt.sh HTTPS only as a fallback or manual investigation path. It can hydrate a certificate by ID (`?d=`), but the public HTTPS service is slow and frequently rate-limited or unavailable.
+Use crt.sh HTTPS only through the existing DomainDetective passive CT fallback or for manual maintainer investigation. It can hydrate a certificate by ID (`?d=`), but the public HTTPS service is slow and frequently rate-limited or unavailable.
 
 Use native CT logs for cursor-based ingestion into a local index. Direct logs are not a good ad-hoc "find everything for this domain" API because logs are append-only streams, not domain indexes.
 
@@ -38,18 +47,6 @@ Single-hostname means `include_subdomains=false`. Use it for `GetLatestCertifica
 
 Full-domain means `include_subdomains=true`. Use it for `DiscoverSubdomains` or domain-tree refreshes such as expanding `example.com` into observed names.
 
-For exact-host full certificate queries, use:
-
-```text
-https://api.certspotter.com/v1/issuances?domain=<host>&include_subdomains=false&match_wildcards=true&expand=dns_names&expand=issuer&expand=cert_der
-```
-
-For controlled domain expansion, use:
-
-```text
-https://api.certspotter.com/v1/issuances?domain=<domain>&include_subdomains=true&expand=dns_names
-```
-
 Only add `expand=cert_der` to full-domain expansion when the caller deliberately wants to spend the full-domain budget on certificate hydration during discovery.
 
 ## Query API Shape
@@ -66,6 +63,22 @@ Use the `CtCertificateQuery` factories when building service workflows. They kee
 Use `ICtCertificateTransparencyProvider.QueryPagesAsync(...)` for provider calls that may return continuation tokens. The helper carries the provider runtime state forward and stops when the provider reports no more pages, returns an empty token, repeats the same token, or reaches the caller's `maxPages` safety cap.
 
 For DD Next ingestion, the safer default is a two-phase flow: run `ForDomainExpansion(domain)` to discover names, then enqueue `ForExactHostLatest(host)` for each accepted host. Only use `ForDomainTreeCertificates(domain)` when the provider is explicitly configured for broad historical collection and the caller expects the larger budget impact.
+
+## Provider HTTP Shape
+
+This section is for maintainers implementing or debugging providers. Consumer code should use DomainDetective cmdlets, CLI commands, or C# APIs rather than constructing provider URLs directly.
+
+For Cert Spotter exact-host full certificate queries, the provider implementation should build a request equivalent to:
+
+```text
+https://api.certspotter.com/v1/issuances?domain=<host>&include_subdomains=false&match_wildcards=true&expand=dns_names&expand=issuer&expand=cert_der
+```
+
+For controlled Cert Spotter domain expansion, the provider implementation should build a request equivalent to:
+
+```text
+https://api.certspotter.com/v1/issuances?domain=<domain>&include_subdomains=true&expand=dns_names
+```
 
 ## crt.sh SQL FTS
 

--- a/Docs/CT_PROVIDERS.MD
+++ b/Docs/CT_PROVIDERS.MD
@@ -31,6 +31,20 @@ Use native CT logs for cursor-based ingestion into a local index. Direct logs ar
 | crt.sh HTTPS | Fallback hydration | Yes, via `?d=<id>` | Slow, 503s are common |
 | Native CT logs | Local ingestion | Yes, from log entries | Needs cursors/local index |
 
+## eurofins.com Smoke-Test Observations
+
+These observations came from an ad-hoc live smoke test against `eurofins.com`. Treat them as directional evidence for service design, not as provider SLAs.
+
+| Path | Observed Time | Observed Result | Service Guidance |
+| --- | --- | --- | --- |
+| Live TLS probe for `eurofins.com` | 468 ms | Returned the live Amazon RSA 2048 M02 certificate, expiring 2026-06-11 | Best current-state source when the endpoint is reachable |
+| Cert Spotter exact-host DER query | 514 ms | Returned 4 rows, latest unexpired CT certificate expiring 2026-05-25 | Good for latest known public issuance when endpoint reachability is not guaranteed |
+| Cert Spotter domain expansion through DomainDetective | 2.37 s | Processed 100 CT observations and produced 397 subdomains; expansion did not include full DER because it used `expand=dns_names` | Good expansion source; follow with exact-host queries for full latest certificates |
+| crt.sh HTTPS exact query with DER hydration | 74.8 s | Eventually returned certificate material, but was much slower than Cert Spotter | Fallback/manual path only |
+| crt.sh HTTPS expansion through DomainDetective | 40 s | Failed with HTTP 503 | Do not rely on this for service-scale expansion |
+| Native CT limited tail scan | 13 s | No `eurofins.com` entries found in the small scanned window | Useful only with persisted cursors/local indexing, not ad-hoc domain lookup |
+| crt.sh PostgreSQL public DB rich query | Not comparable | DomainDetective-style query was canceled by the public replica due recovery conflict; simpler FTS probes against `certificate` worked | Best-effort historical/backfill path with strict timeout and cooldown |
+
 ## Cert Spotter Budgets
 
 The default `CtProviderProfiles.CreateCertSpotter()` profile models the public Small CT Search API limits as separate budgets:
@@ -91,6 +105,8 @@ WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)
 Do not query `certificate_identity` for new code. The public crt.sh database reports that `certificate_identity` has been superseded by the full-text search index on `certificate`.
 
 DomainDetective's current crt.sh PostgreSQL metadata queries already use the supported FTS path and tests assert that `certificate_identity` is not referenced. Keep future `DomainDetective.CtSql` implementation on that path unless crt.sh publishes a new supported schema.
+
+Current typed status: the in-tree fallback uses parameterized Npgsql commands, typed array parameters for domain batches, an internal `CrtShPostgreSqlExactMetadataRow` mapping type, and returns DomainDetective objects such as `SubdomainDiscoveryEntry`. It is not yet a fully typed public `DomainDetective.CtSql` provider surface: the SQL is still a handwritten string in the base package, the public `DomainDetective.CtSql` package is a registration shell, and the CT SQL provider still needs to move into that package with a typed `CtCertificateQuery` / `CtCertificateQueryResult` implementation.
 
 ## DD Next Planning Notes
 

--- a/Docs/CT_TIMELINE.MD
+++ b/Docs/CT_TIMELINE.MD
@@ -60,4 +60,5 @@ When a cap is hit, `ResultsCapped` is set and an informational assessment is emi
 - CT data is an observation set, not a complete certificate inventory.
 - Some CT rows may omit validity window fields; validity status is best-effort.
 - Very large domains may hit caps; raise limits cautiously if needed.
+- Provider behavior and budgets differ by source. See [CT_PROVIDERS.MD](CT_PROVIDERS.MD) before using CT timeline or discovery paths in a service workflow.
 

--- a/Docs/README.MD
+++ b/Docs/README.MD
@@ -23,13 +23,16 @@ Certificate transparency timeline (issuance velocity, issuer diversity, validity
 ### 7. [SUBDOMAINS.MD](SUBDOMAINS.MD)
 CT-backed subdomain discovery (bounded + optional DNS verification).
 
-### 8. [DNS_PROPAGATION.MD](DNS_PROPAGATION.MD)
+### 8. [CT_PROVIDERS.MD](CT_PROVIDERS.MD)
+Certificate transparency provider selection, budgets, and crt.sh SQL FTS guidance.
+
+### 9. [DNS_PROPAGATION.MD](DNS_PROPAGATION.MD)
 Multi-resolver DNS propagation visibility with map visualization and rollups.
 
-### 9. [DESIRED_STATE.MD](DESIRED_STATE.MD)
+### 10. [DESIRED_STATE.MD](DESIRED_STATE.MD)
 Custom baselines (desired state configuration) for drift/non-conformance detection.
 
-### 10. [CERTIFICATE_INVENTORY.MD](CERTIFICATE_INVENTORY.MD)
+### 11. [CERTIFICATE_INVENTORY.MD](CERTIFICATE_INVENTORY.MD)
 End-to-end certificate inventory/discovery usage (live capture, snapshots, risk/drift/policy) with PowerShell and C# examples.
 
 ## Main TODO

--- a/Docs/SUBDOMAINS.MD
+++ b/Docs/SUBDOMAINS.MD
@@ -46,3 +46,4 @@ DNS verification uses `DomainDetective.DnsConfiguration` and supports overriding
 - DNS verification is intentionally bounded for performance; entries beyond the cap remain `Unknown`.
 - IDN normalization is applied; invalid hostnames are skipped.
 - Very large CT result sets may be capped (`ResultsCapped = true`) to protect performance; raise caps cautiously if needed.
+- Cert Spotter exact-host and full-domain expansion queries have different budgets. See [CT_PROVIDERS.MD](CT_PROVIDERS.MD) before scheduling service-scale expansion.

--- a/DomainDetective.CtSql/CrtShPostgreSqlMetadataProvider.cs
+++ b/DomainDetective.CtSql/CrtShPostgreSqlMetadataProvider.cs
@@ -129,6 +129,7 @@ internal sealed class CrtShPostgreSqlMetadataProvider : ICtSqlMetadataProvider {
         }
 
         int timeoutSeconds = Math.Max(1, options?.CrtShPostgreSqlCommandTimeoutSeconds ?? 15);
+        // DBAClientX forwards the connection string to its PostgreSQL driver, so these Npgsql timeout keys remain effective.
         return PostgreSql.BuildConnectionString(
             host: "crt.sh",
             database: "certwatch",

--- a/DomainDetective.CtSql/CrtShPostgreSqlMetadataProvider.cs
+++ b/DomainDetective.CtSql/CrtShPostgreSqlMetadataProvider.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DBAClientX;
+using DomainDetective;
+
+namespace DomainDetective.CtSql;
+
+internal sealed class CrtShPostgreSqlMetadataProvider : ICtSqlMetadataProvider {
+    private readonly PostgreSql _client = new();
+
+    public async Task<SubdomainDiscoveryEntry?> QueryExactMetadataAsync(
+        string hostName,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken) {
+        if (string.IsNullOrWhiteSpace(hostName) || options == null) {
+            return null;
+        }
+
+        string normalizedHost = hostName.Trim().TrimEnd('.').ToLowerInvariant();
+        IReadOnlyList<CertificateInventoryCapture.CrtShPostgreSqlExactMetadataRow> rows = await _client.QueryAsListAsync(
+            BuildCrtShPostgreSqlConnectionString(options),
+            CertificateInventoryCapture.BuildCrtShPostgreSqlExactMetadataQuery(),
+            MapRow,
+            new Dictionary<string, object?> {
+                ["host"] = normalizedHost
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        SubdomainDiscoveryEntry? entry = CertificateInventoryCapture.TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
+            normalizedHost,
+            rows,
+            targetedThumbprints);
+        if (entry != null) {
+            logger?.WriteVerbose(
+                "CT metadata backfill exact PostgreSQL lookup matched {0} row(s) for {1}.",
+                rows.Count,
+                normalizedHost);
+        }
+
+        return entry;
+    }
+
+    public async Task<IReadOnlyDictionary<string, SubdomainDiscoveryEntry>> QueryDomainMetadataAsync(
+        string domain,
+        IReadOnlyCollection<string> hostNames,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken) {
+        var results = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(domain) || hostNames == null || hostNames.Count == 0 || options == null) {
+            return results;
+        }
+
+        string normalizedDomain = domain.Trim().TrimEnd('.').ToLowerInvariant();
+        List<string> normalizedHosts = hostNames
+            .Where(static host => !string.IsNullOrWhiteSpace(host))
+            .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (normalizedHosts.Count == 0) {
+            return results;
+        }
+
+        IReadOnlyList<CertificateInventoryCapture.CrtShPostgreSqlExactMetadataRow> rows = await _client.QueryAsListAsync(
+            BuildCrtShPostgreSqlConnectionString(options),
+            CertificateInventoryCapture.BuildCrtShPostgreSqlDomainMetadataQuery(),
+            MapRow,
+            new Dictionary<string, object?> {
+                ["domain"] = normalizedDomain,
+                ["hosts"] = normalizedHosts.ToArray(),
+                ["wildcardHosts"] = normalizedHosts.Select(CertificateInventoryCapture.BuildWildcardCandidateHost).ToArray(),
+                ["limit"] = Math.Min(Math.Max(32, normalizedHosts.Count * 8), 512)
+            },
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        foreach (string normalizedHost in normalizedHosts) {
+            SubdomainDiscoveryEntry? entry = CertificateInventoryCapture.TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
+                normalizedHost,
+                rows,
+                targetedThumbprints);
+            if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
+                continue;
+            }
+
+            results[normalizedHost] = entry;
+        }
+
+        if (results.Count > 0) {
+            logger?.WriteVerbose(
+                "CT metadata backfill domain PostgreSQL lookup matched {0} host(s) for {1} from {2} candidate certificate row(s).",
+                results.Count,
+                normalizedDomain,
+                rows.Count);
+        }
+
+        return results;
+    }
+
+    private static CertificateInventoryCapture.CrtShPostgreSqlExactMetadataRow MapRow(IDataRecord row) {
+        return new CertificateInventoryCapture.CrtShPostgreSqlExactMetadataRow {
+            CertificateDer = row.IsDBNull(0) ? null : (byte[])row.GetValue(0),
+            EntryTimestampUtc = row.IsDBNull(1) ? null : ReadDateTimeOffset(row.GetValue(1)),
+            CommonName = row.IsDBNull(2) ? null : row.GetString(2),
+            IssuerName = row.IsDBNull(3) ? null : row.GetString(3),
+            SerialNumber = row.IsDBNull(4) ? null : row.GetString(4),
+            NotBeforeUtc = row.IsDBNull(5) ? null : ReadDateTimeOffset(row.GetValue(5)),
+            NotAfterUtc = row.IsDBNull(6) ? null : ReadDateTimeOffset(row.GetValue(6)),
+            CandidateNames = row.IsDBNull(7)
+                ? Array.Empty<string>()
+                : ((string[])row.GetValue(7))
+                    .Select(static name => NormalizeCtMetadataCandidate(name, preserveWildcard: true))
+                    .Where(static name => !string.IsNullOrWhiteSpace(name))
+                    .Select(static name => name!)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList()
+        };
+    }
+
+    private static string BuildCrtShPostgreSqlConnectionString(CertificateInventoryCaptureOptions options) {
+        if (!string.IsNullOrWhiteSpace(options?.CrtShPostgreSqlConnectionString)) {
+            return options!.CrtShPostgreSqlConnectionString!;
+        }
+
+        int timeoutSeconds = Math.Max(1, options?.CrtShPostgreSqlCommandTimeoutSeconds ?? 15);
+        return PostgreSql.BuildConnectionString(
+            host: "crt.sh",
+            database: "certwatch",
+            username: "guest",
+            password: string.Empty,
+            port: 5432,
+            ssl: true) +
+            $";Timeout={timeoutSeconds};Command Timeout={timeoutSeconds}";
+    }
+
+    private static DateTimeOffset? ReadDateTimeOffset(object? value) {
+        return value switch {
+            null => null,
+            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
+            DateTime dateTime => new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)),
+            _ => DateTimeOffset.TryParse(
+                value.ToString(),
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
+                out DateTimeOffset parsed)
+                ? parsed
+                : (DateTimeOffset?)null
+        };
+    }
+
+    private static string? NormalizeCtMetadataCandidate(string? value, bool preserveWildcard = false) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return null;
+        }
+
+        string normalized = value!.Trim().TrimEnd('.').ToLowerInvariant();
+        while (!preserveWildcard && normalized.StartsWith("*.", StringComparison.Ordinal)) {
+            normalized = normalized.Substring(2);
+        }
+
+        return normalized.Length == 0 ? null : normalized;
+    }
+}

--- a/DomainDetective.CtSql/DomainDetective.CtSql.csproj
+++ b/DomainDetective.CtSql/DomainDetective.CtSql.csproj
@@ -16,4 +16,8 @@
         <ProjectReference Include="..\DomainDetective\DomainDetective.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+        <PackageReference Include="DBAClientX.PostgreSql" Version="0.4.0" />
+    </ItemGroup>
+
 </Project>

--- a/DomainDetective.CtSql/DomainDetectiveCtSqlRegistration.cs
+++ b/DomainDetective.CtSql/DomainDetectiveCtSqlRegistration.cs
@@ -6,10 +6,19 @@ using DomainDetective;
 namespace DomainDetective.CtSql;
 
 /// <summary>
-/// Prepared registration entry point for future CT SQL extraction.
+/// Registers the optional CT SQL provider for DomainDetective certificate inventory enrichment.
 /// </summary>
 public static class DomainDetectiveCtSqlRegistration
 {
+    /// <summary>
+    /// Registers the bundled DbaClientX-backed crt.sh PostgreSQL provider.
+    /// </summary>
+    /// <remarks>Call this once during application startup before running CT metadata capture that enables <see cref="CertificateInventoryCaptureOptions.EnableCrtShPostgreSqlMetadataFallback"/>.</remarks>
+    public static void Register()
+    {
+        DomainDetectiveOptionalFeatures.RegisterCtSqlMetadataProvider(new CrtShPostgreSqlMetadataProvider());
+    }
+
     /// <summary>
     /// Registers a caller-supplied CT SQL exact metadata provider, replacing any provider already registered.
     /// </summary>

--- a/DomainDetective.CtSql/NuGet.README.md
+++ b/DomainDetective.CtSql/NuGet.README.md
@@ -1,12 +1,25 @@
 # DomainDetective.CtSql
 
-`DomainDetective.CtSql` is the prepared package shell for the future Certificate Transparency SQL extraction.
+`DomainDetective.CtSql` contains the optional crt.sh PostgreSQL Certificate Transparency metadata provider.
 
-The current PostgreSQL-backed CT implementation still lives in the base `DomainDetective` package. This package exists so the eventual move can happen with a stable package identity and registration surface.
+Use it when you want CT metadata enrichment from the public crt.sh PostgreSQL replica without adding PostgreSQL dependencies to the base `DomainDetective` package.
 
-This package does not activate a built-in provider yet. If you call `DomainDetectiveCtSqlRegistration.Register(...)` in this release, pass your own exact-host metadata provider delegate; the bundled implementation will move here in a future release.
+```csharp
+using DomainDetective;
+using DomainDetective.CtSql;
 
-Future crt.sh PostgreSQL implementation should use crt.sh SQL FTS on the `certificate` table:
+DomainDetectiveCtSqlRegistration.Register();
+
+var options = new CertificateInventoryCaptureOptions {
+    EnableCrtShPostgreSqlMetadataFallback = true,
+    CrtShPostgreSqlCommandTimeoutSeconds = 15,
+    CrtShPostgreSqlMaximumConcurrentRequests = 2
+};
+```
+
+The provider uses DbaClientX for typed PostgreSQL query execution and keeps the supported crt.sh full-text search path (`identities(c.certificate)`) rather than the superseded `certificate_identity` table.
+
+The crt.sh PostgreSQL implementation uses crt.sh SQL FTS on the `certificate` table:
 
 ```sql
 WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)

--- a/DomainDetective.CtSql/NuGet.README.md
+++ b/DomainDetective.CtSql/NuGet.README.md
@@ -5,3 +5,11 @@
 The current PostgreSQL-backed CT implementation still lives in the base `DomainDetective` package. This package exists so the eventual move can happen with a stable package identity and registration surface.
 
 This package does not activate a built-in provider yet. If you call `DomainDetectiveCtSqlRegistration.Register(...)` in this release, pass your own exact-host metadata provider delegate; the bundled implementation will move here in a future release.
+
+Future crt.sh PostgreSQL implementation should use crt.sh SQL FTS on the `certificate` table:
+
+```sql
+WHERE identities(c.certificate) @@ plainto_tsquery('simple', @host)
+```
+
+Do not build new code against `certificate_identity`; crt.sh reports that table is superseded by the full-text search index on `certificate`. Treat public crt.sh PostgreSQL as best-effort historical/backfill infrastructure and apply strict timeouts/cooldowns.

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -4199,9 +4199,6 @@ public class TestCertificateInventoryCapture {
         Assert.Equal("api.example.com", entry.Name);
         Assert.Equal("EXACT-FALLBACK-THUMBPRINT-001", entry.LatestCertificateThumbprint);
         Assert.Contains(
-            warnings,
-            warning => warning.Contains("domain PostgreSQL lookup failed", StringComparison.OrdinalIgnoreCase));
-        Assert.Contains(
             overrideBatches,
             hosts => hosts.Count == 1 &&
                      string.Equals(hosts[0], "example.com", StringComparison.OrdinalIgnoreCase));
@@ -4215,6 +4212,74 @@ public class TestCertificateInventoryCapture {
         Assert.DoesNotContain(
             verboseMessages,
             message => message.Contains("skipping exact passive CT metadata", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task BackfillMissingCtCertificateMetadataAsync_UsesExactPostgreSqlProviderWhenDomainProviderIsUnavailable()
+    {
+        var capture = new CertificateInventoryCapture
+        {
+            CtPassiveMetadataBackfillOverride = (_, _, _, _) =>
+                throw new InvalidOperationException("Passive CT exact metadata query should not run when exact PostgreSQL metadata hydrates the host."),
+            CtExactMetadataPostgreSqlOverride = (host, _, _, _) =>
+            {
+                if (!string.Equals(host, "api.example.com", StringComparison.OrdinalIgnoreCase))
+                {
+                    return Task.FromResult<SubdomainDiscoveryEntry?>(null);
+                }
+
+                return Task.FromResult<SubdomainDiscoveryEntry?>(
+                    new SubdomainDiscoveryEntry
+                    {
+                        Name = "api.example.com",
+                        LatestCertificateThumbprint = "EXACT-SQL-THUMBPRINT-001",
+                        LatestCertificateSubjectAlternativeNames = new[] { "api.example.com" },
+                        CtSources = new[] { "crt.sh-db" }
+                    });
+            }
+        };
+
+        var method = typeof(CertificateInventoryCapture).GetMethod(
+            "BackfillMissingCtCertificateMetadataAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(method);
+
+        var warnings = new List<string>();
+        var options = new CertificateInventoryCaptureOptions
+        {
+            EnablePassiveCtFallback = false,
+            EnablePassiveCtMetadataFallback = false,
+            EnableCrtShPostgreSqlMetadataFallback = true,
+            BackfillMissingCtCertificateMetadata = true
+        };
+
+        Task<IReadOnlyList<SubdomainDiscoveryEntry>> task =
+            (Task<IReadOnlyList<SubdomainDiscoveryEntry>>)method!.Invoke(
+                capture,
+                new object[]
+                {
+                    new[] { "example.com" },
+                    new[]
+                    {
+                        new SubdomainDiscoveryEntry
+                        {
+                            Name = "api.example.com"
+                        }
+                    },
+                    options,
+                    warnings,
+                    new List<PassiveCtDiagnosticEntry>(),
+                    new InternalLogger(false),
+                    CancellationToken.None
+                })!;
+
+        IReadOnlyList<SubdomainDiscoveryEntry> result = await task;
+
+        SubdomainDiscoveryEntry entry = Assert.Single(result);
+        Assert.Equal("api.example.com", entry.Name);
+        Assert.Equal("EXACT-SQL-THUMBPRINT-001", entry.LatestCertificateThumbprint);
+        Assert.Empty(warnings);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -4283,6 +4283,68 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task BackfillMissingCtCertificateMetadataAsync_SkipsPostgreSqlProviderWhenFallbackDisabled()
+    {
+        int exactPostgreSqlLookupCount = 0;
+        var capture = new CertificateInventoryCapture
+        {
+            CtExactMetadataPostgreSqlOverride = (host, _, _, _) =>
+            {
+                exactPostgreSqlLookupCount++;
+                return Task.FromResult<SubdomainDiscoveryEntry?>(
+                    new SubdomainDiscoveryEntry
+                    {
+                        Name = host,
+                        LatestCertificateThumbprint = "SHOULD-NOT-BE-USED"
+                    });
+            }
+        };
+
+        var method = typeof(CertificateInventoryCapture).GetMethod(
+            "BackfillMissingCtCertificateMetadataAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        Assert.NotNull(method);
+
+        var warnings = new List<string>();
+        var options = new CertificateInventoryCaptureOptions
+        {
+            EnablePassiveCtFallback = false,
+            EnablePassiveCtMetadataFallback = false,
+            EnableCrtShPostgreSqlMetadataFallback = false,
+            BackfillMissingCtCertificateMetadata = true
+        };
+
+        Task<IReadOnlyList<SubdomainDiscoveryEntry>> task =
+            (Task<IReadOnlyList<SubdomainDiscoveryEntry>>)method!.Invoke(
+                capture,
+                new object[]
+                {
+                    new[] { "example.com" },
+                    new[]
+                    {
+                        new SubdomainDiscoveryEntry
+                        {
+                            Name = "api.example.com"
+                        }
+                    },
+                    options,
+                    warnings,
+                    new List<PassiveCtDiagnosticEntry>(),
+                    new InternalLogger(false),
+                    CancellationToken.None
+                })!;
+
+        IReadOnlyList<SubdomainDiscoveryEntry> result = await task;
+
+        SubdomainDiscoveryEntry entry = Assert.Single(result);
+        Assert.Equal("api.example.com", entry.Name);
+        Assert.Null(entry.LatestCertificateThumbprint);
+        Assert.Equal(0, exactPostgreSqlLookupCount);
+        Assert.Empty(warnings);
+    }
+
+    [Fact]
     public async Task CaptureAsync_DoesNotAnnounceExactPassiveMetadataQueryWhenSharedCooldownAlreadyBlocksRun()
     {
         PassiveCtSourceClient.ResetSharedStateForTesting();

--- a/DomainDetective.Tests/TestCtCertificateQuery.cs
+++ b/DomainDetective.Tests/TestCtCertificateQuery.cs
@@ -48,9 +48,9 @@ public class TestCtCertificateQuery
     }
 
     [Fact]
-    public async Task QueryPagesStopsWhenProviderRepeatsContinuationToken()
+    public async Task QueryPagesStopsWhenProviderRepeatsAnyContinuationToken()
     {
-        var provider = new RepeatingTokenProvider();
+        var provider = new CyclingTokenProvider();
         var results = new List<CtCertificateQueryResult>();
 
         await foreach (CtCertificateQueryResult result in provider.QueryPagesAsync(
@@ -59,8 +59,8 @@ public class TestCtCertificateQuery
             results.Add(result);
         }
 
-        Assert.Equal(2, results.Count);
-        Assert.Equal(2, provider.CallCount);
+        Assert.Equal(3, results.Count);
+        Assert.Equal(3, provider.CallCount);
     }
 
     [Theory]
@@ -116,15 +116,17 @@ public class TestCtCertificateQuery
         Assert.Equal(CtIngestionOperation.GetDomainTreeCertificates, normalized.Operations);
     }
 
-    private sealed class RepeatingTokenProvider : ICtCertificateTransparencyProvider
+    private sealed class CyclingTokenProvider : ICtCertificateTransparencyProvider
     {
+        private readonly string[] _tokens = { "token-a", "token-b", "token-a" };
+
         public int CallCount { get; private set; }
 
-        public string ProviderId => "repeat-token";
+        public string ProviderId => "cycling-token";
 
         public CtProviderProfile Profile { get; } = new()
         {
-            ProviderId = "repeat-token",
+            ProviderId = "cycling-token",
             Capabilities = CtProviderCapabilities.ExactHostLookup |
                            CtProviderCapabilities.CertificateHistory
         };
@@ -134,12 +136,13 @@ public class TestCtCertificateQuery
             CtProviderRuntimeState? runtimeState = null,
             CancellationToken cancellationToken = default)
         {
+            string continuationToken = _tokens[Math.Min(CallCount, _tokens.Length - 1)];
             CallCount++;
             return Task.FromResult(new CtCertificateQueryResult
             {
                 ProviderId = ProviderId,
                 HasMore = true,
-                ContinuationToken = "repeat-token"
+                ContinuationToken = continuationToken
             });
         }
     }

--- a/DomainDetective.Tests/TestCtCertificateQuery.cs
+++ b/DomainDetective.Tests/TestCtCertificateQuery.cs
@@ -22,10 +22,64 @@ public class TestCtCertificateQuery
         CtCertificateQuery normalized = query.Normalize();
 
         Assert.Equal("www.example.com", normalized.Name);
+        Assert.Equal(CtCertificateQueryKind.ExactHostLatest, normalized.QueryKind);
         Assert.Equal(CtIngestionOperation.GetLatestCertificate, normalized.Operations);
         Assert.False(normalized.RequireFullCertificate);
         Assert.Equal("next-page", normalized.ContinuationToken);
         Assert.Null(normalized.PageSize);
         Assert.Null(normalized.Timeout);
+    }
+
+    [Theory]
+    [InlineData(nameof(CtCertificateQuery.ForExactHostLatest), CtCertificateQueryKind.ExactHostLatest, CtIngestionOperation.GetLatestCertificate, true)]
+    [InlineData(nameof(CtCertificateQuery.ForExactHostHistory), CtCertificateQueryKind.ExactHostHistory, CtIngestionOperation.GetCertificateHistory, true)]
+    [InlineData(nameof(CtCertificateQuery.ForDomainExpansion), CtCertificateQueryKind.DomainExpansion, CtIngestionOperation.DiscoverSubdomains, false)]
+    [InlineData(nameof(CtCertificateQuery.ForDomainTreeCertificates), CtCertificateQueryKind.DomainTreeCertificates, CtIngestionOperation.GetDomainTreeCertificates, true)]
+    public void FactoriesDescribeProviderIntent(string factoryName, CtCertificateQueryKind queryKind, CtIngestionOperation operations, bool requireFullCertificate)
+    {
+        CtCertificateQuery query = factoryName switch
+        {
+            nameof(CtCertificateQuery.ForExactHostLatest) => CtCertificateQuery.ForExactHostLatest("www.example.com"),
+            nameof(CtCertificateQuery.ForExactHostHistory) => CtCertificateQuery.ForExactHostHistory("www.example.com"),
+            nameof(CtCertificateQuery.ForDomainExpansion) => CtCertificateQuery.ForDomainExpansion("example.com"),
+            nameof(CtCertificateQuery.ForDomainTreeCertificates) => CtCertificateQuery.ForDomainTreeCertificates("example.com"),
+            _ => throw new InvalidOperationException("Unexpected CT query factory.")
+        };
+
+        Assert.Equal(queryKind, query.QueryKind);
+        Assert.Equal(operations, query.Operations);
+        Assert.Equal(requireFullCertificate, query.RequireFullCertificate);
+    }
+
+    [Fact]
+    public void NormalizeResolvesOperationsFromQueryKind()
+    {
+        var query = new CtCertificateQuery
+        {
+            Name = "example.com",
+            QueryKind = CtCertificateQueryKind.DomainExpansion,
+            Operations = CtIngestionOperation.None
+        };
+
+        CtCertificateQuery normalized = query.Normalize();
+
+        Assert.Equal(CtCertificateQueryKind.DomainExpansion, normalized.QueryKind);
+        Assert.Equal(CtIngestionOperation.DiscoverSubdomains, normalized.Operations);
+    }
+
+    [Fact]
+    public void NormalizeCorrectsMismatchedQueryKindFromOperations()
+    {
+        var query = new CtCertificateQuery
+        {
+            Name = "example.com",
+            QueryKind = CtCertificateQueryKind.ExactHostLatest,
+            Operations = CtIngestionOperation.GetDomainTreeCertificates
+        };
+
+        CtCertificateQuery normalized = query.Normalize();
+
+        Assert.Equal(CtCertificateQueryKind.DomainTreeCertificates, normalized.QueryKind);
+        Assert.Equal(CtIngestionOperation.GetDomainTreeCertificates, normalized.Operations);
     }
 }

--- a/DomainDetective.Tests/TestCtCertificateQuery.cs
+++ b/DomainDetective.Tests/TestCtCertificateQuery.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using DomainDetective;
 using Xunit;
 
@@ -28,6 +31,36 @@ public class TestCtCertificateQuery
         Assert.Equal("next-page", normalized.ContinuationToken);
         Assert.Null(normalized.PageSize);
         Assert.Null(normalized.Timeout);
+    }
+
+    [Fact]
+    public void NormalizeDropsWhitespaceContinuationToken()
+    {
+        var query = new CtCertificateQuery
+        {
+            Name = "www.example.com",
+            ContinuationToken = "   "
+        };
+
+        CtCertificateQuery normalized = query.Normalize();
+
+        Assert.Null(normalized.ContinuationToken);
+    }
+
+    [Fact]
+    public async Task QueryPagesStopsWhenProviderRepeatsContinuationToken()
+    {
+        var provider = new RepeatingTokenProvider();
+        var results = new List<CtCertificateQueryResult>();
+
+        await foreach (CtCertificateQueryResult result in provider.QueryPagesAsync(
+                           CtCertificateQuery.ForExactHostHistory("www.example.com")))
+        {
+            results.Add(result);
+        }
+
+        Assert.Equal(2, results.Count);
+        Assert.Equal(2, provider.CallCount);
     }
 
     [Theory]
@@ -81,5 +114,33 @@ public class TestCtCertificateQuery
 
         Assert.Equal(CtCertificateQueryKind.DomainTreeCertificates, normalized.QueryKind);
         Assert.Equal(CtIngestionOperation.GetDomainTreeCertificates, normalized.Operations);
+    }
+
+    private sealed class RepeatingTokenProvider : ICtCertificateTransparencyProvider
+    {
+        public int CallCount { get; private set; }
+
+        public string ProviderId => "repeat-token";
+
+        public CtProviderProfile Profile { get; } = new()
+        {
+            ProviderId = "repeat-token",
+            Capabilities = CtProviderCapabilities.ExactHostLookup |
+                           CtProviderCapabilities.CertificateHistory
+        };
+
+        public Task<CtCertificateQueryResult> QueryAsync(
+            CtCertificateQuery query,
+            CtProviderRuntimeState? runtimeState = null,
+            CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(new CtCertificateQueryResult
+            {
+                ProviderId = ProviderId,
+                HasMore = true,
+                ContinuationToken = "repeat-token"
+            });
+        }
     }
 }

--- a/DomainDetective.Tests/TestCtCertificateQuery.cs
+++ b/DomainDetective.Tests/TestCtCertificateQuery.cs
@@ -1,0 +1,31 @@
+using System;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestCtCertificateQuery
+{
+    [Fact]
+    public void NormalizeTrimsNamesAndDropsInvalidPaging()
+    {
+        var query = new CtCertificateQuery
+        {
+            Name = "  www.example.com  ",
+            Operations = CtIngestionOperation.None,
+            RequireFullCertificate = false,
+            ContinuationToken = "  next-page  ",
+            PageSize = 0,
+            Timeout = TimeSpan.Zero
+        };
+
+        CtCertificateQuery normalized = query.Normalize();
+
+        Assert.Equal("www.example.com", normalized.Name);
+        Assert.Equal(CtIngestionOperation.GetLatestCertificate, normalized.Operations);
+        Assert.False(normalized.RequireFullCertificate);
+        Assert.Equal("next-page", normalized.ContinuationToken);
+        Assert.Null(normalized.PageSize);
+        Assert.Null(normalized.Timeout);
+    }
+}

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -1,0 +1,137 @@
+using System;
+using DomainDetective;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestCtIngestionPlanner
+{
+    [Fact]
+    public void CrtShHttpDefaultUsesConservativePublicLimit()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+
+        Assert.Equal(CtProviderProfiles.CrtShHttpProviderId, profile.ProviderId);
+        Assert.Equal(5, profile.RateLimit.MaxRequestsPerMinute);
+        Assert.Equal(1, profile.RateLimit.MaxConcurrentRequests);
+        Assert.True(profile.RateLimit.MinimumRequestSpacing >= TimeSpan.FromSeconds(12));
+        Assert.True(CtIngestionPlanner.SupportsOperation(
+            profile,
+            CtIngestionOperation.DiscoverSubdomains,
+            requireFullCertificate: false));
+        Assert.False(CtIngestionPlanner.SupportsOperation(
+            profile,
+            CtIngestionOperation.GetCertificateHistory,
+            requireFullCertificate: true));
+    }
+
+    [Fact]
+    public void CrtShSqlDefaultSupportsFullHistoryWithLimitedConcurrency()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShPostgreSql();
+
+        Assert.Equal(CtProviderProfiles.CrtShPostgreSqlProviderId, profile.ProviderId);
+        Assert.Equal(2, profile.RateLimit.MaxConcurrentRequests);
+        Assert.True(CtIngestionPlanner.SupportsOperation(
+            profile,
+            CtIngestionOperation.GetCertificateHistory,
+            requireFullCertificate: true));
+        Assert.True(CtIngestionPlanner.SupportsOperation(
+            profile,
+            CtIngestionOperation.GetDomainTreeCertificates,
+            requireFullCertificate: true));
+    }
+
+    [Fact]
+    public void EstimateCapacityUsesMostConservativeSpacing()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+
+        CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 20_000, now);
+
+        Assert.Equal(TimeSpan.FromSeconds(15), estimate.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromSeconds(15 * 19_999), estimate.EstimatedMinimumDuration);
+        Assert.Equal(now + TimeSpan.FromSeconds(15 * 19_999), estimate.EstimatedCompletionUtc);
+        Assert.True(estimate.IsRateLimited);
+    }
+
+    [Fact]
+    public void DecideDefersProviderWhenCooldownIsActive()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var state = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            CooldownUntilUtc = now.AddMinutes(10)
+        };
+
+        CtProviderExecutionDecision decision = CtIngestionPlanner.Decide(profile, state, now);
+
+        Assert.False(decision.CanRunNow);
+        Assert.Equal(now.AddMinutes(10), decision.DeferUntilUtc);
+        Assert.Equal(1, decision.MaxConcurrentRequests);
+    }
+
+    [Fact]
+    public void DecideAllowsProviderWithoutActiveCooldown()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCertSpotter();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+
+        CtProviderExecutionDecision decision = CtIngestionPlanner.Decide(profile, state: null, nowUtc: now);
+
+        Assert.True(decision.CanRunNow);
+        Assert.Null(decision.DeferUntilUtc);
+        Assert.Equal(1, decision.MaxConcurrentRequests);
+    }
+
+    [Fact]
+    public void CtCertificateRecordReportsFullCertificateAvailability()
+    {
+        var metadataOnly = new CtCertificateRecord
+        {
+            ProviderId = CtProviderProfiles.CrtShHttpProviderId,
+            Sha256Fingerprint = "ABC"
+        };
+        var derBacked = new CtCertificateRecord
+        {
+            ProviderId = CtProviderProfiles.CertSpotterProviderId,
+            CertificateDer = new byte[] { 1, 2, 3 }
+        };
+
+        Assert.False(metadataOnly.HasFullCertificate);
+        Assert.True(derBacked.HasFullCertificate);
+    }
+
+    [Fact]
+    public void ProviderProfilesCanReflectInventoryOptions()
+    {
+        var options = new CertificateInventoryCaptureOptions
+        {
+            PassiveCtCrtShMinimumSpacing = TimeSpan.FromSeconds(30),
+            PassiveCtCertSpotterMinimumSpacing = TimeSpan.FromSeconds(45),
+            PassiveCtRequestTimeout = TimeSpan.FromSeconds(10),
+            PassiveCtCrtShMaximumRequestsPerRun = 7,
+            CrtShPostgreSqlMaximumConcurrentRequests = 3,
+            CrtShPostgreSqlCommandTimeoutSeconds = 20,
+            NativeCtRequestDelay = TimeSpan.FromMilliseconds(250),
+            DiscoveryParallelism = 6,
+            NativeCtMaxLogs = 4
+        };
+
+        CtProviderProfile crtSh = CtProviderProfiles.CreateCrtShHttp(options);
+        CtProviderProfile certSpotter = CtProviderProfiles.CreateCertSpotter(options);
+        CtProviderProfile sql = CtProviderProfiles.CreateCrtShPostgreSql(options);
+        CtProviderProfile native = CtProviderProfiles.CreateNativeCtLogs(options);
+
+        Assert.Equal(TimeSpan.FromSeconds(30), crtSh.RateLimit.MinimumRequestSpacing);
+        Assert.Equal(7, crtSh.RateLimit.MaximumRequestsPerRun);
+        Assert.Equal(TimeSpan.FromSeconds(45), certSpotter.RateLimit.MinimumRequestSpacing);
+        Assert.Equal(3, sql.RateLimit.MaxConcurrentRequests);
+        Assert.Equal(TimeSpan.FromSeconds(20), sql.RateLimit.RequestTimeout);
+        Assert.Equal(4, native.RateLimit.MaxConcurrentRequests);
+        Assert.Equal(TimeSpan.FromMilliseconds(250), native.RateLimit.MinimumRequestSpacing);
+    }
+}

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -898,7 +898,11 @@ public class TestCtIngestionPlanner
         string safeFileName = Path.GetFileName(fileName);
         Assert.Equal(fileName, safeFileName);
         Assert.False(Path.IsPathRooted(safeFileName));
-        string dataDirectory = Path.Combine(AppContext.BaseDirectory, "Data");
+        string dataDirectory = AppContext.BaseDirectory.TrimEnd(
+                                   Path.DirectorySeparatorChar,
+                                   Path.AltDirectorySeparatorChar) +
+                               Path.DirectorySeparatorChar +
+                               "Data";
         string path = dataDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
                       Path.DirectorySeparatorChar +
                       safeFileName;

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -109,6 +109,20 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void EstimateCapacityHandlesZeroRequests()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+
+        CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 0);
+
+        Assert.Equal(0, estimate.RequestCount);
+        Assert.Equal(0, estimate.EstimatedRunCount);
+        Assert.Equal(0, estimate.FirstRunRequestCount);
+        Assert.Equal(TimeSpan.Zero, estimate.EstimatedMinimumDuration);
+        Assert.Equal(TimeSpan.Zero, estimate.EstimatedFirstRunDuration);
+    }
+
+    [Fact]
     public void WorkloadEstimateReportsWhenProviderRunBudgetIsExceeded()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp(new CertificateInventoryCaptureOptions
@@ -236,7 +250,11 @@ public class TestCtIngestionPlanner
     [Fact]
     public void WorkloadEstimateRejectsFullCertificateWhenProviderCannotHydrate()
     {
-        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "metadata-only",
+            Capabilities = CtProviderCapabilities.ExactHostLookup
+        };
         var workload = new CtIngestionWorkloadRequest
         {
             HostCount = 100,
@@ -248,6 +266,24 @@ public class TestCtIngestionPlanner
 
         Assert.False(estimate.ProviderSupportsWorkload);
         Assert.Equal(100, estimate.EstimatedRequestCount);
+    }
+
+    [Fact]
+    public void WorkloadEstimateSupportsHydrationCapableProviderWithoutKnownHydrationCount()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            HostCount = 100,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = true
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.True(estimate.ProviderSupportsWorkload);
+        Assert.Equal(0, estimate.EstimatedHydrationRequests);
+        Assert.Contains("hydrate full certificate", estimate.Note, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -344,7 +380,7 @@ public class TestCtIngestionPlanner
         Assert.Equal(1, state.ConsecutiveFailures);
         Assert.Equal(1, state.TotalRequestCount);
         Assert.Equal(1, state.RateLimitedCount);
-        Assert.Equal(1d, state.TransientFailureRatio);
+        Assert.Equal(0d, state.TransientFailureRatio);
         Assert.Equal(429, state.LastHttpStatusCode);
     }
 
@@ -510,7 +546,7 @@ public class TestCtIngestionPlanner
 
     private static byte[] LoadPemCertificateDer(string fileName)
     {
-        string path = Path.Combine(AppContext.BaseDirectory, "Data", fileName);
+        string path = Path.Combine(AppContext.BaseDirectory, "Data", Path.GetFileName(fileName));
         string pem = File.ReadAllText(path);
         const string begin = "-----BEGIN CERTIFICATE-----";
         const string end = "-----END CERTIFICATE-----";

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -28,6 +28,10 @@ public class TestCtIngestionPlanner
             profile,
             CtIngestionOperation.GetCertificateHistory,
             requireFullCertificate: true));
+        Assert.False(CtIngestionPlanner.SupportsOperation(
+            profile,
+            (CtIngestionOperation)16,
+            requireFullCertificate: false));
     }
 
     [Fact]
@@ -120,6 +124,26 @@ public class TestCtIngestionPlanner
         Assert.Equal(0, estimate.FirstRunRequestCount);
         Assert.Equal(TimeSpan.Zero, estimate.EstimatedMinimumDuration);
         Assert.Equal(TimeSpan.Zero, estimate.EstimatedFirstRunDuration);
+    }
+
+    [Fact]
+    public void EstimateCapacityClampsSaturatedCompletionTimestamps()
+    {
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "slow-provider",
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MinimumRequestSpacing = TimeSpan.MaxValue
+            }
+        };
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+
+        CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 2, now);
+
+        Assert.Equal(TimeSpan.MaxValue, estimate.EstimatedMinimumDuration);
+        Assert.Equal(DateTimeOffset.MaxValue, estimate.EstimatedCompletionUtc);
+        Assert.Equal(DateTimeOffset.MaxValue, estimate.EstimatedFirstRunCompletionUtc);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -194,6 +194,7 @@ public class TestCtIngestionPlanner
         Assert.Equal(
             estimate.DomainCapacity.EstimatedMinimumDuration + estimate.HostCapacity.EstimatedMinimumDuration,
             estimate.Capacity.EstimatedMinimumDuration);
+        Assert.Equal(TimeSpan.FromMilliseconds(354_800), estimate.Capacity.EstimatedFirstRunDuration);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -190,6 +190,25 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void WorkloadEstimateDefaultsEmptyOperationsFromCounts()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 2,
+            HostCount = 3,
+            Operations = CtIngestionOperation.None
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.True(estimate.ProviderSupportsWorkload);
+        Assert.Equal(2, estimate.EstimatedDomainRequests);
+        Assert.Equal(3, estimate.EstimatedHostRequests);
+        Assert.Equal(5, estimate.EstimatedRequestCount);
+    }
+
+    [Fact]
     public void DecideDefersProviderWhenCooldownIsActive()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
@@ -638,7 +657,9 @@ public class TestCtIngestionPlanner
 
     private static byte[] LoadPemCertificateDer(string fileName)
     {
-        string path = Path.Combine(AppContext.BaseDirectory, "Data", Path.GetFileName(fileName));
+        string safeFileName = Path.GetFileName(fileName);
+        Assert.Equal(fileName, safeFileName);
+        string path = Path.Combine(AppContext.BaseDirectory, "Data", safeFileName);
         string pem = File.ReadAllText(path);
         const string begin = "-----BEGIN CERTIFICATE-----";
         const string end = "-----END CERTIFICATE-----";

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -335,6 +335,16 @@ public class TestCtIngestionPlanner
         Assert.False(string.IsNullOrWhiteSpace(record.AuthenticationProfile));
     }
 
+    [Fact]
+    public void CtCertificateRecordNormalizesNullProviderIdToEmpty()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+
+        CtCertificateRecord record = CtCertificateRecord.FromDer(null!, der);
+
+        Assert.Equal(string.Empty, record.ProviderId);
+    }
+
 #if NET8_0_OR_GREATER
     [Fact]
     public void CtCertificateRecordDoesNotMarkP256EcdsaAsWeak()
@@ -416,6 +426,31 @@ public class TestCtIngestionPlanner
         Assert.Equal(1, state.SuccessfulRequestCount);
         Assert.Equal(now, state.LastSuccessUtc);
         Assert.Equal(250d, state.LastObservedLatencyMilliseconds);
+    }
+
+    [Fact]
+    public void RuntimeStateUpdaterClearsPermanentFailedFlagAfterSuccess()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var previous = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            IsPermanentlyFailed = true,
+            TotalRequestCount = 1,
+            LastFailureUtc = now.AddMinutes(-1)
+        };
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.Success,
+            OccurredAtUtc = now
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(previous, profile, outcome);
+
+        Assert.False(state.IsPermanentlyFailed);
+        Assert.Equal(now, state.LastSuccessUtc);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -60,6 +60,9 @@ public class TestCtIngestionPlanner
         Assert.Null(estimate.MaximumRequestsPerRun);
         Assert.Equal(1, estimate.EstimatedRunCount);
         Assert.Equal(20_000, estimate.FirstRunRequestCount);
+        Assert.Equal(0, estimate.RemainingRequestCount);
+        Assert.Equal(estimate.EstimatedMinimumDuration, estimate.EstimatedFirstRunDuration);
+        Assert.Equal(estimate.EstimatedCompletionUtc, estimate.EstimatedFirstRunCompletionUtc);
         Assert.False(estimate.ExceedsRunBudget);
         Assert.True(estimate.IsRateLimited);
         Assert.False(estimate.IsConcurrencyLimited);
@@ -98,6 +101,8 @@ public class TestCtIngestionPlanner
         Assert.Equal(100, estimate.MaximumRequestsPerRun);
         Assert.Equal(3, estimate.EstimatedRunCount);
         Assert.Equal(100, estimate.FirstRunRequestCount);
+        Assert.Equal(150, estimate.RemainingRequestCount);
+        Assert.Equal(TimeSpan.FromSeconds(15 * 99 + 5), estimate.EstimatedFirstRunDuration);
         Assert.True(estimate.ExceedsRunBudget);
     }
 

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -458,6 +458,31 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void RuntimeStateUpdaterClampsLargeTransientCooldown()
+    {
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "slow",
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                CooldownAfterRateLimit = TimeSpan.MaxValue
+            }
+        };
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.Timeout,
+            OccurredAtUtc = now,
+            CooldownOnTransientFailure = true
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(null, profile, outcome);
+
+        Assert.Equal(DateTimeOffset.MaxValue, state.CooldownUntilUtc);
+    }
+
+    [Fact]
     public void RuntimeStateUpdaterClearsCooldownAfterSuccess()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
@@ -587,6 +612,33 @@ public class TestCtIngestionPlanner
 
         Assert.True(decision.CanRunNow);
         Assert.Null(decision.DeferUntilUtc);
+    }
+
+    [Fact]
+    public void DecideClampsLargeFailureRatioCooldown()
+    {
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "slow",
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                CooldownAfterRateLimit = TimeSpan.MaxValue
+            }
+        };
+        var state = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            LastFailureUtc = DateTimeOffset.MaxValue.AddDays(-1),
+            TransientFailureRatio = 1d
+        };
+
+        CtProviderExecutionDecision decision = CtIngestionPlanner.Decide(
+            profile,
+            state,
+            new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero));
+
+        Assert.False(decision.CanRunNow);
+        Assert.Equal(DateTimeOffset.MaxValue, decision.DeferUntilUtc);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -54,9 +54,29 @@ public class TestCtIngestionPlanner
         CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 20_000, now);
 
         Assert.Equal(TimeSpan.FromSeconds(15), estimate.EffectiveRequestSpacing);
-        Assert.Equal(TimeSpan.FromSeconds(15 * 19_999), estimate.EstimatedMinimumDuration);
-        Assert.Equal(now + TimeSpan.FromSeconds(15 * 19_999), estimate.EstimatedCompletionUtc);
+        Assert.Equal(TimeSpan.FromSeconds(5), estimate.EstimatedRequestDuration);
+        Assert.Equal(TimeSpan.FromSeconds(15 * 19_999 + 5), estimate.EstimatedMinimumDuration);
+        Assert.Equal(now + TimeSpan.FromSeconds(15 * 19_999 + 5), estimate.EstimatedCompletionUtc);
         Assert.True(estimate.IsRateLimited);
+        Assert.False(estimate.IsConcurrencyLimited);
+    }
+
+    [Fact]
+    public void EstimateCapacityUsesRequestDurationWhenConcurrencyIsTheLimiter()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShPostgreSql();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+
+        CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 20, now);
+
+        Assert.Equal(TimeSpan.Zero, estimate.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromSeconds(10), estimate.EstimatedRequestDuration);
+        Assert.Equal(2, estimate.MaxConcurrentRequests);
+        Assert.Equal(10, estimate.ConcurrencyWaveCount);
+        Assert.Equal(TimeSpan.FromSeconds(100), estimate.EstimatedMinimumDuration);
+        Assert.Equal(now + TimeSpan.FromSeconds(100), estimate.EstimatedCompletionUtc);
+        Assert.False(estimate.IsRateLimited);
+        Assert.True(estimate.IsConcurrencyLimited);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -197,6 +197,63 @@ public class TestCtIngestionPlanner
         Assert.NotEmpty(record.CertificateDer!);
     }
 
+    [Fact]
+    public void RuntimeStateUpdaterAppliesRateLimitCooldown()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.RateLimited,
+            OccurredAtUtc = now,
+            RetryAfter = TimeSpan.FromMinutes(2),
+            HttpStatusCode = 429,
+            Error = "Too many requests"
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(null, profile, outcome);
+
+        Assert.Equal(now.AddMinutes(2), state.CooldownUntilUtc);
+        Assert.Equal(1, state.ConsecutiveFailures);
+        Assert.Equal(1, state.TotalRequestCount);
+        Assert.Equal(1, state.RateLimitedCount);
+        Assert.Equal(1d, state.TransientFailureRatio);
+        Assert.Equal(429, state.LastHttpStatusCode);
+    }
+
+    [Fact]
+    public void RuntimeStateUpdaterClearsCooldownAfterSuccess()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var previous = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            CooldownUntilUtc = now.AddMinutes(2),
+            ConsecutiveFailures = 3,
+            TotalRequestCount = 3,
+            TransientFailureCount = 3,
+            LastFailureUtc = now.AddMinutes(-1)
+        };
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.Success,
+            OccurredAtUtc = now,
+            Latency = TimeSpan.FromMilliseconds(250)
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(previous, profile, outcome);
+
+        Assert.Null(state.CooldownUntilUtc);
+        Assert.Equal(0, state.ConsecutiveFailures);
+        Assert.Equal(4, state.TotalRequestCount);
+        Assert.Equal(1, state.SuccessfulRequestCount);
+        Assert.Equal(now, state.LastSuccessUtc);
+        Assert.Equal(250d, state.LastObservedLatencyMilliseconds);
+    }
+
     private static byte[] LoadPemCertificateDer(string fileName)
     {
         string path = Path.Combine(AppContext.BaseDirectory, "Data", fileName);

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -52,6 +52,27 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void CertSpotterDefaultModelsSeparateSmallPlanBudgets()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCertSpotter();
+
+        Assert.Equal(CtProviderProfiles.CertSpotterProviderId, profile.ProviderId);
+        Assert.Equal(5, profile.RateLimit.MaxRequestsPerSecond);
+        Assert.Equal(75, profile.RateLimit.MaxRequestsPerMinute);
+        Assert.Equal(100, profile.RateLimit.MaxSingleHostnameQueriesPerHour);
+        Assert.Equal(10, profile.RateLimit.MaxFullDomainQueriesPerHour);
+        Assert.Equal(TimeSpan.FromSeconds(15), profile.RateLimit.RequestTimeout);
+        Assert.True(CtIngestionPlanner.SupportsOperation(
+            profile,
+            CtIngestionOperation.GetLatestCertificate,
+            requireFullCertificate: true));
+        Assert.False(CtIngestionPlanner.SupportsOperation(
+            profile,
+            CtIngestionOperation.GetCertificateHistory,
+            requireFullCertificate: true));
+    }
+
+    [Fact]
     public void EstimateCapacityUsesMostConservativeSpacing()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
@@ -72,6 +93,67 @@ public class TestCtIngestionPlanner
         Assert.False(estimate.ExceedsRunBudget);
         Assert.True(estimate.IsRateLimited);
         Assert.False(estimate.IsConcurrencyLimited);
+    }
+
+    [Fact]
+    public void EstimateWorkloadUsesCertSpotterSingleHostnameBudget()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCertSpotter();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var workload = new CtIngestionWorkloadRequest
+        {
+            HostCount = 2,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = true
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload, now);
+
+        Assert.Equal(TimeSpan.FromSeconds(36), estimate.Capacity.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromSeconds(39), estimate.Capacity.EstimatedMinimumDuration);
+    }
+
+    [Fact]
+    public void EstimateWorkloadUsesCertSpotterFullDomainBudgetForExpansion()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCertSpotter();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 2,
+            Operations = CtIngestionOperation.DiscoverSubdomains,
+            RequireFullCertificate = false
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload, now);
+
+        Assert.Equal(TimeSpan.FromMinutes(6), estimate.Capacity.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromMinutes(6) + TimeSpan.FromSeconds(3), estimate.Capacity.EstimatedMinimumDuration);
+    }
+
+    [Fact]
+    public void EstimateWorkloadKeepsCertSpotterExactHostAndFullDomainBudgetsSeparate()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCertSpotter();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 1,
+            HostCount = 100,
+            Operations = CtIngestionOperation.DiscoverSubdomains | CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = false
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload, now);
+
+        Assert.Equal(1, estimate.EstimatedDomainRequests);
+        Assert.Equal(100, estimate.EstimatedHostRequests);
+        Assert.Equal(TimeSpan.FromMinutes(6), estimate.DomainCapacity.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromSeconds(36), estimate.HostCapacity.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromMinutes(6), estimate.Capacity.EffectiveRequestSpacing);
+        Assert.Equal(TimeSpan.FromSeconds(36 * 99 + 3), estimate.HostCapacity.EstimatedMinimumDuration);
+        Assert.Equal(estimate.HostCapacity.EstimatedMinimumDuration, estimate.Capacity.EstimatedMinimumDuration);
+        Assert.Equal(101, estimate.Capacity.FirstRunRequestCount);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using DomainDetective;
 using Xunit;
 
@@ -297,6 +299,30 @@ public class TestCtIngestionPlanner
         Assert.False(string.IsNullOrWhiteSpace(record.AuthenticationProfile));
     }
 
+#if NET8_0_OR_GREATER
+    [Fact]
+    public void CtCertificateRecordDoesNotMarkP256EcdsaAsWeak()
+    {
+        using ECDsa key = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var request = new CertificateRequest("CN=ecdsa.example.com", key, HashAlgorithmName.SHA256);
+        var subjectAlternativeNameBuilder = new SubjectAlternativeNameBuilder();
+        subjectAlternativeNameBuilder.AddDnsName("ecdsa.example.com");
+        request.CertificateExtensions.Add(subjectAlternativeNameBuilder.Build());
+
+        using X509Certificate2 certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+
+        CtCertificateRecord record = CtCertificateRecord.FromDer(
+            CtProviderProfiles.CertSpotterProviderId,
+            certificate.Export(X509ContentType.Cert));
+
+        Assert.False(record.WeakKey);
+        Assert.True(record.IsSelfSigned);
+        Assert.Contains("ecdsa.example.com", record.DnsNames, StringComparer.OrdinalIgnoreCase);
+    }
+#endif
+
     [Fact]
     public void RuntimeStateUpdaterAppliesRateLimitCooldown()
     {
@@ -332,6 +358,7 @@ public class TestCtIngestionPlanner
             ProviderId = profile.ProviderId,
             CooldownUntilUtc = now.AddMinutes(2),
             ConsecutiveFailures = 3,
+            IsPermanentlyFailed = true,
             TotalRequestCount = 3,
             TransientFailureCount = 3,
             LastFailureUtc = now.AddMinutes(-1)
@@ -348,10 +375,84 @@ public class TestCtIngestionPlanner
 
         Assert.Null(state.CooldownUntilUtc);
         Assert.Equal(0, state.ConsecutiveFailures);
+        Assert.False(state.IsPermanentlyFailed);
         Assert.Equal(4, state.TotalRequestCount);
         Assert.Equal(1, state.SuccessfulRequestCount);
         Assert.Equal(now, state.LastSuccessUtc);
         Assert.Equal(250d, state.LastObservedLatencyMilliseconds);
+    }
+
+    [Fact]
+    public void RuntimeStateUpdaterMarksPermanentFailure()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCertSpotter();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.PermanentFailure,
+            OccurredAtUtc = now,
+            HttpStatusCode = 401,
+            Error = "Invalid API token"
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(null, profile, outcome);
+        CtProviderExecutionDecision decision = CtIngestionPlanner.Decide(profile, state, now);
+
+        Assert.True(state.IsPermanentlyFailed);
+        Assert.Null(state.CooldownUntilUtc);
+        Assert.Equal(1, state.ConsecutiveFailures);
+        Assert.Equal(0d, state.TransientFailureRatio);
+        Assert.False(decision.CanRunNow);
+        Assert.Contains("permanent failure", decision.Reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DecideAllowsProviderAfterRecoverySuccess()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var state = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            LastFailureUtc = now.AddMinutes(-1),
+            LastSuccessUtc = now,
+            TransientFailureRatio = 0.5d,
+            TotalRequestCount = 2,
+            SuccessfulRequestCount = 1,
+            TransientFailureCount = 1
+        };
+
+        CtProviderExecutionDecision decision = CtIngestionPlanner.Decide(profile, state, now);
+
+        Assert.True(decision.CanRunNow);
+        Assert.Null(decision.DeferUntilUtc);
+    }
+
+    [Fact]
+    public void DecideUsesConfiguredFailureRatioThreshold()
+    {
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "custom",
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                CooldownAfterRateLimit = TimeSpan.FromMinutes(5),
+                TransientFailureRatioCooldownThreshold = 0.75d
+            }
+        };
+        var state = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            LastFailureUtc = now,
+            TransientFailureRatio = 0.6d
+        };
+
+        CtProviderExecutionDecision decision = CtIngestionPlanner.Decide(profile, state, now);
+
+        Assert.True(decision.CanRunNow);
+        Assert.Null(decision.DeferUntilUtc);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -228,6 +228,7 @@ public class TestCtIngestionPlanner
         Assert.Equal(100, estimate.EstimatedHostRequests);
         Assert.Equal(100, estimate.EstimatedHydrationRequests);
         Assert.Equal(200, estimate.EstimatedRequestCount);
+        Assert.False(estimate.IsRequestCountSaturated);
     }
 
     [Fact]
@@ -245,6 +246,26 @@ public class TestCtIngestionPlanner
 
         Assert.False(estimate.ProviderSupportsWorkload);
         Assert.Equal(100, estimate.EstimatedRequestCount);
+    }
+
+    [Fact]
+    public void WorkloadEstimateSaturatesLargeRequestCounts()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShPostgreSql();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            HostCount = int.MaxValue,
+            Operations = CtIngestionOperation.GetCertificateHistory,
+            RequireFullCertificate = true,
+            RequestsPerHost = 2
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.True(estimate.IsRequestCountSaturated);
+        Assert.Equal(int.MaxValue, estimate.EstimatedHostRequests);
+        Assert.Equal(int.MaxValue, estimate.EstimatedRequestCount);
+        Assert.Contains("capped", estimate.Note, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -551,6 +551,19 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void RateLimitProfileNormalizePreservesZeroFailureRatioThreshold()
+    {
+        var profile = new CtProviderRateLimitProfile
+        {
+            TransientFailureRatioCooldownThreshold = 0d
+        };
+
+        CtProviderRateLimitProfile normalized = profile.Normalize();
+
+        Assert.Equal(0d, normalized.TransientFailureRatioCooldownThreshold);
+    }
+
+    [Fact]
     public void PlanProvidersChoosesSqlForFullCertificateHistory()
     {
         CtProviderProfile http = CtProviderProfiles.CreateCrtShHttp();

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -107,6 +107,29 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void WorkloadEstimateReportsWhenProviderRunBudgetIsExceeded()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp(new CertificateInventoryCaptureOptions
+        {
+            PassiveCtCrtShMaximumRequestsPerRun = 10,
+            PassiveCtCrtShMinimumSpacing = TimeSpan.FromSeconds(15),
+            PassiveCtRequestTimeout = TimeSpan.FromSeconds(30)
+        });
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 25,
+            Operations = CtIngestionOperation.DiscoverSubdomains,
+            RequireFullCertificate = false
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.True(estimate.ProviderSupportsWorkload);
+        Assert.True(estimate.Capacity.ExceedsRunBudget);
+        Assert.Contains("multiple logical runs", estimate.Note, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void DecideDefersProviderWhenCooldownIsActive()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -93,6 +93,26 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void EstimateCapacityCombinesSpacingAndConcurrencyLimits()
+    {
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "combined-limits",
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = 4,
+                MinimumRequestSpacing = TimeSpan.FromMilliseconds(250),
+                EstimatedRequestDuration = TimeSpan.FromSeconds(2)
+            }
+        };
+
+        CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 20);
+
+        Assert.Equal(TimeSpan.FromMilliseconds(10_750), estimate.EstimatedMinimumDuration);
+        Assert.Equal(TimeSpan.FromMilliseconds(10_750), estimate.EstimatedFirstRunDuration);
+    }
+
+    [Fact]
     public void EstimateCapacityReportsRunBudgetSlices()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp(new CertificateInventoryCaptureOptions

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -152,8 +152,48 @@ public class TestCtIngestionPlanner
         Assert.Equal(TimeSpan.FromSeconds(36), estimate.HostCapacity.EffectiveRequestSpacing);
         Assert.Equal(TimeSpan.FromMinutes(6), estimate.Capacity.EffectiveRequestSpacing);
         Assert.Equal(TimeSpan.FromSeconds(36 * 99 + 3), estimate.HostCapacity.EstimatedMinimumDuration);
-        Assert.Equal(estimate.HostCapacity.EstimatedMinimumDuration, estimate.Capacity.EstimatedMinimumDuration);
+        Assert.Equal(
+            estimate.DomainCapacity.EstimatedMinimumDuration + estimate.HostCapacity.EstimatedMinimumDuration,
+            estimate.Capacity.EstimatedMinimumDuration);
         Assert.Equal(101, estimate.Capacity.FirstRunRequestCount);
+    }
+
+    [Fact]
+    public void EstimateWorkloadRecomputesAggregateRunBudgetFromCombinedRequests()
+    {
+        var profile = new CtProviderProfile
+        {
+            ProviderId = "combined-run-budget",
+            Capabilities = CtProviderCapabilities.SubdomainExpansion |
+                           CtProviderCapabilities.ExactHostLookup |
+                           CtProviderCapabilities.FullCertificateDer,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaximumRequestsPerRun = 100,
+                MaxConcurrentRequests = 1,
+                MaxFullDomainQueriesPerHour = 1_000,
+                MaxSingleHostnameQueriesPerHour = 1_000,
+                EstimatedRequestDuration = TimeSpan.FromSeconds(1)
+            }
+        };
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 80,
+            HostCount = 80,
+            Operations = CtIngestionOperation.DiscoverSubdomains | CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = false
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.Equal(160, estimate.Capacity.RequestCount);
+        Assert.Equal(2, estimate.Capacity.EstimatedRunCount);
+        Assert.Equal(100, estimate.Capacity.FirstRunRequestCount);
+        Assert.Equal(60, estimate.Capacity.RemainingRequestCount);
+        Assert.True(estimate.Capacity.ExceedsRunBudget);
+        Assert.Equal(
+            estimate.DomainCapacity.EstimatedMinimumDuration + estimate.HostCapacity.EstimatedMinimumDuration,
+            estimate.Capacity.EstimatedMinimumDuration);
     }
 
     [Fact]
@@ -540,6 +580,33 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void RuntimeStateUpdaterExcludesRateLimitsFromTransientFailureRatio()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var previous = new CtProviderRuntimeState
+        {
+            ProviderId = profile.ProviderId,
+            TotalRequestCount = 3,
+            TransientFailureCount = 1,
+            RateLimitedCount = 2
+        };
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.Timeout,
+            OccurredAtUtc = now
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(previous, profile, outcome);
+
+        Assert.Equal(4, state.TotalRequestCount);
+        Assert.Equal(2, state.TransientFailureCount);
+        Assert.Equal(2, state.RateLimitedCount);
+        Assert.Equal(1d, state.TransientFailureRatio);
+    }
+
+    [Fact]
     public void RuntimeStateUpdaterClampsLargeTransientCooldown()
     {
         var profile = new CtProviderProfile
@@ -793,7 +860,11 @@ public class TestCtIngestionPlanner
     {
         string safeFileName = Path.GetFileName(fileName);
         Assert.Equal(fileName, safeFileName);
-        string path = Path.Combine(AppContext.BaseDirectory, "Data", safeFileName);
+        Assert.False(Path.IsPathRooted(safeFileName));
+        string dataDirectory = Path.Combine(AppContext.BaseDirectory, "Data");
+        string path = dataDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) +
+                      Path.DirectorySeparatorChar +
+                      safeFileName;
         string pem = File.ReadAllText(path);
         const string begin = "-----BEGIN CERTIFICATE-----";
         const string end = "-----END CERTIFICATE-----";

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -57,6 +57,10 @@ public class TestCtIngestionPlanner
         Assert.Equal(TimeSpan.FromSeconds(5), estimate.EstimatedRequestDuration);
         Assert.Equal(TimeSpan.FromSeconds(15 * 19_999 + 5), estimate.EstimatedMinimumDuration);
         Assert.Equal(now + TimeSpan.FromSeconds(15 * 19_999 + 5), estimate.EstimatedCompletionUtc);
+        Assert.Null(estimate.MaximumRequestsPerRun);
+        Assert.Equal(1, estimate.EstimatedRunCount);
+        Assert.Equal(20_000, estimate.FirstRunRequestCount);
+        Assert.False(estimate.ExceedsRunBudget);
         Assert.True(estimate.IsRateLimited);
         Assert.False(estimate.IsConcurrencyLimited);
     }
@@ -77,6 +81,24 @@ public class TestCtIngestionPlanner
         Assert.Equal(now + TimeSpan.FromSeconds(100), estimate.EstimatedCompletionUtc);
         Assert.False(estimate.IsRateLimited);
         Assert.True(estimate.IsConcurrencyLimited);
+    }
+
+    [Fact]
+    public void EstimateCapacityReportsRunBudgetSlices()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp(new CertificateInventoryCaptureOptions
+        {
+            PassiveCtCrtShMaximumRequestsPerRun = 100,
+            PassiveCtCrtShMinimumSpacing = TimeSpan.FromSeconds(15),
+            PassiveCtRequestTimeout = TimeSpan.FromSeconds(30)
+        });
+
+        CtProviderCapacityEstimate estimate = CtIngestionPlanner.EstimateCapacity(profile, 250);
+
+        Assert.Equal(100, estimate.MaximumRequestsPerRun);
+        Assert.Equal(3, estimate.EstimatedRunCount);
+        Assert.Equal(100, estimate.FirstRunRequestCount);
+        Assert.True(estimate.ExceedsRunBudget);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using DomainDetective;
 using Xunit;
@@ -16,6 +17,7 @@ public class TestCtIngestionPlanner
         Assert.Equal(5, profile.RateLimit.MaxRequestsPerMinute);
         Assert.Equal(1, profile.RateLimit.MaxConcurrentRequests);
         Assert.True(profile.RateLimit.MinimumRequestSpacing >= TimeSpan.FromSeconds(12));
+        Assert.True(profile.Supports(CtProviderCapabilities.CertificateHydration));
         Assert.True(CtIngestionPlanner.SupportsOperation(
             profile,
             CtIngestionOperation.DiscoverSubdomains,
@@ -195,6 +197,13 @@ public class TestCtIngestionPlanner
         Assert.NotNull(record.NotBeforeUtc);
         Assert.NotNull(record.NotAfterUtc);
         Assert.NotEmpty(record.CertificateDer!);
+        Assert.NotNull(record.IsSelfSigned);
+        Assert.NotNull(record.WeakKey);
+        Assert.NotNull(record.Sha1Signature);
+        Assert.NotNull(record.AllowsServerAuthentication);
+        Assert.NotNull(record.AllowsClientAuthentication);
+        Assert.NotNull(record.AllowsSecureEmail);
+        Assert.False(string.IsNullOrWhiteSpace(record.AuthenticationProfile));
     }
 
     [Fact]
@@ -252,6 +261,59 @@ public class TestCtIngestionPlanner
         Assert.Equal(1, state.SuccessfulRequestCount);
         Assert.Equal(now, state.LastSuccessUtc);
         Assert.Equal(250d, state.LastObservedLatencyMilliseconds);
+    }
+
+    [Fact]
+    public void PlanProvidersChoosesSqlForFullCertificateHistory()
+    {
+        CtProviderProfile http = CtProviderProfiles.CreateCrtShHttp();
+        CtProviderProfile sql = CtProviderProfiles.CreateCrtShPostgreSql();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            HostCount = 10,
+            Operations = CtIngestionOperation.GetCertificateHistory,
+            RequireFullCertificate = true
+        };
+
+        IReadOnlyList<CtProviderWorkPlan> plans = CtIngestionPlanner.PlanProviders(
+            new[] { http, sql },
+            workload);
+        CtProviderWorkPlan? selected = CtIngestionPlanner.ChooseFirstReadyProvider(plans);
+
+        Assert.Equal(CtProviderPlanStatus.Unsupported, plans[0].Status);
+        Assert.Equal(CtProviderPlanStatus.Ready, plans[1].Status);
+        Assert.NotNull(selected);
+        Assert.Equal(CtProviderProfiles.CrtShPostgreSqlProviderId, selected!.ProviderId);
+    }
+
+    [Fact]
+    public void PlanProvidersDefersProviderInCooldown()
+    {
+        CtProviderProfile http = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 1,
+            Operations = CtIngestionOperation.DiscoverSubdomains
+        };
+        var states = new Dictionary<string, CtProviderRuntimeState>(StringComparer.OrdinalIgnoreCase)
+        {
+            [http.ProviderId] = new CtProviderRuntimeState
+            {
+                ProviderId = http.ProviderId,
+                CooldownUntilUtc = now.AddMinutes(5)
+            }
+        };
+
+        IReadOnlyList<CtProviderWorkPlan> plans = CtIngestionPlanner.PlanProviders(
+            new[] { http },
+            workload,
+            states,
+            now);
+
+        Assert.Single(plans);
+        Assert.Equal(CtProviderPlanStatus.Deferred, plans[0].Status);
+        Assert.Equal(now.AddMinutes(5), plans[0].Decision?.DeferUntilUtc);
     }
 
     private static byte[] LoadPemCertificateDer(string fileName)

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -632,6 +632,24 @@ public class TestCtIngestionPlanner
     }
 
     [Fact]
+    public void RuntimeStateUpdaterAppliesTransientFailureCooldown()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        DateTimeOffset now = new DateTimeOffset(2026, 4, 11, 12, 0, 0, TimeSpan.Zero);
+        var outcome = new CtProviderRequestOutcome
+        {
+            ProviderId = profile.ProviderId,
+            OutcomeKind = CtProviderOutcomeKind.Timeout,
+            OccurredAtUtc = now,
+            CooldownOnTransientFailure = true
+        };
+
+        CtProviderRuntimeState state = CtProviderRuntimeStateUpdater.Apply(null, profile, outcome);
+
+        Assert.Equal(now + profile.RateLimit.CooldownAfterRateLimit, state.CooldownUntilUtc);
+    }
+
+    [Fact]
     public void RuntimeStateUpdaterClearsCooldownAfterSuccess()
     {
         CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
@@ -854,6 +872,24 @@ public class TestCtIngestionPlanner
         Assert.Single(plans);
         Assert.Equal(CtProviderPlanStatus.Deferred, plans[0].Status);
         Assert.Equal(now.AddMinutes(5), plans[0].Decision?.DeferUntilUtc);
+    }
+
+    [Fact]
+    public void PlanProvidersSkipsNullProfiles()
+    {
+        CtProviderProfile http = CtProviderProfiles.CreateCrtShHttp();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            DomainCount = 1,
+            Operations = CtIngestionOperation.DiscoverSubdomains
+        };
+
+        IReadOnlyList<CtProviderWorkPlan> plans = CtIngestionPlanner.PlanProviders(
+            new[] { null!, http },
+            workload);
+
+        CtProviderWorkPlan plan = Assert.Single(plans);
+        Assert.Equal(http.ProviderId, plan.ProviderId);
     }
 
     private static byte[] LoadPemCertificateDer(string fileName)

--- a/DomainDetective.Tests/TestCtIngestionPlanner.cs
+++ b/DomainDetective.Tests/TestCtIngestionPlanner.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using DomainDetective;
 using Xunit;
 
@@ -133,5 +134,82 @@ public class TestCtIngestionPlanner
         Assert.Equal(TimeSpan.FromSeconds(20), sql.RateLimit.RequestTimeout);
         Assert.Equal(4, native.RateLimit.MaxConcurrentRequests);
         Assert.Equal(TimeSpan.FromMilliseconds(250), native.RateLimit.MinimumRequestSpacing);
+    }
+
+    [Fact]
+    public void WorkloadEstimateIncludesHydrationRequestsWhenProviderIsMetadataOnly()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            HostCount = 100,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = true,
+            RequestsPerHost = 1,
+            EstimatedCertificatesToHydrate = 100,
+            HydrationRequestsPerCertificate = 1
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.True(estimate.ProviderSupportsWorkload);
+        Assert.Equal(100, estimate.EstimatedHostRequests);
+        Assert.Equal(100, estimate.EstimatedHydrationRequests);
+        Assert.Equal(200, estimate.EstimatedRequestCount);
+    }
+
+    [Fact]
+    public void WorkloadEstimateRejectsFullCertificateWhenProviderCannotHydrate()
+    {
+        CtProviderProfile profile = CtProviderProfiles.CreateCrtShHttp();
+        var workload = new CtIngestionWorkloadRequest
+        {
+            HostCount = 100,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = true
+        };
+
+        CtIngestionWorkloadEstimate estimate = CtIngestionPlanner.EstimateWorkload(profile, workload);
+
+        Assert.False(estimate.ProviderSupportsWorkload);
+        Assert.Equal(100, estimate.EstimatedRequestCount);
+    }
+
+    [Fact]
+    public void CtCertificateRecordCanBeCreatedFromDer()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+
+        CtCertificateRecord record = CtCertificateRecord.FromDer(
+            CtProviderProfiles.CertSpotterProviderId,
+            der,
+            providerCertificateId: "cert-1");
+
+        Assert.True(record.HasFullCertificate);
+        Assert.Equal(CtProviderProfiles.CertSpotterProviderId, record.ProviderId);
+        Assert.Equal("cert-1", record.ProviderCertificateId);
+        Assert.NotEmpty(record.Sha256Fingerprint!);
+        Assert.NotEmpty(record.Sha1Fingerprint!);
+        Assert.NotEmpty(record.Subject!);
+        Assert.NotEmpty(record.Issuer!);
+        Assert.NotNull(record.NotBeforeUtc);
+        Assert.NotNull(record.NotAfterUtc);
+        Assert.NotEmpty(record.CertificateDer!);
+    }
+
+    private static byte[] LoadPemCertificateDer(string fileName)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "Data", fileName);
+        string pem = File.ReadAllText(path);
+        const string begin = "-----BEGIN CERTIFICATE-----";
+        const string end = "-----END CERTIFICATE-----";
+        int start = pem.IndexOf(begin, StringComparison.Ordinal);
+        int finish = pem.IndexOf(end, StringComparison.Ordinal);
+        Assert.True(start >= 0 && finish > start, "Expected PEM certificate fixture.");
+        string base64 = pem.Substring(start + begin.Length, finish - start - begin.Length)
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Trim();
+        return Convert.FromBase64String(base64);
     }
 }

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -152,14 +152,38 @@ public sealed partial class CertificateInventoryCapture {
 
                 Dictionary<string, SubdomainDiscoveryEntry> domainHydrated;
                 try {
-                    domainHydrated =
-                        await QueryCrtShPostgreSqlMetadataByDomainAsync(
+                    ICtSqlMetadataProvider? domainSqlMetadataProvider =
+                        DomainDetectiveOptionalFeatures.GetCtSqlMetadataProvider();
+                    var exactSqlMetadataProvider =
+                        CtExactMetadataPostgreSqlOverride ?? DomainDetectiveOptionalFeatures.GetCtSqlExactMetadataProvider();
+                    if (domainSqlMetadataProvider != null) {
+                        domainHydrated = await QueryCrtShPostgreSqlMetadataByDomainAsync(
                                 pair.Key,
                                 pair.Value,
                                 options,
                                 logger,
                                 cancellationToken)
                             .ConfigureAwait(false);
+                    } else if (exactSqlMetadataProvider != null) {
+                        domainPostgreSqlLookupFailed = true;
+                        logger.WriteVerbose(
+                            "CT metadata backfill domain PostgreSQL lookup skipped for {0} because only exact PostgreSQL metadata lookup is available.",
+                            pair.Key);
+                        domainHydrated = await QueryCrtShPostgreSqlExactMetadataAsync(
+                                pair.Value
+                                    .OrderBy(static host => host, StringComparer.OrdinalIgnoreCase)
+                                    .ToList(),
+                                options,
+                                logger,
+                                cancellationToken)
+                            .ConfigureAwait(false);
+                    } else {
+                        domainPostgreSqlLookupFailed = true;
+                        logger.WriteVerbose(
+                            "CT metadata backfill domain PostgreSQL lookup skipped for {0} because DomainDetective.CtSql is not registered.",
+                            pair.Key);
+                        continue;
+                    }
                 } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
                     throw;
                 } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -679,10 +679,7 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private bool ShouldUseCrtShPostgreSqlMetadataFallback(CertificateInventoryCaptureOptions options) {
-        ICtSqlMetadataProvider? sqlMetadataProvider = DomainDetectiveOptionalFeatures.GetCtSqlMetadataProvider();
-        var exactMetadataProvider = CtExactMetadataPostgreSqlOverride ?? DomainDetectiveOptionalFeatures.GetCtSqlExactMetadataProvider();
-        return options != null &&
-               (options.EnableCrtShPostgreSqlMetadataFallback || exactMetadataProvider != null || sqlMetadataProvider != null);
+        return options != null && options.EnableCrtShPostgreSqlMetadataFallback;
     }
 
     private async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlExactMetadataAsync(

--- a/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
+++ b/DomainDetective/CertificateInventoryCapture.CtMetadataBackfill.cs
@@ -9,8 +9,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Helpers;
-using Npgsql;
-using NpgsqlTypes;
 
 namespace DomainDetective;
 
@@ -162,37 +160,15 @@ public sealed partial class CertificateInventoryCapture {
                                 logger,
                                 cancellationToken)
                             .ConfigureAwait(false);
+                } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                    throw;
                 } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
                     domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup timed out for {pair.Key}.";
                     warnings.Add(warning);
                     logger.WriteVerbose(warning);
                     continue;
-                } catch (NpgsqlException ex) {
-                    domainPostgreSqlLookupFailed = true;
-                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
-                    warnings.Add(warning);
-                    logger.WriteVerbose(warning);
-                    continue;
-                } catch (TimeoutException ex) {
-                    domainPostgreSqlLookupFailed = true;
-                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
-                    warnings.Add(warning);
-                    logger.WriteVerbose(warning);
-                    continue;
-                } catch (InvalidOperationException ex) {
-                    domainPostgreSqlLookupFailed = true;
-                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
-                    warnings.Add(warning);
-                    logger.WriteVerbose(warning);
-                    continue;
-                } catch (IOException ex) {
-                    domainPostgreSqlLookupFailed = true;
-                    string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
-                    warnings.Add(warning);
-                    logger.WriteVerbose(warning);
-                    continue;
-                } catch (CryptographicException ex) {
+                } catch (Exception ex) {
                     domainPostgreSqlLookupFailed = true;
                     string warning = $"CT metadata backfill domain PostgreSQL lookup failed for {pair.Key}: {ex.Message}";
                     warnings.Add(warning);
@@ -679,9 +655,10 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private bool ShouldUseCrtShPostgreSqlMetadataFallback(CertificateInventoryCaptureOptions options) {
+        ICtSqlMetadataProvider? sqlMetadataProvider = DomainDetectiveOptionalFeatures.GetCtSqlMetadataProvider();
         var exactMetadataProvider = CtExactMetadataPostgreSqlOverride ?? DomainDetectiveOptionalFeatures.GetCtSqlExactMetadataProvider();
         return options != null &&
-               (options.EnableCrtShPostgreSqlMetadataFallback || exactMetadataProvider != null);
+               (options.EnableCrtShPostgreSqlMetadataFallback || exactMetadataProvider != null || sqlMetadataProvider != null);
     }
 
     private async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlExactMetadataAsync(
@@ -694,15 +671,15 @@ public sealed partial class CertificateInventoryCapture {
             return results;
         }
 
+        ICtSqlMetadataProvider? sqlMetadataProvider = DomainDetectiveOptionalFeatures.GetCtSqlMetadataProvider();
         var exactMetadataProvider = CtExactMetadataPostgreSqlOverride ?? DomainDetectiveOptionalFeatures.GetCtSqlExactMetadataProvider();
-        if (exactMetadataProvider == null) {
-            return await QueryCrtShPostgreSqlMetadataExactSequentialAsync(
-                hostNames,
-                options,
-                logger,
-                cancellationToken).ConfigureAwait(false);
+        if (sqlMetadataProvider == null && exactMetadataProvider == null) {
+            logger.WriteVerbose(
+                "CT metadata backfill exact PostgreSQL lookup skipped because DomainDetective.CtSql is not registered.");
+            return results;
         }
 
+        HashSet<string> targetedThumbprints = BuildTargetedCtMetadataThumbprintSet(options);
         int exactParallelism = ResolveExactPassiveCtMetadataBackfillParallelism(
             options.DiscoveryParallelism,
             options.PassiveCtParallelism,
@@ -715,9 +692,11 @@ public sealed partial class CertificateInventoryCapture {
             await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
             tasks.Add(Task.Run(async () => {
                 try {
-                    SubdomainDiscoveryEntry? entry = exactMetadataProvider != null
+                    SubdomainDiscoveryEntry? entry = sqlMetadataProvider != null
+                        ? await sqlMetadataProvider.QueryExactMetadataAsync(hostName, options, logger, targetedThumbprints, cancellationToken).ConfigureAwait(false)
+                        : exactMetadataProvider != null
                         ? await exactMetadataProvider(hostName, options, logger, cancellationToken).ConfigureAwait(false)
-                        : await QueryCrtShPostgreSqlMetadataExactAsync(hostName, options, logger, cancellationToken).ConfigureAwait(false);
+                        : null;
                     if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
                         return;
                     }
@@ -742,99 +721,6 @@ public sealed partial class CertificateInventoryCapture {
         return results;
     }
 
-    private static async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlMetadataExactSequentialAsync(
-        IReadOnlyList<string> hostNames,
-        CertificateInventoryCaptureOptions options,
-        InternalLogger? logger,
-        CancellationToken cancellationToken) {
-        var results = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
-        if (hostNames == null || hostNames.Count == 0 || options == null) {
-            return results;
-        }
-
-        List<string> normalizedHosts = hostNames
-            .Where(static host => !string.IsNullOrWhiteSpace(host))
-            .Select(static host => host.Trim().TrimEnd('.').ToLowerInvariant())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
-        if (normalizedHosts.Count == 0) {
-            return results;
-        }
-
-        string connectionString = BuildCrtShPostgreSqlConnectionString(options);
-        HashSet<string> targetedThumbprints = BuildTargetedCtMetadataThumbprintSet(options);
-        await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-
-        foreach (string normalizedHost in normalizedHosts) {
-            cancellationToken.ThrowIfCancellationRequested();
-            try {
-                SubdomainDiscoveryEntry? entry = await QueryCrtShPostgreSqlMetadataExactAsync(
-                    connection,
-                    normalizedHost,
-                    options,
-                    logger,
-                    targetedThumbprints,
-                    cancellationToken).ConfigureAwait(false);
-                if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
-                    continue;
-                }
-
-                MergeCtSubdomainEntry(results, entry);
-            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
-                throw;
-            } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
-                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
-                if (connection.FullState == System.Data.ConnectionState.Broken ||
-                    connection.FullState == System.Data.ConnectionState.Closed) {
-                    break;
-                }
-            } catch (NpgsqlException ex) {
-                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
-                if (connection.FullState == System.Data.ConnectionState.Broken ||
-                    connection.FullState == System.Data.ConnectionState.Closed) {
-                    break;
-                }
-            } catch (TimeoutException ex) {
-                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
-                if (connection.FullState == System.Data.ConnectionState.Broken ||
-                    connection.FullState == System.Data.ConnectionState.Closed) {
-                    break;
-                }
-            } catch (InvalidOperationException ex) {
-                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
-                if (connection.FullState == System.Data.ConnectionState.Broken ||
-                    connection.FullState == System.Data.ConnectionState.Closed) {
-                    break;
-                }
-            } catch (IOException ex) {
-                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
-                if (connection.FullState == System.Data.ConnectionState.Broken ||
-                    connection.FullState == System.Data.ConnectionState.Closed) {
-                    break;
-                }
-            } catch (CryptographicException ex) {
-                LogCrtShPostgreSqlExactMetadataSequentialFailure(logger, normalizedHost, ex);
-                if (connection.FullState == System.Data.ConnectionState.Broken ||
-                    connection.FullState == System.Data.ConnectionState.Closed) {
-                    break;
-                }
-            }
-        }
-
-        return results;
-    }
-
-    private static void LogCrtShPostgreSqlExactMetadataSequentialFailure(
-        InternalLogger? logger,
-        string normalizedHost,
-        Exception ex) {
-        logger?.WriteVerbose(
-            "CT metadata backfill exact PostgreSQL lookup failed for {0}: {1}",
-            normalizedHost,
-            ex.Message);
-    }
-
     private static HashSet<string> BuildTargetedCtMetadataThumbprintSet(CertificateInventoryCaptureOptions? options) {
         if (options == null || options.CtMetadataTargetThumbprints.Count == 0) {
             return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -849,82 +735,6 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         return thumbprints;
-    }
-
-    private static async Task<SubdomainDiscoveryEntry?> QueryCrtShPostgreSqlMetadataExactAsync(
-        string hostName,
-        CertificateInventoryCaptureOptions options,
-        InternalLogger? logger,
-        CancellationToken cancellationToken) {
-        if (string.IsNullOrWhiteSpace(hostName) || options == null) {
-            return null;
-        }
-
-        string normalizedHost = hostName.Trim().TrimEnd('.').ToLowerInvariant();
-        string connectionString = BuildCrtShPostgreSqlConnectionString(options);
-        await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        return await QueryCrtShPostgreSqlMetadataExactAsync(
-            connection,
-            normalizedHost,
-            options,
-            logger,
-            BuildTargetedCtMetadataThumbprintSet(options),
-            cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task<SubdomainDiscoveryEntry?> QueryCrtShPostgreSqlMetadataExactAsync(
-        NpgsqlConnection connection,
-        string normalizedHost,
-        CertificateInventoryCaptureOptions options,
-        InternalLogger? logger,
-        ISet<string>? targetedThumbprints,
-        CancellationToken cancellationToken) {
-        if (connection == null ||
-            string.IsNullOrWhiteSpace(normalizedHost) ||
-            options == null) {
-            return null;
-        }
-
-        using var command = connection.CreateCommand();
-        command.CommandTimeout = Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds);
-        command.CommandText = BuildCrtShPostgreSqlExactMetadataQuery();
-        command.Parameters.AddWithValue("host", normalizedHost);
-
-        var rows = new List<CrtShPostgreSqlExactMetadataRow>();
-        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false)) {
-            rows.Add(new CrtShPostgreSqlExactMetadataRow {
-                CertificateDer = reader.IsDBNull(0) ? null : (byte[])reader.GetValue(0),
-                EntryTimestampUtc = reader.IsDBNull(1) ? null : ReadDateTimeOffset(reader.GetValue(1)),
-                CommonName = reader.IsDBNull(2) ? null : reader.GetString(2),
-                IssuerName = reader.IsDBNull(3) ? null : reader.GetString(3),
-                SerialNumber = reader.IsDBNull(4) ? null : reader.GetString(4),
-                NotBeforeUtc = reader.IsDBNull(5) ? null : ReadDateTimeOffset(reader.GetValue(5)),
-                NotAfterUtc = reader.IsDBNull(6) ? null : ReadDateTimeOffset(reader.GetValue(6)),
-                CandidateNames = reader.IsDBNull(7)
-                    ? Array.Empty<string>()
-                    : ((string[])reader.GetValue(7))
-                        .Select(static name => NormalizeCtMetadataCandidate(name, preserveWildcard: true))
-                        .Where(static name => !string.IsNullOrWhiteSpace(name))
-                        .Select(static name => name!)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToList()
-            });
-        }
-
-        SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
-            normalizedHost,
-            rows,
-            targetedThumbprints);
-        if (entry != null) {
-            logger?.WriteVerbose(
-                "CT metadata backfill exact PostgreSQL lookup matched {0} row(s) for {1}.",
-                rows.Count,
-                normalizedHost);
-        }
-
-        return entry;
     }
 
     private async Task<Dictionary<string, SubdomainDiscoveryEntry>> QueryCrtShPostgreSqlMetadataByDomainAsync(
@@ -949,56 +759,24 @@ public sealed partial class CertificateInventoryCapture {
 
         string normalizedDomain = domain.Trim().TrimEnd('.').ToLowerInvariant();
         HashSet<string> targetedThumbprints = BuildTargetedCtMetadataThumbprintSet(options);
-        string connectionString = BuildCrtShPostgreSqlConnectionString(options);
-        await using var connection = new NpgsqlConnection(connectionString);
-        await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandTimeout = Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds);
-        command.CommandText = BuildCrtShPostgreSqlDomainMetadataQuery();
-        command.Parameters.AddWithValue("domain", normalizedDomain);
-        command.Parameters.Add(new NpgsqlParameter<string[]>("hosts", NpgsqlDbType.Array | NpgsqlDbType.Text)
-        {
-            TypedValue = normalizedHosts.ToArray()
-        });
-        command.Parameters.Add(new NpgsqlParameter<string[]>("wildcardHosts", NpgsqlDbType.Array | NpgsqlDbType.Text)
-        {
-            TypedValue = normalizedHosts.Select(BuildWildcardCandidateHost).ToArray()
-        });
-        command.Parameters.AddWithValue("limit", Math.Min(Math.Max(32, normalizedHosts.Count * 8), 512));
-
-        var rows = new List<CrtShPostgreSqlExactMetadataRow>();
-        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false)) {
-            rows.Add(new CrtShPostgreSqlExactMetadataRow
-            {
-                CertificateDer = reader.IsDBNull(0) ? null : (byte[])reader.GetValue(0),
-                EntryTimestampUtc = reader.IsDBNull(1) ? null : ReadDateTimeOffset(reader.GetValue(1)),
-                CommonName = reader.IsDBNull(2) ? null : reader.GetString(2),
-                IssuerName = reader.IsDBNull(3) ? null : reader.GetString(3),
-                SerialNumber = reader.IsDBNull(4) ? null : reader.GetString(4),
-                NotBeforeUtc = reader.IsDBNull(5) ? null : ReadDateTimeOffset(reader.GetValue(5)),
-                NotAfterUtc = reader.IsDBNull(6) ? null : ReadDateTimeOffset(reader.GetValue(6)),
-                CandidateNames = reader.IsDBNull(7)
-                    ? Array.Empty<string>()
-                    : ((string[])reader.GetValue(7))
-                        .Select(static name => NormalizeCtMetadataCandidate(name, preserveWildcard: true))
-                        .Where(static name => !string.IsNullOrWhiteSpace(name))
-                        .Select(static name => name!)
-                        .Distinct(StringComparer.OrdinalIgnoreCase)
-                        .ToList()
-            });
+        ICtSqlMetadataProvider? sqlMetadataProvider = DomainDetectiveOptionalFeatures.GetCtSqlMetadataProvider();
+        if (sqlMetadataProvider == null) {
+            throw new InvalidOperationException("DomainDetective.CtSql is not registered. Reference DomainDetective.CtSql and call DomainDetectiveCtSqlRegistration.Register() before enabling crt.sh PostgreSQL metadata fallback.");
         }
 
-        foreach (string normalizedHost in normalizedHosts) {
-            SubdomainDiscoveryEntry? entry = TryBuildExactCtMetadataEntryFromCrtShPostgreSqlRows(
-                normalizedHost,
-                rows,
-                targetedThumbprints);
-            if (entry == null || string.IsNullOrWhiteSpace(entry.Name)) {
+        IReadOnlyDictionary<string, SubdomainDiscoveryEntry> providerResults = await sqlMetadataProvider.QueryDomainMetadataAsync(
+            normalizedDomain,
+            normalizedHosts,
+            options,
+            logger,
+            targetedThumbprints,
+            cancellationToken).ConfigureAwait(false);
+        foreach (KeyValuePair<string, SubdomainDiscoveryEntry> pair in providerResults) {
+            if (pair.Value == null || string.IsNullOrWhiteSpace(pair.Value.Name)) {
                 continue;
             }
 
-            results[normalizedHost] = entry;
+            results[pair.Key] = pair.Value;
         }
 
         if (results.Count > 0) {
@@ -1006,7 +784,7 @@ public sealed partial class CertificateInventoryCapture {
                 "CT metadata backfill domain PostgreSQL lookup matched {0} host(s) for {1} from {2} candidate certificate row(s).",
                 results.Count,
                 normalizedDomain,
-                rows.Count);
+                results.Sum(static pair => Math.Max(0, pair.Value.CertificateObservationCount)));
         }
 
         return results;
@@ -1217,23 +995,6 @@ public sealed partial class CertificateInventoryCapture {
                targetedThumbprints.Contains(thumbprint!);
     }
 
-    private static string BuildCrtShPostgreSqlConnectionString(CertificateInventoryCaptureOptions options) {
-        if (!string.IsNullOrWhiteSpace(options?.CrtShPostgreSqlConnectionString)) {
-            return options!.CrtShPostgreSqlConnectionString!;
-        }
-
-        var builder = new NpgsqlConnectionStringBuilder {
-            Host = "crt.sh",
-            Port = 5432,
-            Database = "certwatch",
-            Username = "guest",
-            SslMode = SslMode.Require,
-            Timeout = Math.Max(1, options?.CrtShPostgreSqlCommandTimeoutSeconds ?? 15),
-            CommandTimeout = Math.Max(1, options?.CrtShPostgreSqlCommandTimeoutSeconds ?? 15)
-        };
-        return builder.ConnectionString;
-    }
-
     internal static string BuildWildcardCandidateHost(string normalizedHost) {
         if (string.IsNullOrWhiteSpace(normalizedHost)) {
             return normalizedHost ?? string.Empty;
@@ -1246,21 +1007,6 @@ public sealed partial class CertificateInventoryCapture {
                firstDotIndex == lastDotIndex
             ? normalizedHost
             : "*." + normalizedHost.Substring(firstDotIndex + 1);
-    }
-
-    private static DateTimeOffset? ReadDateTimeOffset(object? value) {
-        return value switch {
-            null => null,
-            DateTimeOffset dateTimeOffset => dateTimeOffset.ToUniversalTime(),
-            DateTime dateTime => new DateTimeOffset(DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)),
-            _ => DateTimeOffset.TryParse(
-                value.ToString(),
-                System.Globalization.CultureInfo.InvariantCulture,
-                System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal,
-                out DateTimeOffset parsed)
-                ? parsed
-                : (DateTimeOffset?)null
-        };
     }
 
     private static bool IsSha1Signature(string? oid) {

--- a/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
@@ -1,0 +1,27 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes a CT certificate query requested by a caller or service.
+/// </summary>
+public sealed class CtCertificateQuery
+{
+    /// <summary>Domain or host name to query.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Operations requested from the provider.</summary>
+    public CtIngestionOperation Operations { get; init; } = CtIngestionOperation.GetLatestCertificate;
+
+    /// <summary>Whether returned certificate rows must include full DER or PEM material.</summary>
+    public bool RequireFullCertificate { get; init; } = true;
+
+    /// <summary>Optional provider continuation token or cursor.</summary>
+    public string? ContinuationToken { get; init; }
+
+    /// <summary>Maximum records to return in one provider call or page.</summary>
+    public int? PageSize { get; init; }
+
+    /// <summary>Maximum wall-clock time to spend on this query.</summary>
+    public TimeSpan? Timeout { get; init; }
+}

--- a/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
@@ -24,4 +24,36 @@ public sealed class CtCertificateQuery
 
     /// <summary>Maximum wall-clock time to spend on this query.</summary>
     public TimeSpan? Timeout { get; init; }
+
+    /// <summary>
+    /// Returns a normalized copy of the query suitable for provider execution.
+    /// </summary>
+    public CtCertificateQuery Normalize()
+    {
+        string? continuationToken = ContinuationToken;
+        string? normalizedContinuationToken = continuationToken == null
+            ? null
+            : continuationToken.Trim();
+        if (normalizedContinuationToken != null &&
+            normalizedContinuationToken.Length == 0)
+        {
+            normalizedContinuationToken = null;
+        }
+
+        return new CtCertificateQuery
+        {
+            Name = (Name ?? string.Empty).Trim(),
+            Operations = Operations == CtIngestionOperation.None
+                ? CtIngestionOperation.GetLatestCertificate
+                : Operations,
+            RequireFullCertificate = RequireFullCertificate,
+            ContinuationToken = normalizedContinuationToken,
+            PageSize = PageSize.HasValue && PageSize.Value > 0
+                ? PageSize.Value
+                : null,
+            Timeout = Timeout.HasValue && Timeout.Value > TimeSpan.Zero
+                ? Timeout.Value
+                : null
+        };
+    }
 }

--- a/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
@@ -97,15 +97,9 @@ public sealed class CtCertificateQuery
     /// </summary>
     public CtCertificateQuery Normalize()
     {
-        string? continuationToken = ContinuationToken;
-        string? normalizedContinuationToken = continuationToken == null
+        string? normalizedContinuationToken = string.IsNullOrWhiteSpace(ContinuationToken)
             ? null
-            : continuationToken.Trim();
-        if (normalizedContinuationToken != null &&
-            normalizedContinuationToken.Length == 0)
-        {
-            normalizedContinuationToken = null;
-        }
+            : ContinuationToken!.Trim();
 
         CtIngestionOperation operations = Operations == CtIngestionOperation.None
             ? ResolveOperations(QueryKind)
@@ -130,6 +124,20 @@ public sealed class CtCertificateQuery
             Timeout = Timeout.HasValue && Timeout.Value > TimeSpan.Zero
                 ? Timeout.Value
                 : null
+        };
+    }
+
+    internal CtCertificateQuery WithContinuationToken(string continuationToken)
+    {
+        return new CtCertificateQuery
+        {
+            Name = Name,
+            QueryKind = QueryKind,
+            Operations = Operations,
+            RequireFullCertificate = RequireFullCertificate,
+            ContinuationToken = continuationToken,
+            PageSize = PageSize,
+            Timeout = Timeout
         };
     }
 

--- a/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateQuery.cs
@@ -10,6 +10,9 @@ public sealed class CtCertificateQuery
     /// <summary>Domain or host name to query.</summary>
     public string Name { get; init; } = string.Empty;
 
+    /// <summary>Service-level intent of the query.</summary>
+    public CtCertificateQueryKind QueryKind { get; init; }
+
     /// <summary>Operations requested from the provider.</summary>
     public CtIngestionOperation Operations { get; init; } = CtIngestionOperation.GetLatestCertificate;
 
@@ -26,6 +29,70 @@ public sealed class CtCertificateQuery
     public TimeSpan? Timeout { get; init; }
 
     /// <summary>
+    /// Creates a query for the latest known certificate for one exact host.
+    /// </summary>
+    /// <param name="hostName">Exact host name to query.</param>
+    /// <param name="requireFullCertificate">Whether full certificate material is required.</param>
+    public static CtCertificateQuery ForExactHostLatest(string hostName, bool requireFullCertificate = true)
+    {
+        return new CtCertificateQuery
+        {
+            Name = hostName ?? string.Empty,
+            QueryKind = CtCertificateQueryKind.ExactHostLatest,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = requireFullCertificate
+        };
+    }
+
+    /// <summary>
+    /// Creates a query for historical certificates for one exact host.
+    /// </summary>
+    /// <param name="hostName">Exact host name to query.</param>
+    /// <param name="requireFullCertificate">Whether full certificate material is required.</param>
+    public static CtCertificateQuery ForExactHostHistory(string hostName, bool requireFullCertificate = true)
+    {
+        return new CtCertificateQuery
+        {
+            Name = hostName ?? string.Empty,
+            QueryKind = CtCertificateQueryKind.ExactHostHistory,
+            Operations = CtIngestionOperation.GetCertificateHistory,
+            RequireFullCertificate = requireFullCertificate
+        };
+    }
+
+    /// <summary>
+    /// Creates a query that expands a domain into CT-observed subdomains.
+    /// </summary>
+    /// <param name="domainName">Registered or monitored domain to expand.</param>
+    /// <param name="requireFullCertificate">Whether full certificate material is required during expansion.</param>
+    public static CtCertificateQuery ForDomainExpansion(string domainName, bool requireFullCertificate = false)
+    {
+        return new CtCertificateQuery
+        {
+            Name = domainName ?? string.Empty,
+            QueryKind = CtCertificateQueryKind.DomainExpansion,
+            Operations = CtIngestionOperation.DiscoverSubdomains,
+            RequireFullCertificate = requireFullCertificate
+        };
+    }
+
+    /// <summary>
+    /// Creates a query for certificates across a domain tree.
+    /// </summary>
+    /// <param name="domainName">Registered or monitored domain to query.</param>
+    /// <param name="requireFullCertificate">Whether full certificate material is required.</param>
+    public static CtCertificateQuery ForDomainTreeCertificates(string domainName, bool requireFullCertificate = true)
+    {
+        return new CtCertificateQuery
+        {
+            Name = domainName ?? string.Empty,
+            QueryKind = CtCertificateQueryKind.DomainTreeCertificates,
+            Operations = CtIngestionOperation.GetDomainTreeCertificates,
+            RequireFullCertificate = requireFullCertificate
+        };
+    }
+
+    /// <summary>
     /// Returns a normalized copy of the query suitable for provider execution.
     /// </summary>
     public CtCertificateQuery Normalize()
@@ -40,12 +107,21 @@ public sealed class CtCertificateQuery
             normalizedContinuationToken = null;
         }
 
+        CtIngestionOperation operations = Operations == CtIngestionOperation.None
+            ? ResolveOperations(QueryKind)
+            : Operations;
+        CtCertificateQueryKind queryKind = QueryKind == CtCertificateQueryKind.Unspecified ||
+                                           !QueryKindMatchesOperations(QueryKind, operations)
+            ? ResolveQueryKind(operations)
+            : QueryKind;
+
         return new CtCertificateQuery
         {
             Name = (Name ?? string.Empty).Trim(),
-            Operations = Operations == CtIngestionOperation.None
+            QueryKind = queryKind,
+            Operations = operations == CtIngestionOperation.None
                 ? CtIngestionOperation.GetLatestCertificate
-                : Operations,
+                : operations,
             RequireFullCertificate = RequireFullCertificate,
             ContinuationToken = normalizedContinuationToken,
             PageSize = PageSize.HasValue && PageSize.Value > 0
@@ -54,6 +130,49 @@ public sealed class CtCertificateQuery
             Timeout = Timeout.HasValue && Timeout.Value > TimeSpan.Zero
                 ? Timeout.Value
                 : null
+        };
+    }
+
+    private static CtIngestionOperation ResolveOperations(CtCertificateQueryKind queryKind)
+    {
+        return queryKind switch
+        {
+            CtCertificateQueryKind.DomainExpansion => CtIngestionOperation.DiscoverSubdomains,
+            CtCertificateQueryKind.ExactHostHistory => CtIngestionOperation.GetCertificateHistory,
+            CtCertificateQueryKind.DomainTreeCertificates => CtIngestionOperation.GetDomainTreeCertificates,
+            _ => CtIngestionOperation.GetLatestCertificate
+        };
+    }
+
+    private static CtCertificateQueryKind ResolveQueryKind(CtIngestionOperation operations)
+    {
+        if ((operations & CtIngestionOperation.GetDomainTreeCertificates) != 0)
+        {
+            return CtCertificateQueryKind.DomainTreeCertificates;
+        }
+
+        if ((operations & CtIngestionOperation.DiscoverSubdomains) != 0)
+        {
+            return CtCertificateQueryKind.DomainExpansion;
+        }
+
+        if ((operations & CtIngestionOperation.GetCertificateHistory) != 0)
+        {
+            return CtCertificateQueryKind.ExactHostHistory;
+        }
+
+        return CtCertificateQueryKind.ExactHostLatest;
+    }
+
+    private static bool QueryKindMatchesOperations(CtCertificateQueryKind queryKind, CtIngestionOperation operations)
+    {
+        return queryKind switch
+        {
+            CtCertificateQueryKind.DomainExpansion => operations == CtIngestionOperation.DiscoverSubdomains,
+            CtCertificateQueryKind.ExactHostLatest => operations == CtIngestionOperation.GetLatestCertificate,
+            CtCertificateQueryKind.ExactHostHistory => operations == CtIngestionOperation.GetCertificateHistory,
+            CtCertificateQueryKind.DomainTreeCertificates => operations == CtIngestionOperation.GetDomainTreeCertificates,
+            _ => false
         };
     }
 }

--- a/DomainDetective/CertificateTransparency/CtCertificateQueryKind.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateQueryKind.cs
@@ -1,0 +1,22 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Describes the service-level intent of a certificate transparency query.
+/// </summary>
+public enum CtCertificateQueryKind
+{
+    /// <summary>No explicit CT query intent was supplied.</summary>
+    Unspecified = 0,
+
+    /// <summary>Retrieve the latest known certificate for one exact host name.</summary>
+    ExactHostLatest = 1,
+
+    /// <summary>Retrieve historical certificates for one exact host name.</summary>
+    ExactHostHistory = 2,
+
+    /// <summary>Expand a registered or monitored domain into observed subdomains.</summary>
+    DomainExpansion = 3,
+
+    /// <summary>Retrieve certificates for a domain tree and its discovered host names.</summary>
+    DomainTreeCertificates = 4
+}

--- a/DomainDetective/CertificateTransparency/CtCertificateQueryResult.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateQueryResult.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Represents normalized CT query results from a provider.
+/// </summary>
+public sealed class CtCertificateQueryResult
+{
+    /// <summary>Provider that returned the result.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Certificate records returned by the provider.</summary>
+    public IReadOnlyList<CtCertificateRecord> Certificates { get; init; } = Array.Empty<CtCertificateRecord>();
+
+    /// <summary>Discovered DNS names returned by the provider.</summary>
+    public IReadOnlyList<string> DiscoveredNames { get; init; } = Array.Empty<string>();
+
+    /// <summary>Continuation token to request the next page, when supported.</summary>
+    public string? ContinuationToken { get; init; }
+
+    /// <summary>True when more provider data is available through the continuation token.</summary>
+    public bool HasMore { get; init; }
+
+    /// <summary>Provider runtime state observed during the query.</summary>
+    public CtProviderRuntimeState? ProviderState { get; init; }
+
+    /// <summary>Provider warnings or diagnostics useful for scheduling and retries.</summary>
+    public IReadOnlyList<string> Diagnostics { get; init; } = Array.Empty<string>();
+}

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -49,7 +49,7 @@ public sealed class CtCertificateRecord
     /// <summary>Certificate not-after timestamp.</summary>
     public DateTimeOffset? NotAfterUtc { get; init; }
 
-    /// <summary>Subject alternative DNS names and common name candidates observed on the certificate.</summary>
+    /// <summary>Subject alternative DNS names and common name candidates observed on the certificate, sorted case-insensitively.</summary>
     public IReadOnlyList<string> DnsNames { get; init; } = Array.Empty<string>();
 
     /// <summary>True when the certificate subject and issuer match.</summary>
@@ -113,6 +113,7 @@ public sealed class CtCertificateRecord
             throw new ArgumentException("Certificate DER bytes cannot be empty.", nameof(certificateDer));
         }
 
+        // Keep the normalized record immutable even if the caller later mutates their input buffer.
         byte[] rawData = certificateDer.ToArray();
         using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(rawData);
         CertificateExtendedKeyUsageInfo eku = CertificateExtendedKeyUsageAnalyzer.Analyze(certificate);
@@ -353,7 +354,17 @@ public sealed class CtCertificateRecord
             return null;
         }
 
-        return new string(value!.Where(Uri.IsHexDigit).ToArray()).ToUpperInvariant();
+        char[] output = new char[value!.Length];
+        int count = 0;
+        foreach (char character in value)
+        {
+            if (IsHexDigit(character))
+            {
+                output[count++] = char.ToUpperInvariant(character);
+            }
+        }
+
+        return new string(output, 0, count);
     }
 
     private static bool IsSelfSignedCertificate(X509Certificate2 certificate)
@@ -363,10 +374,17 @@ public sealed class CtCertificateRecord
 
     private static bool IsSha1Signature(string? oid)
     {
-        return oid == "1.2.840.113549.1.1.5" ||
-               oid == "1.2.840.10040.4.3" ||
-               oid == "1.2.840.10045.4.1" ||
-               oid == "1.3.14.3.2.29";
+        return oid == "1.2.840.113549.1.1.5" || // sha1WithRSAEncryption
+               oid == "1.2.840.10040.4.3" ||    // id-dsa-with-sha1
+               oid == "1.2.840.10045.4.1" ||    // ecdsa-with-SHA1
+               oid == "1.3.14.3.2.29";          // legacy sha1WithRSA
+    }
+
+    private static bool IsHexDigit(char character)
+    {
+        return (character >= '0' && character <= '9') ||
+               (character >= 'a' && character <= 'f') ||
+               (character >= 'A' && character <= 'F');
     }
 
     private static bool IsWeakPublicKey(X509Certificate2 certificate)
@@ -539,6 +557,7 @@ public sealed class CtCertificateRecord
         int count = first & 0x7F;
         if (count <= 0 || count > 4 || offset + count > data.Length)
         {
+            // Indefinite or unusually large ASN.1 lengths are treated as unsupported by this pre-net8 fallback parser.
             return false;
         }
 

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -218,13 +218,11 @@ public sealed class CtCertificateRecord
         }
 
         foreach (string trimmed in SplitDistinguishedNameParts(subject!)
-            .Select(part => part.Trim()))
+            .Select(part => part.Trim())
+            .Where(part => part.StartsWith("CN=", StringComparison.OrdinalIgnoreCase)))
         {
-            if (trimmed.StartsWith("CN=", StringComparison.OrdinalIgnoreCase))
-            {
-                string value = UnescapeDistinguishedNameValue(trimmed.Substring(3).Trim());
-                return value.Length == 0 ? null : value;
-            }
+            string value = UnescapeDistinguishedNameValue(trimmed.Substring(3).Trim());
+            return value.Length == 0 ? null : value;
         }
 
         return null;
@@ -356,12 +354,9 @@ public sealed class CtCertificateRecord
 
         char[] output = new char[value!.Length];
         int count = 0;
-        foreach (char character in value)
+        foreach (char character in value.Where(IsHexDigit))
         {
-            if (IsHexDigit(character))
-            {
-                output[count++] = char.ToUpperInvariant(character);
-            }
+            output[count++] = char.ToUpperInvariant(character);
         }
 
         return new string(output, 0, count);
@@ -382,9 +377,10 @@ public sealed class CtCertificateRecord
 
     private static bool IsHexDigit(char character)
     {
-        return (character >= '0' && character <= '9') ||
-               (character >= 'a' && character <= 'f') ||
-               (character >= 'A' && character <= 'F');
+        bool isDecimalDigit = character >= '0' && character <= '9';
+        bool isLowerHexLetter = character >= 'a' && character <= 'f';
+        bool isUpperHexLetter = character >= 'A' && character <= 'F';
+        return isDecimalDigit || isLowerHexLetter || isUpperHexLetter;
     }
 
     private static bool IsWeakPublicKey(X509Certificate2 certificate)

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -14,6 +14,7 @@ namespace DomainDetective;
 public sealed class CtCertificateRecord
 {
     private const string SubjectAlternativeNameOid = "2.5.29.17";
+    private static readonly char[] InvalidDnsNameCharacters = { ' ', '/', '@', ',' };
 
     /// <summary>Provider that returned the record.</summary>
     public string ProviderId { get; init; } = string.Empty;
@@ -269,31 +270,59 @@ public sealed class CtCertificateRecord
     private static string UnescapeDistinguishedNameValue(string value)
     {
         var builder = new StringBuilder(value.Length);
-        bool escaped = false;
-        foreach (char character in value)
+        for (int index = 0; index < value.Length; index++)
         {
-            if (escaped)
+            char character = value[index];
+            if (character != '\\')
             {
                 builder.Append(character);
-                escaped = false;
                 continue;
             }
 
-            if (character == '\\')
+            if (TryReadHexEscapedBytes(value, ref index, out string decodedValue))
             {
-                escaped = true;
+                builder.Append(decodedValue);
                 continue;
             }
 
-            builder.Append(character);
-        }
-
-        if (escaped)
-        {
-            builder.Append('\\');
+            if (index + 1 < value.Length)
+            {
+                builder.Append(value[++index]);
+            }
+            else
+            {
+                builder.Append('\\');
+            }
         }
 
         return builder.ToString().Trim();
+    }
+
+    private static bool TryReadHexEscapedBytes(string value, ref int index, out string decodedValue)
+    {
+        decodedValue = string.Empty;
+        if (index + 2 >= value.Length ||
+            !Uri.IsHexDigit(value[index + 1]) ||
+            !Uri.IsHexDigit(value[index + 2]))
+        {
+            return false;
+        }
+
+        var bytes = new List<byte>();
+        int currentIndex = index;
+        while (currentIndex + 2 < value.Length &&
+               value[currentIndex] == '\\' &&
+               Uri.IsHexDigit(value[currentIndex + 1]) &&
+               Uri.IsHexDigit(value[currentIndex + 2]))
+        {
+            string hex = value.Substring(currentIndex + 1, 2);
+            bytes.Add(Convert.ToByte(hex, 16));
+            currentIndex += 3;
+        }
+
+        decodedValue = Encoding.UTF8.GetString(bytes.ToArray());
+        index = currentIndex - 1;
+        return true;
     }
 
     private static void AddDnsNameIfCandidate(HashSet<string> names, string? name)
@@ -308,7 +337,7 @@ public sealed class CtCertificateRecord
             ? value.Substring(2)
             : value;
         if (hostCandidate.Length == 0 ||
-            hostCandidate.IndexOfAny(new[] { ' ', '/', '@', ',' }) >= 0 ||
+            hostCandidate.IndexOfAny(InvalidDnsNameCharacters) >= 0 ||
             Uri.CheckHostName(hostCandidate) != UriHostNameType.Dns)
         {
             return;
@@ -336,6 +365,7 @@ public sealed class CtCertificateRecord
     {
         return oid == "1.2.840.113549.1.1.5" ||
                oid == "1.2.840.10040.4.3" ||
+               oid == "1.2.840.10045.4.1" ||
                oid == "1.3.14.3.2.29";
     }
 

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Represents a normalized certificate transparency certificate record.
+/// </summary>
+public sealed class CtCertificateRecord
+{
+    /// <summary>Provider that returned the record.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Provider-specific certificate or issuance identifier.</summary>
+    public string? ProviderCertificateId { get; init; }
+
+    /// <summary>CT entry timestamp, when supplied by the provider.</summary>
+    public DateTimeOffset? EntryTimestampUtc { get; init; }
+
+    /// <summary>SHA-256 fingerprint of the DER certificate or precertificate.</summary>
+    public string? Sha256Fingerprint { get; init; }
+
+    /// <summary>SHA-1 fingerprint of the DER certificate or precertificate.</summary>
+    public string? Sha1Fingerprint { get; init; }
+
+    /// <summary>TBS certificate SHA-256 value when supplied by the provider.</summary>
+    public string? TbsSha256 { get; init; }
+
+    /// <summary>Subject distinguished name.</summary>
+    public string? Subject { get; init; }
+
+    /// <summary>Issuer distinguished name or provider-normalized issuer name.</summary>
+    public string? Issuer { get; init; }
+
+    /// <summary>Certificate serial number.</summary>
+    public string? SerialNumber { get; init; }
+
+    /// <summary>Certificate not-before timestamp.</summary>
+    public DateTimeOffset? NotBeforeUtc { get; init; }
+
+    /// <summary>Certificate not-after timestamp.</summary>
+    public DateTimeOffset? NotAfterUtc { get; init; }
+
+    /// <summary>Subject alternative DNS names and common name candidates observed on the certificate.</summary>
+    public IReadOnlyList<string> DnsNames { get; init; } = Array.Empty<string>();
+
+    /// <summary>DER-encoded X.509 certificate or precertificate bytes.</summary>
+    public byte[]? CertificateDer { get; init; }
+
+    /// <summary>PEM-encoded certificate text, when supplied or derived by a provider.</summary>
+    public string? CertificatePem { get; init; }
+
+    /// <summary>True when the record is known to represent a precertificate.</summary>
+    public bool? IsPrecertificate { get; init; }
+
+    /// <summary>True when the record contains full certificate material.</summary>
+    public bool HasFullCertificate => (CertificateDer != null && CertificateDer.Length > 0) ||
+                                      !string.IsNullOrWhiteSpace(CertificatePem);
+}

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using DomainDetective.Helpers;
 
 namespace DomainDetective;
@@ -115,7 +116,6 @@ public sealed class CtCertificateRecord
         using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(rawData);
         CertificateExtendedKeyUsageInfo eku = CertificateExtendedKeyUsageAnalyzer.Analyze(certificate);
         string? signatureOid = certificate.SignatureAlgorithm?.Value;
-        int keySize = GetPublicKeySize(certificate);
         byte[] sha256Bytes;
         using (SHA256 sha256 = SHA256.Create())
         {
@@ -137,7 +137,7 @@ public sealed class CtCertificateRecord
             NotAfterUtc = new DateTimeOffset(certificate.NotAfter.ToUniversalTime()),
             DnsNames = ExtractDnsNames(certificate),
             IsSelfSigned = IsSelfSignedCertificate(certificate),
-            WeakKey = keySize > 0 && keySize < 2048,
+            WeakKey = IsWeakPublicKey(certificate),
             Sha1Signature = IsSha1Signature(signatureOid),
             AllowsServerAuthentication = eku.AllowsServerAuthentication,
             AllowsClientAuthentication = eku.AllowsClientAuthentication,
@@ -169,21 +169,18 @@ public sealed class CtCertificateRecord
                     AddIfNotEmpty(names, dnsName);
                 }
 #else
-                string formatted = san.Format(false);
-                foreach (string part in formatted.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                int sanNameCount = 0;
+                foreach (string dnsName in ParseDnsNamesFromSanExtension(san.RawData))
                 {
-                    string item = part.Trim();
-                    int equalsIndex = item.IndexOf('=');
-                    if (equalsIndex <= 0)
-                    {
-                        continue;
-                    }
+                    sanNameCount++;
+                    AddIfNotEmpty(names, dnsName);
+                }
 
-                    string key = item.Substring(0, equalsIndex).Trim();
-                    if (key.Equals("DNS Name", StringComparison.OrdinalIgnoreCase) ||
-                        key.Equals("DNS", StringComparison.OrdinalIgnoreCase))
+                if (sanNameCount == 0)
+                {
+                    foreach (string dnsName in ParseDnsNamesFromSanText(san.Format(false)))
                     {
-                        AddIfNotEmpty(names, item.Substring(equalsIndex + 1).Trim());
+                        AddIfNotEmpty(names, dnsName);
                     }
                 }
 #endif
@@ -251,8 +248,7 @@ public sealed class CtCertificateRecord
 
     private static bool IsSelfSignedCertificate(X509Certificate2 certificate)
     {
-        return !string.IsNullOrWhiteSpace(certificate.Subject) &&
-               string.Equals(certificate.Subject, certificate.Issuer, StringComparison.OrdinalIgnoreCase);
+        return certificate.SubjectName.RawData.SequenceEqual(certificate.IssuerName.RawData);
     }
 
     private static bool IsSha1Signature(string? oid)
@@ -262,11 +258,11 @@ public sealed class CtCertificateRecord
                oid == "1.3.14.3.2.29";
     }
 
-    private static int GetPublicKeySize(X509Certificate2 certificate)
+    private static bool IsWeakPublicKey(X509Certificate2 certificate)
     {
         if (certificate == null)
         {
-            return 0;
+            return false;
         }
 
         try
@@ -274,7 +270,7 @@ public sealed class CtCertificateRecord
             using RSA? rsa = certificate.GetRSAPublicKey();
             if (rsa != null)
             {
-                return rsa.KeySize;
+                return rsa.KeySize < 2048;
             }
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
@@ -286,7 +282,7 @@ public sealed class CtCertificateRecord
             using ECDsa? ecdsa = certificate.GetECDsaPublicKey();
             if (ecdsa != null)
             {
-                return ecdsa.KeySize;
+                return ecdsa.KeySize < 224;
             }
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
@@ -298,14 +294,147 @@ public sealed class CtCertificateRecord
             using DSA? dsa = certificate.GetDSAPublicKey();
             if (dsa != null)
             {
-                return dsa.KeySize;
+                return dsa.KeySize < 2048;
             }
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
         {
         }
 
-        return 0;
+        return false;
+    }
+
+    private static IEnumerable<string> ParseDnsNamesFromSanText(string? formattedSan)
+    {
+        if (string.IsNullOrWhiteSpace(formattedSan))
+        {
+            yield break;
+        }
+
+        foreach (string part in formattedSan!.Split(new[] { ',', ';', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string item = part.Trim();
+            const string dnsNamePrefix = "DNS Name=";
+            const string dnsShortPrefix = "DNS:";
+
+            if (item.StartsWith(dnsNamePrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                string value = item.Substring(dnsNamePrefix.Length).Trim();
+                if (value.Length > 0)
+                {
+                    yield return value;
+                }
+            }
+            else if (item.StartsWith(dnsShortPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                string value = item.Substring(dnsShortPrefix.Length).Trim();
+                if (value.Length > 0)
+                {
+                    yield return value;
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<string> ParseDnsNamesFromSanExtension(byte[] rawData)
+    {
+        if (rawData == null || rawData.Length == 0)
+        {
+            yield break;
+        }
+
+        int offset = 0;
+        int sequenceLimit = rawData.Length;
+        if (rawData[offset] == 0x04)
+        {
+            if (!TryReadTagAndLength(rawData, ref offset, expectedTag: 0x04, out int octetLength) ||
+                offset + octetLength > rawData.Length)
+            {
+                yield break;
+            }
+
+            sequenceLimit = offset + octetLength;
+        }
+
+        if (!TryReadTagAndLength(rawData, ref offset, expectedTag: 0x30, out int sequenceLength))
+        {
+            yield break;
+        }
+
+        int sequenceEnd = offset + sequenceLength;
+        if (sequenceEnd > sequenceLimit)
+        {
+            yield break;
+        }
+
+        while (offset < sequenceEnd)
+        {
+            byte tag = rawData[offset++];
+            if (!TryReadAsnLength(rawData, ref offset, out int length) ||
+                offset + length > sequenceEnd)
+            {
+                yield break;
+            }
+
+            if (tag == 0x82 && length > 0)
+            {
+                string value = Encoding.ASCII.GetString(rawData, offset, length).Trim();
+                if (value.Length > 0)
+                {
+                    yield return value;
+                }
+            }
+
+            offset += length;
+        }
+    }
+
+    private static bool TryReadTagAndLength(byte[] data, ref int offset, byte expectedTag, out int length)
+    {
+        length = 0;
+        if (data == null || offset < 0 || offset >= data.Length)
+        {
+            return false;
+        }
+
+        byte tag = data[offset++];
+        if (tag != expectedTag)
+        {
+            return false;
+        }
+
+        return TryReadAsnLength(data, ref offset, out length);
+    }
+
+    private static bool TryReadAsnLength(byte[] data, ref int offset, out int length)
+    {
+        length = 0;
+        if (data == null || offset < 0 || offset >= data.Length)
+        {
+            return false;
+        }
+
+        byte first = data[offset++];
+        if ((first & 0x80) == 0)
+        {
+            length = first;
+            return true;
+        }
+
+        int count = first & 0x7F;
+        if (count <= 0 || count > 4 || offset + count > data.Length)
+        {
+            return false;
+        }
+
+        int value = 0;
+        for (int i = 0; i < count; i++)
+        {
+            value = (value << 8) | data[offset++];
+        }
+
+        length = value;
+        return true;
     }
 
     private static string ToHex(byte[] bytes)

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using DomainDetective.Helpers;
 
 namespace DomainDetective;
 
@@ -8,6 +12,8 @@ namespace DomainDetective;
 /// </summary>
 public sealed class CtCertificateRecord
 {
+    private const string SubjectAlternativeNameOid = "2.5.29.17";
+
     /// <summary>Provider that returned the record.</summary>
     public string ProviderId { get; init; } = string.Empty;
 
@@ -56,4 +62,170 @@ public sealed class CtCertificateRecord
     /// <summary>True when the record contains full certificate material.</summary>
     public bool HasFullCertificate => (CertificateDer != null && CertificateDer.Length > 0) ||
                                       !string.IsNullOrWhiteSpace(CertificatePem);
+
+    /// <summary>
+    /// Creates a CT certificate record from DER-encoded certificate bytes.
+    /// </summary>
+    /// <param name="providerId">Provider that supplied the certificate.</param>
+    /// <param name="certificateDer">DER-encoded certificate bytes.</param>
+    /// <param name="providerCertificateId">Optional provider-specific certificate identifier.</param>
+    /// <param name="entryTimestampUtc">Optional CT entry timestamp.</param>
+    /// <param name="tbsSha256">Optional provider-supplied TBS certificate SHA-256 value.</param>
+    /// <param name="isPrecertificate">True when the provider reports a precertificate.</param>
+    public static CtCertificateRecord FromDer(
+        string providerId,
+        byte[] certificateDer,
+        string? providerCertificateId = null,
+        DateTimeOffset? entryTimestampUtc = null,
+        string? tbsSha256 = null,
+        bool? isPrecertificate = null)
+    {
+        if (certificateDer == null)
+        {
+            throw new ArgumentNullException(nameof(certificateDer));
+        }
+
+        if (certificateDer.Length == 0)
+        {
+            throw new ArgumentException("Certificate DER bytes cannot be empty.", nameof(certificateDer));
+        }
+
+        byte[] rawData = certificateDer.ToArray();
+        using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(rawData);
+        byte[] sha256Bytes;
+        using (SHA256 sha256 = SHA256.Create())
+        {
+            sha256Bytes = sha256.ComputeHash(rawData);
+        }
+
+        return new CtCertificateRecord
+        {
+            ProviderId = providerId ?? string.Empty,
+            ProviderCertificateId = providerCertificateId,
+            EntryTimestampUtc = entryTimestampUtc,
+            Sha256Fingerprint = ToHex(sha256Bytes),
+            Sha1Fingerprint = NormalizeHex(certificate.Thumbprint),
+            TbsSha256 = NormalizeHex(tbsSha256),
+            Subject = certificate.Subject,
+            Issuer = certificate.Issuer,
+            SerialNumber = certificate.SerialNumber,
+            NotBeforeUtc = new DateTimeOffset(certificate.NotBefore.ToUniversalTime()),
+            NotAfterUtc = new DateTimeOffset(certificate.NotAfter.ToUniversalTime()),
+            DnsNames = ExtractDnsNames(certificate),
+            CertificateDer = rawData,
+            IsPrecertificate = isPrecertificate
+        };
+    }
+
+    private static IReadOnlyList<string> ExtractDnsNames(X509Certificate2 certificate)
+    {
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddIfNotEmpty(names, SafeGetNameInfo(certificate, X509NameType.DnsName));
+        AddIfNotEmpty(names, SafeGetNameInfo(certificate, X509NameType.SimpleName));
+        AddIfNotEmpty(names, TryExtractCommonName(certificate.Subject));
+
+        try
+        {
+            X509Extension? san = certificate.Extensions[SubjectAlternativeNameOid];
+            if (san != null)
+            {
+#if NET8_0_OR_GREATER
+                var sanExtension = new X509SubjectAlternativeNameExtension(san.RawData, san.Critical);
+                foreach (string dnsName in sanExtension.EnumerateDnsNames())
+                {
+                    AddIfNotEmpty(names, dnsName);
+                }
+#else
+                string formatted = san.Format(false);
+                foreach (string part in formatted.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    string item = part.Trim();
+                    int equalsIndex = item.IndexOf('=');
+                    if (equalsIndex <= 0)
+                    {
+                        continue;
+                    }
+
+                    string key = item.Substring(0, equalsIndex).Trim();
+                    if (key.Equals("DNS Name", StringComparison.OrdinalIgnoreCase) ||
+                        key.Equals("DNS", StringComparison.OrdinalIgnoreCase))
+                    {
+                        AddIfNotEmpty(names, item.Substring(equalsIndex + 1).Trim());
+                    }
+                }
+#endif
+            }
+        }
+        catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
+        {
+            // Keep certificate parsing resilient; callers still receive core certificate fields.
+        }
+
+        return names
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string? SafeGetNameInfo(X509Certificate2 certificate, X509NameType type)
+    {
+        try
+        {
+            return certificate.GetNameInfo(type, false);
+        }
+        catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
+        {
+            return null;
+        }
+    }
+
+    private static string? TryExtractCommonName(string? subject)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+        {
+            return null;
+        }
+
+        foreach (string part in subject!.Split(','))
+        {
+            string trimmed = part.Trim();
+            if (trimmed.StartsWith("CN=", StringComparison.OrdinalIgnoreCase))
+            {
+                string value = trimmed.Substring(3).Trim();
+                return value.Length == 0 ? null : value;
+            }
+        }
+
+        return null;
+    }
+
+    private static void AddIfNotEmpty(HashSet<string> names, string? name)
+    {
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            names.Add(name!.Trim());
+        }
+    }
+
+    private static string? NormalizeHex(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        return new string(value!.Where(Uri.IsHexDigit).ToArray()).ToUpperInvariant();
+    }
+
+    private static string ToHex(byte[] bytes)
+    {
+        char[] output = new char[bytes.Length * 2];
+        const string alphabet = "0123456789ABCDEF";
+        for (int i = 0; i < bytes.Length; i++)
+        {
+            output[i * 2] = alphabet[bytes[i] >> 4];
+            output[(i * 2) + 1] = alphabet[bytes[i] & 0x0F];
+        }
+
+        return new string(output);
+    }
 }

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -50,6 +50,27 @@ public sealed class CtCertificateRecord
     /// <summary>Subject alternative DNS names and common name candidates observed on the certificate.</summary>
     public IReadOnlyList<string> DnsNames { get; init; } = Array.Empty<string>();
 
+    /// <summary>True when the certificate subject and issuer match.</summary>
+    public bool? IsSelfSigned { get; init; }
+
+    /// <summary>True when the public key is considered weak for modern TLS use.</summary>
+    public bool? WeakKey { get; init; }
+
+    /// <summary>True when the certificate signature algorithm uses SHA-1.</summary>
+    public bool? Sha1Signature { get; init; }
+
+    /// <summary>True when the certificate can be used for TLS server authentication.</summary>
+    public bool? AllowsServerAuthentication { get; init; }
+
+    /// <summary>True when the certificate can be used for TLS client authentication.</summary>
+    public bool? AllowsClientAuthentication { get; init; }
+
+    /// <summary>True when the certificate can be used for secure email.</summary>
+    public bool? AllowsSecureEmail { get; init; }
+
+    /// <summary>Normalized authentication profile derived from Extended Key Usage.</summary>
+    public string? AuthenticationProfile { get; init; }
+
     /// <summary>DER-encoded X.509 certificate or precertificate bytes.</summary>
     public byte[]? CertificateDer { get; init; }
 
@@ -92,6 +113,9 @@ public sealed class CtCertificateRecord
 
         byte[] rawData = certificateDer.ToArray();
         using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(rawData);
+        CertificateExtendedKeyUsageInfo eku = CertificateExtendedKeyUsageAnalyzer.Analyze(certificate);
+        string? signatureOid = certificate.SignatureAlgorithm?.Value;
+        int keySize = GetPublicKeySize(certificate);
         byte[] sha256Bytes;
         using (SHA256 sha256 = SHA256.Create())
         {
@@ -112,6 +136,15 @@ public sealed class CtCertificateRecord
             NotBeforeUtc = new DateTimeOffset(certificate.NotBefore.ToUniversalTime()),
             NotAfterUtc = new DateTimeOffset(certificate.NotAfter.ToUniversalTime()),
             DnsNames = ExtractDnsNames(certificate),
+            IsSelfSigned = IsSelfSignedCertificate(certificate),
+            WeakKey = keySize > 0 && keySize < 2048,
+            Sha1Signature = IsSha1Signature(signatureOid),
+            AllowsServerAuthentication = eku.AllowsServerAuthentication,
+            AllowsClientAuthentication = eku.AllowsClientAuthentication,
+            AllowsSecureEmail = eku.AllowsSecureEmail,
+            AuthenticationProfile = string.IsNullOrWhiteSpace(eku.AuthenticationProfile)
+                ? CertificateAuthenticationProfileClassifier.Classify(eku)
+                : eku.AuthenticationProfile,
             CertificateDer = rawData,
             IsPrecertificate = isPrecertificate
         };
@@ -214,6 +247,65 @@ public sealed class CtCertificateRecord
         }
 
         return new string(value!.Where(Uri.IsHexDigit).ToArray()).ToUpperInvariant();
+    }
+
+    private static bool IsSelfSignedCertificate(X509Certificate2 certificate)
+    {
+        return !string.IsNullOrWhiteSpace(certificate.Subject) &&
+               string.Equals(certificate.Subject, certificate.Issuer, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsSha1Signature(string? oid)
+    {
+        return oid == "1.2.840.113549.1.1.5" ||
+               oid == "1.2.840.10040.4.3" ||
+               oid == "1.3.14.3.2.29";
+    }
+
+    private static int GetPublicKeySize(X509Certificate2 certificate)
+    {
+        if (certificate == null)
+        {
+            return 0;
+        }
+
+        try
+        {
+            using RSA? rsa = certificate.GetRSAPublicKey();
+            if (rsa != null)
+            {
+                return rsa.KeySize;
+            }
+        }
+        catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
+        {
+        }
+
+        try
+        {
+            using ECDsa? ecdsa = certificate.GetECDsaPublicKey();
+            if (ecdsa != null)
+            {
+                return ecdsa.KeySize;
+            }
+        }
+        catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
+        {
+        }
+
+        try
+        {
+            using DSA? dsa = certificate.GetDSAPublicKey();
+            if (dsa != null)
+            {
+                return dsa.KeySize;
+            }
+        }
+        catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
+        {
+        }
+
+        return 0;
     }
 
     private static string ToHex(byte[] bytes)

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -153,9 +153,8 @@ public sealed class CtCertificateRecord
     private static IReadOnlyList<string> ExtractDnsNames(X509Certificate2 certificate)
     {
         var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        AddIfNotEmpty(names, SafeGetNameInfo(certificate, X509NameType.DnsName));
-        AddIfNotEmpty(names, SafeGetNameInfo(certificate, X509NameType.SimpleName));
-        AddIfNotEmpty(names, TryExtractCommonName(certificate.Subject));
+        AddDnsNameIfCandidate(names, SafeGetNameInfo(certificate, X509NameType.DnsName));
+        AddDnsNameIfCandidate(names, TryExtractCommonName(certificate.Subject));
 
         try
         {
@@ -166,21 +165,22 @@ public sealed class CtCertificateRecord
                 var sanExtension = new X509SubjectAlternativeNameExtension(san.RawData, san.Critical);
                 foreach (string dnsName in sanExtension.EnumerateDnsNames())
                 {
-                    AddIfNotEmpty(names, dnsName);
+                    AddDnsNameIfCandidate(names, dnsName);
                 }
 #else
                 int sanNameCount = 0;
                 foreach (string dnsName in ParseDnsNamesFromSanExtension(san.RawData))
                 {
                     sanNameCount++;
-                    AddIfNotEmpty(names, dnsName);
+                    AddDnsNameIfCandidate(names, dnsName);
                 }
 
                 if (sanNameCount == 0)
                 {
+                    // Last-resort fallback for unusual pre-net8 certificates; the raw parser above avoids relying on localized Format() text in normal cases.
                     foreach (string dnsName in ParseDnsNamesFromSanText(san.Format(false)))
                     {
-                        AddIfNotEmpty(names, dnsName);
+                        AddDnsNameIfCandidate(names, dnsName);
                     }
                 }
 #endif
@@ -215,12 +215,12 @@ public sealed class CtCertificateRecord
             return null;
         }
 
-        foreach (string part in subject!.Split(','))
+        foreach (string trimmed in SplitDistinguishedNameParts(subject!)
+            .Select(part => part.Trim()))
         {
-            string trimmed = part.Trim();
             if (trimmed.StartsWith("CN=", StringComparison.OrdinalIgnoreCase))
             {
-                string value = trimmed.Substring(3).Trim();
+                string value = UnescapeDistinguishedNameValue(trimmed.Substring(3).Trim());
                 return value.Length == 0 ? null : value;
             }
         }
@@ -228,12 +228,93 @@ public sealed class CtCertificateRecord
         return null;
     }
 
-    private static void AddIfNotEmpty(HashSet<string> names, string? name)
+    private static IEnumerable<string> SplitDistinguishedNameParts(string subject)
     {
-        if (!string.IsNullOrWhiteSpace(name))
+        var builder = new StringBuilder();
+        bool escaped = false;
+        foreach (char character in subject)
         {
-            names.Add(name!.Trim());
+            if (escaped)
+            {
+                builder.Append('\\');
+                builder.Append(character);
+                escaped = false;
+                continue;
+            }
+
+            if (character == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (character == ',')
+            {
+                yield return builder.ToString();
+                builder.Clear();
+                continue;
+            }
+
+            builder.Append(character);
         }
+
+        if (escaped)
+        {
+            builder.Append('\\');
+        }
+
+        yield return builder.ToString();
+    }
+
+    private static string UnescapeDistinguishedNameValue(string value)
+    {
+        var builder = new StringBuilder(value.Length);
+        bool escaped = false;
+        foreach (char character in value)
+        {
+            if (escaped)
+            {
+                builder.Append(character);
+                escaped = false;
+                continue;
+            }
+
+            if (character == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            builder.Append(character);
+        }
+
+        if (escaped)
+        {
+            builder.Append('\\');
+        }
+
+        return builder.ToString().Trim();
+    }
+
+    private static void AddDnsNameIfCandidate(HashSet<string> names, string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return;
+        }
+
+        string value = name!.Trim();
+        string hostCandidate = value.StartsWith("*.", StringComparison.Ordinal)
+            ? value.Substring(2)
+            : value;
+        if (hostCandidate.Length == 0 ||
+            hostCandidate.IndexOfAny(new[] { ' ', '/', '@', ',' }) >= 0 ||
+            Uri.CheckHostName(hostCandidate) != UriHostNameType.Dns)
+        {
+            return;
+        }
+
+        names.Add(value);
     }
 
     private static string? NormalizeHex(string? value)
@@ -275,6 +356,7 @@ public sealed class CtCertificateRecord
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
         {
+            // Some platform providers throw for unsupported key algorithms; fall through to the next algorithm probe.
         }
 
         try
@@ -287,6 +369,7 @@ public sealed class CtCertificateRecord
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
         {
+            // Some platform providers throw for unsupported key algorithms; fall through to the next algorithm probe.
         }
 
         try
@@ -299,6 +382,7 @@ public sealed class CtCertificateRecord
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
         {
+            // Some platform providers throw for unsupported key algorithms; treat unknown algorithms as not weak.
         }
 
         return false;
@@ -311,9 +395,10 @@ public sealed class CtCertificateRecord
             yield break;
         }
 
-        foreach (string part in formattedSan!.Split(new[] { ',', ';', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        foreach (string item in formattedSan!
+            .Split(new[] { ',', ';', '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => part.Trim()))
         {
-            string item = part.Trim();
             const string dnsNamePrefix = "DNS Name=";
             const string dnsShortPrefix = "DNS:";
 

--- a/DomainDetective/CertificateTransparency/CtCertificateTransparencyProviderExtensions.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateTransparencyProviderExtensions.cs
@@ -39,7 +39,7 @@ public static class CtCertificateTransparencyProviderExtensions
         int remainingPages = maxPages.HasValue && maxPages.Value > 0
             ? maxPages.Value
             : int.MaxValue;
-        string? previousContinuationToken = null;
+        var seenContinuationTokens = new HashSet<string>(StringComparer.Ordinal);
         CtCertificateQuery currentQuery = query.Normalize();
         while (remainingPages > 0)
         {
@@ -56,12 +56,11 @@ public static class CtCertificateTransparencyProviderExtensions
                 : result.ContinuationToken!.Trim();
             if (!result.HasMore ||
                 continuationToken == null ||
-                string.Equals(continuationToken, previousContinuationToken, StringComparison.Ordinal))
+                !seenContinuationTokens.Add(continuationToken))
             {
                 yield break;
             }
 
-            previousContinuationToken = continuationToken;
             runtimeState = result.ProviderState ?? runtimeState;
             currentQuery = currentQuery.WithContinuationToken(continuationToken);
         }

--- a/DomainDetective/CertificateTransparency/CtCertificateTransparencyProviderExtensions.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateTransparencyProviderExtensions.cs
@@ -66,18 +66,4 @@ public static class CtCertificateTransparencyProviderExtensions
             currentQuery = currentQuery.WithContinuationToken(continuationToken);
         }
     }
-
-    private static CtCertificateQuery WithContinuationToken(this CtCertificateQuery query, string continuationToken)
-    {
-        return new CtCertificateQuery
-        {
-            Name = query.Name,
-            QueryKind = query.QueryKind,
-            Operations = query.Operations,
-            RequireFullCertificate = query.RequireFullCertificate,
-            ContinuationToken = continuationToken,
-            PageSize = query.PageSize,
-            Timeout = query.Timeout
-        };
-    }
 }

--- a/DomainDetective/CertificateTransparency/CtCertificateTransparencyProviderExtensions.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateTransparencyProviderExtensions.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Helper methods for paged certificate transparency providers.
+/// </summary>
+public static class CtCertificateTransparencyProviderExtensions
+{
+    /// <summary>
+    /// Queries a CT provider page-by-page until no continuation token is returned or the optional page limit is reached.
+    /// </summary>
+    /// <param name="provider">Provider to query.</param>
+    /// <param name="query">Initial query.</param>
+    /// <param name="runtimeState">Optional persisted provider runtime state.</param>
+    /// <param name="maxPages">Optional safety cap for provider pages. Null means no explicit cap.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public static async IAsyncEnumerable<CtCertificateQueryResult> QueryPagesAsync(
+        this ICtCertificateTransparencyProvider provider,
+        CtCertificateQuery query,
+        CtProviderRuntimeState? runtimeState = null,
+        int? maxPages = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        if (provider == null)
+        {
+            throw new ArgumentNullException(nameof(provider));
+        }
+
+        if (query == null)
+        {
+            throw new ArgumentNullException(nameof(query));
+        }
+
+        int remainingPages = maxPages.HasValue && maxPages.Value > 0
+            ? maxPages.Value
+            : int.MaxValue;
+        string? previousContinuationToken = null;
+        CtCertificateQuery currentQuery = query.Normalize();
+        while (remainingPages > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CtCertificateQueryResult result = await provider
+                .QueryAsync(currentQuery, runtimeState, cancellationToken)
+                .ConfigureAwait(false);
+
+            yield return result;
+            remainingPages--;
+
+            string? continuationToken = string.IsNullOrWhiteSpace(result.ContinuationToken)
+                ? null
+                : result.ContinuationToken!.Trim();
+            if (!result.HasMore ||
+                continuationToken == null ||
+                string.Equals(continuationToken, previousContinuationToken, StringComparison.Ordinal))
+            {
+                yield break;
+            }
+
+            previousContinuationToken = continuationToken;
+            runtimeState = result.ProviderState ?? runtimeState;
+            currentQuery = currentQuery.WithContinuationToken(continuationToken);
+        }
+    }
+
+    private static CtCertificateQuery WithContinuationToken(this CtCertificateQuery query, string continuationToken)
+    {
+        return new CtCertificateQuery
+        {
+            Name = query.Name,
+            QueryKind = query.QueryKind,
+            Operations = query.Operations,
+            RequireFullCertificate = query.RequireFullCertificate,
+            ContinuationToken = continuationToken,
+            PageSize = query.PageSize,
+            Timeout = query.Timeout
+        };
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtIngestionOperation.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionOperation.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes certificate transparency operations that a provider can execute.
+/// </summary>
+[Flags]
+public enum CtIngestionOperation
+{
+    /// <summary>No certificate transparency operation is requested.</summary>
+    None = 0,
+
+    /// <summary>Discover host names below a registered or monitored domain.</summary>
+    DiscoverSubdomains = 1,
+
+    /// <summary>Retrieve the latest known certificate for an exact host name.</summary>
+    GetLatestCertificate = 2,
+
+    /// <summary>Retrieve historical certificates for an exact host name.</summary>
+    GetCertificateHistory = 4,
+
+    /// <summary>Retrieve certificates for a domain and its discovered host names.</summary>
+    GetDomainTreeCertificates = 8
+}

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -266,6 +266,18 @@ public static class CtIngestionPlanner
 
         DateTimeOffset effectiveNowUtc = nowUtc ?? DateTimeOffset.UtcNow;
         CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        if (state?.IsPermanentlyFailed == true)
+        {
+            return new CtProviderExecutionDecision
+            {
+                ProviderId = profile.ProviderId,
+                CanRunNow = false,
+                DeferUntilUtc = null,
+                MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
+                Reason = "Provider has a recorded permanent failure and should not run until the caller resets provider state."
+            };
+        }
+
         if (state?.CooldownUntilUtc.HasValue == true &&
             state.CooldownUntilUtc.Value > effectiveNowUtc)
         {
@@ -281,8 +293,9 @@ public static class CtIngestionPlanner
 
         if (state != null &&
             state.TransientFailureRatio.HasValue &&
-            state.TransientFailureRatio.Value >= 0.5d &&
-            state.LastFailureUtc.HasValue)
+            state.TransientFailureRatio.Value >= rateLimit.TransientFailureRatioCooldownThreshold &&
+            state.LastFailureUtc.HasValue &&
+            (!state.LastSuccessUtc.HasValue || state.LastSuccessUtc.Value < state.LastFailureUtc.Value))
         {
             DateTimeOffset deferUntilUtc = state.LastFailureUtc.Value + rateLimit.CooldownAfterRateLimit;
             if (deferUntilUtc > effectiveNowUtc)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -424,12 +424,12 @@ public static class CtIngestionPlanner
         TimeSpan estimatedMinimumDuration = capacities
             .Select(static estimate => estimate.EstimatedMinimumDuration)
             .Aggregate(TimeSpan.Zero, AddTimeSpan);
-        TimeSpan estimatedFirstRunDuration = capacities
-            .Select(static estimate => estimate.EstimatedFirstRunDuration)
-            .Aggregate(TimeSpan.Zero, AddTimeSpan);
         int firstRunRequestCount = EstimateFirstRunRequestCount(
             normalizedTotalRequests,
             rateLimit.MaximumRequestsPerRun);
+        TimeSpan estimatedFirstRunDuration = EstimateAggregateFirstRunDuration(
+            capacities,
+            firstRunRequestCount);
         int remainingRequestCount = Math.Max(0, normalizedTotalRequests - firstRunRequestCount);
         int estimatedRunCount = EstimateRunCount(
             normalizedTotalRequests,
@@ -462,6 +462,40 @@ public static class CtIngestionPlanner
                                capacities.Any(static estimate => estimate.ExceedsRunBudget),
             IsConcurrencyLimited = capacities.Any(static estimate => estimate.IsConcurrencyLimited)
         };
+    }
+
+    private static TimeSpan EstimateAggregateFirstRunDuration(
+        IReadOnlyList<CtProviderCapacityEstimate> capacities,
+        int firstRunRequestCount)
+    {
+        int remainingFirstRunRequests = Math.Max(0, firstRunRequestCount);
+        TimeSpan estimatedDuration = TimeSpan.Zero;
+        foreach (CtProviderCapacityEstimate capacity in capacities)
+        {
+            if (remainingFirstRunRequests == 0)
+            {
+                break;
+            }
+
+            int segmentRequestCount = Math.Min(
+                Math.Max(0, capacity.RequestCount),
+                remainingFirstRunRequests);
+            if (segmentRequestCount == 0)
+            {
+                continue;
+            }
+
+            estimatedDuration = AddTimeSpan(
+                estimatedDuration,
+                EstimateDuration(
+                    segmentRequestCount,
+                    capacity.EffectiveRequestSpacing,
+                    capacity.EstimatedRequestDuration,
+                    Math.Max(1, capacity.MaxConcurrentRequests)));
+            remainingFirstRunRequests -= segmentRequestCount;
+        }
+
+        return estimatedDuration;
     }
 
     private static CtProviderCapacityEstimate EstimateCapacity(

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -1,0 +1,166 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Plans certificate transparency provider work using capabilities and configured limits.
+/// </summary>
+public static class CtIngestionPlanner
+{
+    /// <summary>
+    /// Estimates the minimum duration for a number of provider requests.
+    /// </summary>
+    /// <param name="profile">Provider profile that supplies rate-limit settings.</param>
+    /// <param name="requestCount">Number of provider requests to issue.</param>
+    /// <param name="nowUtc">Optional current time used for the completion estimate.</param>
+    public static CtProviderCapacityEstimate EstimateCapacity(
+        CtProviderProfile profile,
+        int requestCount,
+        DateTimeOffset? nowUtc = null)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        int normalizedRequestCount = Math.Max(0, requestCount);
+        CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        TimeSpan effectiveSpacing = ResolveEffectiveRequestSpacing(rateLimit);
+        TimeSpan estimatedDuration = normalizedRequestCount <= 1
+            ? TimeSpan.Zero
+            : TimeSpan.FromTicks(effectiveSpacing.Ticks * (normalizedRequestCount - 1));
+        DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
+
+        return new CtProviderCapacityEstimate
+        {
+            ProviderId = profile.ProviderId,
+            RequestCount = normalizedRequestCount,
+            EffectiveRequestSpacing = effectiveSpacing,
+            EstimatedMinimumDuration = estimatedDuration,
+            EstimatedCompletionUtc = startUtc + estimatedDuration,
+            MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
+            IsRateLimited = effectiveSpacing > TimeSpan.Zero
+        };
+    }
+
+    /// <summary>
+    /// Determines whether a provider should run now or be deferred.
+    /// </summary>
+    /// <param name="profile">Provider profile that supplies safety settings.</param>
+    /// <param name="state">Optional persisted provider runtime state.</param>
+    /// <param name="nowUtc">Optional current time used for decision evaluation.</param>
+    public static CtProviderExecutionDecision Decide(
+        CtProviderProfile profile,
+        CtProviderRuntimeState? state,
+        DateTimeOffset? nowUtc = null)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        DateTimeOffset effectiveNowUtc = nowUtc ?? DateTimeOffset.UtcNow;
+        CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        if (state?.CooldownUntilUtc.HasValue == true &&
+            state.CooldownUntilUtc.Value > effectiveNowUtc)
+        {
+            return new CtProviderExecutionDecision
+            {
+                ProviderId = profile.ProviderId,
+                CanRunNow = false,
+                DeferUntilUtc = state.CooldownUntilUtc,
+                MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
+                Reason = "Provider is cooling down after earlier rate limits or transient failures."
+            };
+        }
+
+        if (state != null &&
+            state.TransientFailureRatio.HasValue &&
+            state.TransientFailureRatio.Value >= 0.5d &&
+            state.LastFailureUtc.HasValue)
+        {
+            DateTimeOffset deferUntilUtc = state.LastFailureUtc.Value + rateLimit.CooldownAfterRateLimit;
+            if (deferUntilUtc > effectiveNowUtc)
+            {
+                return new CtProviderExecutionDecision
+                {
+                    ProviderId = profile.ProviderId,
+                    CanRunNow = false,
+                    DeferUntilUtc = deferUntilUtc,
+                    MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
+                    Reason = "Provider failure ratio is high; deferred according to the configured cooldown."
+                };
+            }
+        }
+
+        return new CtProviderExecutionDecision
+        {
+            ProviderId = profile.ProviderId,
+            CanRunNow = true,
+            DeferUntilUtc = null,
+            MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
+            Reason = "Provider is eligible to run under the current profile."
+        };
+    }
+
+    /// <summary>
+    /// Determines whether a provider can satisfy a requested CT operation with full certificates.
+    /// </summary>
+    /// <param name="profile">Provider profile to evaluate.</param>
+    /// <param name="operation">Operation requested by the caller.</param>
+    /// <param name="requireFullCertificate">Whether the caller requires full certificate DER bytes.</param>
+    public static bool SupportsOperation(
+        CtProviderProfile profile,
+        CtIngestionOperation operation,
+        bool requireFullCertificate)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        CtProviderCapabilities required = CtProviderCapabilities.None;
+        if ((operation & CtIngestionOperation.DiscoverSubdomains) != 0)
+        {
+            required |= CtProviderCapabilities.SubdomainExpansion;
+        }
+
+        if ((operation & CtIngestionOperation.GetLatestCertificate) != 0)
+        {
+            required |= CtProviderCapabilities.ExactHostLookup;
+        }
+
+        if ((operation & CtIngestionOperation.GetCertificateHistory) != 0)
+        {
+            required |= CtProviderCapabilities.ExactHostLookup | CtProviderCapabilities.CertificateHistory;
+        }
+
+        if ((operation & CtIngestionOperation.GetDomainTreeCertificates) != 0)
+        {
+            required |= CtProviderCapabilities.SubdomainExpansion | CtProviderCapabilities.DomainTreeHistory;
+        }
+
+        if (requireFullCertificate)
+        {
+            required |= CtProviderCapabilities.FullCertificateDer;
+        }
+
+        return profile.Supports(required);
+    }
+
+    private static TimeSpan ResolveEffectiveRequestSpacing(CtProviderRateLimitProfile rateLimit)
+    {
+        TimeSpan spacing = rateLimit.MinimumRequestSpacing;
+        if (rateLimit.MaxRequestsPerMinute.HasValue && rateLimit.MaxRequestsPerMinute.Value > 0)
+        {
+            long ticks = TimeSpan.FromMinutes(1).Ticks / rateLimit.MaxRequestsPerMinute.Value;
+            var rateLimitSpacing = TimeSpan.FromTicks(ticks);
+            if (rateLimitSpacing > spacing)
+            {
+                spacing = rateLimitSpacing;
+            }
+        }
+
+        return spacing;
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -420,23 +420,27 @@ public static class CtIngestionPlanner
 
         DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
         var capacities = new[] { domainCapacity, hostCapacity, hydrationCapacity };
+        int normalizedTotalRequests = Math.Max(0, totalRequests);
         TimeSpan estimatedMinimumDuration = capacities
             .Select(static estimate => estimate.EstimatedMinimumDuration)
-            .Aggregate(TimeSpan.Zero, MaxTimeSpan);
+            .Aggregate(TimeSpan.Zero, AddTimeSpan);
         TimeSpan estimatedFirstRunDuration = capacities
             .Select(static estimate => estimate.EstimatedFirstRunDuration)
-            .Aggregate(TimeSpan.Zero, MaxTimeSpan);
-        int firstRunRequestCount = SumSaturating(
-            capacities.Select(static estimate => Math.Max(0, estimate.FirstRunRequestCount)));
-        int remainingRequestCount = SumSaturating(
-            capacities.Select(static estimate => Math.Max(0, estimate.RemainingRequestCount)));
+            .Aggregate(TimeSpan.Zero, AddTimeSpan);
+        int firstRunRequestCount = EstimateFirstRunRequestCount(
+            normalizedTotalRequests,
+            rateLimit.MaximumRequestsPerRun);
+        int remainingRequestCount = Math.Max(0, normalizedTotalRequests - firstRunRequestCount);
+        int estimatedRunCount = EstimateRunCount(
+            normalizedTotalRequests,
+            rateLimit.MaximumRequestsPerRun);
         int concurrencyWaveCount = SumSaturating(
             capacities.Select(static estimate => Math.Max(0, estimate.ConcurrencyWaveCount)));
 
         return new CtProviderCapacityEstimate
         {
             ProviderId = profile.ProviderId,
-            RequestCount = Math.Max(0, totalRequests),
+            RequestCount = normalizedTotalRequests,
             EffectiveRequestSpacing = capacities
                 .Select(static estimate => estimate.EffectiveRequestSpacing)
                 .Aggregate(TimeSpan.Zero, MaxTimeSpan),
@@ -447,14 +451,15 @@ public static class CtIngestionPlanner
             EstimatedCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedMinimumDuration),
             MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
             MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
-            EstimatedRunCount = capacities.Max(static estimate => Math.Max(0, estimate.EstimatedRunCount)),
+            EstimatedRunCount = estimatedRunCount,
             FirstRunRequestCount = firstRunRequestCount,
             RemainingRequestCount = remainingRequestCount,
             EstimatedFirstRunDuration = estimatedFirstRunDuration,
             EstimatedFirstRunCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedFirstRunDuration),
             ConcurrencyWaveCount = concurrencyWaveCount,
             IsRateLimited = capacities.Any(static estimate => estimate.IsRateLimited),
-            ExceedsRunBudget = capacities.Any(static estimate => estimate.ExceedsRunBudget),
+            ExceedsRunBudget = estimatedRunCount > 1 ||
+                               capacities.Any(static estimate => estimate.ExceedsRunBudget),
             IsConcurrencyLimited = capacities.Any(static estimate => estimate.IsConcurrencyLimited)
         };
     }

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -95,10 +95,19 @@ public static class CtIngestionPlanner
         }
 
         CtIngestionWorkloadRequest normalized = workload.Normalize();
-        int domainRequests = EstimateDomainRequests(normalized);
-        int hostRequests = EstimateHostRequests(normalized);
-        int hydrationRequests = EstimateHydrationRequests(profile, normalized);
-        int totalRequests = domainRequests + hostRequests + hydrationRequests;
+        int domainRequests = EstimateDomainRequests(normalized, out bool domainRequestsSaturated);
+        int hostRequests = EstimateHostRequests(normalized, out bool hostRequestsSaturated);
+        int hydrationRequests = EstimateHydrationRequests(profile, normalized, out bool hydrationRequestsSaturated);
+        int totalRequests = SaturatingAdd(
+            SaturatingAdd(domainRequests, hostRequests, out bool hostTotalSaturated),
+            hydrationRequests,
+            out bool totalSaturated);
+        bool requestCountSaturated =
+            domainRequestsSaturated ||
+            hostRequestsSaturated ||
+            hydrationRequestsSaturated ||
+            hostTotalSaturated ||
+            totalSaturated;
         bool supportsWorkload = SupportsWorkload(profile, normalized, hydrationRequests);
         CtProviderCapacityEstimate capacity = EstimateCapacity(profile, totalRequests, nowUtc);
 
@@ -110,8 +119,15 @@ public static class CtIngestionPlanner
             EstimatedDomainRequests = domainRequests,
             EstimatedHostRequests = hostRequests,
             EstimatedHydrationRequests = hydrationRequests,
+            IsRequestCountSaturated = requestCountSaturated,
             Capacity = capacity,
-            Note = BuildWorkloadNote(profile, normalized, supportsWorkload, hydrationRequests, capacity)
+            Note = BuildWorkloadNote(
+                profile,
+                normalized,
+                supportsWorkload,
+                hydrationRequests,
+                capacity,
+                requestCountSaturated)
         };
     }
 
@@ -487,27 +503,30 @@ public static class CtIngestionPlanner
             : right;
     }
 
-    private static int EstimateDomainRequests(CtIngestionWorkloadRequest workload)
+    private static int EstimateDomainRequests(CtIngestionWorkloadRequest workload, out bool saturated)
     {
         bool usesDomainOperation =
             (workload.Operations & CtIngestionOperation.DiscoverSubdomains) != 0 ||
             (workload.Operations & CtIngestionOperation.GetDomainTreeCertificates) != 0;
         return usesDomainOperation
-            ? workload.DomainCount * workload.RequestsPerDomain
-            : 0;
+            ? SaturatingMultiply(workload.DomainCount, workload.RequestsPerDomain, out saturated)
+            : NoEstimatedRequests(out saturated);
     }
 
-    private static int EstimateHostRequests(CtIngestionWorkloadRequest workload)
+    private static int EstimateHostRequests(CtIngestionWorkloadRequest workload, out bool saturated)
     {
         bool usesHostOperation =
             (workload.Operations & CtIngestionOperation.GetLatestCertificate) != 0 ||
             (workload.Operations & CtIngestionOperation.GetCertificateHistory) != 0;
         return usesHostOperation
-            ? workload.HostCount * workload.RequestsPerHost
-            : 0;
+            ? SaturatingMultiply(workload.HostCount, workload.RequestsPerHost, out saturated)
+            : NoEstimatedRequests(out saturated);
     }
 
-    private static int EstimateHydrationRequests(CtProviderProfile profile, CtIngestionWorkloadRequest workload)
+    private static int EstimateHydrationRequests(
+        CtProviderProfile profile,
+        CtIngestionWorkloadRequest workload,
+        out bool saturated)
     {
         if (!RequiresFullCertificateMaterial(workload) ||
             workload.EstimatedCertificatesToHydrate <= 0 ||
@@ -515,10 +534,37 @@ public static class CtIngestionPlanner
             profile.Supports(CtProviderCapabilities.FullCertificateDer) ||
             !profile.Supports(CtProviderCapabilities.CertificateHydration))
         {
-            return 0;
+            return NoEstimatedRequests(out saturated);
         }
 
-        return workload.EstimatedCertificatesToHydrate * workload.HydrationRequestsPerCertificate;
+        return SaturatingMultiply(
+            workload.EstimatedCertificatesToHydrate,
+            workload.HydrationRequestsPerCertificate,
+            out saturated);
+    }
+
+    private static int NoEstimatedRequests(out bool saturated)
+    {
+        saturated = false;
+        return 0;
+    }
+
+    private static int SaturatingMultiply(int left, int right, out bool saturated)
+    {
+        long value = (long)Math.Max(0, left) * Math.Max(0, right);
+        saturated = value > int.MaxValue;
+        return saturated
+            ? int.MaxValue
+            : (int)value;
+    }
+
+    private static int SaturatingAdd(int left, int right, out bool saturated)
+    {
+        long value = (long)Math.Max(0, left) + Math.Max(0, right);
+        saturated = value > int.MaxValue;
+        return saturated
+            ? int.MaxValue
+            : (int)value;
     }
 
     private static bool RequiresFullCertificateMaterial(CtIngestionWorkloadRequest workload)
@@ -538,11 +584,17 @@ public static class CtIngestionPlanner
         CtIngestionWorkloadRequest workload,
         bool supportsWorkload,
         int hydrationRequests,
-        CtProviderCapacityEstimate capacity)
+        CtProviderCapacityEstimate capacity,
+        bool requestCountSaturated)
     {
         if (!supportsWorkload)
         {
             return "Provider does not advertise all requested CT capabilities.";
+        }
+
+        if (requestCountSaturated)
+        {
+            return "Provider can be used, but the estimated request count was capped and the workload should be split into smaller batches before execution.";
         }
 
         if (hydrationRequests > 0)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -29,6 +29,12 @@ public static class CtIngestionPlanner
         CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
         int maxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1);
         TimeSpan effectiveSpacing = ResolveEffectiveRequestSpacing(rateLimit);
+        int firstRunRequestCount = EstimateFirstRunRequestCount(
+            normalizedRequestCount,
+            rateLimit.MaximumRequestsPerRun);
+        int estimatedRunCount = EstimateRunCount(
+            normalizedRequestCount,
+            rateLimit.MaximumRequestsPerRun);
         TimeSpan spacingDuration = EstimateSpacingDuration(
             normalizedRequestCount,
             effectiveSpacing,
@@ -47,8 +53,12 @@ public static class CtIngestionPlanner
             EstimatedMinimumDuration = estimatedDuration,
             EstimatedCompletionUtc = startUtc + estimatedDuration,
             MaxConcurrentRequests = maxConcurrentRequests,
+            MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
+            EstimatedRunCount = estimatedRunCount,
+            FirstRunRequestCount = firstRunRequestCount,
             ConcurrencyWaveCount = concurrencyWaveCount,
             IsRateLimited = effectiveSpacing > TimeSpan.Zero,
+            ExceedsRunBudget = estimatedRunCount > 1,
             IsConcurrencyLimited = normalizedRequestCount > maxConcurrentRequests &&
                 concurrencyDuration >= spacingDuration
         };
@@ -380,7 +390,43 @@ public static class CtIngestionPlanner
         }
 
         int normalizedConcurrency = Math.Max(1, maxConcurrentRequests);
-        return (requestCount + normalizedConcurrency - 1) / normalizedConcurrency;
+        long waveCount = ((long)requestCount + normalizedConcurrency - 1) / normalizedConcurrency;
+        return waveCount > int.MaxValue
+            ? int.MaxValue
+            : (int)waveCount;
+    }
+
+    private static int EstimateRunCount(int requestCount, int? maximumRequestsPerRun)
+    {
+        if (requestCount <= 0)
+        {
+            return 0;
+        }
+
+        if (!maximumRequestsPerRun.HasValue || maximumRequestsPerRun.Value <= 0)
+        {
+            return 1;
+        }
+
+        long runCount = ((long)requestCount + maximumRequestsPerRun.Value - 1) / maximumRequestsPerRun.Value;
+        return runCount > int.MaxValue
+            ? int.MaxValue
+            : (int)runCount;
+    }
+
+    private static int EstimateFirstRunRequestCount(int requestCount, int? maximumRequestsPerRun)
+    {
+        if (requestCount <= 0)
+        {
+            return 0;
+        }
+
+        if (!maximumRequestsPerRun.HasValue || maximumRequestsPerRun.Value <= 0)
+        {
+            return requestCount;
+        }
+
+        return Math.Min(requestCount, maximumRequestsPerRun.Value);
     }
 
     private static TimeSpan MultiplyTimeSpan(TimeSpan value, int multiplier)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -100,6 +100,7 @@ public static class CtIngestionPlanner
         int hydrationRequests = EstimateHydrationRequests(profile, normalized);
         int totalRequests = domainRequests + hostRequests + hydrationRequests;
         bool supportsWorkload = SupportsWorkload(profile, normalized, hydrationRequests);
+        CtProviderCapacityEstimate capacity = EstimateCapacity(profile, totalRequests, nowUtc);
 
         return new CtIngestionWorkloadEstimate
         {
@@ -109,8 +110,8 @@ public static class CtIngestionPlanner
             EstimatedDomainRequests = domainRequests,
             EstimatedHostRequests = hostRequests,
             EstimatedHydrationRequests = hydrationRequests,
-            Capacity = EstimateCapacity(profile, totalRequests, nowUtc),
-            Note = BuildWorkloadNote(profile, normalized, supportsWorkload, hydrationRequests)
+            Capacity = capacity,
+            Note = BuildWorkloadNote(profile, normalized, supportsWorkload, hydrationRequests, capacity)
         };
     }
 
@@ -536,7 +537,8 @@ public static class CtIngestionPlanner
         CtProviderProfile profile,
         CtIngestionWorkloadRequest workload,
         bool supportsWorkload,
-        int hydrationRequests)
+        int hydrationRequests,
+        CtProviderCapacityEstimate capacity)
     {
         if (!supportsWorkload)
         {
@@ -546,6 +548,11 @@ public static class CtIngestionPlanner
         if (hydrationRequests > 0)
         {
             return "Provider requires additional certificate hydration requests to satisfy full-certificate output.";
+        }
+
+        if (capacity.ExceedsRunBudget)
+        {
+            return "Provider can be used, but the estimated workload exceeds the configured per-run budget and should be split across multiple logical runs.";
         }
 
         if (workload.RequireFullCertificate &&

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -27,10 +27,15 @@ public static class CtIngestionPlanner
 
         int normalizedRequestCount = Math.Max(0, requestCount);
         CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        int maxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1);
         TimeSpan effectiveSpacing = ResolveEffectiveRequestSpacing(rateLimit);
-        TimeSpan estimatedDuration = normalizedRequestCount <= 1
-            ? TimeSpan.Zero
-            : TimeSpan.FromTicks(effectiveSpacing.Ticks * (normalizedRequestCount - 1));
+        TimeSpan spacingDuration = EstimateSpacingDuration(
+            normalizedRequestCount,
+            effectiveSpacing,
+            rateLimit.EstimatedRequestDuration);
+        int concurrencyWaveCount = EstimateConcurrencyWaveCount(normalizedRequestCount, maxConcurrentRequests);
+        TimeSpan concurrencyDuration = MultiplyTimeSpan(rateLimit.EstimatedRequestDuration, concurrencyWaveCount);
+        TimeSpan estimatedDuration = MaxTimeSpan(spacingDuration, concurrencyDuration);
         DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
 
         return new CtProviderCapacityEstimate
@@ -38,10 +43,14 @@ public static class CtIngestionPlanner
             ProviderId = profile.ProviderId,
             RequestCount = normalizedRequestCount,
             EffectiveRequestSpacing = effectiveSpacing,
+            EstimatedRequestDuration = rateLimit.EstimatedRequestDuration,
             EstimatedMinimumDuration = estimatedDuration,
             EstimatedCompletionUtc = startUtc + estimatedDuration,
-            MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
-            IsRateLimited = effectiveSpacing > TimeSpan.Zero
+            MaxConcurrentRequests = maxConcurrentRequests,
+            ConcurrencyWaveCount = concurrencyWaveCount,
+            IsRateLimited = effectiveSpacing > TimeSpan.Zero,
+            IsConcurrencyLimited = normalizedRequestCount > maxConcurrentRequests &&
+                concurrencyDuration >= spacingDuration
         };
     }
 
@@ -342,6 +351,69 @@ public static class CtIngestionPlanner
         }
 
         return spacing;
+    }
+
+    private static TimeSpan EstimateSpacingDuration(
+        int requestCount,
+        TimeSpan effectiveSpacing,
+        TimeSpan estimatedRequestDuration)
+    {
+        if (requestCount <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        if (effectiveSpacing <= TimeSpan.Zero)
+        {
+            return estimatedRequestDuration;
+        }
+
+        TimeSpan startSpacingDuration = MultiplyTimeSpan(effectiveSpacing, requestCount - 1);
+        return AddTimeSpan(startSpacingDuration, estimatedRequestDuration);
+    }
+
+    private static int EstimateConcurrencyWaveCount(int requestCount, int maxConcurrentRequests)
+    {
+        if (requestCount <= 0)
+        {
+            return 0;
+        }
+
+        int normalizedConcurrency = Math.Max(1, maxConcurrentRequests);
+        return (requestCount + normalizedConcurrency - 1) / normalizedConcurrency;
+    }
+
+    private static TimeSpan MultiplyTimeSpan(TimeSpan value, int multiplier)
+    {
+        if (value <= TimeSpan.Zero || multiplier <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        double ticks = value.Ticks * (double)multiplier;
+        if (ticks >= TimeSpan.MaxValue.Ticks)
+        {
+            return TimeSpan.MaxValue;
+        }
+
+        return TimeSpan.FromTicks((long)ticks);
+    }
+
+    private static TimeSpan AddTimeSpan(TimeSpan left, TimeSpan right)
+    {
+        if (left >= TimeSpan.MaxValue - right)
+        {
+            return TimeSpan.MaxValue;
+        }
+
+        return left + right;
+    }
+
+    private static TimeSpan MaxTimeSpan(TimeSpan left, TimeSpan right)
+    {
+        return left >= right
+            ? left
+            : right;
     }
 
     private static int EstimateDomainRequests(CtIngestionWorkloadRequest workload)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -26,61 +26,7 @@ public static class CtIngestionPlanner
         int requestCount,
         DateTimeOffset? nowUtc = null)
     {
-        if (profile == null)
-        {
-            throw new ArgumentNullException(nameof(profile));
-        }
-
-        int normalizedRequestCount = Math.Max(0, requestCount);
-        CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
-        int maxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1);
-        TimeSpan effectiveSpacing = ResolveEffectiveRequestSpacing(rateLimit);
-        int firstRunRequestCount = EstimateFirstRunRequestCount(
-            normalizedRequestCount,
-            rateLimit.MaximumRequestsPerRun);
-        int estimatedRunCount = EstimateRunCount(
-            normalizedRequestCount,
-            rateLimit.MaximumRequestsPerRun);
-        int remainingRequestCount = Math.Max(0, normalizedRequestCount - firstRunRequestCount);
-        TimeSpan spacingDuration = EstimateSpacingDuration(
-            normalizedRequestCount,
-            effectiveSpacing,
-            rateLimit.EstimatedRequestDuration);
-        int concurrencyWaveCount = EstimateConcurrencyWaveCount(normalizedRequestCount, maxConcurrentRequests);
-        TimeSpan concurrencyDuration = MultiplyTimeSpan(rateLimit.EstimatedRequestDuration, concurrencyWaveCount);
-        TimeSpan estimatedDuration = EstimateScheduledDuration(
-            normalizedRequestCount,
-            effectiveSpacing,
-            rateLimit.EstimatedRequestDuration,
-            maxConcurrentRequests);
-        TimeSpan estimatedFirstRunDuration = EstimateDuration(
-            firstRunRequestCount,
-            effectiveSpacing,
-            rateLimit.EstimatedRequestDuration,
-            maxConcurrentRequests);
-        DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
-
-        return new CtProviderCapacityEstimate
-        {
-            ProviderId = profile.ProviderId,
-            RequestCount = normalizedRequestCount,
-            EffectiveRequestSpacing = effectiveSpacing,
-            EstimatedRequestDuration = rateLimit.EstimatedRequestDuration,
-            EstimatedMinimumDuration = estimatedDuration,
-            EstimatedCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedDuration),
-            MaxConcurrentRequests = maxConcurrentRequests,
-            MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
-            EstimatedRunCount = estimatedRunCount,
-            FirstRunRequestCount = firstRunRequestCount,
-            RemainingRequestCount = remainingRequestCount,
-            EstimatedFirstRunDuration = estimatedFirstRunDuration,
-            EstimatedFirstRunCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedFirstRunDuration),
-            ConcurrencyWaveCount = concurrencyWaveCount,
-            IsRateLimited = effectiveSpacing > TimeSpan.Zero,
-            ExceedsRunBudget = estimatedRunCount > 1,
-            IsConcurrencyLimited = normalizedRequestCount > maxConcurrentRequests &&
-                concurrencyDuration >= spacingDuration
-        };
+        return EstimateCapacity(profile, requestCount, operations: null, nowUtc);
     }
 
     /// <summary>
@@ -119,7 +65,29 @@ public static class CtIngestionPlanner
             hostTotalSaturated ||
             totalSaturated;
         bool supportsWorkload = SupportsWorkload(profile, normalized, hydrationRequests);
-        CtProviderCapacityEstimate capacity = EstimateCapacity(profile, totalRequests, nowUtc);
+        CtProviderCapacityEstimate domainCapacity = EstimateCapacity(
+            profile,
+            domainRequests,
+            ResolveDomainCapacityOperation(normalized.Operations),
+            nowUtc);
+        CtProviderCapacityEstimate hostCapacity = EstimateCapacity(
+            profile,
+            hostRequests,
+            ResolveHostCapacityOperation(normalized.Operations),
+            nowUtc);
+        CtProviderCapacityEstimate hydrationCapacity = EstimateCapacity(
+            profile,
+            hydrationRequests,
+            operations: null,
+            nowUtc);
+        CtProviderCapacityEstimate capacity = ResolveAggregateWorkloadCapacity(
+            profile,
+            totalRequests,
+            normalized.Operations,
+            domainCapacity,
+            hostCapacity,
+            hydrationCapacity,
+            nowUtc);
 
         return new CtIngestionWorkloadEstimate
         {
@@ -131,6 +99,9 @@ public static class CtIngestionPlanner
             EstimatedHydrationRequests = hydrationRequests,
             IsRequestCountSaturated = requestCountSaturated,
             Capacity = capacity,
+            DomainCapacity = domainCapacity,
+            HostCapacity = hostCapacity,
+            HydrationCapacity = hydrationCapacity,
             Note = BuildWorkloadNote(
                 profile,
                 normalized,
@@ -406,18 +377,218 @@ public static class CtIngestionPlanner
 
     private static TimeSpan ResolveEffectiveRequestSpacing(CtProviderRateLimitProfile rateLimit)
     {
+        return ResolveEffectiveRequestSpacing(rateLimit, null);
+    }
+
+    private static TimeSpan ResolveEffectiveRequestSpacing(
+        CtProviderRateLimitProfile rateLimit,
+        CtIngestionOperation? operations)
+    {
         TimeSpan spacing = rateLimit.MinimumRequestSpacing;
+        spacing = MaxTimeSpan(spacing, ResolveSpacingFromLimit(TimeSpan.FromSeconds(1), rateLimit.MaxRequestsPerSecond));
         if (rateLimit.MaxRequestsPerMinute.HasValue && rateLimit.MaxRequestsPerMinute.Value > 0)
         {
-            long ticks = TimeSpan.FromMinutes(1).Ticks / rateLimit.MaxRequestsPerMinute.Value;
-            var rateLimitSpacing = TimeSpan.FromTicks(ticks);
-            if (rateLimitSpacing > spacing)
-            {
-                spacing = rateLimitSpacing;
-            }
+            spacing = MaxTimeSpan(spacing, ResolveSpacingFromLimit(TimeSpan.FromMinutes(1), rateLimit.MaxRequestsPerMinute));
+        }
+
+        spacing = MaxTimeSpan(spacing, ResolveSpacingFromLimit(TimeSpan.FromHours(1), rateLimit.MaxRequestsPerHour));
+        if (operations.HasValue)
+        {
+            spacing = ResolveOperationSpecificRequestSpacing(rateLimit, operations.Value, spacing);
         }
 
         return spacing;
+    }
+
+    private static CtProviderCapacityEstimate ResolveAggregateWorkloadCapacity(
+        CtProviderProfile profile,
+        int totalRequests,
+        CtIngestionOperation operations,
+        CtProviderCapacityEstimate domainCapacity,
+        CtProviderCapacityEstimate hostCapacity,
+        CtProviderCapacityEstimate hydrationCapacity,
+        DateTimeOffset? nowUtc)
+    {
+        CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        bool hasOperationSpecificBudgets =
+            rateLimit.MaxSingleHostnameQueriesPerHour.HasValue ||
+            rateLimit.MaxFullDomainQueriesPerHour.HasValue;
+        if (!hasOperationSpecificBudgets)
+        {
+            return EstimateCapacity(profile, totalRequests, operations, nowUtc);
+        }
+
+        DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
+        var capacities = new[] { domainCapacity, hostCapacity, hydrationCapacity };
+        TimeSpan estimatedMinimumDuration = capacities
+            .Select(static estimate => estimate.EstimatedMinimumDuration)
+            .Aggregate(TimeSpan.Zero, MaxTimeSpan);
+        TimeSpan estimatedFirstRunDuration = capacities
+            .Select(static estimate => estimate.EstimatedFirstRunDuration)
+            .Aggregate(TimeSpan.Zero, MaxTimeSpan);
+        int firstRunRequestCount = SumSaturating(
+            capacities.Select(static estimate => Math.Max(0, estimate.FirstRunRequestCount)));
+        int remainingRequestCount = SumSaturating(
+            capacities.Select(static estimate => Math.Max(0, estimate.RemainingRequestCount)));
+        int concurrencyWaveCount = SumSaturating(
+            capacities.Select(static estimate => Math.Max(0, estimate.ConcurrencyWaveCount)));
+
+        return new CtProviderCapacityEstimate
+        {
+            ProviderId = profile.ProviderId,
+            RequestCount = Math.Max(0, totalRequests),
+            EffectiveRequestSpacing = capacities
+                .Select(static estimate => estimate.EffectiveRequestSpacing)
+                .Aggregate(TimeSpan.Zero, MaxTimeSpan),
+            EstimatedRequestDuration = capacities
+                .Select(static estimate => estimate.EstimatedRequestDuration)
+                .Aggregate(TimeSpan.Zero, MaxTimeSpan),
+            EstimatedMinimumDuration = estimatedMinimumDuration,
+            EstimatedCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedMinimumDuration),
+            MaxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1),
+            MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
+            EstimatedRunCount = capacities.Max(static estimate => Math.Max(0, estimate.EstimatedRunCount)),
+            FirstRunRequestCount = firstRunRequestCount,
+            RemainingRequestCount = remainingRequestCount,
+            EstimatedFirstRunDuration = estimatedFirstRunDuration,
+            EstimatedFirstRunCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedFirstRunDuration),
+            ConcurrencyWaveCount = concurrencyWaveCount,
+            IsRateLimited = capacities.Any(static estimate => estimate.IsRateLimited),
+            ExceedsRunBudget = capacities.Any(static estimate => estimate.ExceedsRunBudget),
+            IsConcurrencyLimited = capacities.Any(static estimate => estimate.IsConcurrencyLimited)
+        };
+    }
+
+    private static CtProviderCapacityEstimate EstimateCapacity(
+        CtProviderProfile profile,
+        int requestCount,
+        CtIngestionOperation? operations,
+        DateTimeOffset? nowUtc)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        int normalizedRequestCount = Math.Max(0, requestCount);
+        CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        int maxConcurrentRequests = rateLimit.MaxConcurrentRequests.GetValueOrDefault(1);
+        TimeSpan effectiveSpacing = ResolveEffectiveRequestSpacing(rateLimit, operations);
+        int firstRunRequestCount = EstimateFirstRunRequestCount(
+            normalizedRequestCount,
+            rateLimit.MaximumRequestsPerRun);
+        int estimatedRunCount = EstimateRunCount(
+            normalizedRequestCount,
+            rateLimit.MaximumRequestsPerRun);
+        int remainingRequestCount = Math.Max(0, normalizedRequestCount - firstRunRequestCount);
+        TimeSpan spacingDuration = EstimateSpacingDuration(
+            normalizedRequestCount,
+            effectiveSpacing,
+            rateLimit.EstimatedRequestDuration);
+        int concurrencyWaveCount = EstimateConcurrencyWaveCount(normalizedRequestCount, maxConcurrentRequests);
+        TimeSpan concurrencyDuration = MultiplyTimeSpan(rateLimit.EstimatedRequestDuration, concurrencyWaveCount);
+        TimeSpan estimatedDuration = EstimateScheduledDuration(
+            normalizedRequestCount,
+            effectiveSpacing,
+            rateLimit.EstimatedRequestDuration,
+            maxConcurrentRequests);
+        TimeSpan estimatedFirstRunDuration = EstimateDuration(
+            firstRunRequestCount,
+            effectiveSpacing,
+            rateLimit.EstimatedRequestDuration,
+            maxConcurrentRequests);
+        DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
+
+        return new CtProviderCapacityEstimate
+        {
+            ProviderId = profile.ProviderId,
+            RequestCount = normalizedRequestCount,
+            EffectiveRequestSpacing = effectiveSpacing,
+            EstimatedRequestDuration = rateLimit.EstimatedRequestDuration,
+            EstimatedMinimumDuration = estimatedDuration,
+            EstimatedCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedDuration),
+            MaxConcurrentRequests = maxConcurrentRequests,
+            MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
+            EstimatedRunCount = estimatedRunCount,
+            FirstRunRequestCount = firstRunRequestCount,
+            RemainingRequestCount = remainingRequestCount,
+            EstimatedFirstRunDuration = estimatedFirstRunDuration,
+            EstimatedFirstRunCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedFirstRunDuration),
+            ConcurrencyWaveCount = concurrencyWaveCount,
+            IsRateLimited = effectiveSpacing > TimeSpan.Zero,
+            ExceedsRunBudget = estimatedRunCount > 1,
+            IsConcurrencyLimited = normalizedRequestCount > maxConcurrentRequests &&
+                concurrencyDuration >= spacingDuration
+        };
+    }
+
+    private static TimeSpan ResolveOperationSpecificRequestSpacing(
+        CtProviderRateLimitProfile rateLimit,
+        CtIngestionOperation operations,
+        TimeSpan spacing)
+    {
+        bool includesFullDomainQuery =
+            (operations & CtIngestionOperation.DiscoverSubdomains) != 0 ||
+            (operations & CtIngestionOperation.GetDomainTreeCertificates) != 0;
+        bool includesSingleHostnameQuery =
+            (operations & CtIngestionOperation.GetLatestCertificate) != 0 ||
+            (operations & CtIngestionOperation.GetCertificateHistory) != 0;
+        if (includesFullDomainQuery)
+        {
+            spacing = MaxTimeSpan(
+                spacing,
+                ResolveSpacingFromLimit(TimeSpan.FromHours(1), rateLimit.MaxFullDomainQueriesPerHour));
+        }
+
+        if (includesSingleHostnameQuery)
+        {
+            spacing = MaxTimeSpan(
+                spacing,
+                ResolveSpacingFromLimit(TimeSpan.FromHours(1), rateLimit.MaxSingleHostnameQueriesPerHour));
+        }
+
+        return spacing;
+    }
+
+    private static TimeSpan ResolveSpacingFromLimit(TimeSpan window, int? requestLimit)
+    {
+        if (!requestLimit.HasValue || requestLimit.Value <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        long ticks = window.Ticks / requestLimit.Value;
+        return TimeSpan.FromTicks(Math.Max(1, ticks));
+    }
+
+    private static CtIngestionOperation? ResolveDomainCapacityOperation(CtIngestionOperation operations)
+    {
+        if ((operations & CtIngestionOperation.GetDomainTreeCertificates) != 0)
+        {
+            return CtIngestionOperation.GetDomainTreeCertificates;
+        }
+
+        if ((operations & CtIngestionOperation.DiscoverSubdomains) != 0)
+        {
+            return CtIngestionOperation.DiscoverSubdomains;
+        }
+
+        return null;
+    }
+
+    private static CtIngestionOperation? ResolveHostCapacityOperation(CtIngestionOperation operations)
+    {
+        if ((operations & CtIngestionOperation.GetCertificateHistory) != 0)
+        {
+            return CtIngestionOperation.GetCertificateHistory;
+        }
+
+        if ((operations & CtIngestionOperation.GetLatestCertificate) != 0)
+        {
+            return CtIngestionOperation.GetLatestCertificate;
+        }
+
+        return null;
     }
 
     private static TimeSpan EstimateSpacingDuration(
@@ -641,6 +812,26 @@ public static class CtIngestionPlanner
         return saturated
             ? int.MaxValue
             : (int)value;
+    }
+
+    private static int SumSaturating(IEnumerable<int> values)
+    {
+        if (values == null)
+        {
+            return 0;
+        }
+
+        long total = 0;
+        foreach (int value in values)
+        {
+            total += Math.Max(0, value);
+            if (total >= int.MaxValue)
+            {
+                return int.MaxValue;
+            }
+        }
+
+        return (int)total;
     }
 
     private static bool RequiresFullCertificateMaterial(CtIngestionWorkloadRequest workload)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DomainDetective;
 
@@ -69,10 +71,7 @@ public static class CtIngestionPlanner
         int hostRequests = EstimateHostRequests(normalized);
         int hydrationRequests = EstimateHydrationRequests(profile, normalized);
         int totalRequests = domainRequests + hostRequests + hydrationRequests;
-        bool supportsWorkload = SupportsOperation(
-            profile,
-            normalized.Operations,
-            normalized.RequireFullCertificate && hydrationRequests == 0);
+        bool supportsWorkload = SupportsWorkload(profile, normalized, hydrationRequests);
 
         return new CtIngestionWorkloadEstimate
         {
@@ -85,6 +84,123 @@ public static class CtIngestionPlanner
             Capacity = EstimateCapacity(profile, totalRequests, nowUtc),
             Note = BuildWorkloadNote(profile, normalized, supportsWorkload, hydrationRequests)
         };
+    }
+
+    /// <summary>
+    /// Plans a CT workload for a single provider using capabilities, estimates, and runtime state.
+    /// </summary>
+    /// <param name="profile">Provider profile to evaluate.</param>
+    /// <param name="workload">Workload requested by the caller.</param>
+    /// <param name="state">Optional provider runtime state.</param>
+    /// <param name="nowUtc">Optional current time used for planning.</param>
+    public static CtProviderWorkPlan PlanProvider(
+        CtProviderProfile profile,
+        CtIngestionWorkloadRequest workload,
+        CtProviderRuntimeState? state = null,
+        DateTimeOffset? nowUtc = null)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        if (workload == null)
+        {
+            throw new ArgumentNullException(nameof(workload));
+        }
+
+        CtIngestionWorkloadEstimate estimate = EstimateWorkload(profile, workload, nowUtc);
+        if (!estimate.ProviderSupportsWorkload)
+        {
+            return new CtProviderWorkPlan
+            {
+                ProviderId = profile.ProviderId,
+                Status = CtProviderPlanStatus.Unsupported,
+                Estimate = estimate,
+                Decision = null,
+                Reason = estimate.Note ?? "Provider does not support the requested CT workload."
+            };
+        }
+
+        CtProviderExecutionDecision decision = Decide(profile, state, nowUtc);
+        if (!decision.CanRunNow)
+        {
+            return new CtProviderWorkPlan
+            {
+                ProviderId = profile.ProviderId,
+                Status = CtProviderPlanStatus.Deferred,
+                Estimate = estimate,
+                Decision = decision,
+                Reason = decision.Reason
+            };
+        }
+
+        return new CtProviderWorkPlan
+        {
+            ProviderId = profile.ProviderId,
+            Status = CtProviderPlanStatus.Ready,
+            Estimate = estimate,
+            Decision = decision,
+            Reason = estimate.Note ?? decision.Reason
+        };
+    }
+
+    /// <summary>
+    /// Plans a CT workload across multiple providers in caller-supplied preference order.
+    /// </summary>
+    /// <param name="profiles">Provider profiles to evaluate.</param>
+    /// <param name="workload">Workload requested by the caller.</param>
+    /// <param name="states">Optional provider states keyed by provider identifier.</param>
+    /// <param name="nowUtc">Optional current time used for planning.</param>
+    public static IReadOnlyList<CtProviderWorkPlan> PlanProviders(
+        IEnumerable<CtProviderProfile> profiles,
+        CtIngestionWorkloadRequest workload,
+        IReadOnlyDictionary<string, CtProviderRuntimeState>? states = null,
+        DateTimeOffset? nowUtc = null)
+    {
+        if (profiles == null)
+        {
+            throw new ArgumentNullException(nameof(profiles));
+        }
+
+        if (workload == null)
+        {
+            throw new ArgumentNullException(nameof(workload));
+        }
+
+        var output = new List<CtProviderWorkPlan>();
+        foreach (CtProviderProfile profile in profiles)
+        {
+            if (profile == null)
+            {
+                continue;
+            }
+
+            CtProviderRuntimeState? state = null;
+            if (states != null &&
+                !string.IsNullOrWhiteSpace(profile.ProviderId))
+            {
+                states.TryGetValue(profile.ProviderId, out state);
+            }
+
+            output.Add(PlanProvider(profile, workload, state, nowUtc));
+        }
+
+        return output;
+    }
+
+    /// <summary>
+    /// Chooses the first provider that is ready in the supplied work plans.
+    /// </summary>
+    /// <param name="plans">Provider work plans in preference order.</param>
+    public static CtProviderWorkPlan? ChooseFirstReadyProvider(IEnumerable<CtProviderWorkPlan> plans)
+    {
+        if (plans == null)
+        {
+            throw new ArgumentNullException(nameof(plans));
+        }
+
+        return plans.FirstOrDefault(plan => plan != null && plan.Status == CtProviderPlanStatus.Ready);
     }
 
     /// <summary>
@@ -192,6 +308,26 @@ public static class CtIngestionPlanner
         return profile.Supports(required);
     }
 
+    private static bool SupportsWorkload(
+        CtProviderProfile profile,
+        CtIngestionWorkloadRequest workload,
+        int hydrationRequests)
+    {
+        bool requiresFullCertificateMaterial = RequiresFullCertificateMaterial(workload);
+        bool requiresFullCertificateFromProvider = requiresFullCertificateMaterial && hydrationRequests == 0;
+        if (!SupportsOperation(profile, workload.Operations, requiresFullCertificateFromProvider))
+        {
+            return false;
+        }
+
+        if (!requiresFullCertificateMaterial || profile.Supports(CtProviderCapabilities.FullCertificateDer))
+        {
+            return true;
+        }
+
+        return hydrationRequests > 0 && profile.Supports(CtProviderCapabilities.CertificateHydration);
+    }
+
     private static TimeSpan ResolveEffectiveRequestSpacing(CtProviderRateLimitProfile rateLimit)
     {
         TimeSpan spacing = rateLimit.MinimumRequestSpacing;
@@ -230,15 +366,28 @@ public static class CtIngestionPlanner
 
     private static int EstimateHydrationRequests(CtProviderProfile profile, CtIngestionWorkloadRequest workload)
     {
-        if (!workload.RequireFullCertificate ||
+        if (!RequiresFullCertificateMaterial(workload) ||
             workload.EstimatedCertificatesToHydrate <= 0 ||
             workload.HydrationRequestsPerCertificate <= 0 ||
-            profile.Supports(CtProviderCapabilities.FullCertificateDer))
+            profile.Supports(CtProviderCapabilities.FullCertificateDer) ||
+            !profile.Supports(CtProviderCapabilities.CertificateHydration))
         {
             return 0;
         }
 
         return workload.EstimatedCertificatesToHydrate * workload.HydrationRequestsPerCertificate;
+    }
+
+    private static bool RequiresFullCertificateMaterial(CtIngestionWorkloadRequest workload)
+    {
+        if (!workload.RequireFullCertificate)
+        {
+            return false;
+        }
+
+        return (workload.Operations & CtIngestionOperation.GetLatestCertificate) != 0 ||
+               (workload.Operations & CtIngestionOperation.GetCertificateHistory) != 0 ||
+               (workload.Operations & CtIngestionOperation.GetDomainTreeCertificates) != 0;
     }
 
     private static string BuildWorkloadNote(

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -307,7 +307,9 @@ public static class CtIngestionPlanner
             state.LastFailureUtc.HasValue &&
             (!state.LastSuccessUtc.HasValue || state.LastSuccessUtc.Value < state.LastFailureUtc.Value))
         {
-            DateTimeOffset deferUntilUtc = state.LastFailureUtc.Value + rateLimit.CooldownAfterRateLimit;
+            DateTimeOffset deferUntilUtc = AddTimeSpanSaturating(
+                state.LastFailureUtc.Value,
+                rateLimit.CooldownAfterRateLimit);
             if (deferUntilUtc > effectiveNowUtc)
             {
                 return new CtProviderExecutionDecision

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -44,6 +44,50 @@ public static class CtIngestionPlanner
     }
 
     /// <summary>
+    /// Estimates a CT workload against a single provider profile.
+    /// </summary>
+    /// <param name="profile">Provider profile that supplies capabilities and rate limits.</param>
+    /// <param name="workload">Workload to estimate.</param>
+    /// <param name="nowUtc">Optional current time used for the completion estimate.</param>
+    public static CtIngestionWorkloadEstimate EstimateWorkload(
+        CtProviderProfile profile,
+        CtIngestionWorkloadRequest workload,
+        DateTimeOffset? nowUtc = null)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        if (workload == null)
+        {
+            throw new ArgumentNullException(nameof(workload));
+        }
+
+        CtIngestionWorkloadRequest normalized = workload.Normalize();
+        int domainRequests = EstimateDomainRequests(normalized);
+        int hostRequests = EstimateHostRequests(normalized);
+        int hydrationRequests = EstimateHydrationRequests(profile, normalized);
+        int totalRequests = domainRequests + hostRequests + hydrationRequests;
+        bool supportsWorkload = SupportsOperation(
+            profile,
+            normalized.Operations,
+            normalized.RequireFullCertificate && hydrationRequests == 0);
+
+        return new CtIngestionWorkloadEstimate
+        {
+            ProviderId = profile.ProviderId,
+            ProviderSupportsWorkload = supportsWorkload,
+            EstimatedRequestCount = totalRequests,
+            EstimatedDomainRequests = domainRequests,
+            EstimatedHostRequests = hostRequests,
+            EstimatedHydrationRequests = hydrationRequests,
+            Capacity = EstimateCapacity(profile, totalRequests, nowUtc),
+            Note = BuildWorkloadNote(profile, normalized, supportsWorkload, hydrationRequests)
+        };
+    }
+
+    /// <summary>
     /// Determines whether a provider should run now or be deferred.
     /// </summary>
     /// <param name="profile">Provider profile that supplies safety settings.</param>
@@ -162,5 +206,63 @@ public static class CtIngestionPlanner
         }
 
         return spacing;
+    }
+
+    private static int EstimateDomainRequests(CtIngestionWorkloadRequest workload)
+    {
+        bool usesDomainOperation =
+            (workload.Operations & CtIngestionOperation.DiscoverSubdomains) != 0 ||
+            (workload.Operations & CtIngestionOperation.GetDomainTreeCertificates) != 0;
+        return usesDomainOperation
+            ? workload.DomainCount * workload.RequestsPerDomain
+            : 0;
+    }
+
+    private static int EstimateHostRequests(CtIngestionWorkloadRequest workload)
+    {
+        bool usesHostOperation =
+            (workload.Operations & CtIngestionOperation.GetLatestCertificate) != 0 ||
+            (workload.Operations & CtIngestionOperation.GetCertificateHistory) != 0;
+        return usesHostOperation
+            ? workload.HostCount * workload.RequestsPerHost
+            : 0;
+    }
+
+    private static int EstimateHydrationRequests(CtProviderProfile profile, CtIngestionWorkloadRequest workload)
+    {
+        if (!workload.RequireFullCertificate ||
+            workload.EstimatedCertificatesToHydrate <= 0 ||
+            workload.HydrationRequestsPerCertificate <= 0 ||
+            profile.Supports(CtProviderCapabilities.FullCertificateDer))
+        {
+            return 0;
+        }
+
+        return workload.EstimatedCertificatesToHydrate * workload.HydrationRequestsPerCertificate;
+    }
+
+    private static string BuildWorkloadNote(
+        CtProviderProfile profile,
+        CtIngestionWorkloadRequest workload,
+        bool supportsWorkload,
+        int hydrationRequests)
+    {
+        if (!supportsWorkload)
+        {
+            return "Provider does not advertise all requested CT capabilities.";
+        }
+
+        if (hydrationRequests > 0)
+        {
+            return "Provider requires additional certificate hydration requests to satisfy full-certificate output.";
+        }
+
+        if (workload.RequireFullCertificate &&
+            profile.Supports(CtProviderCapabilities.FullCertificateDer))
+        {
+            return "Provider can return full certificate material for the requested workload.";
+        }
+
+        return "Provider can be used for the requested workload under the configured rate profile.";
     }
 }

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -35,6 +35,7 @@ public static class CtIngestionPlanner
         int estimatedRunCount = EstimateRunCount(
             normalizedRequestCount,
             rateLimit.MaximumRequestsPerRun);
+        int remainingRequestCount = Math.Max(0, normalizedRequestCount - firstRunRequestCount);
         TimeSpan spacingDuration = EstimateSpacingDuration(
             normalizedRequestCount,
             effectiveSpacing,
@@ -42,6 +43,11 @@ public static class CtIngestionPlanner
         int concurrencyWaveCount = EstimateConcurrencyWaveCount(normalizedRequestCount, maxConcurrentRequests);
         TimeSpan concurrencyDuration = MultiplyTimeSpan(rateLimit.EstimatedRequestDuration, concurrencyWaveCount);
         TimeSpan estimatedDuration = MaxTimeSpan(spacingDuration, concurrencyDuration);
+        TimeSpan estimatedFirstRunDuration = EstimateDuration(
+            firstRunRequestCount,
+            effectiveSpacing,
+            rateLimit.EstimatedRequestDuration,
+            maxConcurrentRequests);
         DateTimeOffset startUtc = nowUtc ?? DateTimeOffset.UtcNow;
 
         return new CtProviderCapacityEstimate
@@ -56,6 +62,9 @@ public static class CtIngestionPlanner
             MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
             EstimatedRunCount = estimatedRunCount,
             FirstRunRequestCount = firstRunRequestCount,
+            RemainingRequestCount = remainingRequestCount,
+            EstimatedFirstRunDuration = estimatedFirstRunDuration,
+            EstimatedFirstRunCompletionUtc = startUtc + estimatedFirstRunDuration,
             ConcurrencyWaveCount = concurrencyWaveCount,
             IsRateLimited = effectiveSpacing > TimeSpan.Zero,
             ExceedsRunBudget = estimatedRunCount > 1,
@@ -380,6 +389,21 @@ public static class CtIngestionPlanner
 
         TimeSpan startSpacingDuration = MultiplyTimeSpan(effectiveSpacing, requestCount - 1);
         return AddTimeSpan(startSpacingDuration, estimatedRequestDuration);
+    }
+
+    private static TimeSpan EstimateDuration(
+        int requestCount,
+        TimeSpan effectiveSpacing,
+        TimeSpan estimatedRequestDuration,
+        int maxConcurrentRequests)
+    {
+        TimeSpan spacingDuration = EstimateSpacingDuration(
+            requestCount,
+            effectiveSpacing,
+            estimatedRequestDuration);
+        int concurrencyWaveCount = EstimateConcurrencyWaveCount(requestCount, maxConcurrentRequests);
+        TimeSpan concurrencyDuration = MultiplyTimeSpan(estimatedRequestDuration, concurrencyWaveCount);
+        return MaxTimeSpan(spacingDuration, concurrencyDuration);
     }
 
     private static int EstimateConcurrencyWaveCount(int requestCount, int maxConcurrentRequests)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -48,7 +48,11 @@ public static class CtIngestionPlanner
             rateLimit.EstimatedRequestDuration);
         int concurrencyWaveCount = EstimateConcurrencyWaveCount(normalizedRequestCount, maxConcurrentRequests);
         TimeSpan concurrencyDuration = MultiplyTimeSpan(rateLimit.EstimatedRequestDuration, concurrencyWaveCount);
-        TimeSpan estimatedDuration = MaxTimeSpan(spacingDuration, concurrencyDuration);
+        TimeSpan estimatedDuration = EstimateScheduledDuration(
+            normalizedRequestCount,
+            effectiveSpacing,
+            rateLimit.EstimatedRequestDuration,
+            maxConcurrentRequests);
         TimeSpan estimatedFirstRunDuration = EstimateDuration(
             firstRunRequestCount,
             effectiveSpacing,
@@ -439,13 +443,36 @@ public static class CtIngestionPlanner
         TimeSpan estimatedRequestDuration,
         int maxConcurrentRequests)
     {
-        TimeSpan spacingDuration = EstimateSpacingDuration(
+        return EstimateScheduledDuration(
             requestCount,
             effectiveSpacing,
+            estimatedRequestDuration,
+            maxConcurrentRequests);
+    }
+
+    private static TimeSpan EstimateScheduledDuration(
+        int requestCount,
+        TimeSpan effectiveSpacing,
+        TimeSpan estimatedRequestDuration,
+        int maxConcurrentRequests)
+    {
+        if (requestCount <= 0)
+        {
+            return TimeSpan.Zero;
+        }
+
+        int normalizedConcurrency = Math.Max(1, maxConcurrentRequests);
+        int lastRequestIndex = requestCount - 1;
+        int completedWaveCount = lastRequestIndex / normalizedConcurrency;
+        int positionInLastWave = lastRequestIndex % normalizedConcurrency;
+        TimeSpan waveInterval = MaxTimeSpan(
+            estimatedRequestDuration,
+            MultiplyTimeSpan(effectiveSpacing, normalizedConcurrency));
+        TimeSpan lastWaveStart = MultiplyTimeSpan(waveInterval, completedWaveCount);
+        TimeSpan lastRequestStartOffset = MultiplyTimeSpan(effectiveSpacing, positionInLastWave);
+        return AddTimeSpan(
+            AddTimeSpan(lastWaveStart, lastRequestStartOffset),
             estimatedRequestDuration);
-        int concurrencyWaveCount = EstimateConcurrencyWaveCount(requestCount, maxConcurrentRequests);
-        TimeSpan concurrencyDuration = MultiplyTimeSpan(estimatedRequestDuration, concurrencyWaveCount);
-        return MaxTimeSpan(spacingDuration, concurrencyDuration);
     }
 
     private static int EstimateConcurrencyWaveCount(int requestCount, int maxConcurrentRequests)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -372,7 +372,8 @@ public static class CtIngestionPlanner
         int hydrationRequests)
     {
         bool requiresFullCertificateMaterial = RequiresFullCertificateMaterial(workload);
-        bool requiresFullCertificateFromProvider = requiresFullCertificateMaterial && hydrationRequests == 0;
+        bool canHydrateCertificates = profile.Supports(CtProviderCapabilities.CertificateHydration);
+        bool requiresFullCertificateFromProvider = requiresFullCertificateMaterial && !canHydrateCertificates;
         if (!SupportsOperation(profile, workload.Operations, requiresFullCertificateFromProvider))
         {
             return false;
@@ -383,7 +384,7 @@ public static class CtIngestionPlanner
             return true;
         }
 
-        return hydrationRequests > 0 && profile.Supports(CtProviderCapabilities.CertificateHydration);
+        return canHydrateCertificates;
     }
 
     private static TimeSpan ResolveEffectiveRequestSpacing(CtProviderRateLimitProfile rateLimit)
@@ -613,6 +614,13 @@ public static class CtIngestionPlanner
         if (hydrationRequests > 0)
         {
             return "Provider requires additional certificate hydration requests to satisfy full-certificate output.";
+        }
+
+        if (workload.RequireFullCertificate &&
+            !profile.Supports(CtProviderCapabilities.FullCertificateDer) &&
+            profile.Supports(CtProviderCapabilities.CertificateHydration))
+        {
+            return "Provider can hydrate full certificate material, but the workload estimate does not include a hydration count.";
         }
 
         if (capacity.ExceedsRunBudget)

--- a/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionPlanner.cs
@@ -9,6 +9,12 @@ namespace DomainDetective;
 /// </summary>
 public static class CtIngestionPlanner
 {
+    private const CtIngestionOperation KnownOperations =
+        CtIngestionOperation.DiscoverSubdomains |
+        CtIngestionOperation.GetLatestCertificate |
+        CtIngestionOperation.GetCertificateHistory |
+        CtIngestionOperation.GetDomainTreeCertificates;
+
     /// <summary>
     /// Estimates the minimum duration for a number of provider requests.
     /// </summary>
@@ -57,14 +63,14 @@ public static class CtIngestionPlanner
             EffectiveRequestSpacing = effectiveSpacing,
             EstimatedRequestDuration = rateLimit.EstimatedRequestDuration,
             EstimatedMinimumDuration = estimatedDuration,
-            EstimatedCompletionUtc = startUtc + estimatedDuration,
+            EstimatedCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedDuration),
             MaxConcurrentRequests = maxConcurrentRequests,
             MaximumRequestsPerRun = rateLimit.MaximumRequestsPerRun,
             EstimatedRunCount = estimatedRunCount,
             FirstRunRequestCount = firstRunRequestCount,
             RemainingRequestCount = remainingRequestCount,
             EstimatedFirstRunDuration = estimatedFirstRunDuration,
-            EstimatedFirstRunCompletionUtc = startUtc + estimatedFirstRunDuration,
+            EstimatedFirstRunCompletionUtc = AddTimeSpanSaturating(startUtc, estimatedFirstRunDuration),
             ConcurrencyWaveCount = concurrencyWaveCount,
             IsRateLimited = effectiveSpacing > TimeSpan.Zero,
             ExceedsRunBudget = estimatedRunCount > 1,
@@ -338,6 +344,11 @@ public static class CtIngestionPlanner
         }
 
         CtProviderCapabilities required = CtProviderCapabilities.None;
+        if ((operation & ~KnownOperations) != 0)
+        {
+            return false;
+        }
+
         if ((operation & CtIngestionOperation.DiscoverSubdomains) != 0)
         {
             required |= CtProviderCapabilities.SubdomainExpansion;
@@ -508,6 +519,28 @@ public static class CtIngestionPlanner
         }
 
         return left + right;
+    }
+
+    private static DateTimeOffset AddTimeSpanSaturating(DateTimeOffset startUtc, TimeSpan duration)
+    {
+        if (duration <= TimeSpan.Zero)
+        {
+            return startUtc;
+        }
+
+        if (duration == TimeSpan.MaxValue)
+        {
+            return DateTimeOffset.MaxValue;
+        }
+
+        try
+        {
+            return startUtc + duration;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return DateTimeOffset.MaxValue;
+        }
     }
 
     private static TimeSpan MaxTimeSpan(TimeSpan left, TimeSpan right)

--- a/DomainDetective/CertificateTransparency/CtIngestionWorkloadEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionWorkloadEstimate.cs
@@ -31,6 +31,15 @@ public sealed class CtIngestionWorkloadEstimate
     /// <summary>Provider capacity estimate for the total request count.</summary>
     public CtProviderCapacityEstimate Capacity { get; init; } = new();
 
+    /// <summary>Provider capacity estimate for domain-level expansion requests.</summary>
+    public CtProviderCapacityEstimate DomainCapacity { get; init; } = new();
+
+    /// <summary>Provider capacity estimate for exact-host requests.</summary>
+    public CtProviderCapacityEstimate HostCapacity { get; init; } = new();
+
+    /// <summary>Provider capacity estimate for follow-up certificate hydration requests.</summary>
+    public CtProviderCapacityEstimate HydrationCapacity { get; init; } = new();
+
     /// <summary>Human-readable planning note.</summary>
     public string? Note { get; init; }
 }

--- a/DomainDetective/CertificateTransparency/CtIngestionWorkloadEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionWorkloadEstimate.cs
@@ -25,6 +25,9 @@ public sealed class CtIngestionWorkloadEstimate
     /// <summary>Estimated follow-up certificate hydration provider requests.</summary>
     public int EstimatedHydrationRequests { get; init; }
 
+    /// <summary>True when estimated request counts were capped at <see cref="int.MaxValue"/>.</summary>
+    public bool IsRequestCountSaturated { get; init; }
+
     /// <summary>Provider capacity estimate for the total request count.</summary>
     public CtProviderCapacityEstimate Capacity { get; init; } = new();
 

--- a/DomainDetective/CertificateTransparency/CtIngestionWorkloadEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionWorkloadEstimate.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Represents a provider-specific certificate transparency workload estimate.
+/// </summary>
+public sealed class CtIngestionWorkloadEstimate
+{
+    /// <summary>Provider identifier used for the estimate.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>True when the provider advertises the capabilities requested by the workload.</summary>
+    public bool ProviderSupportsWorkload { get; init; }
+
+    /// <summary>Total estimated request count for the provider.</summary>
+    public int EstimatedRequestCount { get; init; }
+
+    /// <summary>Estimated domain-level provider requests.</summary>
+    public int EstimatedDomainRequests { get; init; }
+
+    /// <summary>Estimated exact-host provider requests.</summary>
+    public int EstimatedHostRequests { get; init; }
+
+    /// <summary>Estimated follow-up certificate hydration provider requests.</summary>
+    public int EstimatedHydrationRequests { get; init; }
+
+    /// <summary>Provider capacity estimate for the total request count.</summary>
+    public CtProviderCapacityEstimate Capacity { get; init; } = new();
+
+    /// <summary>Human-readable planning note.</summary>
+    public string? Note { get; init; }
+}

--- a/DomainDetective/CertificateTransparency/CtIngestionWorkloadRequest.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionWorkloadRequest.cs
@@ -34,16 +34,38 @@ public sealed class CtIngestionWorkloadRequest
     /// <summary>Returns a normalized copy of this workload request.</summary>
     public CtIngestionWorkloadRequest Normalize()
     {
+        int domainCount = Math.Max(0, DomainCount);
+        int hostCount = Math.Max(0, HostCount);
         return new CtIngestionWorkloadRequest
         {
-            DomainCount = Math.Max(0, DomainCount),
-            HostCount = Math.Max(0, HostCount),
-            Operations = Operations,
+            DomainCount = domainCount,
+            HostCount = hostCount,
+            Operations = Operations == CtIngestionOperation.None
+                ? ResolveDefaultOperations(domainCount, hostCount)
+                : Operations,
             RequireFullCertificate = RequireFullCertificate,
             RequestsPerDomain = Math.Max(1, RequestsPerDomain),
             RequestsPerHost = Math.Max(1, RequestsPerHost),
             HydrationRequestsPerCertificate = Math.Max(0, HydrationRequestsPerCertificate),
             EstimatedCertificatesToHydrate = Math.Max(0, EstimatedCertificatesToHydrate)
         };
+    }
+
+    private static CtIngestionOperation ResolveDefaultOperations(int domainCount, int hostCount)
+    {
+        CtIngestionOperation operations = CtIngestionOperation.None;
+        if (domainCount > 0)
+        {
+            operations |= CtIngestionOperation.DiscoverSubdomains;
+        }
+
+        if (hostCount > 0)
+        {
+            operations |= CtIngestionOperation.GetLatestCertificate;
+        }
+
+        return operations == CtIngestionOperation.None
+            ? CtIngestionOperation.GetLatestCertificate
+            : operations;
     }
 }

--- a/DomainDetective/CertificateTransparency/CtIngestionWorkloadRequest.cs
+++ b/DomainDetective/CertificateTransparency/CtIngestionWorkloadRequest.cs
@@ -1,0 +1,49 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes an estimated certificate transparency workload for provider planning.
+/// </summary>
+public sealed class CtIngestionWorkloadRequest
+{
+    /// <summary>Number of root domains included in the workload.</summary>
+    public int DomainCount { get; init; }
+
+    /// <summary>Number of exact hosts or assets included in the workload.</summary>
+    public int HostCount { get; init; }
+
+    /// <summary>Operations requested by the workload.</summary>
+    public CtIngestionOperation Operations { get; init; }
+
+    /// <summary>Whether the workload requires full DER or PEM certificate material.</summary>
+    public bool RequireFullCertificate { get; init; } = true;
+
+    /// <summary>Estimated provider requests per domain-level operation.</summary>
+    public int RequestsPerDomain { get; init; } = 1;
+
+    /// <summary>Estimated provider requests per exact-host operation.</summary>
+    public int RequestsPerHost { get; init; } = 1;
+
+    /// <summary>Estimated follow-up full certificate hydration requests per returned certificate.</summary>
+    public int HydrationRequestsPerCertificate { get; init; }
+
+    /// <summary>Estimated number of certificate rows that will need hydration.</summary>
+    public int EstimatedCertificatesToHydrate { get; init; }
+
+    /// <summary>Returns a normalized copy of this workload request.</summary>
+    public CtIngestionWorkloadRequest Normalize()
+    {
+        return new CtIngestionWorkloadRequest
+        {
+            DomainCount = Math.Max(0, DomainCount),
+            HostCount = Math.Max(0, HostCount),
+            Operations = Operations,
+            RequireFullCertificate = RequireFullCertificate,
+            RequestsPerDomain = Math.Max(1, RequestsPerDomain),
+            RequestsPerHost = Math.Max(1, RequestsPerHost),
+            HydrationRequestsPerCertificate = Math.Max(0, HydrationRequestsPerCertificate),
+            EstimatedCertificatesToHydrate = Math.Max(0, EstimatedCertificatesToHydrate)
+        };
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderCapabilities.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderCapabilities.cs
@@ -26,15 +26,18 @@ public enum CtProviderCapabilities
     /// <summary>The provider can return the full certificate DER bytes.</summary>
     FullCertificateDer = 16,
 
+    /// <summary>The provider can hydrate a metadata row into full certificate DER using a follow-up request.</summary>
+    CertificateHydration = 32,
+
     /// <summary>The provider supports paging or cursor-based continuation.</summary>
-    Pagination = 32,
+    Pagination = 64,
 
     /// <summary>The provider supports durable cursor-based ingestion.</summary>
-    DurableCursor = 64,
+    DurableCursor = 128,
 
     /// <summary>The provider is a direct CT log ingestion source rather than a domain index.</summary>
-    NativeLogIngestion = 128,
+    NativeLogIngestion = 256,
 
     /// <summary>The provider usually requires authentication for reliable production-scale use.</summary>
-    AuthenticationRecommended = 256
+    AuthenticationRecommended = 512
 }

--- a/DomainDetective/CertificateTransparency/CtProviderCapabilities.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderCapabilities.cs
@@ -1,0 +1,40 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes reusable certificate transparency provider capabilities.
+/// </summary>
+[Flags]
+public enum CtProviderCapabilities
+{
+    /// <summary>The provider does not advertise any CT capability.</summary>
+    None = 0,
+
+    /// <summary>The provider can expand a domain into observed subdomains.</summary>
+    SubdomainExpansion = 1,
+
+    /// <summary>The provider can query an exact host name.</summary>
+    ExactHostLookup = 2,
+
+    /// <summary>The provider can return historical rows for an exact host name.</summary>
+    CertificateHistory = 4,
+
+    /// <summary>The provider can return historical rows for a domain tree.</summary>
+    DomainTreeHistory = 8,
+
+    /// <summary>The provider can return the full certificate DER bytes.</summary>
+    FullCertificateDer = 16,
+
+    /// <summary>The provider supports paging or cursor-based continuation.</summary>
+    Pagination = 32,
+
+    /// <summary>The provider supports durable cursor-based ingestion.</summary>
+    DurableCursor = 64,
+
+    /// <summary>The provider is a direct CT log ingestion source rather than a domain index.</summary>
+    NativeLogIngestion = 128,
+
+    /// <summary>The provider usually requires authentication for reliable production-scale use.</summary>
+    AuthenticationRecommended = 256
+}

--- a/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
@@ -37,6 +37,15 @@ public sealed class CtProviderCapacityEstimate
     /// <summary>Estimated request count in the first logical run after applying the run budget.</summary>
     public int FirstRunRequestCount { get; init; }
 
+    /// <summary>Estimated request count remaining after the first logical run.</summary>
+    public int RemainingRequestCount { get; init; }
+
+    /// <summary>Estimated wall-clock duration for the first logical run.</summary>
+    public TimeSpan EstimatedFirstRunDuration { get; init; }
+
+    /// <summary>Estimated completion time for the first logical run.</summary>
+    public DateTimeOffset EstimatedFirstRunCompletionUtc { get; init; }
+
     /// <summary>Number of request waves needed under the configured concurrency limit.</summary>
     public int ConcurrencyWaveCount { get; init; }
 

--- a/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
@@ -16,6 +16,9 @@ public sealed class CtProviderCapacityEstimate
     /// <summary>Effective spacing between request starts after applying rate-limit settings.</summary>
     public TimeSpan EffectiveRequestSpacing { get; init; }
 
+    /// <summary>Expected wall-clock duration for one provider request used by the estimate.</summary>
+    public TimeSpan EstimatedRequestDuration { get; init; }
+
     /// <summary>Estimated minimum wall-clock duration for the requested provider calls.</summary>
     public TimeSpan EstimatedMinimumDuration { get; init; }
 
@@ -25,6 +28,12 @@ public sealed class CtProviderCapacityEstimate
     /// <summary>Safe concurrency to use for provider requests.</summary>
     public int MaxConcurrentRequests { get; init; } = 1;
 
+    /// <summary>Number of request waves needed under the configured concurrency limit.</summary>
+    public int ConcurrencyWaveCount { get; init; }
+
     /// <summary>True when the estimate is dominated by request pacing rather than only concurrency.</summary>
     public bool IsRateLimited { get; init; }
+
+    /// <summary>True when request duration and concurrency shape the minimum duration estimate.</summary>
+    public bool IsConcurrencyLimited { get; init; }
 }

--- a/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Estimates how long provider work should take under a configured CT provider profile.
+/// </summary>
+public sealed class CtProviderCapacityEstimate
+{
+    /// <summary>Provider identifier used for the estimate.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Number of provider requests included in the estimate.</summary>
+    public int RequestCount { get; init; }
+
+    /// <summary>Effective spacing between request starts after applying rate-limit settings.</summary>
+    public TimeSpan EffectiveRequestSpacing { get; init; }
+
+    /// <summary>Estimated minimum wall-clock duration for the requested provider calls.</summary>
+    public TimeSpan EstimatedMinimumDuration { get; init; }
+
+    /// <summary>Estimated completion time when starting from the provided current time.</summary>
+    public DateTimeOffset EstimatedCompletionUtc { get; init; }
+
+    /// <summary>Safe concurrency to use for provider requests.</summary>
+    public int MaxConcurrentRequests { get; init; } = 1;
+
+    /// <summary>True when the estimate is dominated by request pacing rather than only concurrency.</summary>
+    public bool IsRateLimited { get; init; }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderCapacityEstimate.cs
@@ -28,11 +28,23 @@ public sealed class CtProviderCapacityEstimate
     /// <summary>Safe concurrency to use for provider requests.</summary>
     public int MaxConcurrentRequests { get; init; } = 1;
 
+    /// <summary>Optional provider request budget for one logical run.</summary>
+    public int? MaximumRequestsPerRun { get; init; }
+
+    /// <summary>Estimated number of logical runs needed for the requested provider calls.</summary>
+    public int EstimatedRunCount { get; init; }
+
+    /// <summary>Estimated request count in the first logical run after applying the run budget.</summary>
+    public int FirstRunRequestCount { get; init; }
+
     /// <summary>Number of request waves needed under the configured concurrency limit.</summary>
     public int ConcurrencyWaveCount { get; init; }
 
     /// <summary>True when the estimate is dominated by request pacing rather than only concurrency.</summary>
     public bool IsRateLimited { get; init; }
+
+    /// <summary>True when the request count exceeds the provider budget for one logical run.</summary>
+    public bool ExceedsRunBudget { get; init; }
 
     /// <summary>True when request duration and concurrency shape the minimum duration estimate.</summary>
     public bool IsConcurrencyLimited { get; init; }

--- a/DomainDetective/CertificateTransparency/CtProviderExecutionDecision.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderExecutionDecision.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes whether a certificate transparency provider should run now or be deferred.
+/// </summary>
+public sealed class CtProviderExecutionDecision
+{
+    /// <summary>Provider identifier that was evaluated.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Whether the provider can be used immediately.</summary>
+    public bool CanRunNow { get; init; }
+
+    /// <summary>Time after which deferred provider work may be retried.</summary>
+    public DateTimeOffset? DeferUntilUtc { get; init; }
+
+    /// <summary>Safe concurrency to use for this provider decision.</summary>
+    public int MaxConcurrentRequests { get; init; } = 1;
+
+    /// <summary>Human-readable reason for the decision.</summary>
+    public string Reason { get; init; } = string.Empty;
+}

--- a/DomainDetective/CertificateTransparency/CtProviderOutcomeKind.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderOutcomeKind.cs
@@ -1,0 +1,22 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Describes the observed outcome of one certificate transparency provider request.
+/// </summary>
+public enum CtProviderOutcomeKind
+{
+    /// <summary>The provider request completed successfully.</summary>
+    Success = 0,
+
+    /// <summary>The provider request failed with a retryable/transient error.</summary>
+    TransientFailure = 1,
+
+    /// <summary>The provider request failed because the provider rate-limited the caller.</summary>
+    RateLimited = 2,
+
+    /// <summary>The provider request timed out.</summary>
+    Timeout = 3,
+
+    /// <summary>The provider request failed with a non-retryable error.</summary>
+    PermanentFailure = 4
+}

--- a/DomainDetective/CertificateTransparency/CtProviderPlanStatus.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderPlanStatus.cs
@@ -1,0 +1,16 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Describes the service-facing status of a planned certificate transparency provider workload.
+/// </summary>
+public enum CtProviderPlanStatus
+{
+    /// <summary>The provider cannot satisfy the requested workload.</summary>
+    Unsupported = 0,
+
+    /// <summary>The provider can satisfy the workload, but should be retried later.</summary>
+    Deferred = 1,
+
+    /// <summary>The provider can satisfy the workload and is eligible to run now.</summary>
+    Ready = 2
+}

--- a/DomainDetective/CertificateTransparency/CtProviderProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfile.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes a certificate transparency provider and its safe default behavior.
+/// </summary>
+public sealed class CtProviderProfile
+{
+    /// <summary>Stable provider identifier used in persisted state and diagnostics.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Human-readable provider name.</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>Provider capabilities that callers can use to select the right CT path.</summary>
+    public CtProviderCapabilities Capabilities { get; init; }
+
+    /// <summary>Provider rate limit and retry profile.</summary>
+    public CtProviderRateLimitProfile RateLimit { get; init; } = new();
+
+    /// <summary>Optional note describing assumptions behind the default profile.</summary>
+    public string? Notes { get; init; }
+
+    /// <summary>Returns true when the provider advertises all requested capabilities.</summary>
+    /// <param name="capabilities">Capabilities required by the caller.</param>
+    public bool Supports(CtProviderCapabilities capabilities)
+    {
+        return (Capabilities & capabilities) == capabilities;
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -239,11 +239,17 @@ public static class CtProviderProfiles
         }
 
         CtProviderProfile defaults = CreateNativeCtLogs();
-        int maxConcurrentLogs = options.DiscoveryParallelism <= 0
-            ? 1
-            : (options.NativeCtMaxLogs > 0
-                ? Math.Min(options.DiscoveryParallelism, options.NativeCtMaxLogs)
-                : options.DiscoveryParallelism);
+        int maxConcurrentLogs = options.DiscoveryParallelism;
+        if (maxConcurrentLogs <= 0)
+        {
+            maxConcurrentLogs = 1;
+        }
+
+        if (options.NativeCtMaxLogs > 0)
+        {
+            maxConcurrentLogs = Math.Min(maxConcurrentLogs, options.NativeCtMaxLogs);
+        }
+
         return new CtProviderProfile
         {
             ProviderId = defaults.ProviderId,

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -251,7 +251,7 @@ public static class CtProviderProfiles
             Capabilities = defaults.Capabilities,
             RateLimit = new CtProviderRateLimitProfile
             {
-                MaxConcurrentRequests = Math.Max(1, maxConcurrentLogs),
+                MaxConcurrentRequests = maxConcurrentLogs,
                 MinimumRequestSpacing = options.NativeCtRequestDelay,
                 RequestTimeout = options.NativeCtRequestTimeout,
                 EstimatedRequestDuration = defaults.RateLimit.EstimatedRequestDuration,

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -38,6 +38,7 @@ public static class CtProviderProfiles
                 MaxConcurrentRequests = 1,
                 MinimumRequestSpacing = TimeSpan.FromSeconds(15),
                 RequestTimeout = TimeSpan.FromSeconds(30),
+                EstimatedRequestDuration = TimeSpan.FromSeconds(5),
                 RetryBaseDelay = TimeSpan.FromSeconds(2),
                 RetryMaxDelay = TimeSpan.FromSeconds(30),
                 CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
@@ -69,6 +70,7 @@ public static class CtProviderProfiles
                 MaxConcurrentRequests = defaults.RateLimit.MaxConcurrentRequests,
                 MinimumRequestSpacing = options.PassiveCtCrtShMinimumSpacing,
                 RequestTimeout = options.PassiveCtRequestTimeout,
+                EstimatedRequestDuration = defaults.RateLimit.EstimatedRequestDuration,
                 RetryBaseDelay = options.PassiveCtRetryBaseDelay,
                 RetryMaxDelay = options.PassiveCtRetryMaxDelay,
                 CooldownAfterRateLimit = options.PassiveCtSourceCooldown,
@@ -98,6 +100,7 @@ public static class CtProviderProfiles
             {
                 MaxConcurrentRequests = 2,
                 RequestTimeout = TimeSpan.FromSeconds(30),
+                EstimatedRequestDuration = TimeSpan.FromSeconds(10),
                 RetryBaseDelay = TimeSpan.FromSeconds(2),
                 RetryMaxDelay = TimeSpan.FromSeconds(30),
                 CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
@@ -127,6 +130,7 @@ public static class CtProviderProfiles
             {
                 MaxConcurrentRequests = Math.Max(1, options.CrtShPostgreSqlMaximumConcurrentRequests),
                 RequestTimeout = TimeSpan.FromSeconds(Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds)),
+                EstimatedRequestDuration = defaults.RateLimit.EstimatedRequestDuration,
                 RetryBaseDelay = defaults.RateLimit.RetryBaseDelay,
                 RetryMaxDelay = defaults.RateLimit.RetryMaxDelay,
                 CooldownAfterRateLimit = defaults.RateLimit.CooldownAfterRateLimit
@@ -154,6 +158,7 @@ public static class CtProviderProfiles
                 MaxConcurrentRequests = 1,
                 MinimumRequestSpacing = TimeSpan.FromSeconds(15),
                 RequestTimeout = TimeSpan.FromSeconds(30),
+                EstimatedRequestDuration = TimeSpan.FromSeconds(3),
                 RetryBaseDelay = TimeSpan.FromSeconds(2),
                 RetryMaxDelay = TimeSpan.FromSeconds(30),
                 CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
@@ -184,6 +189,7 @@ public static class CtProviderProfiles
                 MaxConcurrentRequests = defaults.RateLimit.MaxConcurrentRequests,
                 MinimumRequestSpacing = options.PassiveCtCertSpotterMinimumSpacing,
                 RequestTimeout = options.PassiveCtRequestTimeout,
+                EstimatedRequestDuration = defaults.RateLimit.EstimatedRequestDuration,
                 RetryBaseDelay = options.PassiveCtRetryBaseDelay,
                 RetryMaxDelay = options.PassiveCtRetryMaxDelay,
                 CooldownAfterRateLimit = options.PassiveCtSourceCooldown,
@@ -212,6 +218,7 @@ public static class CtProviderProfiles
             {
                 MaxConcurrentRequests = 4,
                 RequestTimeout = TimeSpan.FromSeconds(30),
+                EstimatedRequestDuration = TimeSpan.FromSeconds(2),
                 RetryBaseDelay = TimeSpan.FromSeconds(1),
                 RetryMaxDelay = TimeSpan.FromSeconds(30),
                 CooldownAfterRateLimit = TimeSpan.FromMinutes(10)
@@ -247,6 +254,7 @@ public static class CtProviderProfiles
                 MaxConcurrentRequests = Math.Max(1, maxConcurrentLogs),
                 MinimumRequestSpacing = options.NativeCtRequestDelay,
                 RequestTimeout = options.NativeCtRequestTimeout,
+                EstimatedRequestDuration = defaults.RateLimit.EstimatedRequestDuration,
                 RetryBaseDelay = options.NativeCtRetryBaseDelay,
                 RetryMaxDelay = options.NativeCtRetryMaxDelay,
                 CooldownAfterRateLimit = options.NativeCtCircuitBreakerDuration

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Provides safe default certificate transparency provider profiles.
+/// </summary>
+public static class CtProviderProfiles
+{
+    /// <summary>crt.sh HTTPS provider identifier.</summary>
+    public const string CrtShHttpProviderId = "crt.sh";
+
+    /// <summary>crt.sh PostgreSQL provider identifier.</summary>
+    public const string CrtShPostgreSqlProviderId = "crt.sh-db";
+
+    /// <summary>CertSpotter provider identifier.</summary>
+    public const string CertSpotterProviderId = "certspotter";
+
+    /// <summary>Native CT log provider identifier.</summary>
+    public const string NativeCtProviderId = "native-ct";
+
+    /// <summary>
+    /// Creates the conservative default profile for crt.sh HTTPS queries.
+    /// </summary>
+    public static CtProviderProfile CreateCrtShHttp()
+    {
+        return new CtProviderProfile
+        {
+            ProviderId = CrtShHttpProviderId,
+            DisplayName = "crt.sh HTTPS",
+            Capabilities = CtProviderCapabilities.SubdomainExpansion |
+                           CtProviderCapabilities.ExactHostLookup,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxRequestsPerMinute = 5,
+                MaxConcurrentRequests = 1,
+                MinimumRequestSpacing = TimeSpan.FromSeconds(15),
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                RetryBaseDelay = TimeSpan.FromSeconds(2),
+                RetryMaxDelay = TimeSpan.FromSeconds(30),
+                CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
+            },
+            Notes = "Public crt.sh HTTPS has historically been heavily loaded; keep this profile conservative and configurable."
+        };
+    }
+
+    /// <summary>
+    /// Creates a crt.sh HTTPS profile from certificate inventory capture options.
+    /// </summary>
+    /// <param name="options">Certificate inventory capture options.</param>
+    public static CtProviderProfile CreateCrtShHttp(CertificateInventoryCaptureOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        CtProviderProfile defaults = CreateCrtShHttp();
+        return new CtProviderProfile
+        {
+            ProviderId = defaults.ProviderId,
+            DisplayName = defaults.DisplayName,
+            Capabilities = defaults.Capabilities,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxRequestsPerMinute = defaults.RateLimit.MaxRequestsPerMinute,
+                MaxConcurrentRequests = defaults.RateLimit.MaxConcurrentRequests,
+                MinimumRequestSpacing = options.PassiveCtCrtShMinimumSpacing,
+                RequestTimeout = options.PassiveCtRequestTimeout,
+                RetryBaseDelay = options.PassiveCtRetryBaseDelay,
+                RetryMaxDelay = options.PassiveCtRetryMaxDelay,
+                CooldownAfterRateLimit = options.PassiveCtSourceCooldown,
+                MaximumRequestsPerRun = options.PassiveCtCrtShMaximumRequestsPerRun > 0
+                    ? options.PassiveCtCrtShMaximumRequestsPerRun
+                    : null
+            },
+            Notes = defaults.Notes
+        };
+    }
+
+    /// <summary>
+    /// Creates the conservative default profile for crt.sh PostgreSQL queries.
+    /// </summary>
+    public static CtProviderProfile CreateCrtShPostgreSql()
+    {
+        return new CtProviderProfile
+        {
+            ProviderId = CrtShPostgreSqlProviderId,
+            DisplayName = "crt.sh PostgreSQL",
+            Capabilities = CtProviderCapabilities.SubdomainExpansion |
+                           CtProviderCapabilities.ExactHostLookup |
+                           CtProviderCapabilities.CertificateHistory |
+                           CtProviderCapabilities.DomainTreeHistory |
+                           CtProviderCapabilities.FullCertificateDer,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = 2,
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                RetryBaseDelay = TimeSpan.FromSeconds(2),
+                RetryMaxDelay = TimeSpan.FromSeconds(30),
+                CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
+            },
+            Notes = "Default concurrency stays below the public crt.sh PostgreSQL per-IP connection limit discussed by crt.sh operators."
+        };
+    }
+
+    /// <summary>
+    /// Creates a crt.sh PostgreSQL profile from certificate inventory capture options.
+    /// </summary>
+    /// <param name="options">Certificate inventory capture options.</param>
+    public static CtProviderProfile CreateCrtShPostgreSql(CertificateInventoryCaptureOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        CtProviderProfile defaults = CreateCrtShPostgreSql();
+        return new CtProviderProfile
+        {
+            ProviderId = defaults.ProviderId,
+            DisplayName = defaults.DisplayName,
+            Capabilities = defaults.Capabilities,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = Math.Max(1, options.CrtShPostgreSqlMaximumConcurrentRequests),
+                RequestTimeout = TimeSpan.FromSeconds(Math.Max(1, options.CrtShPostgreSqlCommandTimeoutSeconds)),
+                RetryBaseDelay = defaults.RateLimit.RetryBaseDelay,
+                RetryMaxDelay = defaults.RateLimit.RetryMaxDelay,
+                CooldownAfterRateLimit = defaults.RateLimit.CooldownAfterRateLimit
+            },
+            Notes = defaults.Notes
+        };
+    }
+
+    /// <summary>
+    /// Creates the default profile for CertSpotter CT Search API queries.
+    /// </summary>
+    public static CtProviderProfile CreateCertSpotter()
+    {
+        return new CtProviderProfile
+        {
+            ProviderId = CertSpotterProviderId,
+            DisplayName = "CertSpotter",
+            Capabilities = CtProviderCapabilities.SubdomainExpansion |
+                           CtProviderCapabilities.ExactHostLookup |
+                           CtProviderCapabilities.FullCertificateDer |
+                           CtProviderCapabilities.Pagination |
+                           CtProviderCapabilities.AuthenticationRecommended,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = 1,
+                MinimumRequestSpacing = TimeSpan.FromSeconds(15),
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                RetryBaseDelay = TimeSpan.FromSeconds(2),
+                RetryMaxDelay = TimeSpan.FromSeconds(30),
+                CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
+            },
+            Notes = "CertSpotter supports paging and cert_der expansion; production use should provide an API token and configured budget."
+        };
+    }
+
+    /// <summary>
+    /// Creates a CertSpotter profile from certificate inventory capture options.
+    /// </summary>
+    /// <param name="options">Certificate inventory capture options.</param>
+    public static CtProviderProfile CreateCertSpotter(CertificateInventoryCaptureOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        CtProviderProfile defaults = CreateCertSpotter();
+        return new CtProviderProfile
+        {
+            ProviderId = defaults.ProviderId,
+            DisplayName = defaults.DisplayName,
+            Capabilities = defaults.Capabilities,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = defaults.RateLimit.MaxConcurrentRequests,
+                MinimumRequestSpacing = options.PassiveCtCertSpotterMinimumSpacing,
+                RequestTimeout = options.PassiveCtRequestTimeout,
+                RetryBaseDelay = options.PassiveCtRetryBaseDelay,
+                RetryMaxDelay = options.PassiveCtRetryMaxDelay,
+                CooldownAfterRateLimit = options.PassiveCtSourceCooldown,
+                MaximumRequestsPerRun = options.PassiveCtCertSpotterMaximumRequestsPerRun > 0
+                    ? options.PassiveCtCertSpotterMaximumRequestsPerRun
+                    : null
+            },
+            Notes = defaults.Notes
+        };
+    }
+
+    /// <summary>
+    /// Creates the default profile for direct native CT log ingestion.
+    /// </summary>
+    public static CtProviderProfile CreateNativeCtLogs()
+    {
+        return new CtProviderProfile
+        {
+            ProviderId = NativeCtProviderId,
+            DisplayName = "Native CT Logs",
+            Capabilities = CtProviderCapabilities.SubdomainExpansion |
+                           CtProviderCapabilities.FullCertificateDer |
+                           CtProviderCapabilities.DurableCursor |
+                           CtProviderCapabilities.NativeLogIngestion,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = 4,
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                RetryBaseDelay = TimeSpan.FromSeconds(1),
+                RetryMaxDelay = TimeSpan.FromSeconds(30),
+                CooldownAfterRateLimit = TimeSpan.FromMinutes(10)
+            },
+            Notes = "Native CT is suited to cursor-based ingestion and local indexing, not ad-hoc full-history domain search."
+        };
+    }
+
+    /// <summary>
+    /// Creates a native CT log profile from certificate inventory capture options.
+    /// </summary>
+    /// <param name="options">Certificate inventory capture options.</param>
+    public static CtProviderProfile CreateNativeCtLogs(CertificateInventoryCaptureOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        CtProviderProfile defaults = CreateNativeCtLogs();
+        int maxConcurrentLogs = options.DiscoveryParallelism <= 0
+            ? 1
+            : (options.NativeCtMaxLogs > 0
+                ? Math.Min(options.DiscoveryParallelism, options.NativeCtMaxLogs)
+                : options.DiscoveryParallelism);
+        return new CtProviderProfile
+        {
+            ProviderId = defaults.ProviderId,
+            DisplayName = defaults.DisplayName,
+            Capabilities = defaults.Capabilities,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = Math.Max(1, maxConcurrentLogs),
+                MinimumRequestSpacing = options.NativeCtRequestDelay,
+                RequestTimeout = options.NativeCtRequestTimeout,
+                RetryBaseDelay = options.NativeCtRetryBaseDelay,
+                RetryMaxDelay = options.NativeCtRetryMaxDelay,
+                CooldownAfterRateLimit = options.NativeCtCircuitBreakerDuration
+            },
+            Notes = defaults.Notes
+        };
+    }
+
+    /// <summary>
+    /// Creates all default CT provider profiles from certificate inventory capture options.
+    /// </summary>
+    /// <param name="options">Certificate inventory capture options.</param>
+    public static IReadOnlyList<CtProviderProfile> CreateFromCertificateInventoryOptions(CertificateInventoryCaptureOptions options)
+    {
+        if (options == null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        return new[]
+        {
+            CreateCrtShHttp(options),
+            CreateCrtShPostgreSql(options),
+            CreateCertSpotter(options),
+            CreateNativeCtLogs(options)
+        };
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -155,15 +155,19 @@ public static class CtProviderProfiles
                            CtProviderCapabilities.AuthenticationRecommended,
             RateLimit = new CtProviderRateLimitProfile
             {
+                MaxRequestsPerSecond = 5,
+                MaxRequestsPerMinute = 75,
+                MaxSingleHostnameQueriesPerHour = 100,
+                MaxFullDomainQueriesPerHour = 10,
                 MaxConcurrentRequests = 1,
                 MinimumRequestSpacing = TimeSpan.FromSeconds(15),
-                RequestTimeout = TimeSpan.FromSeconds(30),
+                RequestTimeout = TimeSpan.FromSeconds(15),
                 EstimatedRequestDuration = TimeSpan.FromSeconds(3),
                 RetryBaseDelay = TimeSpan.FromSeconds(2),
                 RetryMaxDelay = TimeSpan.FromSeconds(30),
                 CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
             },
-            Notes = "CertSpotter supports paging and cert_der expansion; production use should provide an API token and configured budget."
+            Notes = "CertSpotter supports paging and cert_der expansion. The default profile models the Small CT Search API budget: exact-host queries and full-domain expansion have separate hourly limits."
         };
     }
 
@@ -186,6 +190,10 @@ public static class CtProviderProfiles
             Capabilities = defaults.Capabilities,
             RateLimit = new CtProviderRateLimitProfile
             {
+                MaxRequestsPerSecond = defaults.RateLimit.MaxRequestsPerSecond,
+                MaxRequestsPerMinute = defaults.RateLimit.MaxRequestsPerMinute,
+                MaxSingleHostnameQueriesPerHour = defaults.RateLimit.MaxSingleHostnameQueriesPerHour,
+                MaxFullDomainQueriesPerHour = defaults.RateLimit.MaxFullDomainQueriesPerHour,
                 MaxConcurrentRequests = defaults.RateLimit.MaxConcurrentRequests,
                 MinimumRequestSpacing = options.PassiveCtCertSpotterMinimumSpacing,
                 RequestTimeout = options.PassiveCtRequestTimeout,

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -30,7 +30,8 @@ public static class CtProviderProfiles
             ProviderId = CrtShHttpProviderId,
             DisplayName = "crt.sh HTTPS",
             Capabilities = CtProviderCapabilities.SubdomainExpansion |
-                           CtProviderCapabilities.ExactHostLookup,
+                           CtProviderCapabilities.ExactHostLookup |
+                           CtProviderCapabilities.CertificateHydration,
             RateLimit = new CtProviderRateLimitProfile
             {
                 MaxRequestsPerMinute = 5,

--- a/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
@@ -19,6 +19,9 @@ public sealed class CtProviderRateLimitProfile
     /// <summary>Per-request timeout used for provider calls.</summary>
     public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>Expected wall-clock duration for one provider request when estimating throughput.</summary>
+    public TimeSpan EstimatedRequestDuration { get; init; } = TimeSpan.FromSeconds(1);
+
     /// <summary>Base retry delay used after transient provider failures.</summary>
     public TimeSpan RetryBaseDelay { get; init; } = TimeSpan.FromSeconds(1);
 
@@ -50,6 +53,9 @@ public sealed class CtProviderRateLimitProfile
         TimeSpan requestTimeout = RequestTimeout <= TimeSpan.Zero
             ? TimeSpan.FromSeconds(30)
             : RequestTimeout;
+        TimeSpan estimatedRequestDuration = EstimatedRequestDuration <= TimeSpan.Zero
+            ? TimeSpan.FromSeconds(1)
+            : EstimatedRequestDuration;
         TimeSpan retryBaseDelay = RetryBaseDelay < TimeSpan.Zero
             ? TimeSpan.Zero
             : RetryBaseDelay;
@@ -71,6 +77,7 @@ public sealed class CtProviderRateLimitProfile
             MaxConcurrentRequests = maxConcurrentRequests,
             MinimumRequestSpacing = minimumRequestSpacing,
             RequestTimeout = requestTimeout,
+            EstimatedRequestDuration = estimatedRequestDuration,
             RetryBaseDelay = retryBaseDelay,
             RetryMaxDelay = retryMaxDelay,
             CooldownAfterRateLimit = cooldownAfterRateLimit,

--- a/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
@@ -31,6 +31,9 @@ public sealed class CtProviderRateLimitProfile
     /// <summary>Default cooldown after a rate limit or repeated provider failure.</summary>
     public TimeSpan CooldownAfterRateLimit { get; init; } = TimeSpan.FromMinutes(5);
 
+    /// <summary>Transient failure ratio from zero to one at which provider execution should cool down.</summary>
+    public double TransientFailureRatioCooldownThreshold { get; init; } = 0.5d;
+
     /// <summary>Optional request budget for a single logical run. Null means no run-local cap.</summary>
     public int? MaximumRequestsPerRun { get; init; }
 
@@ -70,6 +73,12 @@ public sealed class CtProviderRateLimitProfile
         TimeSpan cooldownAfterRateLimit = CooldownAfterRateLimit < TimeSpan.Zero
             ? TimeSpan.Zero
             : CooldownAfterRateLimit;
+        double transientFailureRatioCooldownThreshold =
+            double.IsNaN(TransientFailureRatioCooldownThreshold) ||
+            double.IsInfinity(TransientFailureRatioCooldownThreshold) ||
+            TransientFailureRatioCooldownThreshold <= 0d
+                ? 0.5d
+                : Math.Min(1d, TransientFailureRatioCooldownThreshold);
 
         return new CtProviderRateLimitProfile
         {
@@ -81,6 +90,7 @@ public sealed class CtProviderRateLimitProfile
             RetryBaseDelay = retryBaseDelay,
             RetryMaxDelay = retryMaxDelay,
             CooldownAfterRateLimit = cooldownAfterRateLimit,
+            TransientFailureRatioCooldownThreshold = transientFailureRatioCooldownThreshold,
             MaximumRequestsPerRun = maximumRequestsPerRun
         };
     }

--- a/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
@@ -1,0 +1,80 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Configures safe request pacing for a certificate transparency provider.
+/// </summary>
+public sealed class CtProviderRateLimitProfile
+{
+    /// <summary>Maximum requests allowed per minute for the provider, when known.</summary>
+    public int? MaxRequestsPerMinute { get; init; }
+
+    /// <summary>Maximum concurrent requests or connections for the provider, when known.</summary>
+    public int? MaxConcurrentRequests { get; init; }
+
+    /// <summary>Minimum spacing between request starts for the provider.</summary>
+    public TimeSpan MinimumRequestSpacing { get; init; } = TimeSpan.Zero;
+
+    /// <summary>Per-request timeout used for provider calls.</summary>
+    public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Base retry delay used after transient provider failures.</summary>
+    public TimeSpan RetryBaseDelay { get; init; } = TimeSpan.FromSeconds(1);
+
+    /// <summary>Maximum retry delay used after transient provider failures.</summary>
+    public TimeSpan RetryMaxDelay { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Default cooldown after a rate limit or repeated provider failure.</summary>
+    public TimeSpan CooldownAfterRateLimit { get; init; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>Optional request budget for a single logical run. Null means no run-local cap.</summary>
+    public int? MaximumRequestsPerRun { get; init; }
+
+    /// <summary>Returns a normalized copy of the rate limit profile.</summary>
+    public CtProviderRateLimitProfile Normalize()
+    {
+        int? maxRequestsPerMinute = MaxRequestsPerMinute.HasValue
+            ? Math.Max(1, MaxRequestsPerMinute.Value)
+            : null;
+        int? maxConcurrentRequests = MaxConcurrentRequests.HasValue
+            ? Math.Max(1, MaxConcurrentRequests.Value)
+            : null;
+        int? maximumRequestsPerRun = MaximumRequestsPerRun.HasValue
+            ? Math.Max(1, MaximumRequestsPerRun.Value)
+            : null;
+
+        TimeSpan minimumRequestSpacing = MinimumRequestSpacing < TimeSpan.Zero
+            ? TimeSpan.Zero
+            : MinimumRequestSpacing;
+        TimeSpan requestTimeout = RequestTimeout <= TimeSpan.Zero
+            ? TimeSpan.FromSeconds(30)
+            : RequestTimeout;
+        TimeSpan retryBaseDelay = RetryBaseDelay < TimeSpan.Zero
+            ? TimeSpan.Zero
+            : RetryBaseDelay;
+        TimeSpan retryMaxDelay = RetryMaxDelay <= TimeSpan.Zero
+            ? TimeSpan.FromSeconds(30)
+            : RetryMaxDelay;
+        if (retryMaxDelay < retryBaseDelay)
+        {
+            retryMaxDelay = retryBaseDelay;
+        }
+
+        TimeSpan cooldownAfterRateLimit = CooldownAfterRateLimit < TimeSpan.Zero
+            ? TimeSpan.Zero
+            : CooldownAfterRateLimit;
+
+        return new CtProviderRateLimitProfile
+        {
+            MaxRequestsPerMinute = maxRequestsPerMinute,
+            MaxConcurrentRequests = maxConcurrentRequests,
+            MinimumRequestSpacing = minimumRequestSpacing,
+            RequestTimeout = requestTimeout,
+            RetryBaseDelay = retryBaseDelay,
+            RetryMaxDelay = retryMaxDelay,
+            CooldownAfterRateLimit = cooldownAfterRateLimit,
+            MaximumRequestsPerRun = maximumRequestsPerRun
+        };
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
@@ -28,7 +28,7 @@ public sealed class CtProviderRateLimitProfile
     /// <summary>Maximum retry delay used after transient provider failures.</summary>
     public TimeSpan RetryMaxDelay { get; init; } = TimeSpan.FromSeconds(30);
 
-    /// <summary>Default cooldown after a rate limit or repeated provider failure.</summary>
+    /// <summary>Default cooldown after a rate limit or a high transient-failure ratio.</summary>
     public TimeSpan CooldownAfterRateLimit { get; init; } = TimeSpan.FromMinutes(5);
 
     /// <summary>Transient failure ratio from zero to one at which provider execution should cool down.</summary>

--- a/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
@@ -10,6 +10,18 @@ public sealed class CtProviderRateLimitProfile
     /// <summary>Maximum requests allowed per minute for the provider, when known.</summary>
     public int? MaxRequestsPerMinute { get; init; }
 
+    /// <summary>Maximum requests allowed per second for the provider, when known.</summary>
+    public int? MaxRequestsPerSecond { get; init; }
+
+    /// <summary>Maximum requests allowed per hour for the provider, when known.</summary>
+    public int? MaxRequestsPerHour { get; init; }
+
+    /// <summary>Maximum exact-host CT queries allowed per hour for the provider, when known.</summary>
+    public int? MaxSingleHostnameQueriesPerHour { get; init; }
+
+    /// <summary>Maximum domain-tree or subdomain-expansion CT queries allowed per hour for the provider, when known.</summary>
+    public int? MaxFullDomainQueriesPerHour { get; init; }
+
     /// <summary>Maximum concurrent requests or connections for the provider, when known.</summary>
     public int? MaxConcurrentRequests { get; init; }
 
@@ -42,6 +54,18 @@ public sealed class CtProviderRateLimitProfile
     {
         int? maxRequestsPerMinute = MaxRequestsPerMinute.HasValue
             ? Math.Max(1, MaxRequestsPerMinute.Value)
+            : null;
+        int? maxRequestsPerSecond = MaxRequestsPerSecond.HasValue
+            ? Math.Max(1, MaxRequestsPerSecond.Value)
+            : null;
+        int? maxRequestsPerHour = MaxRequestsPerHour.HasValue
+            ? Math.Max(1, MaxRequestsPerHour.Value)
+            : null;
+        int? maxSingleHostnameQueriesPerHour = MaxSingleHostnameQueriesPerHour.HasValue
+            ? Math.Max(1, MaxSingleHostnameQueriesPerHour.Value)
+            : null;
+        int? maxFullDomainQueriesPerHour = MaxFullDomainQueriesPerHour.HasValue
+            ? Math.Max(1, MaxFullDomainQueriesPerHour.Value)
             : null;
         int? maxConcurrentRequests = MaxConcurrentRequests.HasValue
             ? Math.Max(1, MaxConcurrentRequests.Value)
@@ -83,6 +107,10 @@ public sealed class CtProviderRateLimitProfile
         return new CtProviderRateLimitProfile
         {
             MaxRequestsPerMinute = maxRequestsPerMinute,
+            MaxRequestsPerSecond = maxRequestsPerSecond,
+            MaxRequestsPerHour = maxRequestsPerHour,
+            MaxSingleHostnameQueriesPerHour = maxSingleHostnameQueriesPerHour,
+            MaxFullDomainQueriesPerHour = maxFullDomainQueriesPerHour,
             MaxConcurrentRequests = maxConcurrentRequests,
             MinimumRequestSpacing = minimumRequestSpacing,
             RequestTimeout = requestTimeout,

--- a/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRateLimitProfile.cs
@@ -76,7 +76,7 @@ public sealed class CtProviderRateLimitProfile
         double transientFailureRatioCooldownThreshold =
             double.IsNaN(TransientFailureRatioCooldownThreshold) ||
             double.IsInfinity(TransientFailureRatioCooldownThreshold) ||
-            TransientFailureRatioCooldownThreshold <= 0d
+            TransientFailureRatioCooldownThreshold < 0d
                 ? 0.5d
                 : Math.Min(1d, TransientFailureRatioCooldownThreshold);
 

--- a/DomainDetective/CertificateTransparency/CtProviderRequestOutcome.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRequestOutcome.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Captures the observed result of a certificate transparency provider request.
+/// </summary>
+public sealed class CtProviderRequestOutcome
+{
+    /// <summary>Provider that produced the outcome.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Observed outcome kind.</summary>
+    public CtProviderOutcomeKind OutcomeKind { get; init; }
+
+    /// <summary>Time at which the outcome was observed.</summary>
+    public DateTimeOffset? OccurredAtUtc { get; init; }
+
+    /// <summary>Provider-requested retry delay, when supplied.</summary>
+    public TimeSpan? RetryAfter { get; init; }
+
+    /// <summary>Observed HTTP status code for HTTP-backed providers.</summary>
+    public int? HttpStatusCode { get; init; }
+
+    /// <summary>Observed request latency.</summary>
+    public TimeSpan? Latency { get; init; }
+
+    /// <summary>Provider error or diagnostic message.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>When true, applies a cooldown for transient non-rate-limit failures.</summary>
+    public bool CooldownOnTransientFailure { get; init; }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Stores runtime health and cooldown state for a certificate transparency provider.
+/// </summary>
+public sealed class CtProviderRuntimeState
+{
+    /// <summary>Stable provider identifier.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Time before which the provider should not be queried.</summary>
+    public DateTimeOffset? CooldownUntilUtc { get; init; }
+
+    /// <summary>Number of consecutive provider failures observed by the caller.</summary>
+    public int ConsecutiveFailures { get; init; }
+
+    /// <summary>Last successful provider request time.</summary>
+    public DateTimeOffset? LastSuccessUtc { get; init; }
+
+    /// <summary>Last failed provider request time.</summary>
+    public DateTimeOffset? LastFailureUtc { get; init; }
+
+    /// <summary>Observed request latency percentile in milliseconds, when tracked by the caller.</summary>
+    public double? ObservedP95LatencyMilliseconds { get; init; }
+
+    /// <summary>Rolling transient failure ratio from zero to one, when tracked by the caller.</summary>
+    public double? TransientFailureRatio { get; init; }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
@@ -27,4 +27,28 @@ public sealed class CtProviderRuntimeState
 
     /// <summary>Rolling transient failure ratio from zero to one, when tracked by the caller.</summary>
     public double? TransientFailureRatio { get; init; }
+
+    /// <summary>Total provider requests observed by the caller.</summary>
+    public long TotalRequestCount { get; init; }
+
+    /// <summary>Total successful provider requests observed by the caller.</summary>
+    public long SuccessfulRequestCount { get; init; }
+
+    /// <summary>Total transient provider failures observed by the caller.</summary>
+    public long TransientFailureCount { get; init; }
+
+    /// <summary>Total provider rate-limit responses observed by the caller.</summary>
+    public long RateLimitedCount { get; init; }
+
+    /// <summary>Total provider timeout responses observed by the caller.</summary>
+    public long TimeoutCount { get; init; }
+
+    /// <summary>Last HTTP status code observed for HTTP-backed providers.</summary>
+    public int? LastHttpStatusCode { get; init; }
+
+    /// <summary>Last provider error message observed by the caller.</summary>
+    public string? LastError { get; init; }
+
+    /// <summary>Last observed request latency in milliseconds.</summary>
+    public double? LastObservedLatencyMilliseconds { get; init; }
 }

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
@@ -16,7 +16,7 @@ public sealed class CtProviderRuntimeState
     /// <summary>Number of consecutive provider failures observed by the caller.</summary>
     public int ConsecutiveFailures { get; init; }
 
-    /// <summary>True when the provider reached a non-retryable failure; a later successful request clears this flag.</summary>
+    /// <summary>True when the provider reached a non-retryable failure; non-success outcomes preserve it, and a later successful request clears it.</summary>
     public bool IsPermanentlyFailed { get; init; }
 
     /// <summary>Last successful provider request time.</summary>
@@ -28,7 +28,7 @@ public sealed class CtProviderRuntimeState
     /// <summary>Observed request latency percentile in milliseconds, when tracked by the caller.</summary>
     public double? ObservedP95LatencyMilliseconds { get; init; }
 
-    /// <summary>Rolling transient failure ratio from zero to one, when tracked by the caller.</summary>
+    /// <summary>Rolling transient failure ratio from zero to one, excluding rate-limit responses that carry explicit cooldown state.</summary>
     public double? TransientFailureRatio { get; init; }
 
     /// <summary>Total provider requests observed by the caller.</summary>

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
@@ -16,6 +16,9 @@ public sealed class CtProviderRuntimeState
     /// <summary>Number of consecutive provider failures observed by the caller.</summary>
     public int ConsecutiveFailures { get; init; }
 
+    /// <summary>True when the provider reached a non-retryable failure and should not be queried until state is reset.</summary>
+    public bool IsPermanentlyFailed { get; init; }
+
     /// <summary>Last successful provider request time.</summary>
     public DateTimeOffset? LastSuccessUtc { get; init; }
 

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeState.cs
@@ -16,7 +16,7 @@ public sealed class CtProviderRuntimeState
     /// <summary>Number of consecutive provider failures observed by the caller.</summary>
     public int ConsecutiveFailures { get; init; }
 
-    /// <summary>True when the provider reached a non-retryable failure and should not be queried until state is reset.</summary>
+    /// <summary>True when the provider reached a non-retryable failure; a later successful request clears this flag.</summary>
     public bool IsPermanentlyFailed { get; init; }
 
     /// <summary>Last successful provider request time.</summary>

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
@@ -81,22 +81,44 @@ public static class CtProviderRuntimeStateUpdater
             TimeSpan cooldown = outcome.RetryAfter.HasValue && outcome.RetryAfter.Value > TimeSpan.Zero
                 ? outcome.RetryAfter.Value
                 : rateLimit.CooldownAfterRateLimit;
-            return Max(previous?.CooldownUntilUtc, occurredAtUtc + cooldown);
+            return Max(previous?.CooldownUntilUtc, AddTimeSpanSaturating(occurredAtUtc, cooldown));
         }
 
         if (outcome.OutcomeKind == CtProviderOutcomeKind.TransientFailure &&
             outcome.CooldownOnTransientFailure)
         {
-            return Max(previous?.CooldownUntilUtc, occurredAtUtc + rateLimit.CooldownAfterRateLimit);
+            return Max(previous?.CooldownUntilUtc, AddTimeSpanSaturating(occurredAtUtc, rateLimit.CooldownAfterRateLimit));
         }
 
         if (outcome.OutcomeKind == CtProviderOutcomeKind.Timeout &&
             outcome.CooldownOnTransientFailure)
         {
-            return Max(previous?.CooldownUntilUtc, occurredAtUtc + rateLimit.CooldownAfterRateLimit);
+            return Max(previous?.CooldownUntilUtc, AddTimeSpanSaturating(occurredAtUtc, rateLimit.CooldownAfterRateLimit));
         }
 
         return previous?.CooldownUntilUtc;
+    }
+
+    private static DateTimeOffset AddTimeSpanSaturating(DateTimeOffset startUtc, TimeSpan duration)
+    {
+        if (duration <= TimeSpan.Zero)
+        {
+            return startUtc;
+        }
+
+        if (duration == TimeSpan.MaxValue)
+        {
+            return DateTimeOffset.MaxValue;
+        }
+
+        try
+        {
+            return startUtc + duration;
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return DateTimeOffset.MaxValue;
+        }
     }
 
     private static DateTimeOffset? Max(DateTimeOffset? left, DateTimeOffset right)

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
@@ -52,6 +52,7 @@ public static class CtProviderRuntimeStateUpdater
             IsPermanentlyFailed = !success && (permanentFailure || previous?.IsPermanentlyFailed == true),
             LastSuccessUtc = success ? occurredAtUtc : previous?.LastSuccessUtc,
             LastFailureUtc = success ? previous?.LastFailureUtc : occurredAtUtc,
+            // Percentiles require a sample window; callers with latency history can persist that aggregate separately.
             ObservedP95LatencyMilliseconds = previous?.ObservedP95LatencyMilliseconds,
             TransientFailureRatio = CalculateTransientFailureRatio(
                 transientFailureCount,

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
@@ -53,7 +53,10 @@ public static class CtProviderRuntimeStateUpdater
             LastSuccessUtc = success ? occurredAtUtc : previous?.LastSuccessUtc,
             LastFailureUtc = success ? previous?.LastFailureUtc : occurredAtUtc,
             ObservedP95LatencyMilliseconds = previous?.ObservedP95LatencyMilliseconds,
-            TransientFailureRatio = (double)transientFailureCount / totalRequestCount,
+            TransientFailureRatio = CalculateTransientFailureRatio(
+                transientFailureCount,
+                totalRequestCount,
+                rateLimitedCount),
             TotalRequestCount = totalRequestCount,
             SuccessfulRequestCount = successfulRequestCount,
             TransientFailureCount = transientFailureCount,
@@ -119,6 +122,20 @@ public static class CtProviderRuntimeStateUpdater
         {
             return DateTimeOffset.MaxValue;
         }
+    }
+
+    private static double CalculateTransientFailureRatio(
+        long transientFailureCount,
+        long totalRequestCount,
+        long rateLimitedCount)
+    {
+        long nonRateLimitedRequestCount = Math.Max(0L, totalRequestCount - rateLimitedCount);
+        if (nonRateLimitedRequestCount == 0L)
+        {
+            return 0d;
+        }
+
+        return (double)transientFailureCount / nonRateLimitedRequestCount;
     }
 
     private static DateTimeOffset? Max(DateTimeOffset? left, DateTimeOffset right)

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
@@ -36,6 +36,7 @@ public static class CtProviderRuntimeStateUpdater
                                 outcome.OutcomeKind == CtProviderOutcomeKind.Timeout;
         bool rateLimited = outcome.OutcomeKind == CtProviderOutcomeKind.RateLimited;
         bool timeout = outcome.OutcomeKind == CtProviderOutcomeKind.Timeout;
+        bool permanentFailure = outcome.OutcomeKind == CtProviderOutcomeKind.PermanentFailure;
         long totalRequestCount = checked((previous?.TotalRequestCount ?? 0L) + 1L);
         long successfulRequestCount = (previous?.SuccessfulRequestCount ?? 0L) + (success ? 1L : 0L);
         long transientFailureCount = (previous?.TransientFailureCount ?? 0L) + (transientFailure ? 1L : 0L);
@@ -49,12 +50,11 @@ public static class CtProviderRuntimeStateUpdater
             ProviderId = string.IsNullOrWhiteSpace(outcome.ProviderId) ? profile.ProviderId : outcome.ProviderId,
             CooldownUntilUtc = cooldownUntilUtc,
             ConsecutiveFailures = consecutiveFailures,
+            IsPermanentlyFailed = success ? false : permanentFailure || previous?.IsPermanentlyFailed == true,
             LastSuccessUtc = success ? occurredAtUtc : previous?.LastSuccessUtc,
             LastFailureUtc = success ? previous?.LastFailureUtc : occurredAtUtc,
             ObservedP95LatencyMilliseconds = previous?.ObservedP95LatencyMilliseconds,
-            TransientFailureRatio = totalRequestCount == 0
-                ? 0d
-                : (double)transientFailureCount / totalRequestCount,
+            TransientFailureRatio = (double)transientFailureCount / totalRequestCount,
             TotalRequestCount = totalRequestCount,
             SuccessfulRequestCount = successfulRequestCount,
             TransientFailureCount = transientFailureCount,

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
@@ -1,0 +1,112 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Applies provider request outcomes to certificate transparency provider runtime state.
+/// </summary>
+public static class CtProviderRuntimeStateUpdater
+{
+    /// <summary>
+    /// Creates an updated provider runtime state from an observed request outcome.
+    /// </summary>
+    /// <param name="previous">Previous provider state, when available.</param>
+    /// <param name="profile">Provider profile used to determine cooldown defaults.</param>
+    /// <param name="outcome">Observed provider request outcome.</param>
+    public static CtProviderRuntimeState Apply(
+        CtProviderRuntimeState? previous,
+        CtProviderProfile profile,
+        CtProviderRequestOutcome outcome)
+    {
+        if (profile == null)
+        {
+            throw new ArgumentNullException(nameof(profile));
+        }
+
+        if (outcome == null)
+        {
+            throw new ArgumentNullException(nameof(outcome));
+        }
+
+        DateTimeOffset occurredAtUtc = outcome.OccurredAtUtc ?? DateTimeOffset.UtcNow;
+        CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
+        bool success = outcome.OutcomeKind == CtProviderOutcomeKind.Success;
+        bool transientFailure = outcome.OutcomeKind == CtProviderOutcomeKind.TransientFailure ||
+                                outcome.OutcomeKind == CtProviderOutcomeKind.RateLimited ||
+                                outcome.OutcomeKind == CtProviderOutcomeKind.Timeout;
+        bool rateLimited = outcome.OutcomeKind == CtProviderOutcomeKind.RateLimited;
+        bool timeout = outcome.OutcomeKind == CtProviderOutcomeKind.Timeout;
+        long totalRequestCount = checked((previous?.TotalRequestCount ?? 0L) + 1L);
+        long successfulRequestCount = (previous?.SuccessfulRequestCount ?? 0L) + (success ? 1L : 0L);
+        long transientFailureCount = (previous?.TransientFailureCount ?? 0L) + (transientFailure ? 1L : 0L);
+        long rateLimitedCount = (previous?.RateLimitedCount ?? 0L) + (rateLimited ? 1L : 0L);
+        long timeoutCount = (previous?.TimeoutCount ?? 0L) + (timeout ? 1L : 0L);
+        int consecutiveFailures = success ? 0 : (previous?.ConsecutiveFailures ?? 0) + 1;
+
+        DateTimeOffset? cooldownUntilUtc = ResolveCooldownUntilUtc(previous, rateLimit, outcome, occurredAtUtc);
+        return new CtProviderRuntimeState
+        {
+            ProviderId = string.IsNullOrWhiteSpace(outcome.ProviderId) ? profile.ProviderId : outcome.ProviderId,
+            CooldownUntilUtc = cooldownUntilUtc,
+            ConsecutiveFailures = consecutiveFailures,
+            LastSuccessUtc = success ? occurredAtUtc : previous?.LastSuccessUtc,
+            LastFailureUtc = success ? previous?.LastFailureUtc : occurredAtUtc,
+            ObservedP95LatencyMilliseconds = previous?.ObservedP95LatencyMilliseconds,
+            TransientFailureRatio = totalRequestCount == 0
+                ? 0d
+                : (double)transientFailureCount / totalRequestCount,
+            TotalRequestCount = totalRequestCount,
+            SuccessfulRequestCount = successfulRequestCount,
+            TransientFailureCount = transientFailureCount,
+            RateLimitedCount = rateLimitedCount,
+            TimeoutCount = timeoutCount,
+            LastHttpStatusCode = outcome.HttpStatusCode,
+            LastError = success ? null : outcome.Error,
+            LastObservedLatencyMilliseconds = outcome.Latency?.TotalMilliseconds
+        };
+    }
+
+    private static DateTimeOffset? ResolveCooldownUntilUtc(
+        CtProviderRuntimeState? previous,
+        CtProviderRateLimitProfile rateLimit,
+        CtProviderRequestOutcome outcome,
+        DateTimeOffset occurredAtUtc)
+    {
+        if (outcome.OutcomeKind == CtProviderOutcomeKind.Success)
+        {
+            return null;
+        }
+
+        if (outcome.OutcomeKind == CtProviderOutcomeKind.RateLimited)
+        {
+            TimeSpan cooldown = outcome.RetryAfter.HasValue && outcome.RetryAfter.Value > TimeSpan.Zero
+                ? outcome.RetryAfter.Value
+                : rateLimit.CooldownAfterRateLimit;
+            return Max(previous?.CooldownUntilUtc, occurredAtUtc + cooldown);
+        }
+
+        if (outcome.OutcomeKind == CtProviderOutcomeKind.TransientFailure &&
+            outcome.CooldownOnTransientFailure)
+        {
+            return Max(previous?.CooldownUntilUtc, occurredAtUtc + rateLimit.CooldownAfterRateLimit);
+        }
+
+        if (outcome.OutcomeKind == CtProviderOutcomeKind.Timeout &&
+            outcome.CooldownOnTransientFailure)
+        {
+            return Max(previous?.CooldownUntilUtc, occurredAtUtc + rateLimit.CooldownAfterRateLimit);
+        }
+
+        return previous?.CooldownUntilUtc;
+    }
+
+    private static DateTimeOffset? Max(DateTimeOffset? left, DateTimeOffset right)
+    {
+        if (!left.HasValue || right > left.Value)
+        {
+            return right;
+        }
+
+        return left.Value;
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderRuntimeStateUpdater.cs
@@ -32,17 +32,16 @@ public static class CtProviderRuntimeStateUpdater
         CtProviderRateLimitProfile rateLimit = (profile.RateLimit ?? new CtProviderRateLimitProfile()).Normalize();
         bool success = outcome.OutcomeKind == CtProviderOutcomeKind.Success;
         bool transientFailure = outcome.OutcomeKind == CtProviderOutcomeKind.TransientFailure ||
-                                outcome.OutcomeKind == CtProviderOutcomeKind.RateLimited ||
                                 outcome.OutcomeKind == CtProviderOutcomeKind.Timeout;
         bool rateLimited = outcome.OutcomeKind == CtProviderOutcomeKind.RateLimited;
         bool timeout = outcome.OutcomeKind == CtProviderOutcomeKind.Timeout;
         bool permanentFailure = outcome.OutcomeKind == CtProviderOutcomeKind.PermanentFailure;
         long totalRequestCount = checked((previous?.TotalRequestCount ?? 0L) + 1L);
-        long successfulRequestCount = (previous?.SuccessfulRequestCount ?? 0L) + (success ? 1L : 0L);
-        long transientFailureCount = (previous?.TransientFailureCount ?? 0L) + (transientFailure ? 1L : 0L);
-        long rateLimitedCount = (previous?.RateLimitedCount ?? 0L) + (rateLimited ? 1L : 0L);
-        long timeoutCount = (previous?.TimeoutCount ?? 0L) + (timeout ? 1L : 0L);
-        int consecutiveFailures = success ? 0 : (previous?.ConsecutiveFailures ?? 0) + 1;
+        long successfulRequestCount = checked((previous?.SuccessfulRequestCount ?? 0L) + (success ? 1L : 0L));
+        long transientFailureCount = checked((previous?.TransientFailureCount ?? 0L) + (transientFailure ? 1L : 0L));
+        long rateLimitedCount = checked((previous?.RateLimitedCount ?? 0L) + (rateLimited ? 1L : 0L));
+        long timeoutCount = checked((previous?.TimeoutCount ?? 0L) + (timeout ? 1L : 0L));
+        int consecutiveFailures = success ? 0 : checked((previous?.ConsecutiveFailures ?? 0) + 1);
 
         DateTimeOffset? cooldownUntilUtc = ResolveCooldownUntilUtc(previous, rateLimit, outcome, occurredAtUtc);
         return new CtProviderRuntimeState
@@ -50,7 +49,7 @@ public static class CtProviderRuntimeStateUpdater
             ProviderId = string.IsNullOrWhiteSpace(outcome.ProviderId) ? profile.ProviderId : outcome.ProviderId,
             CooldownUntilUtc = cooldownUntilUtc,
             ConsecutiveFailures = consecutiveFailures,
-            IsPermanentlyFailed = success ? false : permanentFailure || previous?.IsPermanentlyFailed == true,
+            IsPermanentlyFailed = !success && (permanentFailure || previous?.IsPermanentlyFailed == true),
             LastSuccessUtc = success ? occurredAtUtc : previous?.LastSuccessUtc,
             LastFailureUtc = success ? previous?.LastFailureUtc : occurredAtUtc,
             ObservedP95LatencyMilliseconds = previous?.ObservedP95LatencyMilliseconds,

--- a/DomainDetective/CertificateTransparency/CtProviderWorkPlan.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderWorkPlan.cs
@@ -1,0 +1,22 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Represents a provider-specific certificate transparency work plan.
+/// </summary>
+public sealed class CtProviderWorkPlan
+{
+    /// <summary>Provider identifier used for this plan.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Provider plan status.</summary>
+    public CtProviderPlanStatus Status { get; init; }
+
+    /// <summary>Provider workload estimate.</summary>
+    public CtIngestionWorkloadEstimate Estimate { get; init; } = new();
+
+    /// <summary>Provider execution decision.</summary>
+    public CtProviderExecutionDecision? Decision { get; init; }
+
+    /// <summary>Human-readable reason describing this plan.</summary>
+    public string Reason { get; init; } = string.Empty;
+}

--- a/DomainDetective/CertificateTransparency/ICtCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/ICtCertificateTransparencyProvider.cs
@@ -1,0 +1,27 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Defines a reusable certificate transparency provider for certificate and domain discovery work.
+/// </summary>
+public interface ICtCertificateTransparencyProvider
+{
+    /// <summary>Stable provider identifier.</summary>
+    string ProviderId { get; }
+
+    /// <summary>Provider profile describing capabilities and safe default limits.</summary>
+    CtProviderProfile Profile { get; }
+
+    /// <summary>
+    /// Executes a normalized CT query.
+    /// </summary>
+    /// <param name="query">Query requested by the caller.</param>
+    /// <param name="runtimeState">Optional persisted provider runtime state.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<CtCertificateQueryResult> QueryAsync(
+        CtCertificateQuery query,
+        CtProviderRuntimeState? runtimeState = null,
+        CancellationToken cancellationToken = default);
+}

--- a/DomainDetective/CertificateTransparency/ICtProviderStateStore.cs
+++ b/DomainDetective/CertificateTransparency/ICtProviderStateStore.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Persists certificate transparency provider runtime state for resumable services.
+/// </summary>
+public interface ICtProviderStateStore
+{
+    /// <summary>
+    /// Gets the runtime state for the requested provider.
+    /// </summary>
+    /// <param name="providerId">Stable provider identifier.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task<CtProviderRuntimeState?> GetAsync(string providerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Saves the runtime state for a provider.
+    /// </summary>
+    /// <param name="state">Provider runtime state to persist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    Task SaveAsync(CtProviderRuntimeState state, CancellationToken cancellationToken = default);
+}

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -14,7 +14,6 @@
 
     <ItemGroup>
         <PackageReference Include="DnsClientX" Version="1.0.7" />
-        <PackageReference Include="Npgsql" Version="8.0.6" />
     </ItemGroup>
 
     <ItemGroup>
@@ -43,6 +42,9 @@
     <ItemGroup>
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
             <_Parameter1>DomainDetective.Tests</_Parameter1>
+        </AssemblyAttribute>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>DomainDetective.CtSql</_Parameter1>
         </AssemblyAttribute>
     </ItemGroup>
     <ItemGroup>

--- a/DomainDetective/DomainDetectiveOptionalFeatures.cs
+++ b/DomainDetective/DomainDetectiveOptionalFeatures.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -13,6 +14,7 @@ public static class DomainDetectiveOptionalFeatures
     private static volatile Func<string, string, (bool IsVerified, string ClearText)>? _securityTxtPgpVerifier;
     private static volatile VisualProviderRegistration? _visualProvider;
     private static volatile Func<string, CertificateInventoryCaptureOptions, InternalLogger?, CancellationToken, Task<SubdomainDiscoveryEntry?>>? _ctSqlExactMetadataProvider;
+    private static volatile ICtSqlMetadataProvider? _ctSqlMetadataProvider;
 
     private sealed class VisualProviderRegistration
     {
@@ -42,7 +44,7 @@ public static class DomainDetectiveOptionalFeatures
     /// <summary>
     /// Indicates whether an optional CT SQL exact-metadata provider has been registered.
     /// </summary>
-    public static bool HasCtSqlProvider => _ctSqlExactMetadataProvider != null;
+    public static bool HasCtSqlProvider => _ctSqlExactMetadataProvider != null || _ctSqlMetadataProvider != null;
 
     /// <summary>
     /// Registers PGP-backed security.txt clear-signature verification.
@@ -74,6 +76,11 @@ public static class DomainDetectiveOptionalFeatures
         Func<string, CertificateInventoryCaptureOptions, InternalLogger?, CancellationToken, Task<SubdomainDiscoveryEntry?>> provider)
     {
         _ctSqlExactMetadataProvider = provider ?? throw new ArgumentNullException(nameof(provider));
+    }
+
+    internal static void RegisterCtSqlMetadataProvider(ICtSqlMetadataProvider provider)
+    {
+        _ctSqlMetadataProvider = provider ?? throw new ArgumentNullException(nameof(provider));
     }
 
     internal static bool TryVerifySecurityTxtSignature(string signedText, string? publicKey, out bool isVerified, out string clearText)
@@ -122,4 +129,27 @@ public static class DomainDetectiveOptionalFeatures
     {
         return _ctSqlExactMetadataProvider;
     }
+
+    internal static ICtSqlMetadataProvider? GetCtSqlMetadataProvider()
+    {
+        return _ctSqlMetadataProvider;
+    }
+}
+
+internal interface ICtSqlMetadataProvider
+{
+    Task<SubdomainDiscoveryEntry?> QueryExactMetadataAsync(
+        string hostName,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyDictionary<string, SubdomainDiscoveryEntry>> QueryDomainMetadataAsync(
+        string domain,
+        IReadOnlyCollection<string> hostNames,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken);
 }

--- a/DomainDetective/DomainDetectiveOptionalFeatures.cs
+++ b/DomainDetective/DomainDetectiveOptionalFeatures.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -134,22 +133,4 @@ public static class DomainDetectiveOptionalFeatures
     {
         return _ctSqlMetadataProvider;
     }
-}
-
-internal interface ICtSqlMetadataProvider
-{
-    Task<SubdomainDiscoveryEntry?> QueryExactMetadataAsync(
-        string hostName,
-        CertificateInventoryCaptureOptions options,
-        InternalLogger? logger,
-        ISet<string>? targetedThumbprints,
-        CancellationToken cancellationToken);
-
-    Task<IReadOnlyDictionary<string, SubdomainDiscoveryEntry>> QueryDomainMetadataAsync(
-        string domain,
-        IReadOnlyCollection<string> hostNames,
-        CertificateInventoryCaptureOptions options,
-        InternalLogger? logger,
-        ISet<string>? targetedThumbprints,
-        CancellationToken cancellationToken);
 }

--- a/DomainDetective/ICtSqlMetadataProvider.cs
+++ b/DomainDetective/ICtSqlMetadataProvider.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+internal interface ICtSqlMetadataProvider
+{
+    Task<SubdomainDiscoveryEntry?> QueryExactMetadataAsync(
+        string hostName,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyDictionary<string, SubdomainDiscoveryEntry>> QueryDomainMetadataAsync(
+        string domain,
+        IReadOnlyCollection<string> hostNames,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger? logger,
+        ISet<string>? targetedThumbprints,
+        CancellationToken cancellationToken);
+}

--- a/DomainDetective/NuGet.README.md
+++ b/DomainDetective/NuGet.README.md
@@ -8,7 +8,7 @@ Optional dependency-heavy features are split into companion packages:
 
 - `DomainDetective.Pgp` for PGP-backed `security.txt` verification
 - `DomainDetective.Visual` for Playwright/ImageSharp visual typosquatting checks
-- `DomainDetective.CtSql` for the future CT SQL extraction path
+- `DomainDetective.CtSql` for the future CT SQL extraction path; future crt.sh SQL code should use `identities(c.certificate)` full-text search rather than the superseded `certificate_identity` table
 
 Example:
 

--- a/DomainDetective/NuGet.README.md
+++ b/DomainDetective/NuGet.README.md
@@ -8,7 +8,7 @@ Optional dependency-heavy features are split into companion packages:
 
 - `DomainDetective.Pgp` for PGP-backed `security.txt` verification
 - `DomainDetective.Visual` for Playwright/ImageSharp visual typosquatting checks
-- `DomainDetective.CtSql` for the future CT SQL extraction path; future crt.sh SQL code should use `identities(c.certificate)` full-text search rather than the superseded `certificate_identity` table
+- `DomainDetective.CtSql` for optional DbaClientX-backed crt.sh PostgreSQL CT metadata enrichment; the provider uses `identities(c.certificate)` full-text search rather than the superseded `certificate_identity` table
 
 Example:
 

--- a/README.MD
+++ b/README.MD
@@ -208,15 +208,17 @@ Dependency-heavy features are now split into optional packages so the base `Doma
 
 - `DomainDetective.Pgp` enables PGP-backed `security.txt` signature verification
 - `DomainDetective.Visual` enables Playwright/ImageSharp-powered visual typosquatting capture and fingerprinting
-- `DomainDetective.CtSql` is prepared for future CT SQL extraction, but the current PostgreSQL-backed CT implementation still remains in core for now
+- `DomainDetective.CtSql` enables DbaClientX-backed crt.sh PostgreSQL CT metadata enrichment
 
 Registration is explicit on purpose so app startup stays predictable for trimming and AOT scenarios:
 
 ```csharp
 using DomainDetective;
+using DomainDetective.CtSql;
 using DomainDetective.Pgp;
 using DomainDetective.Visual;
 
+DomainDetectiveCtSqlRegistration.Register();
 DomainDetectivePgpRegistration.Register();
 DomainDetectiveVisualRegistration.Register();
 
@@ -697,7 +699,7 @@ HTTP posture checks inspect common security headers including:
 DomainDetective/                Core analyzers, models, and protocol logic
 DomainDetective.Pgp/            Optional PGP-backed security.txt verification
 DomainDetective.Visual/         Optional Playwright/ImageSharp visual analysis helpers
-DomainDetective.CtSql/          Prepared package shell for future CT SQL extraction
+DomainDetective.CtSql/          Optional DbaClientX-backed crt.sh PostgreSQL CT provider
 DomainDetective.PowerShell/     Compiled PowerShell cmdlets
 DomainDetective.CLI/            Spectre.Console CLI and wizard
 DomainDetective.Reports/        Shared reporting abstractions and dispatch


### PR DESCRIPTION
## Summary
- add CT provider profiles, capabilities, query/result contracts, and state abstractions
- add workload/capacity planning for provider limits, run budgets, first-run estimates, cooldowns, and saturated large workloads
- add certificate record normalization from DER plus runtime outcome tracking for success, rate-limit, timeout, and transient failure signals

## Stacking
This PR is stacked on #1172 (`codex/dependency-isolation-pr`) so the dependency split stays isolated. It does not move or cut out CtSql implementation; it only prepares reusable CT planning contracts for the follow-up provider execution work.

## Validation
- `dotnet test DomainDetective.Tests\DomainDetective.Tests.csproj -c Debug --framework net8.0 --no-restore --filter "TestCtCertificateQuery|TestCtIngestionPlanner"`
- `dotnet build DomainDetective.Tests\DomainDetective.Tests.csproj -c Debug --no-restore`