### PR TITLE
chore(website): retarget PowerForge workflow pin

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,6 +25,7 @@ jobs:
       site_output_path: Website/_site
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
     secrets:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,14 +18,14 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@fc6fbcf85d95be3dadcd99bcedab3970fa2b41e8
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       site_output_path: Website/_site
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: fc6fbcf85d95be3dadcd99bcedab3970fa2b41e8
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -37,12 +37,12 @@ jobs:
 
   website-build:
     needs: website-tests
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@fc6fbcf85d95be3dadcd99bcedab3970fa2b41e8
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: fc6fbcf85d95be3dadcd99bcedab3970fa2b41e8
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -43,6 +43,7 @@ jobs:
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -21,6 +21,7 @@ jobs:
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
+      powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603301051
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,12 +15,12 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@fc6fbcf85d95be3dadcd99bcedab3970fa2b41e8
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@263eb3ccc4e6948132a5bdd3df9a084501291f68
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
-      powerforge_ref: fc6fbcf85d95be3dadcd99bcedab3970fa2b41e8
+      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603301051
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- repin DomainDetective website workflows to the merged PowerForge commit
- keep source-mode workflow execution aligned with the final engine fixes
- ensure the next master deploy uses the merged PowerForge workflow set

## Testing
- workflow pin update only
- verified all website workflow refs now target PowerForge merge commit `263eb3ccc4e6948132a5bdd3df9a084501291f68`