### PR TITLE
fix(website): polish browser tool UX

### DIFF
--- a/DomainDetective.Toolbox/Components/Shared/HostedFeaturePreview.razor
+++ b/DomainDetective.Toolbox/Components/Shared/HostedFeaturePreview.razor
@@ -7,6 +7,8 @@
         @GetIntro(Tool)
     </p>
 
+    <ToolCapabilityMap Tool="Tool" DeploymentMode="ToolsDeploymentMode.StaticOnly" Domain="@Domain" StartOpen="true" />
+
     <div class="tool-summary-grid tool-summary-grid-compact">
         <div class="tool-summary-card">
             <span class="tool-summary-label">What it checks</span>
@@ -35,6 +37,7 @@
 
 @code {
     [Parameter] public required ToolDefinition Tool { get; set; }
+    [Parameter] public string? Domain { get; set; }
 
     private static string GetIntro(ToolDefinition tool) {
         return tool.Slug switch {

--- a/DomainDetective.Toolbox/Components/Shared/ResultTable.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ResultTable.razor
@@ -1,15 +1,17 @@
-<table class="result-table">
-    <thead>
-        <tr>
-            @foreach (var col in Columns) {
-                <th>@col</th>
-            }
-        </tr>
-    </thead>
-    <tbody>
-        @ChildContent
-    </tbody>
-</table>
+<div class="result-table-shell">
+    <table class="result-table">
+        <thead>
+            <tr>
+                @foreach (var col in Columns) {
+                    <th>@col</th>
+                }
+            </tr>
+        </thead>
+        <tbody>
+            @ChildContent
+        </tbody>
+    </table>
+</div>
 
 @code {
     [Parameter] public string[] Columns { get; set; } = Array.Empty<string>();

--- a/DomainDetective.Toolbox/Components/Shared/ToolCapabilityMap.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolCapabilityMap.razor
@@ -3,7 +3,7 @@
 @using Microsoft.JSInterop
 @inject IJSRuntime JS
 
-<details class="tool-capability-map" open="@ShouldStartOpen">
+<details class="tool-capability-map" open="@StartOpen">
     <summary>
         <span class="tool-capability-kicker">Web edition coverage</span>
         <strong>@Capability.Title</strong>
@@ -51,8 +51,6 @@
     private string? _copyState;
 
     private ToolCapabilityInfo Capability => ToolCapabilityPresentation.Build(Tool, DeploymentMode);
-
-    private bool ShouldStartOpen => StartOpen;
 
     private bool ShouldShowLocalCommand() {
         return DeploymentMode == ToolsDeploymentMode.StaticOnly &&

--- a/DomainDetective.Toolbox/Components/Shared/ToolCapabilityMap.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolCapabilityMap.razor
@@ -1,0 +1,131 @@
+@using DomainDetective.Toolbox.Models
+@using DomainDetective.Toolbox.Services
+@using Microsoft.JSInterop
+@inject IJSRuntime JS
+
+<details class="tool-capability-map" open="@ShouldStartOpen">
+    <summary>
+        <span class="tool-capability-kicker">Web edition coverage</span>
+        <strong>@Capability.Title</strong>
+        <span>@Capability.Description</span>
+    </summary>
+    <div class="tool-capability-grid">
+        <section class="tool-capability-column" aria-label="Runs here">
+            <span class="tool-summary-label">Runs here</span>
+            <ul class="tool-bullet-list">
+                @foreach (var item in Capability.BrowserChecks) {
+                    <li>@item</li>
+                }
+            </ul>
+        </section>
+        <section class="tool-capability-column" aria-label="Deeper run adds">
+            <span class="tool-summary-label">Deeper run adds</span>
+            <ul class="tool-bullet-list">
+                @foreach (var item in Capability.DeeperChecks) {
+                    <li>@item</li>
+                }
+            </ul>
+        </section>
+    </div>
+    @if (ShouldShowLocalCommand()) {
+        <div class="tool-capability-command">
+            <div class="tool-capability-command-header">
+                <span class="tool-summary-label">Run deeper locally</span>
+                <button type="button"
+                        class="@GetCopyButtonClass()"
+                        @onclick="CopyLocalCommandAsync">
+                    @GetCopyButtonText()
+                </button>
+            </div>
+            <pre><code class="language-powershell">@GetLocalPowerShellCommand()</code></pre>
+        </div>
+    }
+</details>
+
+@code {
+    [Parameter] public required ToolDefinition Tool { get; set; }
+    [Parameter] public ToolsDeploymentMode DeploymentMode { get; set; }
+    [Parameter] public string? Domain { get; set; }
+    [Parameter] public bool StartOpen { get; set; }
+
+    private string? _copyState;
+
+    private ToolCapabilityInfo Capability => ToolCapabilityPresentation.Build(Tool, DeploymentMode);
+
+    private bool ShouldStartOpen => StartOpen;
+
+    private bool ShouldShowLocalCommand() {
+        return DeploymentMode == ToolsDeploymentMode.StaticOnly &&
+            (Tool.LiteCompatible || !Tool.BrowserCompatible) &&
+            !string.IsNullOrWhiteSpace(Domain);
+    }
+
+    private async Task CopyLocalCommandAsync() {
+        var copied = await JS.InvokeAsync<bool>("domainDetectiveTools.copyText", GetLocalPowerShellCommand());
+        _copyState = copied ? "copied" : "failed";
+        StateHasChanged();
+
+        var currentState = _copyState;
+        await Task.Delay(1600);
+        if (_copyState == currentState) {
+            _copyState = null;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private string GetCopyButtonClass() {
+        var cssClass = "tool-capability-copy-btn";
+        if (_copyState == "copied") {
+            cssClass += " is-success";
+        } else if (_copyState == "failed") {
+            cssClass += " is-failure";
+        }
+
+        return cssClass;
+    }
+
+    private string GetCopyButtonText() {
+        return _copyState switch {
+            "copied" => "Copied",
+            "failed" => "Copy failed",
+            _ => "Copy"
+        };
+    }
+
+    private string GetLocalPowerShellCommand() {
+        var sampleDomain = EscapePowerShellDoubleQuotedString(Domain?.Trim() ?? "example.com");
+        return Tool.Slug switch {
+            "m365-overview" or "domain-overview" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"$check = Get-DomainHealthCheck -Domain \"{sampleDomain}\"",
+            "mta-sts" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"$check = Get-DomainHealthCheck -Domain \"{sampleDomain}\" -Type MTASTS",
+            "dns-propagation" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"Test-DDDnsPropagation -DomainName \"{sampleDomain}\" -RecordType A",
+            "cert-check" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"Test-DDDomainCertificate -Url \"{sampleDomain}\"",
+            "http-headers" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"Test-DDWebsiteSecurity -DomainName \"{sampleDomain}\"",
+            "security-txt" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"Test-DDDomainSecurityTxt -DomainName \"{sampleDomain}\"",
+            "rdap" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"Get-DDRdap -DomainName \"{sampleDomain}\"",
+            "ct-subdomains" => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"Invoke-DDCertificateInventory -DomainName \"{sampleDomain}\" -IncludeCtSubdomains",
+            _ => "Install-Module DomainDetective -Scope CurrentUser\n" +
+                "Import-Module DomainDetective\n" +
+                $"$check = Get-DomainHealthCheck -Domain \"{sampleDomain}\""
+        };
+    }
+
+    private static string EscapePowerShellDoubleQuotedString(string value) {
+        return value.Replace("`", "``", StringComparison.Ordinal).Replace("\"", "`\"", StringComparison.Ordinal);
+    }
+}

--- a/DomainDetective.Toolbox/Components/Shared/ToolCategoryGrid.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolCategoryGrid.razor
@@ -12,9 +12,12 @@
             </div>
             <div class="category-tools">
                 @foreach (var tool in categoryTools) {
-                    <a href="@($"/tools/{tool.Slug}/")" class="category-tool-link">
+                    <a href="@BuildToolUrl(tool)"
+                       class="category-tool-link"
+                       title="@GetAvailabilityLabel(tool)"
+                       aria-label="@GetAvailabilityLabel(tool)">
                         @if (DeploymentMode == ToolsDeploymentMode.StaticOnly) {
-                            <span class="tool-availability-dot @GetDotClass(tool)"></span>
+                            <span class="tool-availability-dot @GetDotClass(tool)" aria-hidden="true"></span>
                         }
                         <span class="category-tool-name">@tool.Name</span>
                     </a>
@@ -27,6 +30,7 @@
 @code {
     [Parameter] public required IReadOnlyList<ToolDefinition> Tools { get; set; }
     [Parameter] public ToolsDeploymentMode? DeploymentMode { get; set; }
+    [Parameter] public string? Domain { get; set; }
 
     private IEnumerable<ToolCategory> GetCategories() =>
         Tools.Select(t => t.Category).Distinct().OrderBy(c => c);
@@ -35,5 +39,18 @@
         if (tool.BrowserCompatible) return "tool-availability-dot-browser";
         if (tool.LiteCompatible) return "tool-availability-dot-partial";
         return "tool-availability-dot-local";
+    }
+
+    private static string GetAvailabilityLabel(ToolDefinition tool) {
+        if (tool.BrowserCompatible) return $"{tool.Name}: runs in browser";
+        if (tool.LiteCompatible) return $"{tool.Name}: partial browser support";
+        return $"{tool.Name}: guided local workflow";
+    }
+
+    private string BuildToolUrl(ToolDefinition tool) {
+        var baseUrl = $"/tools/{tool.Slug}/";
+        return string.IsNullOrWhiteSpace(Domain)
+            ? baseUrl
+            : $"{baseUrl}?q={Uri.EscapeDataString(Domain.Trim())}";
     }
 }

--- a/DomainDetective.Toolbox/Components/Shared/ToolNotAvailable.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolNotAvailable.razor
@@ -8,6 +8,8 @@
         This check relies on network capabilities that browser sandboxing limits. Use the CLI or PowerShell module for the full experience.
     </p>
 
+    <ToolCapabilityMap Tool="Tool" DeploymentMode="ToolsDeploymentMode.StaticOnly" Domain="@Domain" StartOpen="true" />
+
     <ToolUsageExamples Definition="Tool" StartOpen="true" />
 
     <div class="tool-link-row">
@@ -19,6 +21,7 @@
 
 @code {
     [Parameter] public required ToolDefinition Tool { get; set; }
+    [Parameter] public string? Domain { get; set; }
 
     private string BuildDescriptionPrefix() {
         return (Tool.Description ?? string.Empty).TrimEnd('.', ' ') + ".";

--- a/DomainDetective.Toolbox/Components/Shared/ToolPage.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolPage.razor
@@ -74,10 +74,10 @@
             </div>
         </form>
 
-        @if (GetExampleDomains().Count > 0) {
+        @if (_exampleDomains.Count > 0) {
             <div class="tool-example-row" aria-label="Example domains">
                 <span class="tool-example-label">Try</span>
-                @foreach (var exampleDomain in GetExampleDomains()) {
+                @foreach (var exampleDomain in _exampleDomains) {
                     <button type="button"
                             class="tool-example-chip"
                             disabled="@_isLoading"
@@ -281,6 +281,7 @@
     private DomainDetective.Views.SubdomainsInfo? _subdomainsInfo;
     private DomainDetective.Views.Microsoft365OverviewInfo? _microsoft365OverviewInfo;
     private DomainDetective.Views.DomainOverviewInfo? _domainOverviewInfo;
+    private IReadOnlyList<string> _exampleDomains = Array.Empty<string>();
     private string? _dnsRequestedTypes;
     private string? _dnsHostLabel;
     private string? _dnsBrowserResolverName;
@@ -291,6 +292,7 @@
 
     protected override async Task OnParametersSetAsync() {
         await Availability.InitializeAsync();
+        _exampleDomains = BuildExampleDomains();
         await SyncWithCurrentUriAsync();
     }
 
@@ -793,17 +795,125 @@
         return elapsedSeconds <= 0 ? "starting" : $"{elapsedSeconds}s";
     }
 
+    private static readonly IReadOnlyList<string> OverviewProgressActivities = new[] {
+        "Resolving DNS inventory and provider hints.",
+        "Checking mail authentication records.",
+        "Evaluating DNSSEC, CAA, DANE, and transport evidence.",
+        "Assembling overview cards and section status.",
+        "Waiting for the remaining resolver responses."
+    };
+
+    private static readonly IReadOnlyList<string> DefaultToolProgressActivities = new[] {
+        "Starting the browser-safe DD checks.",
+        "Resolving public DNS evidence.",
+        "Normalizing findings into report cards.",
+        "Waiting for slower resolver responses."
+    };
+
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> ToolProgressActivitiesBySlug =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase) {
+            ["spf"] = new[] {
+                "Looking up the SPF TXT policy.",
+                "Expanding SPF mechanisms and include references.",
+                "Checking SPF limits and policy strength.",
+                "Building SPF findings and record details."
+            },
+            ["dkim"] = new[] {
+                "Looking for DKIM selectors.",
+                "Resolving DKIM public keys.",
+                "Checking key posture and selector coverage.",
+                "Building DKIM findings and selector details."
+            },
+            ["dmarc"] = new[] {
+                "Looking up the DMARC policy.",
+                "Reading reporting and alignment settings.",
+                "Checking enforcement posture.",
+                "Building DMARC findings and record details."
+            },
+            ["mx"] = new[] {
+                "Resolving MX hosts.",
+                "Checking mail provider hints.",
+                "Sorting priorities and target records.",
+                "Building MX findings and transport details."
+            },
+            ["mta-sts"] = new[] {
+                "Looking up the MTA-STS bootstrap record.",
+                "Checking DNS policy hints.",
+                "Marking policy fetch work for the deeper run.",
+                "Building MTA-STS findings."
+            },
+            ["tls-rpt"] = new[] {
+                "Looking up TLS-RPT records.",
+                "Reading reporting endpoints.",
+                "Checking reporting posture.",
+                "Building TLS-RPT findings."
+            },
+            ["bimi"] = new[] {
+                "Looking up BIMI records.",
+                "Reading logo and authority evidence.",
+                "Checking browser-safe BIMI posture.",
+                "Building BIMI findings."
+            },
+            ["dns-lookup"] = new[] {
+                "Resolving the DNS inventory.",
+                "Checking provider and application fingerprints.",
+                "Normalizing record families.",
+                "Building DNS inventory cards."
+            },
+            ["dnssec"] = new[] {
+                "Checking DNSSEC records.",
+                "Reading delegation and signing signals.",
+                "Evaluating chain posture.",
+                "Building DNSSEC findings."
+            },
+            ["soa"] = new[] {
+                "Resolving the SOA record.",
+                "Reading zone authority details.",
+                "Checking serial and timing values.",
+                "Building SOA findings."
+            },
+            ["ns"] = new[] {
+                "Resolving authoritative nameservers.",
+                "Checking nameserver coverage.",
+                "Reading provider hints.",
+                "Building NS findings."
+            },
+            ["dns-propagation"] = new[] {
+                "Querying the web-edition resolver sample.",
+                "Comparing resolver answers.",
+                "Checking answer drift and availability.",
+                "Waiting for slower public resolvers."
+            },
+            ["caa"] = new[] {
+                "Looking up CAA records.",
+                "Reading certificate authority rules.",
+                "Checking issue and reporting directives.",
+                "Building CAA findings."
+            },
+            ["dane"] = new[] {
+                "Looking up TLSA records.",
+                "Checking SMTP and HTTPS service hints.",
+                "Evaluating DANE coverage.",
+                "Building DANE findings."
+            },
+            ["dnsbl"] = new[] {
+                "Resolving mail hosts for DNSBL checks.",
+                "Querying browser-safe blacklist evidence.",
+                "Checking listed and clean responses.",
+                "Building DNSBL findings."
+            },
+            ["dangling-cname"] = new[] {
+                "Resolving CNAME records.",
+                "Checking takeover provider fingerprints.",
+                "Evaluating dangling target evidence.",
+                "Building dangling CNAME findings."
+            }
+        };
+
     private string GetActiveProgressActivity() {
         var elapsedSeconds = GetElapsedSeconds(_quickReadyAt ?? _scanStartedAt);
         if (IsOverviewTool(Definition)) {
-            var activities = new[] {
-                "Resolving DNS inventory and provider hints.",
-                "Checking mail authentication records.",
-                "Evaluating DNSSEC, CAA, DANE, and transport evidence.",
-                "Assembling overview cards and section status.",
-                "Waiting for the remaining resolver responses."
-            };
-            return activities[Math.Min(activities.Length - 1, elapsedSeconds / 6)];
+            return OverviewProgressActivities[Math.Min(OverviewProgressActivities.Count - 1, elapsedSeconds / 6)];
         }
 
         var toolActivities = GetToolProgressActivities();
@@ -811,113 +921,10 @@
     }
 
     private IReadOnlyList<string> GetToolProgressActivities() {
-        return Definition.Slug switch {
-            "spf" => new[] {
-                "Looking up the SPF TXT policy.",
-                "Expanding SPF mechanisms and include references.",
-                "Checking SPF limits and policy strength.",
-                "Building SPF findings and record details."
-            },
-            "dkim" => new[] {
-                "Looking for DKIM selectors.",
-                "Resolving DKIM public keys.",
-                "Checking key posture and selector coverage.",
-                "Building DKIM findings and selector details."
-            },
-            "dmarc" => new[] {
-                "Looking up the DMARC policy.",
-                "Reading reporting and alignment settings.",
-                "Checking enforcement posture.",
-                "Building DMARC findings and record details."
-            },
-            "mx" => new[] {
-                "Resolving MX hosts.",
-                "Checking mail provider hints.",
-                "Sorting priorities and target records.",
-                "Building MX findings and transport details."
-            },
-            "mta-sts" => new[] {
-                "Looking up the MTA-STS bootstrap record.",
-                "Checking DNS policy hints.",
-                "Marking policy fetch work for the deeper run.",
-                "Building MTA-STS findings."
-            },
-            "tls-rpt" => new[] {
-                "Looking up TLS-RPT records.",
-                "Reading reporting endpoints.",
-                "Checking reporting posture.",
-                "Building TLS-RPT findings."
-            },
-            "bimi" => new[] {
-                "Looking up BIMI records.",
-                "Reading logo and authority evidence.",
-                "Checking browser-safe BIMI posture.",
-                "Building BIMI findings."
-            },
-            "dns-lookup" => new[] {
-                "Resolving the DNS inventory.",
-                "Checking provider and application fingerprints.",
-                "Normalizing record families.",
-                "Building DNS inventory cards."
-            },
-            "dnssec" => new[] {
-                "Checking DNSSEC records.",
-                "Reading delegation and signing signals.",
-                "Evaluating chain posture.",
-                "Building DNSSEC findings."
-            },
-            "soa" => new[] {
-                "Resolving the SOA record.",
-                "Reading zone authority details.",
-                "Checking serial and timing values.",
-                "Building SOA findings."
-            },
-            "ns" => new[] {
-                "Resolving authoritative nameservers.",
-                "Checking nameserver coverage.",
-                "Reading provider hints.",
-                "Building NS findings."
-            },
-            "dns-propagation" => new[] {
-                "Querying the web-edition resolver sample.",
-                "Comparing resolver answers.",
-                "Checking answer drift and availability.",
-                "Waiting for slower public resolvers."
-            },
-            "caa" => new[] {
-                "Looking up CAA records.",
-                "Reading certificate authority rules.",
-                "Checking issue and reporting directives.",
-                "Building CAA findings."
-            },
-            "dane" => new[] {
-                "Looking up TLSA records.",
-                "Checking SMTP and HTTPS service hints.",
-                "Evaluating DANE coverage.",
-                "Building DANE findings."
-            },
-            "dnsbl" => new[] {
-                "Resolving mail hosts for DNSBL checks.",
-                "Querying browser-safe blacklist evidence.",
-                "Checking listed and clean responses.",
-                "Building DNSBL findings."
-            },
-            "dangling-cname" => new[] {
-                "Resolving CNAME records.",
-                "Checking takeover provider fingerprints.",
-                "Evaluating dangling target evidence.",
-                "Building dangling CNAME findings."
-            },
-            _ => new[] {
-                "Starting the browser-safe DD checks.",
-                "Resolving public DNS evidence.",
-                "Normalizing findings into report cards.",
-                "Waiting for slower resolver responses."
-            }
-        };
+        return ToolProgressActivitiesBySlug.TryGetValue(Definition.Slug, out var activities) ? activities : DefaultToolProgressActivities;
     }
 
-    private IReadOnlyList<string> GetExampleDomains() {
+    private IReadOnlyList<string> BuildExampleDomains() {
         return Definition.Slug switch {
             "m365-overview" => new[] { "evotec.pl", "microsoft.com" },
             "domain-overview" => new[] { "evotec.pl", "microsoft.com", "cloudflare.com" },

--- a/DomainDetective.Toolbox/Components/Shared/ToolPage.razor
+++ b/DomainDetective.Toolbox/Components/Shared/ToolPage.razor
@@ -23,6 +23,10 @@
     @if (!CanRunOnline(Definition)) {
         <ToolNotAvailable Tool="Definition" />
     } else if (UsesCustomToolLayout(Definition)) {
+        @if (Availability.IsStaticOnly) {
+            <ToolCapabilityMap Tool="Definition" DeploymentMode="Availability.Mode" />
+        }
+
         @switch (Definition.Slug) {
             case "raw-dns-query":
                 <DomainDetective.Toolbox.Components.Tools.Dns.RawDnsQueryTool />
@@ -47,24 +51,46 @@
         }
 
         <form class="tool-input-form" @onsubmit="RunAnalysis" @onsubmit:preventDefault>
-            <input type="text" @bind="_domain" placeholder="@(Definition.InputPlaceholder ?? "example.com")" />
-            @if (Definition.SecondaryInputLabel is not null) {
-                <input type="text"
-                       @bind="_secondaryInput"
-                       placeholder="@(Definition.SecondaryInputPlaceholder ?? "")"
-                       aria-label="@Definition.SecondaryInputLabel"
-                       title="@Definition.SecondaryInputLabel"
-                       class="tool-input-secondary" />
-            }
-            <button type="submit" class="tool-run-btn" disabled="@_isLoading">
-                @(_isLoading ? "Analyzing..." : "Analyze")
-            </button>
-            @if (SupportsHostedCache(Definition)) {
-                <button type="button" class="tool-run-btn tool-run-btn-secondary" @onclick="RunFreshAnalysis" disabled="@_isLoading">
-                    @(_isLoading ? "Working..." : "Refresh")
+            <div class="tool-input-fields">
+                <input type="text" @bind="_domain" placeholder="@(Definition.InputPlaceholder ?? "example.com")" />
+                @if (Definition.SecondaryInputLabel is not null) {
+                    <input type="text"
+                           @bind="_secondaryInput"
+                           placeholder="@(Definition.SecondaryInputPlaceholder ?? "")"
+                           aria-label="@Definition.SecondaryInputLabel"
+                           title="@Definition.SecondaryInputLabel"
+                           class="tool-input-secondary" />
+                }
+            </div>
+            <div class="tool-input-actions">
+                <button type="submit" class="tool-run-btn" disabled="@_isLoading">
+                    @(_isLoading ? "Analyzing..." : "Analyze")
                 </button>
-            }
+                @if (SupportsHostedCache(Definition)) {
+                    <button type="button" class="tool-run-btn tool-run-btn-secondary" @onclick="RunFreshAnalysis" disabled="@_isLoading">
+                        @(_isLoading ? "Working..." : "Refresh")
+                    </button>
+                }
+            </div>
         </form>
+
+        @if (GetExampleDomains().Count > 0) {
+            <div class="tool-example-row" aria-label="Example domains">
+                <span class="tool-example-label">Try</span>
+                @foreach (var exampleDomain in GetExampleDomains()) {
+                    <button type="button"
+                            class="tool-example-chip"
+                            disabled="@_isLoading"
+                            @onclick="() => RunExampleAsync(exampleDomain)">
+                        @exampleDomain
+                    </button>
+                }
+            </div>
+        }
+
+        @if (Availability.IsStaticOnly) {
+            <ToolCapabilityMap Tool="Definition" DeploymentMode="Availability.Mode" Domain="@_domain" />
+        }
 
         @if (_recentRuns.Count > 0) {
             <div class="tool-history-row" aria-label="Recent runs">
@@ -242,6 +268,7 @@
     private DateTimeOffset? _scanStartedAt;
     private DateTimeOffset? _quickReadyAt;
     private DateTimeOffset? _deepReadyAt;
+    private System.Threading.Timer? _progressTimer;
     private List<RecentToolRun> _recentRuns = new();
     private DomainHealthCheck? _healthCheck;
     private DomainDetective.Views.HttpInfo? _httpInfo;
@@ -293,6 +320,7 @@
         _scanStartedAt = DateTimeOffset.Now;
         _quickReadyAt = null;
         _deepReadyAt = null;
+        StartProgressTicker();
         _healthCheck = null;
         _httpInfo = null;
         _securityTxtInfo = null;
@@ -420,6 +448,10 @@
         } finally {
             _forceHostedRefresh = false;
             _isLoading = false;
+            if (!_isHydratingDeep) {
+                StopProgressTicker();
+            }
+
             StateHasChanged();
         }
     }
@@ -471,6 +503,7 @@
         } finally {
             if (analysisVersion == _analysisVersion) {
                 _isHydratingDeep = false;
+                StopProgressTicker();
                 await InvokeAsync(StateHasChanged);
             }
         }
@@ -533,6 +566,7 @@
         _scanStartedAt = null;
         _quickReadyAt = null;
         _deepReadyAt = null;
+        StopProgressTicker();
         _healthCheck = null;
         _httpInfo = null;
         _securityTxtInfo = null;
@@ -560,6 +594,19 @@
         _dnsRequestedTypes = Definition.Slug == "dns-lookup" ? item.SecondaryInput : null;
         _dnsHostLabel = item.DnsHost;
         _dnsBrowserResolverName = NormalizeDnsBrowserResolverName(item.DnsResolver);
+        await RunAnalysis();
+    }
+
+    private async Task RunExampleAsync(string domainName) {
+        if (_isLoading || string.IsNullOrWhiteSpace(domainName)) {
+            return;
+        }
+
+        _domain = domainName.Trim();
+        _secondaryInput = null;
+        _dnsRequestedTypes = null;
+        _dnsHostLabel = null;
+        _dnsBrowserResolverName = null;
         await RunAnalysis();
     }
 
@@ -656,11 +703,11 @@
 
     private int GetProgressPercentage() {
         if (_isLoading && !IsOverviewTool(Definition)) {
-            return 32;
+            return GetElapsedProgress(18, 86, 4.5);
         }
 
         if (_isLoading && IsOverviewTool(Definition) && _quickReadyAt is null) {
-            return 18;
+            return GetElapsedProgress(14, 72, 3.2);
         }
 
         if (_isHydratingDeep) {
@@ -669,9 +716,10 @@
                 "domain-overview" => 7,
                 _ => 1
             };
-            var pendingCount = GetPendingSections().Count;
+            var pendingCount = GetPendingSectionCount();
             var completed = Math.Max(1, totalSections - pendingCount);
-            return Math.Clamp((int)Math.Round((double)completed / totalSections * 100), 40, 96);
+            var sectionProgress = Math.Clamp((int)Math.Round((double)completed / totalSections * 100), 40, 92);
+            return Math.Max(sectionProgress, GetElapsedProgress(48, 96, 1.25, _quickReadyAt ?? _scanStartedAt));
         }
 
         if (_quickReadyAt.HasValue && _deepReadyAt.HasValue) {
@@ -691,14 +739,14 @@
 
     private string GetProgressLabel() {
         if (_isHydratingDeep) {
-            return $"Step 2 of 2 · {GetProgressPercentage()}%";
+            return $"Step 2 of 2 - {GetProgressPercentage()}% - {GetElapsedLabel(_quickReadyAt ?? _scanStartedAt)}";
         }
 
         if (IsOverviewTool(Definition)) {
-            return "Step 1 of 2";
+            return $"Step 1 of 2 - {GetProgressPercentage()}% - {GetElapsedLabel(_scanStartedAt)}";
         }
 
-        return "Running checks";
+        return $"Running checks - {GetProgressPercentage()}% - {GetElapsedLabel(_scanStartedAt)}";
     }
 
     private string GetProgressDescription() {
@@ -710,8 +758,191 @@
         }
 
         return IsOverviewTool(Definition)
-            ? "Running the first report pass and preparing the deeper sections."
-            : "Running DomainDetective checks and building the result view.";
+            ? $"{GetActiveProgressActivity()} Browser DNS resolvers can pause while public answers come back, so DD keeps this progress view moving until the first result is ready."
+            : $"{GetActiveProgressActivity()} DD is building the result view from the browser-safe checks for this tool.";
+    }
+
+    private int GetPendingSectionCount() {
+        if (_microsoft365OverviewInfo is not null) {
+            return _microsoft365OverviewInfo.PendingSections.Count;
+        }
+
+        if (_domainOverviewInfo is not null) {
+            return _domainOverviewInfo.PendingSections.Count;
+        }
+
+        return 0;
+    }
+
+    private int GetElapsedProgress(int minimum, int maximum, double pointsPerSecond, DateTimeOffset? startedAt = null) {
+        var elapsedSeconds = GetElapsedSeconds(startedAt ?? _scanStartedAt);
+        var progress = minimum + (int)Math.Floor(elapsedSeconds * pointsPerSecond);
+        return Math.Clamp(progress, minimum, maximum);
+    }
+
+    private static int GetElapsedSeconds(DateTimeOffset? startedAt) {
+        if (!startedAt.HasValue) {
+            return 0;
+        }
+
+        return Math.Max(0, (int)Math.Floor((DateTimeOffset.Now - startedAt.Value).TotalSeconds));
+    }
+
+    private static string GetElapsedLabel(DateTimeOffset? startedAt) {
+        var elapsedSeconds = GetElapsedSeconds(startedAt);
+        return elapsedSeconds <= 0 ? "starting" : $"{elapsedSeconds}s";
+    }
+
+    private string GetActiveProgressActivity() {
+        var elapsedSeconds = GetElapsedSeconds(_quickReadyAt ?? _scanStartedAt);
+        if (IsOverviewTool(Definition)) {
+            var activities = new[] {
+                "Resolving DNS inventory and provider hints.",
+                "Checking mail authentication records.",
+                "Evaluating DNSSEC, CAA, DANE, and transport evidence.",
+                "Assembling overview cards and section status.",
+                "Waiting for the remaining resolver responses."
+            };
+            return activities[Math.Min(activities.Length - 1, elapsedSeconds / 6)];
+        }
+
+        var toolActivities = GetToolProgressActivities();
+        return toolActivities[Math.Min(toolActivities.Count - 1, elapsedSeconds / 6)];
+    }
+
+    private IReadOnlyList<string> GetToolProgressActivities() {
+        return Definition.Slug switch {
+            "spf" => new[] {
+                "Looking up the SPF TXT policy.",
+                "Expanding SPF mechanisms and include references.",
+                "Checking SPF limits and policy strength.",
+                "Building SPF findings and record details."
+            },
+            "dkim" => new[] {
+                "Looking for DKIM selectors.",
+                "Resolving DKIM public keys.",
+                "Checking key posture and selector coverage.",
+                "Building DKIM findings and selector details."
+            },
+            "dmarc" => new[] {
+                "Looking up the DMARC policy.",
+                "Reading reporting and alignment settings.",
+                "Checking enforcement posture.",
+                "Building DMARC findings and record details."
+            },
+            "mx" => new[] {
+                "Resolving MX hosts.",
+                "Checking mail provider hints.",
+                "Sorting priorities and target records.",
+                "Building MX findings and transport details."
+            },
+            "mta-sts" => new[] {
+                "Looking up the MTA-STS bootstrap record.",
+                "Checking DNS policy hints.",
+                "Marking policy fetch work for the deeper run.",
+                "Building MTA-STS findings."
+            },
+            "tls-rpt" => new[] {
+                "Looking up TLS-RPT records.",
+                "Reading reporting endpoints.",
+                "Checking reporting posture.",
+                "Building TLS-RPT findings."
+            },
+            "bimi" => new[] {
+                "Looking up BIMI records.",
+                "Reading logo and authority evidence.",
+                "Checking browser-safe BIMI posture.",
+                "Building BIMI findings."
+            },
+            "dns-lookup" => new[] {
+                "Resolving the DNS inventory.",
+                "Checking provider and application fingerprints.",
+                "Normalizing record families.",
+                "Building DNS inventory cards."
+            },
+            "dnssec" => new[] {
+                "Checking DNSSEC records.",
+                "Reading delegation and signing signals.",
+                "Evaluating chain posture.",
+                "Building DNSSEC findings."
+            },
+            "soa" => new[] {
+                "Resolving the SOA record.",
+                "Reading zone authority details.",
+                "Checking serial and timing values.",
+                "Building SOA findings."
+            },
+            "ns" => new[] {
+                "Resolving authoritative nameservers.",
+                "Checking nameserver coverage.",
+                "Reading provider hints.",
+                "Building NS findings."
+            },
+            "dns-propagation" => new[] {
+                "Querying the web-edition resolver sample.",
+                "Comparing resolver answers.",
+                "Checking answer drift and availability.",
+                "Waiting for slower public resolvers."
+            },
+            "caa" => new[] {
+                "Looking up CAA records.",
+                "Reading certificate authority rules.",
+                "Checking issue and reporting directives.",
+                "Building CAA findings."
+            },
+            "dane" => new[] {
+                "Looking up TLSA records.",
+                "Checking SMTP and HTTPS service hints.",
+                "Evaluating DANE coverage.",
+                "Building DANE findings."
+            },
+            "dnsbl" => new[] {
+                "Resolving mail hosts for DNSBL checks.",
+                "Querying browser-safe blacklist evidence.",
+                "Checking listed and clean responses.",
+                "Building DNSBL findings."
+            },
+            "dangling-cname" => new[] {
+                "Resolving CNAME records.",
+                "Checking takeover provider fingerprints.",
+                "Evaluating dangling target evidence.",
+                "Building dangling CNAME findings."
+            },
+            _ => new[] {
+                "Starting the browser-safe DD checks.",
+                "Resolving public DNS evidence.",
+                "Normalizing findings into report cards.",
+                "Waiting for slower resolver responses."
+            }
+        };
+    }
+
+    private IReadOnlyList<string> GetExampleDomains() {
+        return Definition.Slug switch {
+            "m365-overview" => new[] { "evotec.pl", "microsoft.com" },
+            "domain-overview" => new[] { "evotec.pl", "microsoft.com", "cloudflare.com" },
+            "mta-sts" or "tls-rpt" or "bimi" => new[] { "evotec.pl", "microsoft.com", "google.com" },
+            "spf" or "dkim" or "dmarc" or "mx" => new[] { "evotec.pl", "microsoft.com", "gmail.com" },
+            "dns-lookup" or "dnssec" or "soa" or "ns" or "dns-propagation" or "caa" or "dane" => new[] { "evotec.pl", "cloudflare.com", "microsoft.com" },
+            "dnsbl" or "dangling-cname" => new[] { "evotec.pl", "microsoft.com" },
+            _ => Array.Empty<string>()
+        };
+    }
+
+    private void StartProgressTicker() {
+        StopProgressTicker();
+        _progressTimer = new System.Threading.Timer(_ => {
+            _ = InvokeAsync(() => {
+                if (_isLoading || _isHydratingDeep) {
+                    StateHasChanged();
+                }
+            });
+        }, null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+    }
+
+    private void StopProgressTicker() {
+        var timer = Interlocked.Exchange(ref _progressTimer, null);
+        timer?.Dispose();
     }
 
     private static string GetProgressStepClass(bool isReady, bool isActive) {
@@ -835,6 +1066,7 @@
     public void Dispose() {
         Navigation.LocationChanged -= HandleLocationChanged;
         CancelOverviewHydration();
+        StopProgressTicker();
     }
 
     private sealed class RecentToolRun {

--- a/DomainDetective.Toolbox/Components/Tools/Overview/DomainOverviewTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/DomainOverviewTool.razor
@@ -538,7 +538,7 @@
             $"Risk: {GetShareRiskLabel(info)}",
             $"Updated: {FormatUtc(info.GeneratedAtUtc)}",
             $"Pending sections: {pending}",
-            $"Unavailable sections: {unavailable}",
+            $"Deeper-run sections: {unavailable}",
             $"Mail provider: {provider}",
             $"DNS provider: {dnsProvider}",
             $"Warnings/Errors: {info.WarningCount}/{info.ErrorCount}",
@@ -558,7 +558,7 @@
             $"Risk: {GetShareRiskLabel(info)}",
             $"Updated: {FormatUtc(info.GeneratedAtUtc)}",
             $"Warnings/Errors: {info.WarningCount}/{info.ErrorCount}",
-            $"Unavailable sections: {(info.UnavailableSections.Count == 0 ? "None" : string.Join(", ", info.UnavailableSections))}"
+            $"Deeper-run sections: {(info.UnavailableSections.Count == 0 ? "None" : string.Join(", ", info.UnavailableSections))}"
         };
 
         var failingChecks = info.MailDnsChecks
@@ -654,7 +654,7 @@
 
     private static string GetSectionBadgeLabel(bool isPending, bool isUnavailable) {
         if (isUnavailable) {
-            return "Unavailable";
+            return "Needs deeper run";
         }
 
         return isPending ? "Loading" : "Ready";
@@ -704,7 +704,7 @@
 
     private static string GetSharePendingLabel(DomainOverviewInfo info) {
         if (info.UnavailableSections.Count > 0) {
-            return $"{info.UnavailableSections.Count} sections unavailable";
+            return $"{info.UnavailableSections.Count} sections need deeper run";
         }
 
         return info.PendingSections.Count > 0
@@ -736,9 +736,9 @@
 
     private static string GetUnavailableSectionMessage(string section) {
         return section switch {
-            "Web and registration" => "Web headers, certificates, security.txt, and registration data are unavailable in the web edition.",
-            "Exposure" => "Subdomain discovery is unavailable in the web edition.",
-            _ => "This section is unavailable in the web edition."
+            "Web and registration" => "Web headers, certificates, security.txt, and registration data need the deeper online run.",
+            "Exposure" => "Subdomain discovery needs the deeper online run.",
+            _ => "This section needs the deeper online run."
         };
     }
 

--- a/DomainDetective.Toolbox/Components/Tools/Overview/M365OverviewTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/M365OverviewTool.razor
@@ -556,7 +556,9 @@
 
     private static string BuildSummary(Microsoft365OverviewInfo info) {
         if (info.IsBrowserLimited) {
-            return "Web edition Microsoft 365 report built from web-ready DNS and mail evidence. Identity probing and tenant-correlation sections are marked clearly when they need deeper online validation.";
+            return info.Tenant.IsMicrosoft365Tenant
+                ? "Web edition found Microsoft 365 DNS or mail evidence. Identity probing and tenant-correlation sections still need deeper online validation."
+                : "Web edition did not find enough browser-safe Microsoft 365 evidence to confirm the tenant. Identity probing and tenant-correlation sections still need deeper online validation.";
         }
 
         if (!info.Tenant.IsMicrosoft365Tenant) {
@@ -588,7 +590,7 @@
             $"Risk: {GetShareRiskLabel(info)}",
             $"Updated: {FormatUtc(info.GeneratedAtUtc)}",
             $"Pending sections: {pending}",
-            $"Unavailable sections: {unavailable}",
+            $"Deeper-run sections: {unavailable}",
             $"Tenant: {tenantName}",
             $"Identity: {identity}",
             $"Detected services: {detectedServices}",
@@ -608,7 +610,7 @@
             $"Risk: {GetShareRiskLabel(info)}",
             $"Updated: {FormatUtc(info.GeneratedAtUtc)}",
             $"Warnings/Errors: {info.WarningCount}/{info.ErrorCount}",
-            $"Unavailable sections: {(info.UnavailableSections.Count == 0 ? "None" : string.Join(", ", info.UnavailableSections))}"
+            $"Deeper-run sections: {(info.UnavailableSections.Count == 0 ? "None" : string.Join(", ", info.UnavailableSections))}"
         };
 
         var failingChecks = info.MailDnsChecks
@@ -704,7 +706,7 @@
 
     private static string GetSectionBadgeLabel(bool isPending, bool isUnavailable) {
         if (isUnavailable) {
-            return "Unavailable";
+            return "Needs deeper run";
         }
 
         return isPending ? "Loading" : "Ready";
@@ -754,7 +756,7 @@
 
     private static string GetSharePendingLabel(Microsoft365OverviewInfo info) {
         if (info.UnavailableSections.Count > 0) {
-            return $"{info.UnavailableSections.Count} sections unavailable";
+            return $"{info.UnavailableSections.Count} sections need deeper run";
         }
 
         return info.PendingSections.Count > 0
@@ -786,10 +788,10 @@
 
     private static string GetUnavailableSectionMessage(string section) {
         return section switch {
-            "Identity" => "Tenant identity and Microsoft authentication probing are unavailable in the web edition.",
-            "Services" => "Microsoft workload detection in this section depends on identity and tenant correlation that the web edition does not run.",
-            "Domains" => "Tenant domain and Microsoft subdomain correlation are unavailable in the web edition.",
-            _ => "This section is unavailable in the web edition."
+            "Identity" => "Tenant identity and Microsoft authentication probing need the deeper online run.",
+            "Services" => "Microsoft workload detection in this section depends on identity and tenant correlation that the browser edition does not run.",
+            "Domains" => "Tenant domain and Microsoft subdomain correlation need the deeper online run.",
+            _ => "This section needs the deeper online run."
         };
     }
 

--- a/DomainDetective.Toolbox/Components/Tools/Overview/Microsoft365OverviewPresentation.cs
+++ b/DomainDetective.Toolbox/Components/Tools/Overview/Microsoft365OverviewPresentation.cs
@@ -116,16 +116,28 @@ internal static class Microsoft365OverviewPresentation
         return new DomainOverviewDetailCardView
         {
             Title = "Tenant detection",
-            ValueLabel = tenant.IsMicrosoft365Tenant ? "Detected" : "Not detected",
-            Summary = "DD combined namespace, tenant, and Microsoft identity evidence to decide whether this domain maps to a Microsoft 365 tenant.",
+            ValueLabel = FormatTenantDetectionLabel(info),
+            Summary = info.IsBrowserLimited
+                ? "DD used the browser-safe DNS, mail, and application evidence available here. Tenant identity and auth probes require the deeper online run."
+                : "DD combined namespace, tenant, and Microsoft identity evidence to decide whether this domain maps to a Microsoft 365 tenant.",
             Tags = new[]
             {
                 "Confidence: " + FormatConfidence(tenant.DetectionConfidence),
                 "Cloud: " + Humanize(tenant.CloudInstance.ToString()),
-                "Region: " + Humanize(tenant.Region.ToString())
+                info.IsBrowserLimited ? "Identity probes: unavailable" : "Region: " + Humanize(tenant.Region.ToString())
             },
             Samples = samples.Take(3).ToArray()
         };
+    }
+
+    private static string FormatTenantDetectionLabel(Microsoft365OverviewInfo info)
+    {
+        if (info.IsBrowserLimited)
+        {
+            return info.Tenant.IsMicrosoft365Tenant ? "Microsoft evidence observed" : "Not confirmed";
+        }
+
+        return info.Tenant.IsMicrosoft365Tenant ? "Detected" : "Not detected";
     }
 
     private static DomainOverviewDetailCardView BuildIdentitySnapshotCard(Microsoft365OverviewInfo info)
@@ -147,13 +159,15 @@ internal static class Microsoft365OverviewPresentation
         return new DomainOverviewDetailCardView
         {
             Title = "Identity posture",
-            ValueLabel = FormatIdentityPostureLabel(tenant),
-            Summary = "Authentication flow, identity provider, and exposed Microsoft protocol hints shape the public identity posture DD reports here.",
+            ValueLabel = FormatIdentityPostureLabel(info),
+            Summary = info.IsBrowserLimited
+                ? "Microsoft authentication probes do not run in the browser edition, so DD keeps identity posture separate from DNS and mail evidence."
+                : "Authentication flow, identity provider, and exposed Microsoft protocol hints shape the public identity posture DD reports here.",
             Tags = new[]
             {
-                tenant.FederationMode == Microsoft365FederationMode.CloudManaged ? "Cloud-managed" : Humanize(tenant.FederationMode.ToString()),
-                tenant.UserEnumerationStatus == Microsoft365AuthExposureStatus.Exposed ? "User enumeration exposed" : Humanize(tenant.UserEnumerationStatus.ToString()),
-                tenant.ThrottlingStatus == Microsoft365AuthThrottlingStatus.ThrottlingObserved ? "Throttling detected" : Humanize(tenant.ThrottlingStatus.ToString())
+                info.IsBrowserLimited ? "Auth path: unavailable in web edition" : tenant.FederationMode == Microsoft365FederationMode.CloudManaged ? "Cloud-managed" : Humanize(tenant.FederationMode.ToString()),
+                info.IsBrowserLimited ? "Provider: deeper online run" : tenant.UserEnumerationStatus == Microsoft365AuthExposureStatus.Exposed ? "User enumeration exposed" : Humanize(tenant.UserEnumerationStatus.ToString()),
+                info.IsBrowserLimited ? "Throttling: not probed" : tenant.ThrottlingStatus == Microsoft365AuthThrottlingStatus.ThrottlingObserved ? "Throttling detected" : Humanize(tenant.ThrottlingStatus.ToString())
             },
             Samples = samples.Where(static item => !string.IsNullOrWhiteSpace(item)).Distinct(StringComparer.OrdinalIgnoreCase).Take(3).ToArray()
         };
@@ -1160,8 +1174,14 @@ internal static class Microsoft365OverviewPresentation
             : Humanize(confidence.ToString());
     }
 
-    private static string FormatIdentityPostureLabel(Microsoft365TenantInfo tenant)
+    private static string FormatIdentityPostureLabel(Microsoft365OverviewInfo info)
     {
+        var tenant = info.Tenant;
+        if (info.IsBrowserLimited && tenant.AuthenticationPath == Microsoft365AuthPathKind.Unknown && tenant.IdentityProviderKind == TenantIdentityProviderKind.Unknown)
+        {
+            return "Auth not probed";
+        }
+
         if (tenant.FederationMode == Microsoft365FederationMode.CloudManaged)
         {
             return tenant.UserEnumerationStatus == Microsoft365AuthExposureStatus.Exposed ? "Cloud-managed, exposed realm" : "Cloud-managed";

--- a/DomainDetective.Toolbox/Services/BrowserOverviewService.cs
+++ b/DomainDetective.Toolbox/Services/BrowserOverviewService.cs
@@ -1,4 +1,5 @@
 using DomainDetective.Providers.Email;
+using DomainDetective.Providers.Dns;
 using DomainDetective.Views;
 
 namespace DomainDetective.Toolbox.Services;
@@ -125,11 +126,7 @@ public sealed class BrowserOverviewService {
         overview.GeneratedAtUtc = generatedAtUtc;
         overview.CompletedAtUtc = generatedAtUtc;
         overview.PendingSections = Array.Empty<string>();
-        overview.UnavailableSections = new[] {
-            "Identity",
-            "Services",
-            "Domains"
-        };
+        overview.UnavailableSections = BuildBrowserMicrosoft365UnavailableSections(tenant);
         return overview;
     }
 
@@ -276,23 +273,257 @@ public sealed class BrowserOverviewService {
     }
 
     private static Microsoft365TenantInfo BuildBrowserMicrosoft365Tenant(string domainName, DnsInventoryInfo dnsInventory) {
+        var microsoftApps = dnsInventory.DetectedDnsApplications
+            .Where(IsMicrosoft365Application)
+            .ToArray();
+        var hasMicrosoftMail = dnsInventory.MailProvider == MailProviderKind.Microsoft365;
+        var hasMicrosoftVerification = dnsInventory.TxtSignals.HasFlag(DnsTxtSignals.MicrosoftDomainVerification);
+        var isMicrosoft365Observed = hasMicrosoftMail || hasMicrosoftVerification || microsoftApps.Length > 0;
+        var confidence = BuildBrowserTenantConfidence(hasMicrosoftMail, hasMicrosoftVerification, microsoftApps);
+        var services = BuildBrowserServiceDetections(hasMicrosoftMail, dnsInventory.MailProviderEvidence);
+        var tenantDomains = BuildBrowserTenantDomains(domainName, isMicrosoft365Observed, confidence, dnsInventory);
+        var evidenceLedger = BuildBrowserEvidenceLedger(dnsInventory, hasMicrosoftMail, hasMicrosoftVerification, microsoftApps);
         var highlights = new List<string>();
-        if (dnsInventory.MailProvider != MailProviderKind.Unknown) {
+        if (hasMicrosoftMail) {
+            highlights.Add("Microsoft 365 mail routing observed from MX evidence.");
+        } else if (dnsInventory.MailProvider != MailProviderKind.Unknown) {
             highlights.Add("Mail provider hint: " + dnsInventory.MailProvider);
+        }
+
+        if (hasMicrosoftVerification) {
+            highlights.Add("Microsoft domain verification TXT evidence observed.");
         }
 
         if (dnsInventory.DetectedDnsApplications.Count > 0) {
             highlights.Add($"Detected {dnsInventory.DetectedDnsApplications.Count} DNS application hint(s).");
         }
 
-        highlights.Add("Web edition: identity, tenant, and auth probing are unavailable.");
+        highlights.Add("Web edition: identity, tenant, and auth probing require the deeper online run.");
 
         return new Microsoft365TenantInfo {
             Subject = domainName,
+            QuerySucceeded = dnsInventory.QuerySucceeded,
+            IsMicrosoft365Tenant = isMicrosoft365Observed,
+            DetectionConfidence = confidence,
             TenantName = domainName,
+            TenantDomains = tenantDomains,
+            Services = services,
+            WorkloadSummary = BuildBrowserWorkloadSummary(services),
+            DnsApplicationSummary = BuildBrowserDnsApplicationSummary(dnsInventory.DetectedDnsApplications),
+            EvidenceSummary = BuildBrowserEvidenceSummary(evidenceLedger),
             DetectedDnsApplications = dnsInventory.DetectedDnsApplications,
+            EvidenceLedger = evidenceLedger,
             Highlights = highlights,
-            Summary = "Web edition Microsoft 365 overview built from public DNS and mail posture only."
+            Summary = isMicrosoft365Observed
+                ? "Web edition Microsoft 365 overview built from observed DNS, mail, and application evidence. Tenant identity and auth posture need the deeper online run."
+                : "Web edition Microsoft 365 overview built from public DNS and mail posture only. Tenant identity and auth posture need the deeper online run."
+        };
+    }
+
+    private static IReadOnlyList<string> BuildBrowserMicrosoft365UnavailableSections(Microsoft365TenantInfo tenant) {
+        var sections = new List<string> {
+            "Identity"
+        };
+
+        if (tenant.Services.Count == 0) {
+            sections.Add("Services");
+        }
+
+        if (tenant.TenantDomains.Count == 0 && tenant.KnownSubdomains.Count == 0) {
+            sections.Add("Domains");
+        }
+
+        return sections;
+    }
+
+    private static bool IsMicrosoft365Application(DetectedDnsApplication app) {
+        return string.Equals(app.Id, "mail-provider-microsoft365", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(app.Id, "microsoft-365", StringComparison.OrdinalIgnoreCase) ||
+            app.Name.Contains("Microsoft", StringComparison.OrdinalIgnoreCase) ||
+            app.Name.Contains("Office 365", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static Microsoft365DetectionConfidence BuildBrowserTenantConfidence(bool hasMicrosoftMail, bool hasMicrosoftVerification, IReadOnlyList<DetectedDnsApplication> microsoftApps) {
+        if (hasMicrosoftMail || hasMicrosoftVerification ||
+            microsoftApps.Any(static app => app.Confidence == Microsoft365DetectionConfidence.Strong)) {
+            return Microsoft365DetectionConfidence.Strong;
+        }
+
+        if (microsoftApps.Any(static app => app.Confidence == Microsoft365DetectionConfidence.Moderate)) {
+            return Microsoft365DetectionConfidence.Moderate;
+        }
+
+        if (microsoftApps.Any(static app => app.Confidence == Microsoft365DetectionConfidence.Weak)) {
+            return Microsoft365DetectionConfidence.Weak;
+        }
+
+        return Microsoft365DetectionConfidence.Unknown;
+    }
+
+    private static IReadOnlyList<Microsoft365ServiceDetection> BuildBrowserServiceDetections(bool hasMicrosoftMail, IReadOnlyList<string> mailProviderEvidence) {
+        if (!hasMicrosoftMail) {
+            return Array.Empty<Microsoft365ServiceDetection>();
+        }
+
+        return new[] {
+            new Microsoft365ServiceDetection {
+                Kind = Microsoft365ServiceKind.ExchangeOnline,
+                Status = Microsoft365DetectionStatus.Detected,
+                Confidence = Microsoft365DetectionConfidence.Strong,
+                EvidenceSource = Microsoft365ServiceEvidenceSourceKind.MailProtocol,
+                Evidence = mailProviderEvidence.Count > 0
+                    ? mailProviderEvidence
+                    : new[] { "Mail provider: Microsoft 365" }
+            }
+        };
+    }
+
+    private static IReadOnlyList<Microsoft365TenantDomain> BuildBrowserTenantDomains(string domainName, bool isMicrosoft365Observed, Microsoft365DetectionConfidence confidence, DnsInventoryInfo dnsInventory) {
+        if (!isMicrosoft365Observed) {
+            return Array.Empty<Microsoft365TenantDomain>();
+        }
+
+        var evidence = new List<string>();
+        evidence.AddRange(dnsInventory.MailProviderEvidence.Where(static item => !string.IsNullOrWhiteSpace(item)).Take(3));
+        evidence.AddRange(dnsInventory.TxtSignalsEvidence.Where(static item => !string.IsNullOrWhiteSpace(item)).Take(2));
+
+        if (evidence.Count == 0) {
+            evidence.Add("Browser-safe DNS and mail evidence observed.");
+        }
+
+        return new[] {
+            new Microsoft365TenantDomain {
+                Domain = domainName,
+                Role = Microsoft365TenantDomainRole.AcceptedCustomDomain,
+                Confidence = confidence == Microsoft365DetectionConfidence.Unknown ? Microsoft365DetectionConfidence.Weak : confidence,
+                Evidence = evidence
+            }
+        };
+    }
+
+    private static IReadOnlyList<Microsoft365EvidenceItem> BuildBrowserEvidenceLedger(
+        DnsInventoryInfo dnsInventory,
+        bool hasMicrosoftMail,
+        bool hasMicrosoftVerification,
+        IReadOnlyList<DetectedDnsApplication> microsoftApps) {
+        var items = new List<Microsoft365EvidenceItem>();
+
+        if (hasMicrosoftMail) {
+            items.Add(new Microsoft365EvidenceItem {
+                Id = "browser-mail-provider-microsoft365",
+                Label = "Microsoft 365 mail provider",
+                Category = Microsoft365EvidenceCategory.Mail,
+                Confidence = Microsoft365DetectionConfidence.Strong,
+                Evidence = dnsInventory.MailProviderEvidence.Count > 0
+                    ? dnsInventory.MailProviderEvidence
+                    : new[] { "Mail provider: Microsoft 365" }
+            });
+        }
+
+        if (hasMicrosoftVerification) {
+            items.Add(new Microsoft365EvidenceItem {
+                Id = "browser-txt-microsoft-verification",
+                Label = "Microsoft TXT verification",
+                Category = Microsoft365EvidenceCategory.DnsApplication,
+                Confidence = Microsoft365DetectionConfidence.Strong,
+                Evidence = dnsInventory.TxtSignalsEvidence.Count > 0
+                    ? dnsInventory.TxtSignalsEvidence
+                    : new[] { "Microsoft domain verification TXT signal" }
+            });
+        }
+
+        foreach (var app in microsoftApps) {
+            items.Add(new Microsoft365EvidenceItem {
+                Id = "browser-app-" + app.Id,
+                Label = app.Name,
+                Category = Microsoft365EvidenceCategory.DnsApplication,
+                Confidence = app.Confidence,
+                Evidence = string.IsNullOrWhiteSpace(app.Evidence)
+                    ? Array.Empty<string>()
+                    : new[] { app.Evidence }
+            });
+        }
+
+        return items
+            .GroupBy(static item => item.Id, StringComparer.OrdinalIgnoreCase)
+            .Select(static group => group.First())
+            .ToArray();
+    }
+
+    private static Microsoft365WorkloadConfidenceSummary BuildBrowserWorkloadSummary(IReadOnlyList<Microsoft365ServiceDetection> services) {
+        return new Microsoft365WorkloadConfidenceSummary {
+            DetectedCount = services.Count(static service => service.Status == Microsoft365DetectionStatus.Detected),
+            StrongCount = services.Count(static service => service.Status == Microsoft365DetectionStatus.Detected && service.Confidence == Microsoft365DetectionConfidence.Strong),
+            ModerateCount = services.Count(static service => service.Status == Microsoft365DetectionStatus.Detected && service.Confidence == Microsoft365DetectionConfidence.Moderate),
+            WeakCount = services.Count(static service => service.Status == Microsoft365DetectionStatus.Detected && service.Confidence == Microsoft365DetectionConfidence.Weak),
+            StrongServices = services
+                .Where(static service => service.Status == Microsoft365DetectionStatus.Detected && service.Confidence == Microsoft365DetectionConfidence.Strong)
+                .Select(static service => service.Kind)
+                .ToArray(),
+            ModerateServices = services
+                .Where(static service => service.Status == Microsoft365DetectionStatus.Detected && service.Confidence == Microsoft365DetectionConfidence.Moderate)
+                .Select(static service => service.Kind)
+                .ToArray(),
+            WeakServices = services
+                .Where(static service => service.Status == Microsoft365DetectionStatus.Detected && service.Confidence == Microsoft365DetectionConfidence.Weak)
+                .Select(static service => service.Kind)
+                .ToArray()
+        };
+    }
+
+    private static Microsoft365DnsApplicationSummary BuildBrowserDnsApplicationSummary(IReadOnlyList<DetectedDnsApplication> applications) {
+        var categories = applications
+            .GroupBy(static app => app.Category)
+            .Select(static group => new Microsoft365DnsApplicationCategorySummary {
+                Category = group.Key,
+                Count = group.Count(),
+                HighestConfidence = group.Max(static app => app.Confidence),
+                ApplicationNames = group
+                    .Select(static app => app.Name)
+                    .Where(static name => !string.IsNullOrWhiteSpace(name))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Take(6)
+                    .ToArray()
+            })
+            .OrderByDescending(static category => category.Count)
+            .ThenBy(static category => category.Category)
+            .ToArray();
+        var dominantCategory = categories.FirstOrDefault();
+
+        return new Microsoft365DnsApplicationSummary {
+            TotalCount = applications.Count,
+            CategoryCount = categories.Length,
+            DominantCategory = dominantCategory?.Category ?? DetectedDnsAppCategory.Unknown,
+            DominantCategoryCount = dominantCategory?.Count ?? 0,
+            Categories = categories
+        };
+    }
+
+    private static Microsoft365EvidenceSummary BuildBrowserEvidenceSummary(IReadOnlyList<Microsoft365EvidenceItem> evidence) {
+        var categories = evidence
+            .GroupBy(static item => item.Category)
+            .Select(static group => new Microsoft365EvidenceCategorySummary {
+                Category = group.Key,
+                Count = group.Count(),
+                HighestConfidence = group.Max(static item => item.Confidence),
+                Labels = group
+                    .Select(static item => item.Label)
+                    .Where(static label => !string.IsNullOrWhiteSpace(label))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .Take(6)
+                    .ToArray()
+            })
+            .OrderByDescending(static category => category.Count)
+            .ThenBy(static category => category.Category)
+            .ToArray();
+        var dominantCategory = categories.FirstOrDefault();
+
+        return new Microsoft365EvidenceSummary {
+            TotalCount = evidence.Count,
+            CategoryCount = categories.Length,
+            DominantCategory = dominantCategory?.Category ?? Microsoft365EvidenceCategory.Unknown,
+            DominantCategoryCount = dominantCategory?.Count ?? 0,
+            Categories = categories
         };
     }
 

--- a/DomainDetective.Toolbox/Services/ToolCapabilityPresentation.cs
+++ b/DomainDetective.Toolbox/Services/ToolCapabilityPresentation.cs
@@ -1,0 +1,166 @@
+using DomainDetective.Toolbox.Models;
+
+namespace DomainDetective.Toolbox.Services;
+
+public sealed record ToolCapabilityInfo(
+    string Title,
+    string Description,
+    IReadOnlyList<string> BrowserChecks,
+    IReadOnlyList<string> DeeperChecks);
+
+public static class ToolCapabilityPresentation {
+    public static ToolCapabilityInfo Build(ToolDefinition tool, ToolsDeploymentMode deploymentMode) {
+        ArgumentNullException.ThrowIfNull(tool);
+
+        if (deploymentMode == ToolsDeploymentMode.HostedOnline) {
+            return new ToolCapabilityInfo(
+                "Online coverage",
+                "This deployment can use the hosted DD analysis path when the tool needs network access beyond the browser sandbox.",
+                new[] { "Live hosted analysis where configured", "Browser-safe fallback checks for DNS-oriented tools" },
+                new[] { "CLI, PowerShell, and C# workflows for repeatable local automation" });
+        }
+
+        return tool.Slug switch {
+            "m365-overview" => new ToolCapabilityInfo(
+                "Partial browser support",
+                "The GitHub Pages edition builds a Microsoft 365 posture from public DNS and mail evidence, then marks tenant-only probes as deeper-run work.",
+                new[] {
+                    "SPF, DKIM, DMARC, MX, TLS-RPT, BIMI, CAA, and DANE evidence",
+                    "Microsoft mail provider and DNS application fingerprints",
+                    "Browser-safe evidence ledger and posture notes"
+                },
+                new[] {
+                    "Tenant identity and Microsoft authentication probes",
+                    "Tenant domain and Microsoft subdomain correlation",
+                    "Full service detection and deeper recommendations"
+                }),
+            "domain-overview" => new ToolCapabilityInfo(
+                "Partial browser support",
+                "The GitHub Pages edition runs the DD checks that are safe through browser DNS and keeps deeper network sections visible as deeper-run work.",
+                new[] {
+                    "DNS inventory, provider hints, and DNS application fingerprints",
+                    "Core mail authentication and transport DNS controls",
+                    "Browser-safe evidence ledger and posture notes"
+                },
+                new[] {
+                    "HTTP headers, security.txt, and TLS certificate handshake details",
+                    "RDAP registration data and DNSBL/exposure checks",
+                    "Certificate Transparency subdomain discovery"
+                }),
+            "mta-sts" => new ToolCapabilityInfo(
+                "Partial browser support",
+                "The web edition validates the DNS bootstrap record and leaves policy hosting checks to the deeper online run.",
+                new[] {
+                    "MTA-STS TXT bootstrap lookup",
+                    "Record presence and syntax-oriented posture",
+                    "Mail transport context from DNS"
+                },
+                new[] {
+                    "HTTPS policy fetch and parsing",
+                    "MX-to-policy host coverage",
+                    "Full enforcement and duplicate-field validation"
+                }),
+            "dns-propagation" => new ToolCapabilityInfo(
+                "Partial browser support",
+                "The web edition compares a compact public resolver sample so propagation checks still work on GitHub Pages.",
+                new[] {
+                    "Public resolver sample from the browser",
+                    "Answer drift and resolver availability",
+                    "Fast propagation signal for common records"
+                },
+                new[] {
+                    "Broader DD resolver pool",
+                    "Hosted cache refresh and wider vantage points",
+                    "Repeatable CLI or PowerShell propagation audits"
+                }),
+            "raw-dns-query" => new ToolCapabilityInfo(
+                "Runs in browser",
+                "This workspace is designed for direct browser DNS-over-HTTPS queries and copyable DnsClientX examples.",
+                new[] {
+                    "Record-by-record DNS-over-HTTPS queries",
+                    "Resolver selection for browser-safe providers",
+                    "Raw JSON answer review"
+                },
+                new[] {
+                    "Local resolver targets and private network DNS",
+                    "Scripted DnsClientX automation",
+                    "Bulk checks across many hosts and record types"
+                }),
+            _ => BuildGenericStaticMap(tool)
+        };
+    }
+
+    private static ToolCapabilityInfo BuildGenericStaticMap(ToolDefinition tool) {
+        if (tool.BrowserCompatible) {
+            return new ToolCapabilityInfo(
+                "Runs in browser",
+                "This check can run directly from the GitHub Pages edition using browser-safe DD lookups.",
+                BuildBrowserCompatibleChecks(tool),
+                new[] {
+                    "CLI, PowerShell, and C# automation",
+                    "Local scripting across many domains",
+                    "Resolver and environment choices outside the browser"
+                });
+        }
+
+        if (tool.LiteCompatible) {
+            return new ToolCapabilityInfo(
+                "Partial browser support",
+                "This check has a lighter web edition here and a deeper DD path outside GitHub Pages.",
+                new[] {
+                    "Browser-safe public evidence",
+                    "Clear status for checks that are not run here",
+                    "Local workflow guidance"
+                },
+                new[] {
+                    "Network probes that browser sandboxing blocks",
+                    "Hosted or local DD validation",
+                    "Full remediation evidence"
+                });
+        }
+
+        return new ToolCapabilityInfo(
+            "Guided locally",
+            "This check needs network access that the GitHub Pages browser edition cannot provide.",
+            new[] {
+                "Tool description and exact run commands",
+                "Related DD workflows",
+                "Install and usage links"
+            },
+            new[] {
+                "Full DD analysis through CLI, PowerShell, or C#",
+                "Network probes from your environment",
+                "Repeatable local automation"
+            });
+    }
+
+    private static IReadOnlyList<string> BuildBrowserCompatibleChecks(ToolDefinition tool) {
+        return tool.Category switch {
+            ToolCategory.EmailSecurity => new[] {
+                "Public DNS records for this mail control",
+                "DD parsing and posture classification",
+                "Actionable findings and record details"
+            },
+            ToolCategory.Dns => new[] {
+                "Public DNS answers through browser-safe resolvers",
+                "DD normalization and provider hints",
+                "Record details and copyable evidence"
+            },
+            ToolCategory.TlsCert => new[] {
+                "Public DNS records related to certificate posture",
+                "DD parsing and posture classification",
+                "Actionable findings and record details"
+            },
+            ToolCategory.ThreatIntel => new[] {
+                "DNS-backed posture checks available to the browser",
+                "DD findings for public takeover or blacklist signals",
+                "Actionable result cards"
+            },
+            _ => new[] {
+                "Browser-safe public evidence",
+                "DD parsing and result cards",
+                "Actionable findings"
+            }
+        };
+    }
+}

--- a/DomainDetective.Toolbox/Services/ToolPlannerPresentation.cs
+++ b/DomainDetective.Toolbox/Services/ToolPlannerPresentation.cs
@@ -57,10 +57,10 @@ public static class ToolPlannerPresentation {
 
     public static string GetModeLabel(ToolDefinition tool, ToolsDeploymentMode deploymentMode) {
         return GetMode(tool, deploymentMode) switch {
-            ToolPlannerMode.Adaptive => "Adaptive",
+            ToolPlannerMode.Adaptive => "Partial browser",
             ToolPlannerMode.GuidedLocally => "Guided locally",
             ToolPlannerMode.Online => "Online",
-            _ => "Available now"
+            _ => "Runs in browser"
         };
     }
 

--- a/DomainDetective.Website.Tests/ToolCapabilityPresentationTests.cs
+++ b/DomainDetective.Website.Tests/ToolCapabilityPresentationTests.cs
@@ -1,0 +1,42 @@
+using DomainDetective.Toolbox.Models;
+using DomainDetective.Toolbox.Services;
+
+namespace DomainDetective.Website.Tests;
+
+public sealed class ToolCapabilityPresentationTests {
+    [Fact]
+    public void BuildDescribesM365StaticCoverageAsPartialBrowserSupport() {
+        var tool = CreateTool("m365-overview", ToolCategory.Overview, browserCompatible: false, hostedCompatible: true, liteCompatible: true);
+
+        var capability = ToolCapabilityPresentation.Build(tool, ToolsDeploymentMode.StaticOnly);
+
+        Assert.Equal("Partial browser support", capability.Title);
+        Assert.Contains(capability.BrowserChecks, item => item.Contains("Microsoft mail provider", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(capability.DeeperChecks, item => item.Contains("Tenant identity", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void BuildDescribesHostedOnlyStaticCoverageAsGuidedLocally() {
+        var tool = CreateTool("cert-check", ToolCategory.TlsCert, browserCompatible: false, hostedCompatible: true);
+
+        var capability = ToolCapabilityPresentation.Build(tool, ToolsDeploymentMode.StaticOnly);
+
+        Assert.Equal("Guided locally", capability.Title);
+        Assert.Contains("GitHub Pages browser edition", capability.Description, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(capability.DeeperChecks, item => item.Contains("CLI", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static ToolDefinition CreateTool(string slug, ToolCategory category, bool browserCompatible, bool hostedCompatible = false, bool liteCompatible = false) {
+        return new ToolDefinition {
+            Name = slug,
+            Slug = slug,
+            Description = $"{slug} description",
+            Category = category,
+            Icon = "globe",
+            BrowserCompatible = browserCompatible,
+            HostedCompatible = hostedCompatible,
+            LiteCompatible = liteCompatible,
+            InputPlaceholder = "example.com"
+        };
+    }
+}

--- a/DomainDetective.Website.Tests/ToolCategoryGridComponentTests.cs
+++ b/DomainDetective.Website.Tests/ToolCategoryGridComponentTests.cs
@@ -18,8 +18,25 @@ public sealed class ToolCategoryGridComponentTests : TestContext {
         var dot = cut.Find(".tool-availability-dot");
 
         Assert.Equal("/tools/ct-subdomains/", link.GetAttribute("href"));
+        Assert.Equal("ct-subdomains: guided local workflow", link.GetAttribute("aria-label"));
         Assert.Contains("tool-availability-dot-local", dot.ClassName);
         Assert.Contains("ct-subdomains", link.TextContent);
+    }
+
+    [Fact]
+    public void AddsDomainQueryToToolLinksWhenDomainIsProvided() {
+        var tools = new[] {
+            CreateTool("spf", ToolCategory.EmailSecurity)
+        };
+
+        var cut = RenderComponent<ToolCategoryGrid>(parameters => parameters
+            .Add(component => component.Tools, tools)
+            .Add(component => component.DeploymentMode, ToolsDeploymentMode.StaticOnly)
+            .Add(component => component.Domain, "evotec.pl"));
+
+        var link = cut.Find("a.category-tool-link");
+
+        Assert.Equal("/tools/spf/?q=evotec.pl", link.GetAttribute("href"));
     }
 
     private static ToolDefinition CreateTool(string slug, ToolCategory category, bool browserCompatible = true, bool hostedCompatible = false, bool liteCompatible = false) {

--- a/DomainDetective.Website.Tests/ToolPageComponentTests.cs
+++ b/DomainDetective.Website.Tests/ToolPageComponentTests.cs
@@ -72,6 +72,61 @@ public sealed class ToolPageComponentTests : TestContext {
         });
     }
 
+    [Fact]
+    public void M365OverviewBrowserLimitedTenantUsesNotConfirmedLanguage() {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("http://localhost/tools/m365-overview/?q=contoso.com");
+
+        var tool = _registry.GetBySlug("m365-overview")!;
+        var cut = RenderComponent<ToolPage>(parameters => parameters
+            .Add(component => component.Definition, tool));
+
+        cut.WaitForAssertion(() => {
+            Assert.Contains("Not confirmed", cut.Markup);
+            Assert.Contains("Tenant identity and Microsoft authentication probing need the deeper online run.", cut.Markup);
+            Assert.Contains("Partial browser support", cut.Markup);
+            Assert.Contains("Tenant identity and Microsoft authentication probes", cut.Markup);
+            Assert.Contains("Run deeper locally", cut.Markup);
+            Assert.Contains("Get-DomainHealthCheck -Domain", cut.Markup);
+            Assert.Contains("contoso.com", cut.Markup);
+            Assert.DoesNotContain("Not detected", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void RunnableToolPageShowsExampleDomainsAndRunsSelectedExample() {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("http://localhost/tools/m365-overview/");
+
+        var tool = _registry.GetBySlug("m365-overview")!;
+        var cut = RenderComponent<ToolPage>(parameters => parameters
+            .Add(component => component.Definition, tool));
+
+        var exampleButton = cut.FindAll("button.tool-example-chip")
+            .Single(button => button.TextContent.Contains("evotec.pl", StringComparison.OrdinalIgnoreCase));
+
+        exampleButton.Click();
+
+        cut.WaitForAssertion(() => {
+            Assert.Contains("q=evotec.pl", navigation.Uri);
+            Assert.Contains("evotec.pl", cut.Find("form.tool-input-form input[type='text']").GetAttribute("value"));
+        });
+    }
+
+    [Fact]
+    public void HostedOnlyStaticToolExplainsGuidedLocalCoverage() {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("http://localhost/tools/cert-check/");
+
+        var tool = _registry.GetBySlug("cert-check")!;
+        var cut = RenderComponent<ToolPage>(parameters => parameters
+            .Add(component => component.Definition, tool));
+
+        Assert.Contains("Guided locally", cut.Markup);
+        Assert.Contains("This check needs network access that the GitHub Pages browser edition cannot provide.", cut.Markup);
+        Assert.Contains("Full DD analysis through CLI, PowerShell, or C#", cut.Markup);
+    }
+
     private sealed class RecordingDnsHandler : HttpMessageHandler {
         public List<Uri> RequestUris { get; } = new();
 

--- a/DomainDetective.Website.Tests/ToolPlannerPresentationTests.cs
+++ b/DomainDetective.Website.Tests/ToolPlannerPresentationTests.cs
@@ -61,6 +61,15 @@ public sealed class ToolPlannerPresentationTests {
         Assert.Equal("Guided locally", label);
     }
 
+    [Fact]
+    public void GetModeLabelUsesBrowserSpecificStaticLabels() {
+        var available = CreateTool("spf", browserCompatible: true);
+        var adaptive = CreateTool("mta-sts", browserCompatible: false, hostedCompatible: true, liteCompatible: true);
+
+        Assert.Equal("Runs in browser", ToolPlannerPresentation.GetModeLabel(available, ToolsDeploymentMode.StaticOnly));
+        Assert.Equal("Partial browser", ToolPlannerPresentation.GetModeLabel(adaptive, ToolsDeploymentMode.StaticOnly));
+    }
+
     private static ToolDefinition CreateTool(string slug, bool browserCompatible = true, bool hostedCompatible = false, bool liteCompatible = false) {
         return new ToolDefinition {
             Name = slug,

--- a/DomainDetective.Website.Tests/ToolsPageComponentTests.cs
+++ b/DomainDetective.Website.Tests/ToolsPageComponentTests.cs
@@ -8,6 +8,8 @@ namespace DomainDetective.Website.Tests;
 
 public sealed class ToolsPageComponentTests : TestContext {
     public ToolsPageComponentTests() {
+        JSInterop.Mode = JSRuntimeMode.Loose;
+
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> {
                 ["Tools:Mode"] = "StaticOnly"
@@ -47,6 +49,35 @@ public sealed class ToolsPageComponentTests : TestContext {
         RenderComponent<DomainDetective.Website.Pages.Tools>();
 
         Assert.Equal("http://localhost/tools/domain-overview/?q=contoso.com", navigation.Uri);
+    }
+
+    [Fact]
+    public void ToolsPagePreservesQDomainInCatalogLinks() {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("http://localhost/tools/?q=evotec.pl");
+
+        var cut = RenderComponent<DomainDetective.Website.Pages.Tools>();
+
+        cut.WaitForAssertion(() => {
+            Assert.Contains("/tools/spf/?q=evotec.pl", cut.Markup);
+            Assert.Contains("/tools/cert-check/?q=evotec.pl", cut.Markup);
+        });
+    }
+
+    [Fact]
+    public void HostedOnlyToolUsesDomainQueryInLocalCommand() {
+        var navigation = Services.GetRequiredService<NavigationManager>();
+        navigation.NavigateTo("http://localhost/tools/cert-check/?q=evotec.pl");
+
+        var cut = RenderComponent<DomainDetective.Website.Pages.Tools>(parameters => parameters
+            .Add(component => component.ToolSlug, "cert-check"));
+
+        cut.WaitForAssertion(() => {
+            Assert.Contains("Run deeper locally", cut.Markup);
+            Assert.Contains("Test-DDDomainCertificate -Url", cut.Markup);
+            Assert.Contains("evotec.pl", cut.Markup);
+            Assert.DoesNotContain("_domain", cut.Markup);
+        });
     }
 
     private sealed class StaticHttpMessageHandler : HttpMessageHandler {

--- a/DomainDetective.Website/Pages/Tools.razor
+++ b/DomainDetective.Website/Pages/Tools.razor
@@ -31,14 +31,14 @@
 
         @if (!string.IsNullOrEmpty(_searchQuery)) {
             @if (_filteredAllTools.Count > 0) {
-                <ToolCategoryGrid Tools="_filteredAllTools" DeploymentMode="Availability.Mode" />
+                <ToolCategoryGrid Tools="_filteredAllTools" DeploymentMode="Availability.Mode" Domain="@GetToolDomainQuery()" />
             } else {
                 <div class="tools-empty">
                     <p>No tools match "<strong>@_searchQuery</strong>"</p>
                 </div>
             }
         } else {
-            <ToolCategoryGrid Tools="_allTools" DeploymentMode="Availability.Mode" />
+            <ToolCategoryGrid Tools="_allTools" DeploymentMode="Availability.Mode" Domain="@GetToolDomainQuery()" />
         }
     </div>
 } else {
@@ -59,7 +59,7 @@
                 <p>@tool.Description</p>
             </div>
 
-            <HostedFeaturePreview Tool="tool" />
+            <HostedFeaturePreview Tool="tool" Domain="@GetToolDomainQuery()" />
         </div>
     } else if (!Availability.CanRun(tool)) {
         <div class="tool-page">
@@ -72,7 +72,7 @@
                 <p>@tool.Description</p>
             </div>
 
-            <ToolNotAvailable Tool="tool" />
+            <ToolNotAvailable Tool="tool" Domain="@GetToolDomainQuery()" />
         </div>
     } else {
         <ToolPage Definition="tool" />
@@ -82,6 +82,7 @@
 @code {
     [Parameter] public string? ToolSlug { get; set; }
     [SupplyParameterFromQuery(Name = "domain")] public string? DomainQuery { get; set; }
+    [SupplyParameterFromQuery(Name = "q")] public string? ToolDomainQuery { get; set; }
 
     private bool _isReady;
     private string? _searchQuery;
@@ -121,5 +122,9 @@
         if (!_isReady || string.IsNullOrEmpty(ToolSlug)) return "Tools | Domain Detective";
         var tool = Registry.GetBySlug(ToolSlug);
         return tool is not null ? $"{tool.Name} | Domain Detective" : "Tool Not Available | Domain Detective";
+    }
+
+    private string? GetToolDomainQuery() {
+        return string.IsNullOrWhiteSpace(ToolDomainQuery) ? null : ToolDomainQuery.Trim();
     }
 }

--- a/DomainDetective.Website/wwwroot/css/app.css
+++ b/DomainDetective.Website/wwwroot/css/app.css
@@ -849,15 +849,29 @@ a:hover { color: var(--dd-accent-light); }
 /* ── Tool Input ─────────────────────────────────────────────────── */
 
 .tool-input-form {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.9rem;
+    margin-bottom: 1.25rem;
+    align-items: stretch;
+}
+
+.tool-input-fields {
     display: flex;
     gap: 0.75rem;
-    margin-bottom: 1.5rem;
-    flex-wrap: wrap;
+    min-width: 0;
+}
+
+.tool-input-actions {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(9.5rem, 1fr);
+    gap: 0.75rem;
     align-items: stretch;
 }
 .tool-input-form input {
     flex: 1;
-    min-width: 200px;
+    min-width: 0;
     padding: 0.75rem 1rem;
     background: rgba(16, 24, 39, 0.74);
     border: 1px solid var(--dd-border);
@@ -872,6 +886,37 @@ a:hover { color: var(--dd-accent-light); }
     border-color: var(--dd-accent);
     background: rgba(16, 24, 39, 0.92);
     box-shadow: 0 0 0 3px var(--dd-glow);
+}
+
+.tool-callout-inline + .tool-input-form {
+    margin-top: 1.1rem;
+}
+
+.tool-input-form + .tool-capability-map,
+.tool-example-row + .tool-capability-map,
+.tool-history-row + .tool-capability-map,
+.tool-callout-inline + .tool-capability-map {
+    margin-top: 1rem;
+}
+
+.tool-capability-map + .tool-history-row,
+.tool-example-row + .tool-history-row {
+    margin-top: 1rem;
+}
+
+.tool-input-form + .tool-progress-panel,
+.tool-example-row + .tool-progress-panel,
+.tool-capability-map + .tool-progress-panel,
+.tool-history-row + .tool-progress-panel {
+    margin-top: 1.15rem;
+}
+
+.tool-example-row + .result-card,
+.tool-history-row + .result-card,
+.tool-capability-map + .result-card,
+.tool-progress-panel + .result-card,
+.tool-callout-inline + .result-card {
+    margin-top: 1.35rem;
 }
 
 .tool-input-form input::placeholder {
@@ -891,7 +936,7 @@ a:hover { color: var(--dd-accent-light); }
 
 .tool-input-secondary {
     flex: 0 1 17rem;
-    min-width: 17rem;
+    min-width: 14rem;
     max-width: 20rem;
 }
 
@@ -908,6 +953,9 @@ a:hover { color: var(--dd-accent-light); }
     font-family: var(--dd-font-body);
     position: relative;
     overflow: hidden;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     transition: transform 0.15s ease, box-shadow 0.3s ease, filter 0.3s ease;
     box-shadow: 0 12px 30px rgba(0, 217, 255, 0.18);
 }
@@ -1037,8 +1085,16 @@ a:hover { color: var(--dd-accent-light); }
 
 /* ── Result Tables ──────────────────────────────────────────────── */
 
+.result-table-shell {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
 .result-table {
     width: 100%;
+    table-layout: fixed;
     border-collapse: collapse;
     position: relative;
 }
@@ -1048,6 +1104,10 @@ a:hover { color: var(--dd-accent-light); }
     text-align: left;
     border-bottom: 1px solid var(--dd-border);
     font-size: 0.9rem;
+    vertical-align: top;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
     transition: background 0.15s ease;
 }
 .result-table th {
@@ -1176,6 +1236,13 @@ a:hover { color: var(--dd-accent-light); }
     font-size: 0.9rem;
     transition: background 0.15s ease, padding-left 0.2s ease;
 }
+
+.issues-list li > span:last-child {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+}
+
 .issues-list li:hover {
     background: rgba(0, 217, 255, 0.03);
     padding-left: 0.25rem;
@@ -1277,6 +1344,37 @@ a:hover { color: var(--dd-accent-light); }
 .tool-stack {
     display: grid;
     gap: 1rem;
+    min-width: 0;
+}
+
+.tool-stack > *,
+.tool-summary-card > * {
+    min-width: 0;
+    max-width: 100%;
+}
+
+.tool-export-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    min-width: 0;
+    max-width: 100%;
+}
+
+.tool-export-preview {
+    max-width: 100%;
+    overflow-x: auto;
+    padding: 0.75rem 0.85rem;
+    border-radius: var(--dd-radius-sm);
+    border: 1px solid rgba(0, 217, 255, 0.1);
+    background: rgba(7, 13, 27, 0.74);
+    color: var(--dd-ink);
+    font-family: var(--dd-font-mono);
+    font-size: 0.8rem;
+    line-height: 1.55;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 .tool-callout {
@@ -1389,6 +1487,171 @@ a:hover { color: var(--dd-accent-light); }
 [data-theme="light"] .tool-callout-soft {
     background: linear-gradient(180deg, rgba(250, 252, 255, 0.98), rgba(244, 249, 255, 0.94));
     border-color: rgba(15, 143, 176, 0.12);
+}
+
+.tool-capability-map {
+    display: grid;
+    gap: 0.9rem;
+    padding: 0.95rem 1rem;
+    border: 1px solid rgba(0, 217, 255, 0.11);
+    border-radius: var(--dd-radius-sm);
+    background: linear-gradient(180deg, rgba(13, 21, 48, 0.82), rgba(13, 21, 48, 0.66));
+    box-shadow: 0 10px 22px rgba(2, 6, 23, 0.13);
+}
+
+.tool-capability-map summary {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    gap: 0.3rem 0.7rem;
+    align-items: center;
+    cursor: pointer;
+    color: var(--dd-muted);
+}
+
+.tool-capability-map summary::-webkit-details-marker {
+    display: none;
+}
+
+.tool-capability-map summary::after {
+    content: "+";
+    justify-self: end;
+    grid-column: 3;
+    grid-row: 1;
+    color: var(--dd-accent);
+    font-weight: 800;
+}
+
+.tool-capability-map[open] summary::after {
+    content: "-";
+}
+
+.tool-capability-map summary strong {
+    color: var(--dd-ink-strong);
+    min-width: 0;
+}
+
+.tool-capability-map summary span:last-child {
+    grid-column: 1 / -1;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+
+.tool-capability-kicker {
+    display: inline-flex;
+    width: fit-content;
+    padding: 0.25rem 0.55rem;
+    border-radius: 999px;
+    border: 1px solid rgba(0, 217, 255, 0.13);
+    background: rgba(0, 217, 255, 0.08);
+    color: var(--dd-accent);
+    font-size: 0.74rem;
+    font-weight: 800;
+    text-transform: uppercase;
+}
+
+.tool-capability-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.tool-capability-column {
+    min-width: 0;
+    display: grid;
+    align-content: start;
+    gap: 0.65rem;
+}
+
+.tool-capability-command {
+    display: grid;
+    gap: 0.6rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.tool-capability-command-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.6rem;
+}
+
+.tool-capability-command pre {
+    min-width: 0;
+    overflow-x: auto;
+    padding: 0.75rem 0.85rem;
+    border-radius: var(--dd-radius-sm);
+    border: 1px solid rgba(0, 217, 255, 0.1);
+    background: rgba(7, 13, 27, 0.74);
+    color: var(--dd-ink);
+    font-family: var(--dd-font-mono);
+    font-size: 0.8rem;
+    line-height: 1.55;
+    white-space: pre;
+}
+
+.tool-capability-copy-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2rem;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid rgba(0, 217, 255, 0.14);
+    border-radius: 999px;
+    background: rgba(0, 217, 255, 0.08);
+    color: var(--dd-ink-strong);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.78rem;
+    font-weight: 800;
+}
+
+.tool-capability-copy-btn:hover {
+    border-color: rgba(0, 217, 255, 0.28);
+    background: rgba(0, 217, 255, 0.14);
+}
+
+.tool-capability-copy-btn.is-success {
+    border-color: rgba(34, 197, 94, 0.26);
+    background: rgba(34, 197, 94, 0.12);
+    color: #73e2a1;
+}
+
+.tool-capability-copy-btn.is-failure {
+    border-color: rgba(239, 68, 68, 0.28);
+    background: rgba(239, 68, 68, 0.12);
+    color: #fca5a5;
+}
+
+[data-theme="light"] .tool-capability-map {
+    border-color: rgba(15, 143, 176, 0.14);
+    background: linear-gradient(180deg, rgba(250, 252, 255, 0.98), rgba(244, 249, 255, 0.94));
+}
+
+[data-theme="light"] .tool-capability-kicker {
+    border-color: rgba(15, 143, 176, 0.16);
+    background: rgba(15, 143, 176, 0.08);
+}
+
+[data-theme="light"] .tool-capability-command pre {
+    border-color: rgba(15, 143, 176, 0.14);
+    background: rgba(237, 244, 251, 0.9);
+}
+
+[data-theme="light"] .tool-capability-copy-btn {
+    border-color: rgba(15, 143, 176, 0.16);
+    background: rgba(15, 143, 176, 0.08);
+}
+
+[data-theme="light"] .tool-capability-copy-btn.is-success {
+    color: #157347;
+}
+
+[data-theme="light"] .tool-capability-copy-btn.is-failure {
+    color: #b91c1c;
 }
 
 .overview-detail-card::before,
@@ -1683,7 +1946,7 @@ a:hover { color: var(--dd-accent-light); }
 
 .tool-section-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 380px), 1fr));
     gap: 1.1rem;
     align-items: start;
     max-width: 100%;
@@ -2208,6 +2471,47 @@ a:hover { color: var(--dd-accent-light); }
     margin-top: 0.9rem;
 }
 
+.tool-example-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
+    margin-top: 0.8rem;
+}
+
+.tool-example-label {
+    color: var(--dd-muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.tool-example-chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding: 0.32rem 0.72rem;
+    border: 1px solid rgba(0, 217, 255, 0.12);
+    border-radius: 999px;
+    background: rgba(0, 217, 255, 0.06);
+    color: var(--dd-ink);
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.86rem;
+    transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+
+.tool-example-chip:hover {
+    border-color: rgba(0, 217, 255, 0.24);
+    background: rgba(0, 217, 255, 0.12);
+    transform: translateY(-1px);
+}
+
+.tool-example-chip:disabled {
+    cursor: wait;
+    opacity: 0.62;
+    transform: none;
+}
+
 .tool-history-label {
     color: var(--dd-muted);
     font-size: 0.84rem;
@@ -2246,6 +2550,16 @@ a:hover { color: var(--dd-accent-light); }
 [data-theme="light"] .tool-history-chip:hover {
     border-color: rgba(15, 143, 176, 0.22);
     background: rgba(15, 143, 176, 0.06);
+}
+
+[data-theme="light"] .tool-example-chip {
+    border-color: rgba(15, 143, 176, 0.15);
+    background: rgba(15, 143, 176, 0.06);
+}
+
+[data-theme="light"] .tool-example-chip:hover {
+    border-color: rgba(15, 143, 176, 0.24);
+    background: rgba(15, 143, 176, 0.1);
 }
 
 .tool-progress-panel {
@@ -2306,6 +2620,27 @@ a:hover { color: var(--dd-accent-light); }
     background: linear-gradient(90deg, var(--dd-accent), var(--dd-accent2));
     box-shadow: 0 0 24px rgba(0, 217, 255, 0.18);
     transition: width 0.28s ease;
+    position: relative;
+    overflow: hidden;
+}
+
+.tool-progress-fill::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.42), transparent);
+    transform: translateX(-100%);
+    animation: tool-progress-shimmer 1.35s ease-in-out infinite;
+}
+
+@keyframes tool-progress-shimmer {
+    0% {
+        transform: translateX(-100%);
+    }
+
+    100% {
+        transform: translateX(100%);
+    }
 }
 
 [data-theme="light"] .tool-meta-pill {
@@ -2587,7 +2922,33 @@ a:hover { color: var(--dd-accent-light); }
 @media (max-width: 768px) {
     .tools-hero h1 { font-size: 1.75rem; }
     .category-grid { grid-template-columns: 1fr; }
-    .tool-input-form { flex-direction: column; }
+    .tool-input-form {
+        grid-template-columns: 1fr;
+    }
+    .tool-input-fields,
+    .tool-input-actions {
+        grid-auto-flow: row;
+        grid-auto-columns: auto;
+    }
+    .tool-input-fields {
+        flex-direction: column;
+    }
+    .tool-capability-map summary {
+        grid-template-columns: 1fr auto;
+    }
+    .tool-capability-kicker {
+        grid-column: 1;
+    }
+    .tool-capability-map summary strong {
+        grid-column: 1 / -1;
+    }
+    .tool-capability-map summary::after {
+        grid-column: 2;
+        grid-row: 1;
+    }
+    .tool-capability-grid {
+        grid-template-columns: 1fr;
+    }
     .dd-footer {
         padding: 48px 1.5rem 24px;
     }

--- a/DomainDetective.Website/wwwroot/css/app.css
+++ b/DomainDetective.Website/wwwroot/css/app.css
@@ -2925,7 +2925,6 @@ a:hover { color: var(--dd-accent-light); }
     .tool-input-form {
         grid-template-columns: 1fr;
     }
-    .tool-input-fields,
     .tool-input-actions {
         grid-auto-flow: row;
         grid-auto-columns: auto;

--- a/DomainDetective.Website/wwwroot/data/tools-runtime.json
+++ b/DomainDetective.Website/wwwroot/data/tools-runtime.json
@@ -1,1 +1,3 @@
-{}
+{
+  "mode": "StaticOnly"
+}


### PR DESCRIPTION
## Summary
- Improve browser-mode tool progress updates so long scans keep showing active work.
- Add web-edition capability guidance with deeper local command hints for static/limited tools.
- Improve M365/domain overview wording and browser-safe M365 evidence detection so limited checks do not read like false failures.
- Preserve catalog/tool query domains and improve examples/recent-run affordances.
- Fix responsive spacing, result-table wrapping, and long DNS/export text overflow in tool result cards.

## Validation
- `dotnet test .\DomainDetective.Website.Tests\DomainDetective.Website.Tests.csproj --configuration Release --framework net10.0`
- `git diff --check`
- PowerForge local dev builds with `Website\build.ps1 -Serve -Port <port> -SkipBuildTool`
- Playwright layout audits for SPF, DMARC, DKIM, DNS lookup, M365 overview, Domain overview, hosted-only guided tool, and tools catalog across desktop/mobile widths
