### PR TITLE
Propagate Retry-After from CT ingestion client

### DIFF
--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -1,13 +1,16 @@
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Headers;
 
 namespace DomainDetective.Tests;
 
 public sealed class TestCtLogIngestionClient {
+    private const HttpStatusCode TooManyRequestsStatusCode = (HttpStatusCode)429;
+
     [Fact]
     public async Task GetTreeSizeAsync_PropagatesRetryAfterDelta_FromHttpResponse() {
         var client = new CtLogIngestionClient {
-            SendOverride = static (_, _) => Task.FromResult(CreateFailureResponse(HttpStatusCode.TooManyRequests, delta: TimeSpan.FromSeconds(45)))
+            SendOverride = static (_, _) => Task.FromResult(CreateFailureResponse(TooManyRequestsStatusCode, delta: TimeSpan.FromSeconds(45)))
         };
 
         HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>

--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -1,0 +1,63 @@
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace DomainDetective.Tests;
+
+public sealed class TestCtLogIngestionClient {
+    [Fact]
+    public async Task GetTreeSizeAsync_PropagatesRetryAfterDelta_FromHttpResponse() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateFailureResponse(HttpStatusCode.TooManyRequests, delta: TimeSpan.FromSeconds(45)))
+        };
+
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.GetTreeSizeAsync("https://ct.example.test/", TimeSpan.FromSeconds(5), CancellationToken.None));
+
+        Assert.Contains("Retry-After 45s", exception.Message, StringComparison.Ordinal);
+        TimeSpan retryAfter = Assert.IsType<TimeSpan>(exception.Data["RetryAfter"]);
+        Assert.Equal(TimeSpan.FromSeconds(45), retryAfter);
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_PropagatesRetryAfterDate_FromHttpResponse() {
+        DateTimeOffset retryAfterAt = DateTimeOffset.UtcNow.AddSeconds(75);
+        var client = new CtLogIngestionClient {
+            SendOverride = (_, _) => Task.FromResult(CreateFailureResponse(HttpStatusCode.ServiceUnavailable, date: retryAfterAt))
+        };
+
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.GetTreeSizeAsync("https://ct.example.test/", TimeSpan.FromSeconds(5), CancellationToken.None));
+
+        Assert.Contains("Retry-After", exception.Message, StringComparison.Ordinal);
+        TimeSpan retryAfter = Assert.IsType<TimeSpan>(exception.Data["RetryAfter"]);
+        Assert.InRange(retryAfter, TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(75));
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_DoesNotAttachRetryAfter_WhenHeaderIsMissing() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateFailureResponse(HttpStatusCode.BadGateway))
+        };
+
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.GetTreeSizeAsync("https://ct.example.test/", TimeSpan.FromSeconds(5), CancellationToken.None));
+
+        Assert.DoesNotContain("Retry-After", exception.Message, StringComparison.Ordinal);
+        Assert.False(exception.Data.Contains("RetryAfter"));
+    }
+
+    private static HttpResponseMessage CreateFailureResponse(HttpStatusCode statusCode, TimeSpan? delta = null, DateTimeOffset? date = null) {
+        var response = new HttpResponseMessage(statusCode) {
+            ReasonPhrase = statusCode.ToString(),
+            Content = new StringContent("{}")
+        };
+
+        if (delta.HasValue) {
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(delta.Value);
+        } else if (date.HasValue) {
+            response.Headers.RetryAfter = new RetryConditionHeaderValue(date.Value);
+        }
+
+        return response;
+    }
+}

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
@@ -103,6 +104,7 @@ public sealed class CtLogIngestionClient {
 
     /// <summary>Optional HTTP override used by tests and host applications.</summary>
     public Func<string, CancellationToken, Task<string>>? HttpGetOverride { get; set; }
+    internal Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? SendOverride { get; set; }
 
     /// <summary>
     /// Resolves CT logs from a v3/v2 Google-compatible log list.
@@ -292,9 +294,57 @@ public sealed class CtLogIngestionClient {
         }
 
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        using HttpResponseMessage response = await SharedHttpClient.Instance.SendAsync(request, effectiveToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        using HttpResponseMessage response = SendOverride != null
+            ? await SendOverride(request, effectiveToken).ConfigureAwait(false)
+            : await SharedHttpClient.Instance.SendAsync(request, effectiveToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode) {
+            throw CreateRequestFailure(response);
+        }
+
         return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+    }
+
+    internal static HttpRequestException CreateRequestFailure(HttpResponseMessage response) {
+        ArgumentNullException.ThrowIfNull(response);
+
+        string message = "HTTP " + (int)response.StatusCode + " " + response.ReasonPhrase;
+        TimeSpan retryAfter = ComputeRetryAfterDelay(response);
+        if (retryAfter > TimeSpan.Zero) {
+            message += " (Retry-After " + (int)Math.Ceiling(retryAfter.TotalSeconds) + "s)";
+        }
+
+#if NET5_0_OR_GREATER
+        var exception = new HttpRequestException(message, null, response.StatusCode);
+#else
+        var exception = new HttpRequestException(message);
+#endif
+        if (retryAfter > TimeSpan.Zero) {
+            exception.Data["RetryAfter"] = retryAfter;
+        }
+
+        return exception;
+    }
+
+    internal static TimeSpan ComputeRetryAfterDelay(HttpResponseMessage response) {
+        ArgumentNullException.ThrowIfNull(response);
+
+        if (response.Headers.RetryAfter == null) {
+            return TimeSpan.Zero;
+        }
+
+        if (response.Headers.RetryAfter.Delta.HasValue &&
+            response.Headers.RetryAfter.Delta.Value > TimeSpan.Zero) {
+            return response.Headers.RetryAfter.Delta.Value;
+        }
+
+        if (response.Headers.RetryAfter.Date.HasValue) {
+            TimeSpan delta = response.Headers.RetryAfter.Date.Value - DateTimeOffset.UtcNow;
+            if (delta > TimeSpan.Zero) {
+                return delta;
+            }
+        }
+
+        return TimeSpan.Zero;
     }
 
     private static bool TryDecodeCertificate(

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -104,6 +104,7 @@ public sealed class CtLogIngestionClient {
 
     /// <summary>Optional HTTP override used by tests and host applications.</summary>
     public Func<string, CancellationToken, Task<string>>? HttpGetOverride { get; set; }
+    /// <summary>HTTP send override used by unit tests to inject controlled responses.</summary>
     internal Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? SendOverride { get; set; }
 
     /// <summary>
@@ -305,13 +306,14 @@ public sealed class CtLogIngestionClient {
     }
 
     internal static HttpRequestException CreateRequestFailure(HttpResponseMessage response) {
-        ArgumentNullException.ThrowIfNull(response);
-
-        string message = "HTTP " + (int)response.StatusCode + " " + response.ReasonPhrase;
-        TimeSpan retryAfter = ComputeRetryAfterDelay(response);
-        if (retryAfter > TimeSpan.Zero) {
-            message += " (Retry-After " + (int)Math.Ceiling(retryAfter.TotalSeconds) + "s)";
+        if (response == null) {
+            throw new ArgumentNullException(nameof(response));
         }
+
+        string message = response.ReasonPhrase is { Length: > 0 } reasonPhrase
+            ? "HTTP " + (int)response.StatusCode + " " + reasonPhrase
+            : "HTTP " + (int)response.StatusCode;
+        TimeSpan retryAfter = ComputeRetryAfterDelay(response);
 
 #if NET5_0_OR_GREATER
         var exception = new HttpRequestException(message, null, response.StatusCode);
@@ -319,6 +321,8 @@ public sealed class CtLogIngestionClient {
         var exception = new HttpRequestException(message);
 #endif
         if (retryAfter > TimeSpan.Zero) {
+            message += " (Retry-After " + (long)Math.Ceiling(retryAfter.TotalSeconds) + "s)";
+            exception = CreateRetriableRequestException(message, response.StatusCode);
             exception.Data["RetryAfter"] = retryAfter;
         }
 
@@ -326,7 +330,9 @@ public sealed class CtLogIngestionClient {
     }
 
     internal static TimeSpan ComputeRetryAfterDelay(HttpResponseMessage response) {
-        ArgumentNullException.ThrowIfNull(response);
+        if (response == null) {
+            throw new ArgumentNullException(nameof(response));
+        }
 
         if (response.Headers.RetryAfter == null) {
             return TimeSpan.Zero;
@@ -345,6 +351,14 @@ public sealed class CtLogIngestionClient {
         }
 
         return TimeSpan.Zero;
+    }
+
+    private static HttpRequestException CreateRetriableRequestException(string message, HttpStatusCode statusCode) {
+#if NET5_0_OR_GREATER
+        return new HttpRequestException(message, null, statusCode);
+#else
+        return new HttpRequestException(message);
+#endif
     }
 
     private static bool TryDecodeCertificate(


### PR DESCRIPTION
## Summary
- preserve CT log Retry-After guidance in CtLogIngestionClient failures instead of dropping it via EnsureSuccessStatusCode
- attach Retry-After to the thrown HttpRequestException message and Exception.Data so DDCT and other consumers can honor it
- add focused tests covering Retry-After delta, Retry-After date, and missing-header behavior

## Why
DDCT already knows how to honor a Retry-After value when the underlying exception carries it. The native CT ingestion client was losing that signal, which forced DDCT to fall back to heuristic cooldowns even when the CT server provided explicit retry guidance.

## Validation
- dotnet test DomainDetective.Tests\\DomainDetective.Tests.csproj -c Release -f net10.0 --filter TestCtLogIngestionClient