### PR TITLE
Retarget website workflows to latest PowerForgeWeb preview

### DIFF
--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -22,6 +22,6 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 263eb3ccc4e6948132a5bdd3df9a084501291f68
-      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202603311925
+      powerforge_ref: d2f478c85c5141c255554505d5d536c0fd4b8222
+      powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- retarget website workflows to PSPublishModule commit d2f478c85c5141c255554505d5d536c0fd4b8222
- update package-mode sites to PowerForgeWeb-v1.0.0-preview-202604140746
- keep the scope to workflow pins only

## Why
This picks up the merged Magick.NET-Q8-AnyCPU 14.12.0 engine fix from PSPublishModule PR #316 and points the website workflows at the fresh preview release built from that merge.
