### PR TITLE
Refresh website PowerForge targets and local CLI rebuild

### DIFF
--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -23,5 +23,5 @@ jobs:
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603301051
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/build.ps1
+++ b/Website/build.ps1
@@ -131,15 +131,7 @@ if (-not [string]::IsNullOrWhiteSpace($PowerForgeRoot)) {
 
 if ((-not $SkipBuildTool) -and
     $PowerForgeCliProject -and
-    (Test-Path $PowerForgeCliProject) -and
-    ($ForceBuildTool -or -not (
-        ($PowerForgeReleaseExe -and (Test-Path $PowerForgeReleaseExe)) -or
-        ($PowerForgeReleaseAppHost -and (Test-Path $PowerForgeReleaseAppHost)) -or
-        ($PowerForgeReleaseDll -and (Test-Path $PowerForgeReleaseDll)) -or
-        ($PowerForgeDebugExe -and (Test-Path $PowerForgeDebugExe)) -or
-        ($PowerForgeDebugAppHost -and (Test-Path $PowerForgeDebugAppHost)) -or
-        ($PowerForgeDebugDll -and (Test-Path $PowerForgeDebugDll))
-    ))) {
+    (Test-Path $PowerForgeCliProject)) {
     Write-Host "Building PowerForge.Web.Cli..." -ForegroundColor Cyan
     dotnet.exe build $PowerForgeCliProject -c Release | Out-Host
     if ($LASTEXITCODE -ne 0) { throw "PowerForge.Web.Cli build failed (exit code $LASTEXITCODE)" }


### PR DESCRIPTION
## Summary
- update website automation to the current PSPublishModule reusable workflow SHA 263eb3ccc4e6948132a5bdd3df9a084501291f68
- keep package-mode website runs on PowerForgeWeb-v1.0.0-preview-202603311925 where applicable
- rebuild PowerForge.Web.Cli from source during local website runs so stale local binaries do not mask engine dependency changes

## Notes
- this is aimed at keeping website builds aligned ahead of the Magick-related engine bump