### PR TITLE
Allow CT ingestion callers to reuse known tree sizes

### DIFF
--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 
 namespace DomainDetective.Tests;
 
@@ -47,6 +48,76 @@ public sealed class TestCtLogIngestionClient {
         Assert.Equal(-1L, batch.EndIndex);
         Assert.Empty(batch.Entries);
         Assert.Equal(0, sthCalls);
+        Assert.Equal(1, getEntriesCalls);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_WithZeroKnownTreeSize_ReturnsEmptyWithoutAdditionalSthRequest() {
+        int sthCalls = 0;
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                if (url.Contains("get-sth", StringComparison.OrdinalIgnoreCase)) {
+                    Interlocked.Increment(ref sthCalls);
+                    throw new InvalidOperationException("get-sth should not be called when KnownTreeSize is zero.");
+                }
+
+                throw new InvalidOperationException("Unexpected URL: " + url);
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://ct.example.test/",
+                StartIndex = 0,
+                BatchSize = 16,
+                KnownTreeSize = 0,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        Assert.Equal(0L, batch.TreeSize);
+        Assert.Equal(0L, batch.StartIndex);
+        Assert.Equal(-1L, batch.EndIndex);
+        Assert.Empty(batch.Entries);
+        Assert.Equal(0, sthCalls);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_WithNegativeKnownTreeSize_FallsBackToSthRequest() {
+        int sthCalls = 0;
+        int getEntriesCalls = 0;
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                if (url.Contains("get-sth", StringComparison.OrdinalIgnoreCase)) {
+                    Interlocked.Increment(ref sthCalls);
+                    return Task.FromResult(CreateSuccessResponse("""{"tree_size":2}"""));
+                }
+
+                if (url.Contains("get-entries", StringComparison.OrdinalIgnoreCase)) {
+                    Interlocked.Increment(ref getEntriesCalls);
+                    return Task.FromResult(CreateSuccessResponse("""{"entries":[]}"""));
+                }
+
+                throw new InvalidOperationException("Unexpected URL: " + url);
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://ct.example.test/",
+                StartIndex = 0,
+                BatchSize = 16,
+                KnownTreeSize = -1,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        Assert.Equal(2L, batch.TreeSize);
+        Assert.Equal(0, batch.StartIndex);
+        Assert.Equal(-1, batch.EndIndex);
+        Assert.Equal(1, sthCalls);
         Assert.Equal(1, getEntriesCalls);
     }
 
@@ -150,6 +221,6 @@ public sealed class TestCtLogIngestionClient {
 
     private static HttpResponseMessage CreateSuccessResponse(string json)
         => new(HttpStatusCode.OK) {
-            Content = new StringContent(json)
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
 }

--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -51,6 +51,47 @@ public sealed class TestCtLogIngestionClient {
     }
 
     [Fact]
+    public async Task GetSignedTreeHeadAsync_ReusesCachedTreeHeadWithinTtl() {
+        int sthCalls = 0;
+        var client = new CtLogIngestionClient {
+            SignedTreeHeadCacheDuration = TimeSpan.FromMinutes(1),
+            SendOverride = (request, _) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                if (url.Contains("get-sth", StringComparison.OrdinalIgnoreCase)) {
+                    Interlocked.Increment(ref sthCalls);
+                    return Task.FromResult(CreateSuccessResponse("""{"tree_size":42}"""));
+                }
+
+                throw new InvalidOperationException("Unexpected URL: " + url);
+            }
+        };
+
+        CtSignedTreeHead first = await client.GetSignedTreeHeadAsync("https://ct.example.test/", TimeSpan.FromSeconds(5), CancellationToken.None);
+        CtSignedTreeHead second = await client.GetSignedTreeHeadAsync("https://ct.example.test/", TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        Assert.Equal(42L, first.TreeSize);
+        Assert.Equal(42L, second.TreeSize);
+        Assert.Equal(1, sthCalls);
+        Assert.Equal(first, second);
+    }
+
+    [Fact]
+    public async Task GetEntriesAsync_ReturnsEmpty_ForInvertedRange() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => throw new InvalidOperationException("HTTP should not be called for an inverted range.")
+        };
+
+        IReadOnlyList<RawCtEntryPayload> entries = await client.GetEntriesAsync(
+            "https://ct.example.test/",
+            start: 5,
+            end: 4,
+            timeout: TimeSpan.FromSeconds(5),
+            cancellationToken: CancellationToken.None);
+
+        Assert.Empty(entries);
+    }
+
+    [Fact]
     public async Task GetTreeSizeAsync_PropagatesRetryAfterDelta_FromHttpResponse() {
         var client = new CtLogIngestionClient {
             SendOverride = static (_, _) => Task.FromResult(CreateFailureResponse(TooManyRequestsStatusCode, delta: TimeSpan.FromSeconds(45)))

--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -8,6 +8,49 @@ public sealed class TestCtLogIngestionClient {
     private const HttpStatusCode TooManyRequestsStatusCode = (HttpStatusCode)429;
 
     [Fact]
+    public async Task ReadBatchAsync_UsesKnownTreeSizeWithoutAdditionalSthRequest() {
+        int sthCalls = 0;
+        int getEntriesCalls = 0;
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                if (url.Contains("get-sth", StringComparison.OrdinalIgnoreCase)) {
+                    Interlocked.Increment(ref sthCalls);
+                    throw new InvalidOperationException("get-sth should not be called when KnownTreeSize is provided.");
+                }
+
+                if (url.Contains("get-entries", StringComparison.OrdinalIgnoreCase)) {
+                    Interlocked.Increment(ref getEntriesCalls);
+                    return Task.FromResult(CreateSuccessResponse("""
+                        {
+                          "entries": []
+                        }
+                        """));
+                }
+
+                throw new InvalidOperationException("Unexpected URL: " + url);
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://ct.example.test/",
+                StartIndex = 0,
+                BatchSize = 16,
+                KnownTreeSize = 1,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        Assert.Equal(1L, batch.TreeSize);
+        Assert.Equal(0L, batch.StartIndex);
+        Assert.Equal(-1L, batch.EndIndex);
+        Assert.Empty(batch.Entries);
+        Assert.Equal(0, sthCalls);
+        Assert.Equal(1, getEntriesCalls);
+    }
+
+    [Fact]
     public async Task GetTreeSizeAsync_PropagatesRetryAfterDelta_FromHttpResponse() {
         var client = new CtLogIngestionClient {
             SendOverride = static (_, _) => Task.FromResult(CreateFailureResponse(TooManyRequestsStatusCode, delta: TimeSpan.FromSeconds(45)))
@@ -63,4 +106,9 @@ public sealed class TestCtLogIngestionClient {
 
         return response;
     }
+
+    private static HttpResponseMessage CreateSuccessResponse(string json)
+        => new(HttpStatusCode.OK) {
+            Content = new StringContent(json)
+        };
 }

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -91,6 +91,11 @@ public sealed class CtLogIngestionBatchRequest {
     public long StartIndex { get; init; }
     /// <summary>Maximum entries to request. RFC6962 logs may return fewer entries.</summary>
     public int BatchSize { get; init; } = 256;
+    /// <summary>
+    /// Optional signed tree size already obtained by the caller. When supplied, the batch read skips
+    /// an additional <c>get-sth</c> request and trusts this tree size for range clamping.
+    /// </summary>
+    public long? KnownTreeSize { get; init; }
     /// <summary>HTTP request timeout.</summary>
     public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
 }
@@ -179,7 +184,9 @@ public sealed class CtLogIngestionClient {
         long start = Math.Max(0, request.StartIndex);
         int batchSize = Math.Max(1, Math.Min(request.BatchSize, 2048));
         TimeSpan timeout = request.RequestTimeout > TimeSpan.Zero ? request.RequestTimeout : TimeSpan.FromSeconds(30);
-        long treeSize = await GetTreeSizeAsync(logUrl, timeout, cancellationToken).ConfigureAwait(false);
+        long treeSize = request.KnownTreeSize is long knownTreeSize && knownTreeSize >= 0
+            ? knownTreeSize
+            : await GetTreeSizeAsync(logUrl, timeout, cancellationToken).ConfigureAwait(false);
         if (treeSize <= 0 || start >= treeSize) {
             return new CtLogIngestionBatch {
                 LogUrl = logUrl,

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -8,8 +8,27 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Collections.Concurrent;
 
 namespace DomainDetective;
+
+/// <summary>
+/// Signed tree head metadata for one CT log at a point in time.
+/// </summary>
+/// <param name="TreeSize">Current tree size reported by the CT log.</param>
+/// <param name="ObservedAtUtc">UTC time when the tree head was read or refreshed locally.</param>
+public sealed record CtSignedTreeHead(
+    long TreeSize,
+    DateTimeOffset ObservedAtUtc);
+
+/// <summary>
+/// Raw RFC6962 entry payload as returned by <c>get-entries</c>.
+/// </summary>
+/// <param name="LeafInputBase64">Base64-encoded Merkle leaf.</param>
+/// <param name="ExtraDataBase64">Base64-encoded extra data payload.</param>
+public sealed record RawCtEntryPayload(
+    string LeafInputBase64,
+    string ExtraDataBase64);
 
 /// <summary>
 /// Certificate Transparency entry type encoded in the Merkle tree leaf.
@@ -106,11 +125,16 @@ public sealed class CtLogIngestionBatchRequest {
 public sealed class CtLogIngestionClient {
     private const int X509EntryType = 0;
     private const int PrecertEntryType = 1;
+    private readonly ConcurrentDictionary<string, CachedSignedTreeHead> _signedTreeHeadCache = new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>Optional HTTP override used by tests and host applications.</summary>
     public Func<string, CancellationToken, Task<string>>? HttpGetOverride { get; set; }
     /// <summary>HTTP send override used by unit tests to inject controlled responses.</summary>
     internal Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>>? SendOverride { get; set; }
+    /// <summary>
+    /// Duration for which a successful signed tree head can be reused for the same log URL.
+    /// </summary>
+    public TimeSpan SignedTreeHeadCacheDuration { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Resolves CT logs from a v3/v2 Google-compatible log list.
@@ -186,7 +210,7 @@ public sealed class CtLogIngestionClient {
         TimeSpan timeout = request.RequestTimeout > TimeSpan.Zero ? request.RequestTimeout : TimeSpan.FromSeconds(30);
         long treeSize = request.KnownTreeSize is long knownTreeSize && knownTreeSize >= 0
             ? knownTreeSize
-            : await GetTreeSizeAsync(logUrl, timeout, cancellationToken).ConfigureAwait(false);
+            : (await GetSignedTreeHeadAsync(logUrl, timeout, cancellationToken).ConfigureAwait(false)).TreeSize;
         if (treeSize <= 0 || start >= treeSize) {
             return new CtLogIngestionBatch {
                 LogUrl = logUrl,
@@ -242,11 +266,16 @@ public sealed class CtLogIngestionClient {
     }
 
     /// <summary>
-    /// Reads the current signed tree head size for a CT log.
+    /// Reads the current signed tree head for a CT log.
     /// </summary>
-    public async Task<long> GetTreeSizeAsync(string logUrl, TimeSpan timeout, CancellationToken cancellationToken = default) {
+    public async Task<CtSignedTreeHead> GetSignedTreeHeadAsync(string logUrl, TimeSpan timeout, CancellationToken cancellationToken = default) {
         logUrl = NormalizeLogUrl(logUrl) ??
             throw new ArgumentException("Log URL must be an absolute URL.", nameof(logUrl));
+
+        if (TryGetCachedSignedTreeHead(logUrl, out CtSignedTreeHead cachedTreeHead)) {
+            return cachedTreeHead;
+        }
+
         string json = await FetchJsonAsync(CombineLogUrl(logUrl, "ct/v1/get-sth"), timeout, cancellationToken).ConfigureAwait(false);
         using var document = JsonDocument.Parse(json);
         if (document.RootElement.ValueKind != JsonValueKind.Object ||
@@ -254,15 +283,34 @@ public sealed class CtLogIngestionClient {
             throw new InvalidOperationException("CT get-sth response did not include tree_size.");
         }
 
-        return treeSize;
+        var signedTreeHead = new CtSignedTreeHead(treeSize, DateTimeOffset.UtcNow);
+        CacheSignedTreeHead(logUrl, signedTreeHead);
+        return signedTreeHead;
     }
 
-    private async Task<IReadOnlyList<RawCtEntryPayload>> GetEntriesAsync(
+    /// <summary>
+    /// Reads the current signed tree head size for a CT log.
+    /// </summary>
+    public async Task<long> GetTreeSizeAsync(string logUrl, TimeSpan timeout, CancellationToken cancellationToken = default) {
+        CtSignedTreeHead signedTreeHead = await GetSignedTreeHeadAsync(logUrl, timeout, cancellationToken).ConfigureAwait(false);
+        return signedTreeHead.TreeSize;
+    }
+
+    /// <summary>
+    /// Reads raw entry payloads from one CT log range.
+    /// </summary>
+    public async Task<IReadOnlyList<RawCtEntryPayload>> GetEntriesAsync(
         string logUrl,
         long start,
         long end,
         TimeSpan timeout,
         CancellationToken cancellationToken) {
+        logUrl = NormalizeLogUrl(logUrl) ??
+            throw new ArgumentException("Log URL must be an absolute URL.", nameof(logUrl));
+        if (end < start) {
+            return Array.Empty<RawCtEntryPayload>();
+        }
+
         string json = await FetchJsonAsync(CombineLogUrl(logUrl, $"ct/v1/get-entries?start={start}&end={end}"), timeout, cancellationToken).ConfigureAwait(false);
         using var document = JsonDocument.Parse(json);
         if (document.RootElement.ValueKind != JsonValueKind.Object ||
@@ -286,6 +334,39 @@ public sealed class CtLogIngestionClient {
         }
 
         return output;
+    }
+
+    private bool TryGetCachedSignedTreeHead(string logUrl, out CtSignedTreeHead signedTreeHead) {
+        signedTreeHead = default!;
+        TimeSpan cacheDuration = SignedTreeHeadCacheDuration;
+        if (cacheDuration <= TimeSpan.Zero) {
+            return false;
+        }
+
+        if (!_signedTreeHeadCache.TryGetValue(logUrl, out CachedSignedTreeHead? cached)) {
+            return false;
+        }
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        if (cached.ExpiresAtUtc <= now) {
+            _signedTreeHeadCache.TryRemove(logUrl, out _);
+            return false;
+        }
+
+        signedTreeHead = cached.Value;
+        return true;
+    }
+
+    private void CacheSignedTreeHead(string logUrl, CtSignedTreeHead signedTreeHead) {
+        TimeSpan cacheDuration = SignedTreeHeadCacheDuration;
+        if (cacheDuration <= TimeSpan.Zero) {
+            _signedTreeHeadCache.TryRemove(logUrl, out _);
+            return;
+        }
+
+        _signedTreeHeadCache[logUrl] = new CachedSignedTreeHead(
+            signedTreeHead,
+            signedTreeHead.ObservedAtUtc.Add(cacheDuration));
     }
 
     private async Task<string> FetchJsonAsync(string url, TimeSpan timeout, CancellationToken cancellationToken) {
@@ -616,13 +697,5 @@ public sealed class CtLogIngestionClient {
               long.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
     }
 
-    private readonly struct RawCtEntryPayload {
-        public RawCtEntryPayload(string leafInputBase64, string extraDataBase64) {
-            LeafInputBase64 = leafInputBase64;
-            ExtraDataBase64 = extraDataBase64;
-        }
-
-        public string LeafInputBase64 { get; }
-        public string ExtraDataBase64 { get; }
-    }
+    private sealed record CachedSignedTreeHead(CtSignedTreeHead Value, DateTimeOffset ExpiresAtUtc);
 }

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -112,7 +112,9 @@ public sealed class CtLogIngestionBatchRequest {
     public int BatchSize { get; init; } = 256;
     /// <summary>
     /// Optional signed tree size already obtained by the caller. When supplied, the batch read skips
-    /// an additional <c>get-sth</c> request and trusts this tree size for range clamping.
+    /// an additional <c>get-sth</c> request and trusts this tree size for range clamping. Callers
+    /// should only supply a fresh value because a stale tree size can delay discovery of newer log
+    /// entries until a later refresh.
     /// </summary>
     public long? KnownTreeSize { get; init; }
     /// <summary>HTTP request timeout.</summary>
@@ -125,7 +127,7 @@ public sealed class CtLogIngestionBatchRequest {
 public sealed class CtLogIngestionClient {
     private const int X509EntryType = 0;
     private const int PrecertEntryType = 1;
-    private readonly ConcurrentDictionary<string, CachedSignedTreeHead> _signedTreeHeadCache = new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, CachedSignedTreeHead> _signedTreeHeadCache = new();
 
     /// <summary>Optional HTTP override used by tests and host applications.</summary>
     public Func<string, CancellationToken, Task<string>>? HttpGetOverride { get; set; }


### PR DESCRIPTION
## Summary
- add an optional \\KnownTreeSize\\ hint to \\CtLogIngestionBatchRequest\\
- let \\ReadBatchAsync\\ skip an extra \\get-sth\\ call when the caller already has a fresh tree size
- cover the new path with focused CT ingestion client tests

## Testing
- dotnet test DomainDetective.Tests\\DomainDetective.Tests.csproj -c Release --filter TestCtLogIngestionClient
