### PR TITLE
Preserve CT fingerprints for names-only records

### DIFF
--- a/DomainDetective.Tests/CtCertificateRecordTests.cs
+++ b/DomainDetective.Tests/CtCertificateRecordTests.cs
@@ -17,7 +17,7 @@ public sealed class CtCertificateRecordTests {
         Assert.Equal(CtCertificateRecordDetailLevel.NamesOnly, record.DetailLevel);
         Assert.Contains("names-only.example.test", record.DnsNames, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("www.names-only.example.test", record.DnsNames, StringComparer.OrdinalIgnoreCase);
-        Assert.Null(record.Sha256Fingerprint);
+        Assert.NotNull(record.Sha256Fingerprint);
         Assert.Null(record.Subject);
         Assert.NotNull(record.CertificateDer);
         Assert.Equal(certificateDer, record.CertificateDer);

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -137,12 +137,20 @@ public sealed class CtCertificateRecord
         using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(rawData);
         if (detailLevel == CtCertificateRecordDetailLevel.NamesOnly)
         {
+            byte[] namesOnlySha256Bytes;
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                namesOnlySha256Bytes = sha256.ComputeHash(rawData);
+            }
+
             return new CtCertificateRecord
             {
                 ProviderId = providerId ?? string.Empty,
                 ProviderCertificateId = providerCertificateId,
                 DetailLevel = CtCertificateRecordDetailLevel.NamesOnly,
                 EntryTimestampUtc = entryTimestampUtc,
+                Sha256Fingerprint = ToHex(namesOnlySha256Bytes),
+                TbsSha256 = NormalizeHex(tbsSha256),
                 DnsNames = ExtractDnsNames(certificate),
                 CertificateDer = rawData,
                 IsPrecertificate = isPrecertificate


### PR DESCRIPTION
## Summary
- preserve SHA-256 fingerprints when CT records are parsed in names-only mode
- keep the focused CT record test aligned with the names-only behavior
- prevent downstream DDCT storage from losing certificate identity on allowlist-first ingestion paths

## Testing
- existing focused CT tests in this change set