### PR TITLE
Add DDCT API CT provider

### DIFF
--- a/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
@@ -15,6 +15,7 @@ public class TestDdctApiCertificateTransparencyProvider
     public async Task QueryAsyncHydratesLatestCertificateFromDerEndpoint()
     {
         byte[] der = LoadPemCertificateDer("multi.pem");
+        string? noContinuation = null;
         var handler = new HttpStubMessageHandler((request, _) =>
         {
             string pathAndQuery = request.RequestUri!.PathAndQuery;
@@ -36,7 +37,7 @@ public class TestDdctApiCertificateTransparencyProvider
                     },
                     limit = 100,
                     offset = 0,
-                    nextContinuation = (string?)null,
+                    nextContinuation = noContinuation,
                     hasMore = false
                 });
             }
@@ -51,10 +52,7 @@ public class TestDdctApiCertificateTransparencyProvider
 
             throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
         });
-        using var httpClient = new HttpClient(handler)
-        {
-            BaseAddress = new Uri("http://127.0.0.1:8080")
-        };
+        using var httpClient = new HttpClient(handler);
         var provider = new DdctApiCertificateTransparencyProvider(
             httpClient,
             new DdctApiCertificateTransparencyProviderOptions
@@ -81,6 +79,7 @@ public class TestDdctApiCertificateTransparencyProvider
     public async Task QueryAsyncUsesObservationPagesForDomainExpansion()
     {
         int requestCount = 0;
+        string? noContinuation = null;
         var handler = new HttpStubMessageHandler((request, _) =>
         {
             requestCount++;
@@ -96,7 +95,7 @@ public class TestDdctApiCertificateTransparencyProvider
                     },
                     limit = 2,
                     offset = 2,
-                    nextContinuation = (string?)null,
+                    nextContinuation = noContinuation,
                     hasMore = false
                 });
             }
@@ -133,6 +132,163 @@ public class TestDdctApiCertificateTransparencyProvider
         Assert.False(result.HasMore);
     }
 
+    [Fact]
+    public async Task QueryAsyncReturnsEmptyResultWhenCertificatePageIsMissing()
+    {
+        var handler = new HttpStubMessageHandler((_, _) => new HttpResponseMessage(HttpStatusCode.NotFound));
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080"
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForExactHostLatest("missing.example.test"));
+
+        Assert.Empty(result.Certificates);
+        Assert.Empty(result.DiscoveredNames);
+        Assert.False(result.HasMore);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public async Task QueryAsyncAddsDiagnosticWhenHistoryHitsConfiguredPageCap()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+        int page = 0;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates/paged?", StringComparison.Ordinal))
+            {
+                page++;
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[]
+                    {
+                        new
+                        {
+                            sha256Fingerprint = "cert-" + page,
+                            matchedName = "www.example.test",
+                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 1,
+                    offset = page - 1,
+                    nextContinuation = "token-" + page,
+                    hasMore = true
+                });
+            }
+
+            if (pathAndQuery.StartsWith("/api/v1/certificates/cert-", StringComparison.Ordinal))
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(der)
+                };
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                QueryPageSize = 1,
+                MaxPagesPerQuery = 2
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForExactHostHistory("www.example.test"));
+
+        Assert.Single(result.Certificates);
+        Assert.True(result.HasMore);
+        Assert.Contains(result.Diagnostics, message => message.Contains("page cap", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task QueryAsyncUsesBearerAuthorizationHeaderWhenRequested()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+        string? noContinuation = null;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            Assert.Equal("Bearer", request.Headers.Authorization?.Scheme);
+            Assert.Equal("secret", request.Headers.Authorization?.Parameter);
+
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates/paged?", StringComparison.Ordinal))
+            {
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[]
+                    {
+                        new
+                        {
+                            sha256Fingerprint = "bearer123",
+                            matchedName = "www.example.test",
+                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 100,
+                    offset = 0,
+                    nextContinuation = noContinuation,
+                    hasMore = false
+                });
+            }
+
+            if (pathAndQuery == "/api/v1/certificates/bearer123/der")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(der)
+                };
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                ApiKey = "secret",
+                ApiKeyHeaderName = "Authorization"
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForExactHostLatest("www.example.test"));
+
+        Assert.Single(result.Certificates);
+    }
+
+    [Fact]
+    public async Task QueryAsyncThrowsForNonSuccessResponses()
+    {
+        var handler = new HttpStubMessageHandler((_, _) => new HttpResponseMessage(HttpStatusCode.BadGateway));
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080"
+            });
+
+        HttpRequestException ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            provider.QueryAsync(CtCertificateQuery.ForExactHostLatest("www.example.test")));
+
+        Assert.Contains("502", ex.Message, StringComparison.Ordinal);
+    }
+
     private static HttpResponseMessage Json<T>(HttpStatusCode statusCode, T value)
     {
         return new HttpResponseMessage(statusCode)
@@ -145,8 +301,11 @@ public class TestDdctApiCertificateTransparencyProvider
     {
         string safeFileName = Path.GetFileName(fileName);
         Assert.Equal(fileName, safeFileName);
+        Assert.False(Path.IsPathRooted(safeFileName));
         string dataDirectory = Path.Combine(AppContext.BaseDirectory, "Data");
-        string pem = File.ReadAllText(Path.Combine(dataDirectory, safeFileName));
+        string pemPath = Path.GetFullPath(Path.Combine(dataDirectory, safeFileName));
+        Assert.StartsWith(Path.GetFullPath(dataDirectory), Path.GetDirectoryName(pemPath) ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+        string pem = File.ReadAllText(pemPath);
         const string begin = "-----BEGIN CERTIFICATE-----";
         const string end = "-----END CERTIFICATE-----";
         int start = pem.IndexOf(begin, StringComparison.Ordinal);

--- a/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestDdctApiCertificateTransparencyProvider
+{
+    [Fact]
+    public async Task QueryAsyncHydratesLatestCertificateFromDerEndpoint()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates/paged?", StringComparison.Ordinal))
+            {
+                Assert.Equal("secret", string.Join(",", request.Headers.GetValues("X-DDCT-Api-Key")));
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[]
+                    {
+                        new
+                        {
+                            sha256Fingerprint = "abc123",
+                            matchedName = "www.example.test",
+                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 100,
+                    offset = 0,
+                    nextContinuation = (string?)null,
+                    hasMore = false
+                });
+            }
+
+            if (pathAndQuery == "/api/v1/certificates/abc123/der")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(der)
+                };
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("http://127.0.0.1:8080")
+        };
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                ApiKey = "secret",
+                ScopeName = "internal",
+                QueryPageSize = 100,
+                MaxPagesPerQuery = 5
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForExactHostLatest("www.example.test"));
+
+        CtCertificateRecord record = Assert.Single(result.Certificates);
+        Assert.Equal(CtProviderProfiles.DdctApiProviderId, result.ProviderId);
+        Assert.Equal(CtProviderProfiles.DdctApiProviderId, record.ProviderId);
+        Assert.Equal("www.example.test", Assert.Single(result.DiscoveredNames));
+        Assert.Equal("abc123", record.ProviderCertificateId);
+        Assert.False(result.HasMore);
+    }
+
+    [Fact]
+    public async Task QueryAsyncUsesObservationPagesForDomainExpansion()
+    {
+        int requestCount = 0;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            requestCount++;
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.Contains("continuation=next-token", StringComparison.Ordinal))
+            {
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[]
+                    {
+                        new { matchedName = "mail.example.test" },
+                        new { matchedName = "api.example.test" }
+                    },
+                    limit = 2,
+                    offset = 2,
+                    nextContinuation = (string?)null,
+                    hasMore = false
+                });
+            }
+
+            return Json(HttpStatusCode.OK, new
+            {
+                items = new[]
+                {
+                    new { matchedName = "api.example.test" },
+                    new { matchedName = "www.example.test" }
+                },
+                limit = 2,
+                offset = 0,
+                nextContinuation = "next-token",
+                hasMore = true
+            });
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                MaxPagesPerQuery = 5
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForDomainExpansion("example.test"));
+
+        Assert.Equal(2, requestCount);
+        Assert.Equal(
+            new[] { "api.example.test", "mail.example.test", "www.example.test" },
+            result.DiscoveredNames);
+        Assert.False(result.HasMore);
+    }
+
+    private static HttpResponseMessage Json<T>(HttpStatusCode statusCode, T value)
+    {
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(value), Encoding.UTF8, "application/json")
+        };
+    }
+
+    private static byte[] LoadPemCertificateDer(string fileName)
+    {
+        string safeFileName = Path.GetFileName(fileName);
+        Assert.Equal(fileName, safeFileName);
+        string dataDirectory = Path.Combine(AppContext.BaseDirectory, "Data");
+        string pem = File.ReadAllText(Path.Combine(dataDirectory, safeFileName));
+        const string begin = "-----BEGIN CERTIFICATE-----";
+        const string end = "-----END CERTIFICATE-----";
+        int start = pem.IndexOf(begin, StringComparison.Ordinal);
+        int finish = pem.IndexOf(end, StringComparison.Ordinal);
+        Assert.True(start >= 0 && finish > start, "Expected PEM certificate fixture.");
+        string base64 = pem.Substring(start + begin.Length, finish - start - begin.Length)
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Trim();
+        return Convert.FromBase64String(base64);
+    }
+}

--- a/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
@@ -44,6 +44,7 @@ public class TestDdctApiCertificateTransparencyProvider
 
             if (pathAndQuery == "/api/v1/certificates/abc123/der")
             {
+                Assert.DoesNotContain(request.Headers.Accept, static header => string.Equals(header.MediaType, "application/json", StringComparison.OrdinalIgnoreCase));
                 return new HttpResponseMessage(HttpStatusCode.OK)
                 {
                     Content = new ByteArrayContent(der)
@@ -125,11 +126,12 @@ public class TestDdctApiCertificateTransparencyProvider
         CtCertificateQueryResult result = await provider.QueryAsync(
             CtCertificateQuery.ForDomainExpansion("example.test"));
 
-        Assert.Equal(2, requestCount);
+        Assert.Equal(1, requestCount);
         Assert.Equal(
-            new[] { "api.example.test", "mail.example.test", "www.example.test" },
+            new[] { "api.example.test", "www.example.test" },
             result.DiscoveredNames);
-        Assert.False(result.HasMore);
+        Assert.True(result.HasMore);
+        Assert.Equal("next-token", result.ContinuationToken);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
@@ -289,6 +289,87 @@ public class TestDdctApiCertificateTransparencyProvider
         Assert.Contains("502", ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task QueryAsyncRejectsEmptyQueryNames()
+    {
+        using var httpClient = new HttpClient(new HttpStubMessageHandler((_, _) => throw new InvalidOperationException("HTTP should not be called for empty names.")));
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080"
+            });
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            provider.QueryAsync(CtCertificateQuery.ForExactHostLatest("   ")));
+    }
+
+    [Fact]
+    public async Task QueryAsyncClampsRequestedCertificateCountToEffectivePageSize()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+        int pageRequestCount = 0;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates/paged?", StringComparison.Ordinal))
+            {
+                pageRequestCount++;
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[]
+                    {
+                        new
+                        {
+                            sha256Fingerprint = "oversized-page",
+                            matchedName = "www.example.test",
+                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 500,
+                    offset = 0,
+                    nextContinuation = "next-token",
+                    hasMore = true
+                });
+            }
+
+            if (pathAndQuery == "/api/v1/certificates/oversized-page/der")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(der)
+                };
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                QueryPageSize = 500,
+                MaxPagesPerQuery = 5
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            new CtCertificateQuery
+            {
+                Name = "www.example.test",
+                QueryKind = CtCertificateQueryKind.ExactHostHistory,
+                Operations = CtIngestionOperation.GetCertificateHistory,
+                RequireFullCertificate = true,
+                PageSize = 600
+            });
+
+        Assert.Single(result.Certificates);
+        Assert.Equal(1, pageRequestCount);
+        Assert.Contains(result.Diagnostics, message => message.Contains("page cap", StringComparison.OrdinalIgnoreCase));
+    }
+
     private static HttpResponseMessage Json<T>(HttpStatusCode statusCode, T value)
     {
         return new HttpResponseMessage(statusCode)

--- a/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
+++ b/DomainDetective/CertificateTransparency/CtProviderProfiles.cs
@@ -20,6 +20,9 @@ public static class CtProviderProfiles
     /// <summary>Native CT log provider identifier.</summary>
     public const string NativeCtProviderId = "native-ct";
 
+    /// <summary>DomainDetectiveCertificateTransparency API provider identifier.</summary>
+    public const string DdctApiProviderId = "ddct-api";
+
     /// <summary>
     /// Creates the conservative default profile for crt.sh HTTPS queries.
     /// </summary>
@@ -274,6 +277,35 @@ public static class CtProviderProfiles
                 CooldownAfterRateLimit = options.NativeCtCircuitBreakerDuration
             },
             Notes = defaults.Notes
+        };
+    }
+
+    /// <summary>
+    /// Creates the default profile for a DomainDetectiveCertificateTransparency API endpoint.
+    /// </summary>
+    public static CtProviderProfile CreateDdctApi()
+    {
+        return new CtProviderProfile
+        {
+            ProviderId = DdctApiProviderId,
+            DisplayName = "DDCT API",
+            Capabilities = CtProviderCapabilities.SubdomainExpansion |
+                           CtProviderCapabilities.ExactHostLookup |
+                           CtProviderCapabilities.CertificateHistory |
+                           CtProviderCapabilities.DomainTreeHistory |
+                           CtProviderCapabilities.FullCertificateDer |
+                           CtProviderCapabilities.Pagination |
+                           CtProviderCapabilities.AuthenticationRecommended,
+            RateLimit = new CtProviderRateLimitProfile
+            {
+                MaxConcurrentRequests = 2,
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                EstimatedRequestDuration = TimeSpan.FromSeconds(3),
+                RetryBaseDelay = TimeSpan.FromSeconds(1),
+                RetryMaxDelay = TimeSpan.FromSeconds(30),
+                CooldownAfterRateLimit = TimeSpan.FromMinutes(5)
+            },
+            Notes = "Queries a local DomainDetectiveCertificateTransparency service for CT search, history, and certificate DER hydration."
         };
     }
 

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -87,7 +87,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         CtProviderRuntimeState? runtimeState = null,
         CancellationToken cancellationToken = default)
     {
-        CtCertificateQuery normalized = (query ?? throw new ArgumentNullException(nameof(query))).Normalize();
+        CtCertificateQuery normalized = WithNormalizedName((query ?? throw new ArgumentNullException(nameof(query))).Normalize());
         using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         if (normalized.Timeout.HasValue)
         {
@@ -266,7 +266,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             throw new HttpRequestException($"DDCT API returned {(int)response.StatusCode} {response.ReasonPhrase}");
         }
 
-        using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        using Stream stream = await ReadContentStreamAsync(response.Content, cancellationToken).ConfigureAwait(false);
         T? payload = await JsonSerializer.DeserializeAsync<T>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
         return payload ?? throw new InvalidOperationException("DDCT API returned an empty JSON payload.");
     }
@@ -286,7 +286,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             throw new HttpRequestException($"DDCT DER endpoint returned {(int)response.StatusCode} {response.ReasonPhrase}");
         }
 
-        return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+        return await ReadContentBytesAsync(response.Content, cancellationToken).ConfigureAwait(false);
     }
 
     private HttpRequestMessage CreateRequest(HttpMethod method, string url)
@@ -339,7 +339,33 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             DdctApiCertificateTransparencyProviderOptions.MaxQueryPageSize);
 
     private int ResolveRequestedCertificateCount(CtCertificateQuery query)
-        => Math.Max(query.PageSize.GetValueOrDefault(_configuredQueryPageSize), 1);
+        => ClampInt(
+            query.PageSize.GetValueOrDefault(_configuredQueryPageSize),
+            1,
+            DdctApiCertificateTransparencyProviderOptions.MaxQueryPageSize);
+
+    private static string NormalizeQueryName(string? value)
+    {
+        string normalized = NormalizeHostName(value);
+        if (normalized.Length == 0)
+        {
+            throw new ArgumentException("CT query name must not be empty.", nameof(value));
+        }
+
+        return normalized;
+    }
+
+    private static CtCertificateQuery WithNormalizedName(CtCertificateQuery query)
+        => new CtCertificateQuery
+        {
+            Name = NormalizeQueryName(query.Name),
+            QueryKind = query.QueryKind,
+            Operations = query.Operations,
+            RequireFullCertificate = query.RequireFullCertificate,
+            ContinuationToken = query.ContinuationToken,
+            PageSize = query.PageSize,
+            Timeout = query.Timeout
+        };
 
     private int ResolveMaximumPageCount(int pageSize, int maxCertificates)
     {
@@ -362,6 +388,26 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
 
     private static IReadOnlyList<string> BuildDiagnostics(bool truncated)
         => truncated ? new[] { "DDCT query reached the configured page cap before exhausting results." } : Array.Empty<string>();
+
+    private static async Task<Stream> ReadContentStreamAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+#if NET472
+        cancellationToken.ThrowIfCancellationRequested();
+        return await content.ReadAsStreamAsync().ConfigureAwait(false);
+#else
+        return await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#endif
+    }
+
+    private static async Task<byte[]> ReadContentBytesAsync(HttpContent content, CancellationToken cancellationToken)
+    {
+#if NET472
+        cancellationToken.ThrowIfCancellationRequested();
+        return await content.ReadAsByteArrayAsync().ConfigureAwait(false);
+#else
+        return await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+#endif
+    }
 
     private sealed class DdctPage<TItem>
     {

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -215,34 +215,19 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         string? continuation,
         CancellationToken cancellationToken)
     {
-        var items = new List<DdctObservationDto>();
-        string? currentContinuation = continuation;
-        string? lastContinuation = continuation;
-
-        for (int pageIndex = 0; pageIndex < _maxPagesPerQuery; pageIndex++)
+        string url = BuildPagedUrl("/api/v1/observations/paged", name, includeSubdomains, pageSize, continuation);
+        DdctPageDto<DdctObservationDto> page = await SendPageAsync<DdctObservationDto>(url, cancellationToken).ConfigureAwait(false);
+        if (page.Items.Count == 0)
         {
-            string url = BuildPagedUrl("/api/v1/observations/paged", name, includeSubdomains, pageSize, currentContinuation);
-            DdctPageDto<DdctObservationDto> page = await SendPageAsync<DdctObservationDto>(url, cancellationToken).ConfigureAwait(false);
-            if (page.Items.Count == 0)
-            {
-                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, null, false, false);
-            }
-
-            items.AddRange(page.Items);
-            if (!page.HasMore || string.IsNullOrWhiteSpace(page.NextContinuation) || string.Equals(page.NextContinuation, lastContinuation, StringComparison.Ordinal))
-            {
-                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, false);
-            }
-
-            lastContinuation = currentContinuation = page.NextContinuation;
+            return new DdctPage<DdctObservationDto>(Array.Empty<DdctObservationDto>(), page.Limit, page.Offset, null, false, false);
         }
 
-        return new DdctPage<DdctObservationDto>(items, pageSize, 0, currentContinuation, true, true);
+        return new DdctPage<DdctObservationDto>(page.Items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, false);
     }
 
     private async Task<DdctPageDto<TItem>> SendPageAsync<TItem>(string url, CancellationToken cancellationToken)
     {
-        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url);
+        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url, acceptJson: false);
         using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -274,7 +259,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
     private async Task<byte[]> DownloadCertificateDerAsync(string sha256Fingerprint, CancellationToken cancellationToken)
     {
         string url = BuildPath("/api/v1/certificates/" + Uri.EscapeDataString(sha256Fingerprint) + "/der");
-        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url);
+        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url, acceptJson: false);
         using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
@@ -289,7 +274,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         return await ReadContentBytesAsync(response.Content, cancellationToken).ConfigureAwait(false);
     }
 
-    private HttpRequestMessage CreateRequest(HttpMethod method, string url)
+    private HttpRequestMessage CreateRequest(HttpMethod method, string url, bool acceptJson = true)
     {
         var request = new HttpRequestMessage(method, url);
         if (!string.IsNullOrWhiteSpace(_apiKey))
@@ -304,7 +289,11 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             }
         }
 
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        if (acceptJson)
+        {
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        }
+
         return request;
     }
 

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -137,6 +137,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             query.Name,
             includeSubdomains,
             pageSize,
+            maxCertificates,
             query.ContinuationToken,
             cancellationToken).ConfigureAwait(false);
 
@@ -177,31 +178,31 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         string name,
         bool includeSubdomains,
         int pageSize,
+        int maxCertificates,
         string? continuation,
         CancellationToken cancellationToken)
     {
         var items = new List<DdctCertificateSearchDto>();
         string? currentContinuation = continuation;
         string? lastContinuation = continuation;
-        bool truncated = false;
+        int maxPages = ResolveMaximumPageCount(pageSize, maxCertificates);
 
-        for (int pageIndex = 0; pageIndex < _maxPagesPerQuery; pageIndex++)
+        for (int pageIndex = 0; pageIndex < maxPages; pageIndex++)
         {
             string url = BuildPagedUrl("/api/v1/certificates/paged", name, includeSubdomains, pageSize, currentContinuation);
-            DdctPageDto<DdctCertificateSearchDto> page = await SendJsonAsync<DdctPageDto<DdctCertificateSearchDto>>(HttpMethod.Get, url, cancellationToken).ConfigureAwait(false);
+            DdctPageDto<DdctCertificateSearchDto> page = await SendPageAsync<DdctCertificateSearchDto>(url, cancellationToken).ConfigureAwait(false);
             if (page.Items.Count == 0)
             {
-                return new DdctPage<DdctCertificateSearchDto>(items, page.Limit, page.Offset, null, false, truncated);
+                return new DdctPage<DdctCertificateSearchDto>(items, page.Limit, page.Offset, null, false, false);
             }
 
             items.AddRange(page.Items);
             if (!page.HasMore || string.IsNullOrWhiteSpace(page.NextContinuation) || string.Equals(page.NextContinuation, lastContinuation, StringComparison.Ordinal))
             {
-                return new DdctPage<DdctCertificateSearchDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, truncated);
+                return new DdctPage<DdctCertificateSearchDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, false);
             }
 
             lastContinuation = currentContinuation = page.NextContinuation;
-            truncated = pageIndex + 1 >= _maxPagesPerQuery - 1;
         }
 
         return new DdctPage<DdctCertificateSearchDto>(items, pageSize, 0, currentContinuation, true, true);
@@ -217,59 +218,49 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         var items = new List<DdctObservationDto>();
         string? currentContinuation = continuation;
         string? lastContinuation = continuation;
-        bool truncated = false;
 
         for (int pageIndex = 0; pageIndex < _maxPagesPerQuery; pageIndex++)
         {
             string url = BuildPagedUrl("/api/v1/observations/paged", name, includeSubdomains, pageSize, currentContinuation);
-            DdctPageDto<DdctObservationDto> page = await SendJsonAsync<DdctPageDto<DdctObservationDto>>(HttpMethod.Get, url, cancellationToken).ConfigureAwait(false);
+            DdctPageDto<DdctObservationDto> page = await SendPageAsync<DdctObservationDto>(url, cancellationToken).ConfigureAwait(false);
             if (page.Items.Count == 0)
             {
-                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, null, false, truncated);
+                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, null, false, false);
             }
 
             items.AddRange(page.Items);
             if (!page.HasMore || string.IsNullOrWhiteSpace(page.NextContinuation) || string.Equals(page.NextContinuation, lastContinuation, StringComparison.Ordinal))
             {
-                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, truncated);
+                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, false);
             }
 
             lastContinuation = currentContinuation = page.NextContinuation;
-            truncated = pageIndex + 1 >= _maxPagesPerQuery - 1;
         }
 
         return new DdctPage<DdctObservationDto>(items, pageSize, 0, currentContinuation, true, true);
     }
 
-    private async Task<T> SendJsonAsync<T>(HttpMethod method, string url, CancellationToken cancellationToken)
+    private async Task<DdctPageDto<TItem>> SendPageAsync<TItem>(string url, CancellationToken cancellationToken)
     {
-        using HttpRequestMessage request = CreateRequest(method, url);
+        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url);
         using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            if (typeof(T) == typeof(DdctPageDto<DdctCertificateSearchDto>))
+            return new DdctPageDto<TItem>
             {
-                return (T)(object)new DdctPageDto<DdctCertificateSearchDto> {
-                    Items = Array.Empty<DdctCertificateSearchDto>(),
-                    Limit = 0,
-                    Offset = 0,
-                    NextContinuation = null,
-                    HasMore = false
-                };
-            }
-
-            if (typeof(T) == typeof(DdctPageDto<DdctObservationDto>))
-            {
-                return (T)(object)new DdctPageDto<DdctObservationDto> {
-                    Items = Array.Empty<DdctObservationDto>(),
-                    Limit = 0,
-                    Offset = 0,
-                    NextContinuation = null,
-                    HasMore = false
-                };
-            }
+                Items = Array.Empty<TItem>(),
+                Limit = 0,
+                Offset = 0,
+                NextContinuation = null,
+                HasMore = false
+            };
         }
 
+        return await DeserializeJsonAsync<DdctPageDto<TItem>>(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<T> DeserializeJsonAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
+    {
         if (!response.IsSuccessStatusCode)
         {
             throw new HttpRequestException($"DDCT API returned {(int)response.StatusCode} {response.ReasonPhrase}");
@@ -347,18 +338,24 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             1,
             DdctApiCertificateTransparencyProviderOptions.MaxQueryPageSize);
 
-    private static int ResolveRequestedCertificateCount(CtCertificateQuery query)
-        => Math.Max(query.PageSize.GetValueOrDefault(DdctApiCertificateTransparencyProviderOptions.DefaultQueryPageSize), 1);
+    private int ResolveRequestedCertificateCount(CtCertificateQuery query)
+        => Math.Max(query.PageSize.GetValueOrDefault(_configuredQueryPageSize), 1);
+
+    private int ResolveMaximumPageCount(int pageSize, int maxCertificates)
+    {
+        int pagesNeeded = (int)Math.Ceiling(Math.Max(maxCertificates, 1) / (double)Math.Max(pageSize, 1));
+        return ClampInt(pagesNeeded, 1, _maxPagesPerQuery);
+    }
 
     private static string NormalizeEndpointUrl(string? value)
         => string.IsNullOrWhiteSpace(value)
             ? DdctApiCertificateTransparencyProviderOptions.DefaultEndpointUrl
-            : (value ?? string.Empty).Trim().TrimEnd('/');
+            : value!.Trim().TrimEnd('/');
 
     private static string NormalizeHostName(string? value)
         => string.IsNullOrWhiteSpace(value)
             ? string.Empty
-            : (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+            : value!.Trim().TrimEnd('.').ToLowerInvariant();
 
     private static int ClampInt(int value, int minimum, int maximum)
         => value < minimum ? minimum : (value > maximum ? maximum : value);

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -1,0 +1,433 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>
+/// CT provider that queries a DomainDetectiveCertificateTransparency API endpoint.
+/// </summary>
+public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTransparencyProvider
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly string _endpointUrl;
+    private readonly string? _apiKey;
+    private readonly string _apiKeyHeaderName;
+    private readonly string? _scopeName;
+    private readonly int _configuredQueryPageSize;
+    private readonly int _maxPagesPerQuery;
+
+    /// <summary>
+    /// Creates a provider that uses a default shared <see cref="HttpClient"/>.
+    /// </summary>
+    public DdctApiCertificateTransparencyProvider()
+        : this(SharedHttpClient.Instance, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider with a caller-supplied <see cref="HttpClient"/>.
+    /// </summary>
+    public DdctApiCertificateTransparencyProvider(HttpClient httpClient)
+        : this(httpClient, null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a provider with caller-supplied <see cref="HttpClient"/> and options.
+    /// </summary>
+    public DdctApiCertificateTransparencyProvider(
+        HttpClient httpClient,
+        DdctApiCertificateTransparencyProviderOptions? options)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        DdctApiCertificateTransparencyProviderOptions normalized = options ?? new DdctApiCertificateTransparencyProviderOptions();
+        _endpointUrl = NormalizeEndpointUrl(normalized.EndpointUrl);
+        string apiKey = normalized.ApiKey ?? string.Empty;
+        _apiKey = string.IsNullOrWhiteSpace(apiKey) ? null : apiKey.Trim();
+        string apiKeyHeaderName = normalized.ApiKeyHeaderName ?? string.Empty;
+        _apiKeyHeaderName = string.IsNullOrWhiteSpace(apiKeyHeaderName)
+            ? DdctApiCertificateTransparencyProviderOptions.DefaultApiKeyHeaderName
+            : apiKeyHeaderName.Trim();
+        string scopeName = normalized.ScopeName ?? string.Empty;
+        _scopeName = string.IsNullOrWhiteSpace(scopeName) ? null : scopeName.Trim();
+        _configuredQueryPageSize = ClampInt(
+            normalized.QueryPageSize,
+            1,
+            DdctApiCertificateTransparencyProviderOptions.MaxQueryPageSize);
+        _maxPagesPerQuery = ClampInt(
+            normalized.MaxPagesPerQuery,
+            1,
+            DdctApiCertificateTransparencyProviderOptions.MaxAllowedPagesPerQuery);
+        Profile = CtProviderProfiles.CreateDdctApi();
+    }
+
+    /// <inheritdoc />
+    public string ProviderId => CtProviderProfiles.DdctApiProviderId;
+
+    /// <inheritdoc />
+    public CtProviderProfile Profile { get; }
+
+    /// <inheritdoc />
+    public async Task<CtCertificateQueryResult> QueryAsync(
+        CtCertificateQuery query,
+        CtProviderRuntimeState? runtimeState = null,
+        CancellationToken cancellationToken = default)
+    {
+        CtCertificateQuery normalized = (query ?? throw new ArgumentNullException(nameof(query))).Normalize();
+        using CancellationTokenSource timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        if (normalized.Timeout.HasValue)
+        {
+            timeout.CancelAfter(normalized.Timeout.Value);
+        }
+
+        return normalized.QueryKind switch
+        {
+            CtCertificateQueryKind.DomainExpansion => await QueryDomainExpansionAsync(normalized, timeout.Token).ConfigureAwait(false),
+            CtCertificateQueryKind.ExactHostHistory => await QueryCertificatesAsync(normalized, includeSubdomains: false, ResolveRequestedCertificateCount(normalized), timeout.Token).ConfigureAwait(false),
+            CtCertificateQueryKind.DomainTreeCertificates => await QueryCertificatesAsync(normalized, includeSubdomains: true, ResolveRequestedCertificateCount(normalized), timeout.Token).ConfigureAwait(false),
+            _ => await QueryCertificatesAsync(normalized, includeSubdomains: false, 1, timeout.Token).ConfigureAwait(false)
+        };
+    }
+
+    private async Task<CtCertificateQueryResult> QueryDomainExpansionAsync(CtCertificateQuery query, CancellationToken cancellationToken)
+    {
+        int pageSize = ResolvePageSize(query.PageSize);
+        DdctPage<DdctObservationDto> page = await QueryObservationPagesAsync(
+            query.Name,
+            includeSubdomains: true,
+            pageSize,
+            query.ContinuationToken,
+            cancellationToken).ConfigureAwait(false);
+
+        string[] names = page.Items
+            .Select(static item => NormalizeHostName(item.MatchedName))
+            .Where(static name => name.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new CtCertificateQueryResult
+        {
+            ProviderId = ProviderId,
+            DiscoveredNames = names,
+            HasMore = page.HasMore,
+            ContinuationToken = page.NextContinuation,
+            Diagnostics = BuildDiagnostics(page.Truncated)
+        };
+    }
+
+    private async Task<CtCertificateQueryResult> QueryCertificatesAsync(CtCertificateQuery query, bool includeSubdomains, int maxCertificates, CancellationToken cancellationToken)
+    {
+        int pageSize = ResolvePageSize(query.PageSize);
+        DdctPage<DdctCertificateSearchDto> page = await QueryCertificatePagesAsync(
+            query.Name,
+            includeSubdomains,
+            pageSize,
+            query.ContinuationToken,
+            cancellationToken).ConfigureAwait(false);
+
+        IEnumerable<DdctCertificateSearchDto> ordered = page.Items
+            .OrderByDescending(static item => item.LastCtObservedAtUtc ?? item.FirstCtObservedAtUtc ?? item.LastIngestedByDdctAtUtc ?? DateTimeOffset.MinValue)
+            .ThenByDescending(static item => item.NotAfterUtc ?? DateTimeOffset.MinValue);
+
+        var certificates = new List<CtCertificateRecord>(maxCertificates);
+        foreach (DdctCertificateSearchDto item in ordered.Take(maxCertificates))
+        {
+            byte[] der = await DownloadCertificateDerAsync(item.Sha256Fingerprint, cancellationToken).ConfigureAwait(false);
+            certificates.Add(CtCertificateRecord.FromDer(
+                ProviderId,
+                der,
+                providerCertificateId: item.Sha256Fingerprint,
+                entryTimestampUtc: item.LastCtObservedAtUtc ?? item.FirstCtObservedAtUtc));
+        }
+
+        string[] discoveredNames = page.Items
+            .Select(static item => NormalizeHostName(item.MatchedName))
+            .Where(static name => name.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        return new CtCertificateQueryResult
+        {
+            ProviderId = ProviderId,
+            Certificates = certificates,
+            DiscoveredNames = discoveredNames,
+            HasMore = page.HasMore,
+            ContinuationToken = page.NextContinuation,
+            Diagnostics = BuildDiagnostics(page.Truncated)
+        };
+    }
+
+    private async Task<DdctPage<DdctCertificateSearchDto>> QueryCertificatePagesAsync(
+        string name,
+        bool includeSubdomains,
+        int pageSize,
+        string? continuation,
+        CancellationToken cancellationToken)
+    {
+        var items = new List<DdctCertificateSearchDto>();
+        string? currentContinuation = continuation;
+        string? lastContinuation = continuation;
+        bool truncated = false;
+
+        for (int pageIndex = 0; pageIndex < _maxPagesPerQuery; pageIndex++)
+        {
+            string url = BuildPagedUrl("/api/v1/certificates/paged", name, includeSubdomains, pageSize, currentContinuation);
+            DdctPageDto<DdctCertificateSearchDto> page = await SendJsonAsync<DdctPageDto<DdctCertificateSearchDto>>(HttpMethod.Get, url, cancellationToken).ConfigureAwait(false);
+            if (page.Items.Count == 0)
+            {
+                return new DdctPage<DdctCertificateSearchDto>(items, page.Limit, page.Offset, null, false, truncated);
+            }
+
+            items.AddRange(page.Items);
+            if (!page.HasMore || string.IsNullOrWhiteSpace(page.NextContinuation) || string.Equals(page.NextContinuation, lastContinuation, StringComparison.Ordinal))
+            {
+                return new DdctPage<DdctCertificateSearchDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, truncated);
+            }
+
+            lastContinuation = currentContinuation = page.NextContinuation;
+            truncated = pageIndex + 1 >= _maxPagesPerQuery - 1;
+        }
+
+        return new DdctPage<DdctCertificateSearchDto>(items, pageSize, 0, currentContinuation, true, true);
+    }
+
+    private async Task<DdctPage<DdctObservationDto>> QueryObservationPagesAsync(
+        string name,
+        bool includeSubdomains,
+        int pageSize,
+        string? continuation,
+        CancellationToken cancellationToken)
+    {
+        var items = new List<DdctObservationDto>();
+        string? currentContinuation = continuation;
+        string? lastContinuation = continuation;
+        bool truncated = false;
+
+        for (int pageIndex = 0; pageIndex < _maxPagesPerQuery; pageIndex++)
+        {
+            string url = BuildPagedUrl("/api/v1/observations/paged", name, includeSubdomains, pageSize, currentContinuation);
+            DdctPageDto<DdctObservationDto> page = await SendJsonAsync<DdctPageDto<DdctObservationDto>>(HttpMethod.Get, url, cancellationToken).ConfigureAwait(false);
+            if (page.Items.Count == 0)
+            {
+                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, null, false, truncated);
+            }
+
+            items.AddRange(page.Items);
+            if (!page.HasMore || string.IsNullOrWhiteSpace(page.NextContinuation) || string.Equals(page.NextContinuation, lastContinuation, StringComparison.Ordinal))
+            {
+                return new DdctPage<DdctObservationDto>(items, page.Limit, page.Offset, page.NextContinuation, page.HasMore, truncated);
+            }
+
+            lastContinuation = currentContinuation = page.NextContinuation;
+            truncated = pageIndex + 1 >= _maxPagesPerQuery - 1;
+        }
+
+        return new DdctPage<DdctObservationDto>(items, pageSize, 0, currentContinuation, true, true);
+    }
+
+    private async Task<T> SendJsonAsync<T>(HttpMethod method, string url, CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = CreateRequest(method, url);
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            if (typeof(T) == typeof(DdctPageDto<DdctCertificateSearchDto>))
+            {
+                return (T)(object)new DdctPageDto<DdctCertificateSearchDto> {
+                    Items = Array.Empty<DdctCertificateSearchDto>(),
+                    Limit = 0,
+                    Offset = 0,
+                    NextContinuation = null,
+                    HasMore = false
+                };
+            }
+
+            if (typeof(T) == typeof(DdctPageDto<DdctObservationDto>))
+            {
+                return (T)(object)new DdctPageDto<DdctObservationDto> {
+                    Items = Array.Empty<DdctObservationDto>(),
+                    Limit = 0,
+                    Offset = 0,
+                    NextContinuation = null,
+                    HasMore = false
+                };
+            }
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"DDCT API returned {(int)response.StatusCode} {response.ReasonPhrase}");
+        }
+
+        using Stream stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        T? payload = await JsonSerializer.DeserializeAsync<T>(stream, JsonOptions, cancellationToken).ConfigureAwait(false);
+        return payload ?? throw new InvalidOperationException("DDCT API returned an empty JSON payload.");
+    }
+
+    private async Task<byte[]> DownloadCertificateDerAsync(string sha256Fingerprint, CancellationToken cancellationToken)
+    {
+        string url = BuildPath("/api/v1/certificates/" + Uri.EscapeDataString(sha256Fingerprint) + "/der");
+        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url);
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new InvalidOperationException("DDCT API did not have DER material for certificate " + sha256Fingerprint + ".");
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new HttpRequestException($"DDCT DER endpoint returned {(int)response.StatusCode} {response.ReasonPhrase}");
+        }
+
+        return await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+    }
+
+    private HttpRequestMessage CreateRequest(HttpMethod method, string url)
+    {
+        var request = new HttpRequestMessage(method, url);
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+        {
+            if (string.Equals(_apiKeyHeaderName, "Authorization", StringComparison.OrdinalIgnoreCase))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+            }
+            else
+            {
+                request.Headers.TryAddWithoutValidation(_apiKeyHeaderName, _apiKey);
+            }
+        }
+
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return request;
+    }
+
+    private string BuildPagedUrl(string relativePath, string name, bool includeSubdomains, int limit, string? continuation)
+    {
+        var query = new List<string>
+        {
+            "name=" + Uri.EscapeDataString(name),
+            "includeSubdomains=" + (includeSubdomains ? "true" : "false"),
+            "limit=" + limit.ToString(CultureInfo.InvariantCulture)
+        };
+        if (!string.IsNullOrWhiteSpace(_scopeName))
+        {
+            query.Add("scope=" + Uri.EscapeDataString(_scopeName));
+        }
+
+        if (!string.IsNullOrWhiteSpace(continuation))
+        {
+            query.Add("continuation=" + Uri.EscapeDataString(continuation));
+        }
+
+        return BuildPath(relativePath + "?" + string.Join("&", query));
+    }
+
+    private string BuildPath(string relativePath)
+        => _endpointUrl + relativePath;
+
+    private int ResolvePageSize(int? requested)
+        => ClampInt(
+            requested.GetValueOrDefault(_configuredQueryPageSize),
+            1,
+            DdctApiCertificateTransparencyProviderOptions.MaxQueryPageSize);
+
+    private static int ResolveRequestedCertificateCount(CtCertificateQuery query)
+        => Math.Max(query.PageSize.GetValueOrDefault(DdctApiCertificateTransparencyProviderOptions.DefaultQueryPageSize), 1);
+
+    private static string NormalizeEndpointUrl(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? DdctApiCertificateTransparencyProviderOptions.DefaultEndpointUrl
+            : (value ?? string.Empty).Trim().TrimEnd('/');
+
+    private static string NormalizeHostName(string? value)
+        => string.IsNullOrWhiteSpace(value)
+            ? string.Empty
+            : (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+
+    private static int ClampInt(int value, int minimum, int maximum)
+        => value < minimum ? minimum : (value > maximum ? maximum : value);
+
+    private static IReadOnlyList<string> BuildDiagnostics(bool truncated)
+        => truncated ? new[] { "DDCT query reached the configured page cap before exhausting results." } : Array.Empty<string>();
+
+    private sealed class DdctPage<TItem>
+    {
+        public DdctPage(IReadOnlyList<TItem> items, int limit, int offset, string? nextContinuation, bool hasMore, bool truncated)
+        {
+            Items = items;
+            Limit = limit;
+            Offset = offset;
+            NextContinuation = nextContinuation;
+            HasMore = hasMore;
+            Truncated = truncated;
+        }
+
+        public IReadOnlyList<TItem> Items { get; }
+        public int Limit { get; }
+        public int Offset { get; }
+        public string? NextContinuation { get; }
+        public bool HasMore { get; }
+        public bool Truncated { get; }
+    }
+
+    private sealed class DdctPageDto<TItem>
+    {
+        public IReadOnlyList<TItem> Items { get; init; } = Array.Empty<TItem>();
+        public int Limit { get; init; }
+        public int Offset { get; init; }
+        public string? NextContinuation { get; init; }
+        public bool HasMore { get; init; }
+    }
+
+    private sealed class DdctCertificateSearchDto
+    {
+        public string Sha256Fingerprint { get; init; } = string.Empty;
+        public string? Sha1Thumbprint { get; init; }
+        public string? SerialNumber { get; init; }
+        public string? Subject { get; init; }
+        public string? Issuer { get; init; }
+        public DateTimeOffset? NotBeforeUtc { get; init; }
+        public DateTimeOffset? NotAfterUtc { get; init; }
+        public DateTimeOffset? FirstCtObservedAtUtc { get; init; }
+        public DateTimeOffset? LastCtObservedAtUtc { get; init; }
+        public DateTimeOffset? FirstIngestedByDdctAtUtc { get; init; }
+        public DateTimeOffset? LastIngestedByDdctAtUtc { get; init; }
+        public string MatchedName { get; init; } = string.Empty;
+        public bool IsPrecertificate { get; init; }
+    }
+
+    private sealed class DdctObservationDto
+    {
+        public string ScopeName { get; init; } = string.Empty;
+        public string MatchedName { get; init; } = string.Empty;
+        public string Sha256Fingerprint { get; init; } = string.Empty;
+        public string? Subject { get; init; }
+        public string? Issuer { get; init; }
+        public DateTimeOffset? NotBeforeUtc { get; init; }
+        public DateTimeOffset? NotAfterUtc { get; init; }
+        public DateTimeOffset? CtObservedAtUtc { get; init; }
+        public DateTimeOffset? DdctRecordedAtUtc { get; init; }
+        public long? CertificateAgeAtObservationSeconds { get; init; }
+        public string? LogOperatorName { get; init; }
+        public string LogUrl { get; init; } = string.Empty;
+        public long EntryIndex { get; init; }
+        public string EntryType { get; init; } = string.Empty;
+        public bool IsPrecertificate { get; init; }
+    }
+}

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProviderOptions.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProviderOptions.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Options for querying a DomainDetectiveCertificateTransparency API endpoint as a CT provider.
+/// </summary>
+public sealed class DdctApiCertificateTransparencyProviderOptions
+{
+    /// <summary>Default DDCT API endpoint when none is provided.</summary>
+    public const string DefaultEndpointUrl = "http://127.0.0.1:8080";
+
+    /// <summary>Default request header for DDCT API keys.</summary>
+    public const string DefaultApiKeyHeaderName = "X-DDCT-Api-Key";
+
+    /// <summary>Default certificate or observation page size.</summary>
+    public const int DefaultQueryPageSize = 100;
+
+    /// <summary>Maximum allowed page size.</summary>
+    public const int MaxQueryPageSize = 500;
+
+    /// <summary>Default maximum pages fetched for a single logical query.</summary>
+    public const int DefaultMaxPagesPerQuery = 5;
+
+    /// <summary>Maximum allowed pages fetched for a single logical query.</summary>
+    public const int MaxAllowedPagesPerQuery = 25;
+
+    /// <summary>Base API endpoint URL.</summary>
+    public string EndpointUrl { get; set; } = DefaultEndpointUrl;
+
+    /// <summary>Optional API key used when the DDCT API requires authentication.</summary>
+    public string? ApiKey { get; set; }
+
+    /// <summary>Request header name for the API key. Use <c>Authorization</c> for bearer auth.</summary>
+    public string ApiKeyHeaderName { get; set; } = DefaultApiKeyHeaderName;
+
+    /// <summary>Optional DDCT logical scope to constrain queries.</summary>
+    public string? ScopeName { get; set; }
+
+    /// <summary>Default page size when the query does not request one explicitly.</summary>
+    public int QueryPageSize { get; set; } = DefaultQueryPageSize;
+
+    /// <summary>Maximum pages fetched before the provider returns a truncated result with diagnostics.</summary>
+    public int MaxPagesPerQuery { get; set; } = DefaultMaxPagesPerQuery;
+}


### PR DESCRIPTION
## Summary
- add a reusable DDCT API-backed certificate transparency provider to DomainDetective
- expose a DDCT provider profile and options type for endpoint, auth, scope, and paging
- add targeted tests for latest certificate hydration and domain expansion through the DDCT API

## Testing
- dotnet test .\\DomainDetective.Tests\\DomainDetective.Tests.csproj --filter DdctApi -v minimal