### PR TITLE
Add Static CT ingestion support

### DIFF
--- a/DomainDetective.Tests/CtCertificateRecordTests.cs
+++ b/DomainDetective.Tests/CtCertificateRecordTests.cs
@@ -17,7 +17,7 @@ public sealed class CtCertificateRecordTests {
         Assert.Equal(CtCertificateRecordDetailLevel.NamesOnly, record.DetailLevel);
         Assert.Contains("names-only.example.test", record.DnsNames, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("www.names-only.example.test", record.DnsNames, StringComparer.OrdinalIgnoreCase);
-        Assert.Null(record.Sha256Fingerprint);
+        Assert.NotNull(record.Sha256Fingerprint);
         Assert.Null(record.Subject);
         Assert.NotNull(record.CertificateDer);
         Assert.Equal(certificateDer, record.CertificateDer);

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
         <PackageReference Include="MailKit" Version="4.16.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.4" Condition=" '$(TargetFramework)' != 'net472' " />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+        <PackageReference Include="MailKit" Version="4.16.0" />
         <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.5.4" Condition=" '$(TargetFramework)' != 'net472' " />
         <PackageReference Include="xunit" Version="2.9.3" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -122,6 +122,42 @@ public sealed class TestCtLogIngestionClient {
     }
 
     [Fact]
+    public async Task ReadBatchAsync_ClampsLargeBatchSize_ToConfiguredMaximum() {
+        Uri? requestedUri = null;
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                if (url.Contains("get-sth", StringComparison.OrdinalIgnoreCase)) {
+                    return Task.FromResult(CreateSuccessResponse("""{"tree_size":50000}"""));
+                }
+
+                if (url.Contains("get-entries", StringComparison.OrdinalIgnoreCase)) {
+                    requestedUri = request.RequestUri;
+                    return Task.FromResult(CreateSuccessResponse("""{"entries":[]}"""));
+                }
+
+                throw new InvalidOperationException("Unexpected URL: " + url);
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://ct.example.test/",
+                StartIndex = 10,
+                BatchSize = 50_000,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        Assert.NotNull(requestedUri);
+        string requestedUrl = requestedUri!.ToString();
+        Assert.Contains("start=10", requestedUrl, StringComparison.Ordinal);
+        Assert.Contains("end=8201", requestedUrl, StringComparison.Ordinal);
+        Assert.Equal(10L, batch.StartIndex);
+        Assert.Equal(9L, batch.EndIndex);
+    }
+
+    [Fact]
     public async Task GetSignedTreeHeadAsync_ReusesCachedTreeHeadWithinTtl() {
         int sthCalls = 0;
         var client = new CtLogIngestionClient {
@@ -160,6 +196,424 @@ public sealed class TestCtLogIngestionClient {
             cancellationToken: CancellationToken.None);
 
         Assert.Empty(entries);
+    }
+
+    [Fact]
+    public async Task GetLogsAsync_ReadsStaticCtTiledLogs() {
+        var client = new CtLogIngestionClient {
+            HttpGetOverride = static (_, _) => Task.FromResult("""
+                {
+                  "operators": [
+                    {
+                      "name": "Let's Encrypt",
+                      "tiled_logs": [
+                        {
+                          "description": "Sycamore 2026h1",
+                          "log_id": "abc123",
+                          "key": "key123",
+                          "mmd": 86400,
+                          "submission_url": "https://log.sycamore.ct.example/2026h1/",
+                          "monitoring_url": "https://mon.sycamore.ct.example/2026h1/",
+                          "state": { "usable": { "timestamp": "2025-12-18T00:00:00Z" } },
+                          "temporal_interval": {
+                            "start_inclusive": "2025-12-18T00:00:00Z",
+                            "end_exclusive": "2026-06-18T00:00:00Z"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """)
+        };
+
+        IReadOnlyList<CtLogDescriptor> logs = await client.GetLogsAsync("https://logs.example.test/list.json");
+
+        CtLogDescriptor log = Assert.Single(logs);
+        Assert.Equal(CtLogApiKind.StaticCt, log.ApiKind);
+        Assert.Equal("https://log.sycamore.ct.example/2026h1/", log.Url);
+        Assert.Equal("https://mon.sycamore.ct.example/2026h1/", log.MonitoringUrl);
+        Assert.Equal("Let's Encrypt", log.OperatorName);
+        Assert.Equal("usable", log.State);
+        Assert.Equal("abc123", log.LogId);
+        Assert.Equal("key123", log.PublicKey);
+        Assert.Equal(86400, log.MaximumMergeDelaySeconds);
+        Assert.True(log.IsUsable);
+        Assert.False(log.IsReadOnly);
+    }
+
+    [Fact]
+    public async Task GetLogsAsync_AcceptsStaticCtWithOnlyMonitoringUrl() {
+        var client = new CtLogIngestionClient {
+            HttpGetOverride = static (_, _) => Task.FromResult("""
+                {
+                  "operators": [
+                    {
+                      "name": "Static Only",
+                      "tiled_logs": [
+                        {
+                          "description": "Monitor only",
+                          "monitoring_url": "https://mon.static.example/log/",
+                          "state": "usable"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """)
+        };
+
+        IReadOnlyList<CtLogDescriptor> logs = await client.GetLogsAsync("https://logs.example.test/list.json");
+
+        CtLogDescriptor log = Assert.Single(logs);
+        Assert.Equal(CtLogApiKind.StaticCt, log.ApiKind);
+        Assert.Equal("https://mon.static.example/log/", log.Url);
+        Assert.Equal("https://mon.static.example/log/", log.MonitoringUrl);
+        Assert.Null(log.SubmissionUrl);
+        Assert.True(log.IsUsable);
+    }
+
+    [Fact]
+    public async Task GetLogsAsync_FiltersRejectedLogs_AndHonorsPendingOption() {
+        var client = new CtLogIngestionClient {
+            HttpGetOverride = static (_, _) => Task.FromResult("""
+                {
+                  "operators": [
+                    {
+                      "name": "Example",
+                      "logs": [
+                        {
+                          "description": "Rejected",
+                          "url": "https://rejected.ct.example/",
+                          "state": "rejected"
+                        },
+                        {
+                          "description": "Pending",
+                          "url": "https://pending.ct.example/",
+                          "state": { "pending": { "timestamp": "2026-01-01T00:00:00Z" } }
+                        },
+                        {
+                          "description": "Readonly",
+                          "url": "https://readonly.ct.example/",
+                          "state": "readonly"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """)
+        };
+
+        IReadOnlyList<CtLogDescriptor> defaultLogs = await client.GetLogsAsync("https://logs.example.test/list.json");
+        IReadOnlyList<CtLogDescriptor> withPending = await client.GetLogsAsync(
+            "https://logs.example.test/list.json",
+            includeRetired: false,
+            includePending: true);
+
+        CtLogDescriptor readonlyLog = Assert.Single(defaultLogs);
+        Assert.Equal("https://readonly.ct.example/", readonlyLog.Url);
+        Assert.True(readonlyLog.IsReadOnly);
+        Assert.Equal([
+            "https://pending.ct.example/",
+            "https://readonly.ct.example/"
+        ], withPending.Select(static log => log.Url).OrderBy(static value => value, StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public async Task GetLogsAsync_CanExcludeLogsWithoutLifecycleState() {
+        var client = new CtLogIngestionClient {
+            HttpGetOverride = static (_, _) => Task.FromResult("""
+                {
+                  "operators": [
+                    {
+                      "name": "Example",
+                      "logs": [
+                        {
+                          "description": "No state",
+                          "url": "https://unknown-state.ct.example/"
+                        },
+                        {
+                          "description": "Usable",
+                          "url": "https://usable.ct.example/",
+                          "state": "usable"
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """)
+        };
+
+        IReadOnlyList<CtLogDescriptor> defaultLogs = await client.GetLogsAsync("https://logs.example.test/list.json");
+        IReadOnlyList<CtLogDescriptor> knownStateOnly = await client.GetLogsAsync(
+            "https://logs.example.test/list.json",
+            includeUnknownState: false);
+
+        Assert.Equal([
+            "https://unknown-state.ct.example/",
+            "https://usable.ct.example/"
+        ], defaultLogs.Select(static log => log.Url).OrderBy(static value => value, StringComparer.Ordinal).ToArray());
+        CtLogDescriptor log = Assert.Single(knownStateOnly);
+        Assert.Equal("https://usable.ct.example/", log.Url);
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_ReadsStaticCtCheckpoint() {
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                Assert.Equal("https://mon.ct.example.test/2026h1/checkpoint", request.RequestUri?.ToString());
+                return Task.FromResult(CreateTextResponse("""
+                    log.ct.example.test/2026h1
+                    12345
+                    abc=
+
+                    — log.ct.example.test/2026h1 sig=
+                    """));
+            }
+        };
+
+        long treeSize = await client.GetTreeSizeAsync(
+            new CtLogDescriptor {
+                Url = "https://log.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/"
+            },
+            TimeSpan.FromSeconds(5),
+            CancellationToken.None);
+
+        Assert.Equal(12345L, treeSize);
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_RejectsStaticCtCheckpointWithNegativeTreeSize() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateTextResponse("""
+                log.ct.example.test/2026h1
+                -1
+                abc=
+
+                — log.ct.example.test/2026h1 sig=
+                """))
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.GetTreeSizeAsync(
+                new CtLogDescriptor {
+                    Url = "https://log.ct.example.test/2026h1/",
+                    ApiKind = CtLogApiKind.StaticCt,
+                    MonitoringUrl = "https://mon.ct.example.test/2026h1/"
+                },
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None));
+
+        Assert.Contains("tree size", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_RejectsStaticCtCheckpointWithUnexpectedOrigin() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateTextResponse("""
+                other.ct.example.test/2026h1
+                12345
+                abc=
+
+                — other.ct.example.test/2026h1 sig=
+                """))
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.GetTreeSizeAsync(
+                new CtLogDescriptor {
+                    Url = "https://log.ct.example.test/2026h1/",
+                    ApiKind = CtLogApiKind.StaticCt,
+                    MonitoringUrl = "https://mon.ct.example.test/2026h1/"
+                },
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None));
+
+        Assert.Contains("checkpoint origin", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("log.ct.example.test/2026h1", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_RejectsStaticCtCheckpointWithoutExpectedOriginSignature() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateTextResponse("""
+                log.ct.example.test/2026h1
+                12345
+                abc=
+
+                — witness.ct.example.test sig=
+                """))
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.GetTreeSizeAsync(
+                new CtLogDescriptor {
+                    Url = "https://log.ct.example.test/2026h1/",
+                    ApiKind = CtLogApiKind.StaticCt,
+                    MonitoringUrl = "https://mon.ct.example.test/2026h1/"
+                },
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None));
+
+        Assert.Contains("note signature", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("log.ct.example.test/2026h1", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetTreeSizeAsync_SkipsStaticCtCheckpointOriginValidation_WhenOnlyMonitoringUrlIsKnown() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateTextResponse("""
+                log.ct.example.test/2026h1
+                12345
+                abc=
+
+                — log.ct.example.test/2026h1 sig=
+                """))
+        };
+
+        long treeSize = await client.GetTreeSizeAsync(
+            new CtLogDescriptor {
+                Url = "https://mon.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/"
+            },
+            TimeSpan.FromSeconds(5),
+            CancellationToken.None);
+
+        Assert.Equal(12345L, treeSize);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_ReadsStaticCtDataTile() {
+        byte[] certificateDer = LoadCertificateDer("multi.pem");
+        byte[] tile = CreateStaticCtX509Tile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:05Z"));
+        Uri? requestedUri = null;
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                requestedUri = request.RequestUri;
+                return Task.FromResult(CreateBinaryResponse(tile));
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://log.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                StartIndex = 0,
+                BatchSize = 1,
+                KnownTreeSize = 1,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        Assert.Equal("https://mon.ct.example.test/2026h1/tile/data/000.p/1", requestedUri?.ToString());
+        CtLogIngestionEntry entry = Assert.Single(batch.Entries);
+        Assert.Equal(0L, entry.EntryIndex);
+        Assert.Equal(CtLogEntryType.X509, entry.EntryType);
+        Assert.Contains("site1.com", entry.Certificate.DnsNames, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_FallsBackToFullStaticCtDataTile_WhenPartialTileIsGone() {
+        byte[] certificateDer = LoadCertificateDer("multi.pem");
+        byte[] fullTile = Enumerable
+            .Range(0, 256)
+            .SelectMany(index => CreateStaticCtX509Tile(
+                certificateDer,
+                DateTimeOffset.Parse("2026-01-02T03:04:05Z").AddSeconds(index)))
+            .ToArray();
+        List<string> requestedUrls = [];
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                requestedUrls.Add(url);
+                if (url.EndsWith("/tile/data/000.p/1", StringComparison.Ordinal)) {
+                    return Task.FromResult(CreateFailureResponse(HttpStatusCode.NotFound));
+                }
+
+                if (url.EndsWith("/tile/data/000", StringComparison.Ordinal)) {
+                    return Task.FromResult(CreateBinaryResponse(fullTile));
+                }
+
+                throw new InvalidOperationException("Unexpected URL: " + url);
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://log.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                StartIndex = 0,
+                BatchSize = 1,
+                KnownTreeSize = 1,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        Assert.Equal([
+            "https://mon.ct.example.test/2026h1/tile/data/000.p/1",
+            "https://mon.ct.example.test/2026h1/tile/data/000"
+        ], requestedUrls);
+        CtLogIngestionEntry entry = Assert.Single(batch.Entries);
+        Assert.Equal(0L, entry.EntryIndex);
+        Assert.Equal(CtLogEntryType.X509, entry.EntryType);
+        Assert.Contains("site1.com", entry.Certificate.DnsNames, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_RejectsStaticCtDataTileWithUnexpectedEntryCount() {
+        byte[] certificateDer = LoadCertificateDer("multi.pem");
+        byte[] first = CreateStaticCtX509Tile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:05Z"));
+        byte[] second = CreateStaticCtX509Tile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:06Z"));
+        byte[] tile = first.Concat(second).ToArray();
+        var client = new CtLogIngestionClient {
+            SendOverride = (_, _) => Task.FromResult(CreateBinaryResponse(tile))
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.ReadBatchAsync(
+                new CtLogIngestionBatchRequest {
+                    LogUrl = "https://log.ct.example.test/2026h1/",
+                    ApiKind = CtLogApiKind.StaticCt,
+                    MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                    StartIndex = 0,
+                    BatchSize = 1,
+                    KnownTreeSize = 1,
+                    RequestTimeout = TimeSpan.FromSeconds(5)
+                },
+                CancellationToken.None));
+
+        Assert.Contains("contained 2 entries", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_ReadsStaticCtPrecertificateLeaf() {
+        byte[] certificateDer = LoadCertificateDer("multi.pem");
+        byte[] tile = CreateStaticCtPrecertificateTile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:05Z"));
+        var client = new CtLogIngestionClient {
+            SendOverride = (_, _) => Task.FromResult(CreateBinaryResponse(tile))
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://log.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                StartIndex = 0,
+                BatchSize = 1,
+                KnownTreeSize = 1,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        CtLogIngestionEntry entry = Assert.Single(batch.Entries);
+        Assert.Equal(CtLogEntryType.Precertificate, entry.EntryType);
+        Assert.True(entry.IsPrecertificate);
+        Assert.Contains("site1.com", entry.Certificate.DnsNames, StringComparer.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -223,4 +677,70 @@ public sealed class TestCtLogIngestionClient {
         => new(HttpStatusCode.OK) {
             Content = new StringContent(json, Encoding.UTF8, "application/json")
         };
+
+    private static HttpResponseMessage CreateTextResponse(string text)
+        => new(HttpStatusCode.OK) {
+            Content = new StringContent(text, Encoding.UTF8, "text/plain")
+        };
+
+    private static HttpResponseMessage CreateBinaryResponse(byte[] bytes)
+        => new(HttpStatusCode.OK) {
+            Content = new ByteArrayContent(bytes)
+        };
+
+    private static byte[] LoadCertificateDer(string fileName) {
+        string pem = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Data", fileName));
+        string base64 = pem
+            .Replace("-----BEGIN CERTIFICATE-----", string.Empty)
+            .Replace("-----END CERTIFICATE-----", string.Empty)
+            .Replace("\r", string.Empty)
+            .Replace("\n", string.Empty)
+            .Trim();
+        return Convert.FromBase64String(base64);
+    }
+
+    private static byte[] CreateStaticCtX509Tile(byte[] certificateDer, DateTimeOffset timestampUtc) {
+        using var stream = new MemoryStream();
+        WriteUInt64(stream, (ulong)timestampUtc.ToUnixTimeMilliseconds());
+        WriteUInt16(stream, 0);
+        WriteVector24(stream, certificateDer);
+        WriteVector16(stream, Array.Empty<byte>());
+        WriteVector16(stream, Array.Empty<byte>());
+        return stream.ToArray();
+    }
+
+    private static byte[] CreateStaticCtPrecertificateTile(byte[] certificateDer, DateTimeOffset timestampUtc) {
+        using var stream = new MemoryStream();
+        WriteUInt64(stream, (ulong)timestampUtc.ToUnixTimeMilliseconds());
+        WriteUInt16(stream, 1);
+        stream.Write(new byte[32], 0, 32);
+        WriteVector24(stream, Array.Empty<byte>());
+        WriteVector16(stream, Array.Empty<byte>());
+        WriteVector24(stream, certificateDer);
+        WriteVector16(stream, Array.Empty<byte>());
+        return stream.ToArray();
+    }
+
+    private static void WriteUInt16(Stream stream, int value) {
+        stream.WriteByte((byte)((value >> 8) & 0xff));
+        stream.WriteByte((byte)(value & 0xff));
+    }
+
+    private static void WriteUInt64(Stream stream, ulong value) {
+        for (int i = 7; i >= 0; i--) {
+            stream.WriteByte((byte)((value >> (i * 8)) & 0xff));
+        }
+    }
+
+    private static void WriteVector16(Stream stream, byte[] bytes) {
+        WriteUInt16(stream, bytes.Length);
+        stream.Write(bytes, 0, bytes.Length);
+    }
+
+    private static void WriteVector24(Stream stream, byte[] bytes) {
+        stream.WriteByte((byte)((bytes.Length >> 16) & 0xff));
+        stream.WriteByte((byte)((bytes.Length >> 8) & 0xff));
+        stream.WriteByte((byte)(bytes.Length & 0xff));
+        stream.Write(bytes, 0, bytes.Length);
+    }
 }

--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.IO.Compression;
 using System.Text;
 
 namespace DomainDetective.Tests;
@@ -410,6 +411,25 @@ public sealed class TestCtLogIngestionClient {
     }
 
     [Fact]
+    public async Task GetTreeSizeAsync_RejectsStaticCtCheckpointWithoutTreeSizeLine() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => Task.FromResult(CreateTextResponse("log.ct.example.test/2026h1"))
+        };
+
+        InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            client.GetTreeSizeAsync(
+                new CtLogDescriptor {
+                    Url = "https://log.ct.example.test/2026h1/",
+                    ApiKind = CtLogApiKind.StaticCt,
+                    MonitoringUrl = "https://mon.ct.example.test/2026h1/"
+                },
+                TimeSpan.FromSeconds(5),
+                CancellationToken.None));
+
+        Assert.Contains("tree size", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task GetTreeSizeAsync_RejectsStaticCtCheckpointWithUnexpectedOrigin() {
         var client = new CtLogIngestionClient {
             SendOverride = static (_, _) => Task.FromResult(CreateTextResponse("""
@@ -514,6 +534,62 @@ public sealed class TestCtLogIngestionClient {
         Assert.Equal(0L, entry.EntryIndex);
         Assert.Equal(CtLogEntryType.X509, entry.EntryType);
         Assert.Contains("site1.com", entry.Certificate.DnsNames, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_ReadsGzipEncodedStaticCtDataTile() {
+        byte[] certificateDer = LoadCertificateDer("multi.pem");
+        byte[] tile = CreateStaticCtX509Tile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:05Z"));
+        var client = new CtLogIngestionClient {
+            SendOverride = (request, _) => {
+                Assert.Contains("/tile/data/000.p/1", request.RequestUri?.ToString(), StringComparison.Ordinal);
+                return Task.FromResult(CreateGzipResponse(tile));
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://log.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                StartIndex = 0,
+                BatchSize = 1,
+                KnownTreeSize = 1,
+                RequestTimeout = TimeSpan.FromSeconds(5)
+            },
+            CancellationToken.None);
+
+        CtLogIngestionEntry entry = Assert.Single(batch.Entries);
+        Assert.Equal(CtLogEntryType.X509, entry.EntryType);
+        Assert.Contains("site1.com", entry.Certificate.DnsNames, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ReadBatchAsync_RejectsStaticCtDataTileWithOversizedContentLength() {
+        var client = new CtLogIngestionClient {
+            SendOverride = static (_, _) => {
+                var content = new ByteArrayContent(Array.Empty<byte>());
+                content.Headers.ContentLength = CtLogIngestionClient.MaxResponseBodyBytes + 1L;
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                    Content = content
+                });
+            }
+        };
+
+        HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            client.ReadBatchAsync(
+                new CtLogIngestionBatchRequest {
+                    LogUrl = "https://log.ct.example.test/2026h1/",
+                    ApiKind = CtLogApiKind.StaticCt,
+                    MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                    StartIndex = 0,
+                    BatchSize = 1,
+                    KnownTreeSize = 1,
+                    RequestTimeout = TimeSpan.FromSeconds(5)
+                },
+                CancellationToken.None));
+
+        Assert.Contains("limit", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -687,6 +763,19 @@ public sealed class TestCtLogIngestionClient {
         => new(HttpStatusCode.OK) {
             Content = new ByteArrayContent(bytes)
         };
+
+    private static HttpResponseMessage CreateGzipResponse(byte[] bytes) {
+        using var compressedStream = new MemoryStream();
+        using (var gzip = new GZipStream(compressedStream, CompressionMode.Compress, leaveOpen: true)) {
+            gzip.Write(bytes, 0, bytes.Length);
+        }
+
+        var content = new ByteArrayContent(compressedStream.ToArray());
+        content.Headers.ContentEncoding.Add("gzip");
+        return new HttpResponseMessage(HttpStatusCode.OK) {
+            Content = content
+        };
+    }
 
     private static byte[] LoadCertificateDer(string fileName) {
         string pem = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Data", fileName));

--- a/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
+++ b/DomainDetective/CertificateTransparency/CtCertificateRecord.cs
@@ -137,12 +137,20 @@ public sealed class CtCertificateRecord
         using X509Certificate2 certificate = CertificateLoaderCompat.LoadCertificate(rawData);
         if (detailLevel == CtCertificateRecordDetailLevel.NamesOnly)
         {
+            byte[] namesOnlySha256Bytes;
+            using (SHA256 sha256 = SHA256.Create())
+            {
+                namesOnlySha256Bytes = sha256.ComputeHash(rawData);
+            }
+
             return new CtCertificateRecord
             {
                 ProviderId = providerId ?? string.Empty,
                 ProviderCertificateId = providerCertificateId,
                 DetailLevel = CtCertificateRecordDetailLevel.NamesOnly,
                 EntryTimestampUtc = entryTimestampUtc,
+                Sha256Fingerprint = ToHex(namesOnlySha256Bytes),
+                TbsSha256 = NormalizeHex(tbsSha256),
                 DnsNames = ExtractDnsNames(certificate),
                 CertificateDer = rawData,
                 IsPrecertificate = isPrecertificate

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -171,6 +172,7 @@ public sealed class CtLogIngestionBatchRequest {
 public sealed class CtLogIngestionClient {
     /// <summary>Maximum number of entries requested from one RFC6962 <c>get-entries</c> call.</summary>
     public const int MaxBatchSize = 8192;
+    internal const int MaxResponseBodyBytes = 64 * 1024 * 1024;
     private const int StaticCtTileWidth = 256;
     private const int X509EntryType = 0;
     private const int PrecertEntryType = 1;
@@ -576,7 +578,9 @@ public sealed class CtLogIngestionClient {
             throw CreateRequestFailure(response);
         }
 
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        byte[] bytes = await ReadContentBytesWithLimitAsync(response.Content, MaxResponseBodyBytes, effectiveToken).ConfigureAwait(false);
+        Encoding encoding = GetResponseEncoding(response.Content.Headers.ContentType?.CharSet);
+        return encoding.GetString(bytes);
     }
 
     private async Task<byte[]> FetchBytesAsync(string url, TimeSpan timeout, CancellationToken cancellationToken) {
@@ -598,16 +602,58 @@ public sealed class CtLogIngestionClient {
             throw CreateRequestFailure(response);
         }
 
-        byte[] bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+        byte[] bytes = await ReadContentBytesWithLimitAsync(response.Content, MaxResponseBodyBytes, effectiveToken).ConfigureAwait(false);
         if (response.Content.Headers.ContentEncoding.Any(static value => string.Equals(value, "gzip", StringComparison.OrdinalIgnoreCase))) {
             using var compressed = new MemoryStream(bytes);
             using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
-            using var decompressed = new MemoryStream();
-            await gzip.CopyToAsync(decompressed).ConfigureAwait(false);
-            return decompressed.ToArray();
+            return await ReadStreamBytesWithLimitAsync(gzip, MaxResponseBodyBytes, effectiveToken).ConfigureAwait(false);
         }
 
         return bytes;
+    }
+
+    private static async Task<byte[]> ReadContentBytesWithLimitAsync(
+        HttpContent content,
+        int maxBytes,
+        CancellationToken cancellationToken) {
+        if (content.Headers.ContentLength is long contentLength && contentLength > maxBytes) {
+            throw new HttpRequestException($"HTTP response body exceeded the {maxBytes} byte limit.");
+        }
+
+        using Stream stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+        return await ReadStreamBytesWithLimitAsync(stream, maxBytes, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<byte[]> ReadStreamBytesWithLimitAsync(
+        Stream stream,
+        int maxBytes,
+        CancellationToken cancellationToken) {
+        var buffer = new byte[81920];
+        using var output = new MemoryStream();
+        while (true) {
+            int read = await stream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+            if (read == 0) {
+                return output.ToArray();
+            }
+
+            if (output.Length + read > maxBytes) {
+                throw new HttpRequestException($"HTTP response body exceeded the {maxBytes} byte limit.");
+            }
+
+            output.Write(buffer, 0, read);
+        }
+    }
+
+    private static Encoding GetResponseEncoding(string? charset) {
+        if (!string.IsNullOrWhiteSpace(charset)) {
+            string charsetValue = charset!;
+            try {
+                return Encoding.GetEncoding(charsetValue.Trim('"'));
+            } catch (ArgumentException) {
+            }
+        }
+
+        return Encoding.UTF8;
     }
 
     internal static HttpRequestException CreateRequestFailure(HttpResponseMessage response) {
@@ -935,6 +981,10 @@ public sealed class CtLogIngestionClient {
         }
 
         string[] lines = checkpoint.Replace("\r\n", "\n").Split('\n');
+        if (lines.Length < 2) {
+            throw new InvalidOperationException("Static CT checkpoint did not include a tree size on the second line.");
+        }
+
         if (!string.IsNullOrWhiteSpace(expectedOrigin)) {
             string checkpointOrigin = NormalizeStaticCheckpointOrigin(lines[0]);
             string expected = NormalizeStaticCheckpointOrigin(expectedOrigin);
@@ -947,8 +997,7 @@ public sealed class CtLogIngestionClient {
             }
         }
 
-        if (lines.Length < 2 ||
-            !long.TryParse(lines[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long treeSize) ||
+        if (!long.TryParse(lines[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long treeSize) ||
             treeSize < 0) {
             throw new InvalidOperationException("Static CT checkpoint did not include a tree size on the second line.");
         }
@@ -964,7 +1013,7 @@ public sealed class CtLogIngestionClient {
             return null;
         }
 
-        return ToStaticCheckpointOrigin(normalizedSubmissionUrl);
+        return ToStaticCheckpointOrigin(normalizedSubmissionUrl!);
     }
 
     private static string ToStaticCheckpointOrigin(string normalizedUrl) {
@@ -976,6 +1025,10 @@ public sealed class CtLogIngestionClient {
     private static string NormalizeStaticCheckpointOrigin(string? origin)
         => (origin ?? string.Empty).Trim().TrimEnd('/');
 
+    /// <remarks>
+    /// Static CT checkpoints use note signatures. This check confirms a signature line for the
+    /// expected origin is present, but does not cryptographically verify the signature value.
+    /// </remarks>
     private static bool HasStaticCheckpointSignatureForOrigin(string[] checkpointLines, string expectedOrigin) {
         string asciiExpectedPrefix = "- " + expectedOrigin + " ";
         string noteExpectedPrefix = "\u2014 " + expectedOrigin + " ";

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -2,9 +2,12 @@ using DomainDetective.Helpers;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -43,11 +46,33 @@ public enum CtLogEntryType {
 }
 
 /// <summary>
+/// Describes the CT log read API used by an endpoint.
+/// </summary>
+public enum CtLogApiKind {
+    /// <summary>RFC6962 JSON APIs such as <c>get-sth</c> and <c>get-entries</c>.</summary>
+    Rfc6962 = 0,
+    /// <summary>Static CT monitoring API with checkpoints and immutable data tiles.</summary>
+    StaticCt = 1
+}
+
+/// <summary>
 /// Describes one CT log endpoint.
 /// </summary>
 public sealed class CtLogDescriptor {
     /// <summary>Base CT log URL.</summary>
     public string Url { get; init; } = string.Empty;
+    /// <summary>Base64 CT log ID when supplied by an authoritative log list.</summary>
+    public string? LogId { get; init; }
+    /// <summary>Base64 public key when supplied by an authoritative log list.</summary>
+    public string? PublicKey { get; init; }
+    /// <summary>Maximum merge delay in seconds when supplied by an authoritative log list.</summary>
+    public int? MaximumMergeDelaySeconds { get; init; }
+    /// <summary>Read API used by this log.</summary>
+    public CtLogApiKind ApiKind { get; init; } = CtLogApiKind.Rfc6962;
+    /// <summary>Static CT monitoring prefix when <see cref="ApiKind"/> is <see cref="CtLogApiKind.StaticCt"/>.</summary>
+    public string? MonitoringUrl { get; init; }
+    /// <summary>Static CT submission prefix, or the RFC6962 base URL.</summary>
+    public string? SubmissionUrl { get; init; }
     /// <summary>Human-readable CT log operator name when supplied by the log list.</summary>
     public string? OperatorName { get; init; }
     /// <summary>Human-readable log description when available.</summary>
@@ -60,6 +85,19 @@ public sealed class CtLogDescriptor {
     public DateTimeOffset? TemporalStartUtc { get; init; }
     /// <summary>Temporal interval end when supplied by the log list.</summary>
     public DateTimeOffset? TemporalEndUtc { get; init; }
+    /// <summary>True when the log list marks this log read-only.</summary>
+    public bool IsReadOnly => IsState("readonly");
+    /// <summary>True when the log list marks this log pending.</summary>
+    public bool IsPending => IsState("pending");
+    /// <summary>True when the log list marks this log rejected.</summary>
+    public bool IsRejected => IsState("rejected");
+    /// <summary>True when the log list marks this log usable.</summary>
+    public bool IsUsable => IsState("usable");
+    /// <summary>True when the log list marks this log qualified.</summary>
+    public bool IsQualified => IsState("qualified");
+
+    private bool IsState(string state)
+        => string.Equals(State?.Trim(), state, StringComparison.OrdinalIgnoreCase);
 }
 
 /// <summary>
@@ -106,6 +144,10 @@ public sealed class CtLogIngestionBatch {
 public sealed class CtLogIngestionBatchRequest {
     /// <summary>Base CT log URL.</summary>
     public string LogUrl { get; init; } = string.Empty;
+    /// <summary>Read API used by this log.</summary>
+    public CtLogApiKind ApiKind { get; init; } = CtLogApiKind.Rfc6962;
+    /// <summary>Static CT monitoring prefix used for checkpoint and tile reads.</summary>
+    public string? MonitoringUrl { get; init; }
     /// <summary>First entry index to fetch.</summary>
     public long StartIndex { get; init; }
     /// <summary>Maximum entries to request. RFC6962 logs may return fewer entries.</summary>
@@ -124,11 +166,12 @@ public sealed class CtLogIngestionBatchRequest {
 }
 
 /// <summary>
-/// Reads native RFC6962 Certificate Transparency log entries and returns normalized certificate records.
+/// Reads native Certificate Transparency log entries and returns normalized certificate records.
 /// </summary>
 public sealed class CtLogIngestionClient {
     /// <summary>Maximum number of entries requested from one RFC6962 <c>get-entries</c> call.</summary>
     public const int MaxBatchSize = 8192;
+    private const int StaticCtTileWidth = 256;
     private const int X509EntryType = 0;
     private const int PrecertEntryType = 1;
     private readonly ConcurrentDictionary<string, CachedSignedTreeHead> _signedTreeHeadCache = new();
@@ -149,6 +192,7 @@ public sealed class CtLogIngestionClient {
         string logListUrl = "https://www.gstatic.com/ct/log_list/v3/log_list.json",
         bool includeRetired = true,
         bool includePending = false,
+        bool includeUnknownState = true,
         CancellationToken cancellationToken = default) {
         if (string.IsNullOrWhiteSpace(logListUrl)) {
             throw new ArgumentException("Log list URL cannot be null or whitespace.", nameof(logListUrl));
@@ -164,32 +208,9 @@ public sealed class CtLogIngestionClient {
 
         var output = new Dictionary<string, CtLogDescriptor>(StringComparer.OrdinalIgnoreCase);
         foreach (JsonElement op in operators.EnumerateArray()) {
-            if (!op.TryGetProperty("logs", out JsonElement logs) || logs.ValueKind != JsonValueKind.Array) {
-                continue;
-            }
-
             string? operatorName = GetString(op, "name");
-            foreach (JsonElement log in logs.EnumerateArray()) {
-                if (!ShouldIncludeLog(log, includeRetired, includePending)) {
-                    continue;
-                }
-
-                string? url = NormalizeLogUrl(GetString(log, "url"));
-                if (url == null) {
-                    continue;
-                }
-
-                TryGetTemporalInterval(log, out DateTimeOffset? startUtc, out DateTimeOffset? endUtc);
-                output[url] = new CtLogDescriptor {
-                    Url = url,
-                    OperatorName = operatorName,
-                    Description = GetString(log, "description"),
-                    State = GetLogState(log),
-                    IsRetired = IsRetiredLog(log),
-                    TemporalStartUtc = startUtc,
-                    TemporalEndUtc = endUtc
-                };
-            }
+            AppendLogListEntries(output, op, "logs", operatorName, CtLogApiKind.Rfc6962, includeRetired, includePending, includeUnknownState);
+            AppendLogListEntries(output, op, "tiled_logs", operatorName, CtLogApiKind.StaticCt, includeRetired, includePending, includeUnknownState);
         }
 
         return output.Values
@@ -211,6 +232,10 @@ public sealed class CtLogIngestionClient {
 
         string logUrl = NormalizeLogUrl(request.LogUrl) ??
             throw new ArgumentException("Log URL must be an absolute URL.", nameof(request));
+        if (request.ApiKind == CtLogApiKind.StaticCt) {
+            return await ReadStaticBatchAsync(request, logUrl, cancellationToken).ConfigureAwait(false);
+        }
+
         long start = Math.Max(0, request.StartIndex);
         int batchSize = Math.Max(1, Math.Min(request.BatchSize, MaxBatchSize));
         TimeSpan timeout = request.RequestTimeout > TimeSpan.Zero ? request.RequestTimeout : TimeSpan.FromSeconds(30);
@@ -297,10 +322,36 @@ public sealed class CtLogIngestionClient {
     }
 
     /// <summary>
+    /// Reads the current signed tree head for a described CT log.
+    /// </summary>
+    public Task<CtSignedTreeHead> GetSignedTreeHeadAsync(CtLogDescriptor log, TimeSpan timeout, CancellationToken cancellationToken = default) {
+        if (log == null) {
+            throw new ArgumentNullException(nameof(log));
+        }
+
+        string? monitoringUrl = log.MonitoringUrl ?? log.Url;
+        return log.ApiKind == CtLogApiKind.StaticCt
+            ? GetStaticSignedTreeHeadAsync(
+                monitoringUrl,
+                GetStaticCheckpointExpectedOrigin(log.Url, monitoringUrl, log.SubmissionUrl),
+                timeout,
+                cancellationToken)
+            : GetSignedTreeHeadAsync(log.Url, timeout, cancellationToken);
+    }
+
+    /// <summary>
     /// Reads the current signed tree head size for a CT log.
     /// </summary>
     public async Task<long> GetTreeSizeAsync(string logUrl, TimeSpan timeout, CancellationToken cancellationToken = default) {
         CtSignedTreeHead signedTreeHead = await GetSignedTreeHeadAsync(logUrl, timeout, cancellationToken).ConfigureAwait(false);
+        return signedTreeHead.TreeSize;
+    }
+
+    /// <summary>
+    /// Reads the current signed tree head size for a described CT log.
+    /// </summary>
+    public async Task<long> GetTreeSizeAsync(CtLogDescriptor log, TimeSpan timeout, CancellationToken cancellationToken = default) {
+        CtSignedTreeHead signedTreeHead = await GetSignedTreeHeadAsync(log, timeout, cancellationToken).ConfigureAwait(false);
         return signedTreeHead.TreeSize;
     }
 
@@ -344,6 +395,129 @@ public sealed class CtLogIngestionClient {
         return output;
     }
 
+    private async Task<CtLogIngestionBatch> ReadStaticBatchAsync(
+        CtLogIngestionBatchRequest request,
+        string submissionUrl,
+        CancellationToken cancellationToken) {
+        string monitoringUrl = NormalizeLogUrl(request.MonitoringUrl) ??
+            throw new ArgumentException("Static CT logs require an absolute monitoring URL.", nameof(request));
+        long start = Math.Max(0, request.StartIndex);
+        int batchSize = Math.Max(1, Math.Min(request.BatchSize, MaxBatchSize));
+        TimeSpan timeout = request.RequestTimeout > TimeSpan.Zero ? request.RequestTimeout : TimeSpan.FromSeconds(30);
+        CtCertificateRecordDetailLevel certificateDetailLevel = request.CertificateDetailLevel;
+        long treeSize = request.KnownTreeSize is long knownTreeSize && knownTreeSize >= 0
+            ? knownTreeSize
+            : (await GetStaticSignedTreeHeadAsync(
+                monitoringUrl,
+                GetStaticCheckpointExpectedOrigin(submissionUrl, monitoringUrl, submissionUrl),
+                timeout,
+                cancellationToken).ConfigureAwait(false)).TreeSize;
+        if (treeSize <= 0 || start >= treeSize) {
+            return new CtLogIngestionBatch {
+                LogUrl = submissionUrl,
+                TreeSize = treeSize,
+                StartIndex = start,
+                EndIndex = start - 1
+            };
+        }
+
+        long end = Math.Min(treeSize - 1, start + batchSize - 1);
+        var entries = new List<CtLogIngestionEntry>();
+        var diagnostics = new List<string>();
+        for (long tileIndex = start / StaticCtTileWidth; tileIndex <= end / StaticCtTileWidth; tileIndex++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            IReadOnlyList<StaticCtTileEntry> tileEntries = await GetStaticDataTileEntriesAsync(
+                monitoringUrl,
+                tileIndex,
+                treeSize,
+                timeout,
+                cancellationToken).ConfigureAwait(false);
+            long tileStartIndex = tileIndex * StaticCtTileWidth;
+            for (int tileOffset = 0; tileOffset < tileEntries.Count; tileOffset++) {
+                long entryIndex = tileStartIndex + tileOffset;
+                if (entryIndex < start || entryIndex > end) {
+                    continue;
+                }
+
+                StaticCtTileEntry tileEntry = tileEntries[tileOffset];
+                try {
+                    entries.Add(new CtLogIngestionEntry {
+                        LogUrl = submissionUrl,
+                        EntryIndex = entryIndex,
+                        TreeSize = treeSize,
+                        EntryTimestampUtc = tileEntry.TimestampUtc,
+                        EntryType = tileEntry.EntryType,
+                        Certificate = CtCertificateRecord.FromDer(
+                            CtProviderProfiles.NativeCtProviderId,
+                            tileEntry.CertificateDer,
+                            providerCertificateId: $"{submissionUrl}#{entryIndex}",
+                            entryTimestampUtc: tileEntry.TimestampUtc,
+                            isPrecertificate: tileEntry.EntryType == CtLogEntryType.Precertificate,
+                            detailLevel: certificateDetailLevel)
+                    });
+                } catch (Exception ex) when (!ExceptionHelper.IsFatal(ex)) {
+                    diagnostics.Add($"Entry {entryIndex}: certificate decode failed: {ex.Message}");
+                }
+            }
+        }
+
+        return new CtLogIngestionBatch {
+            LogUrl = submissionUrl,
+            TreeSize = treeSize,
+            StartIndex = start,
+            EndIndex = end,
+            Entries = entries,
+            Diagnostics = diagnostics
+        };
+    }
+
+    private async Task<CtSignedTreeHead> GetStaticSignedTreeHeadAsync(
+        string monitoringUrl,
+        string? expectedOrigin,
+        TimeSpan timeout,
+        CancellationToken cancellationToken) {
+        monitoringUrl = NormalizeLogUrl(monitoringUrl) ??
+            throw new ArgumentException("Static CT monitoring URL must be an absolute URL.", nameof(monitoringUrl));
+        string cacheKey = "static:" + monitoringUrl;
+        if (TryGetCachedSignedTreeHead(cacheKey, out CtSignedTreeHead cachedTreeHead)) {
+            return cachedTreeHead;
+        }
+
+        string checkpoint = await FetchTextAsync(CombineLogUrl(monitoringUrl, "checkpoint"), timeout, cancellationToken).ConfigureAwait(false);
+        long treeSize = ParseStaticCheckpointTreeSize(checkpoint, expectedOrigin);
+        var signedTreeHead = new CtSignedTreeHead(treeSize, DateTimeOffset.UtcNow);
+        CacheSignedTreeHead(cacheKey, signedTreeHead);
+        return signedTreeHead;
+    }
+
+    private async Task<IReadOnlyList<StaticCtTileEntry>> GetStaticDataTileEntriesAsync(
+        string monitoringUrl,
+        long tileIndex,
+        long treeSize,
+        TimeSpan timeout,
+        CancellationToken cancellationToken) {
+        long firstEntryIndex = tileIndex * StaticCtTileWidth;
+        int width = checked((int)Math.Min(StaticCtTileWidth, treeSize - firstEntryIndex));
+        if (width <= 0) {
+            return Array.Empty<StaticCtTileEntry>();
+        }
+
+        string encodedTileIndex = EncodeStaticTileIndex(tileIndex);
+        string relativePath = width == StaticCtTileWidth
+            ? $"tile/data/{encodedTileIndex}"
+            : $"tile/data/{encodedTileIndex}.p/{width}";
+        byte[] tileBytes;
+        int expectedWidth = width;
+        try {
+            tileBytes = await FetchBytesAsync(CombineLogUrl(monitoringUrl, relativePath), timeout, cancellationToken).ConfigureAwait(false);
+        } catch (HttpRequestException ex) when (width < StaticCtTileWidth && IsStaticPartialTileFallbackFailure(ex)) {
+            tileBytes = await FetchBytesAsync(CombineLogUrl(monitoringUrl, $"tile/data/{encodedTileIndex}"), timeout, cancellationToken).ConfigureAwait(false);
+            expectedWidth = StaticCtTileWidth;
+        }
+
+        return ParseStaticDataTile(tileBytes, expectedWidth);
+    }
+
     private bool TryGetCachedSignedTreeHead(string logUrl, out CtSignedTreeHead signedTreeHead) {
         signedTreeHead = default!;
         TimeSpan cacheDuration = SignedTreeHeadCacheDuration;
@@ -378,6 +552,10 @@ public sealed class CtLogIngestionClient {
     }
 
     private async Task<string> FetchJsonAsync(string url, TimeSpan timeout, CancellationToken cancellationToken) {
+        return await FetchTextAsync(url, timeout, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> FetchTextAsync(string url, TimeSpan timeout, CancellationToken cancellationToken) {
         using var timeoutCts = timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan
             ? new CancellationTokenSource(timeout)
             : null;
@@ -399,6 +577,37 @@ public sealed class CtLogIngestionClient {
         }
 
         return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+    }
+
+    private async Task<byte[]> FetchBytesAsync(string url, TimeSpan timeout, CancellationToken cancellationToken) {
+        using var timeoutCts = timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan
+            ? new CancellationTokenSource(timeout)
+            : null;
+        using var linkedCts = timeoutCts != null
+            ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token)
+            : null;
+        CancellationToken effectiveToken = linkedCts?.Token ?? cancellationToken;
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
+        using HttpResponseMessage response = SendOverride != null
+            ? await SendOverride(request, effectiveToken).ConfigureAwait(false)
+            : await SharedHttpClient.Instance.SendAsync(request, effectiveToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode) {
+            throw CreateRequestFailure(response);
+        }
+
+        byte[] bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+        if (response.Content.Headers.ContentEncoding.Any(static value => string.Equals(value, "gzip", StringComparison.OrdinalIgnoreCase))) {
+            using var compressed = new MemoryStream(bytes);
+            using var gzip = new GZipStream(compressed, CompressionMode.Decompress);
+            using var decompressed = new MemoryStream();
+            await gzip.CopyToAsync(decompressed).ConfigureAwait(false);
+            return decompressed.ToArray();
+        }
+
+        return bytes;
     }
 
     internal static HttpRequestException CreateRequestFailure(HttpResponseMessage response) {
@@ -457,6 +666,15 @@ public sealed class CtLogIngestionClient {
 #endif
     }
 
+    private static bool IsStaticPartialTileFallbackFailure(HttpRequestException exception) {
+#if NET5_0_OR_GREATER
+        return exception.StatusCode is HttpStatusCode.NotFound or HttpStatusCode.Gone;
+#else
+        return exception.Message.Contains("HTTP 404", StringComparison.Ordinal) ||
+               exception.Message.Contains("HTTP 410", StringComparison.Ordinal);
+#endif
+    }
+
     private static bool TryDecodeCertificate(
         RawCtEntryPayload payload,
         out DateTimeOffset? timestampUtc,
@@ -508,6 +726,100 @@ public sealed class CtLogIngestionClient {
             return false;
         }
 
+        return true;
+    }
+
+    private static IReadOnlyList<StaticCtTileEntry> ParseStaticDataTile(byte[] tileBytes, int expectedWidth) {
+        if (tileBytes == null) {
+            throw new ArgumentNullException(nameof(tileBytes));
+        }
+
+        var entries = new List<StaticCtTileEntry>(Math.Max(0, expectedWidth));
+        int offset = 0;
+        while (offset < tileBytes.Length) {
+            int entryOffset = offset;
+            if (!TryParseStaticTileLeaf(tileBytes, ref offset, out StaticCtTileEntry? entry)) {
+                throw new InvalidOperationException($"Static CT data tile could not be parsed at byte offset {entryOffset}.");
+            }
+
+            entries.Add(entry!);
+        }
+
+        if (expectedWidth > 0 && entries.Count != expectedWidth) {
+            throw new InvalidOperationException($"Static CT data tile contained {entries.Count} entries but {expectedWidth} were expected.");
+        }
+
+        return entries;
+    }
+
+    private static bool TryParseStaticTileLeaf(byte[] data, ref int offset, out StaticCtTileEntry? entry) {
+        entry = null;
+        int startOffset = offset;
+        if (!TryReadUInt64BigEndian(data, ref offset, out ulong timestampMs) ||
+            !TryReadUInt16BigEndian(data, ref offset, out int rawEntryType)) {
+            offset = startOffset;
+            return false;
+        }
+
+        DateTimeOffset? timestampUtc;
+        try {
+            timestampUtc = DateTimeOffset.FromUnixTimeMilliseconds((long)timestampMs);
+        } catch (ArgumentOutOfRangeException) {
+            timestampUtc = null;
+        }
+
+        byte[]? certificateDer = null;
+        CtLogEntryType entryType = rawEntryType switch {
+            X509EntryType => CtLogEntryType.X509,
+            PrecertEntryType => CtLogEntryType.Precertificate,
+            _ => CtLogEntryType.Unknown
+        };
+
+        if (rawEntryType == X509EntryType) {
+            if (!TryReadVector24(data, ref offset, out certificateDer)) {
+                offset = startOffset;
+                return false;
+            }
+        } else if (rawEntryType == PrecertEntryType) {
+            if (offset + 32 > data.Length) {
+                offset = startOffset;
+                return false;
+            }
+
+            offset += 32;
+            if (!TryReadVector24(data, ref offset, out _)) {
+                offset = startOffset;
+                return false;
+            }
+        } else {
+            offset = startOffset;
+            return false;
+        }
+
+        if (!TryReadVector16(data, ref offset, out _)) {
+            offset = startOffset;
+            return false;
+        }
+
+        if (rawEntryType == PrecertEntryType &&
+            !TryReadVector24(data, ref offset, out certificateDer)) {
+            offset = startOffset;
+            return false;
+        }
+
+        if (!TryReadVector16(data, ref offset, out byte[]? certificateChain)) {
+            offset = startOffset;
+            return false;
+        }
+
+        if (certificateDer == null || certificateDer.Length == 0 ||
+            certificateChain == null ||
+            certificateChain.Length % 32 != 0) {
+            offset = startOffset;
+            return false;
+        }
+
+        entry = new StaticCtTileEntry(timestampUtc, entryType, certificateDer);
         return true;
     }
 
@@ -589,6 +901,18 @@ public sealed class CtLogIngestionClient {
         return true;
     }
 
+    private static bool TryReadVector16(byte[] data, ref int offset, out byte[]? bytes) {
+        bytes = null;
+        if (!TryReadUInt16BigEndian(data, ref offset, out int length) || length < 0 || offset + length > data.Length) {
+            return false;
+        }
+
+        bytes = new byte[length];
+        Buffer.BlockCopy(data, offset, bytes, 0, length);
+        offset += length;
+        return true;
+    }
+
     private static bool TryReadUInt24(byte[] data, ref int offset, out int value) {
         value = 0;
         if (data == null || offset < 0 || offset + 3 > data.Length) {
@@ -603,6 +927,141 @@ public sealed class CtLogIngestionClient {
     private static string CombineLogUrl(string logUrl, string relative) {
         string baseUrl = logUrl.EndsWith("/", StringComparison.Ordinal) ? logUrl : logUrl + "/";
         return baseUrl + relative;
+    }
+
+    private static long ParseStaticCheckpointTreeSize(string checkpoint, string? expectedOrigin) {
+        if (string.IsNullOrWhiteSpace(checkpoint)) {
+            throw new InvalidOperationException("Static CT checkpoint was empty.");
+        }
+
+        string[] lines = checkpoint.Replace("\r\n", "\n").Split('\n');
+        if (!string.IsNullOrWhiteSpace(expectedOrigin)) {
+            string checkpointOrigin = NormalizeStaticCheckpointOrigin(lines[0]);
+            string expected = NormalizeStaticCheckpointOrigin(expectedOrigin);
+            if (!string.Equals(checkpointOrigin, expected, StringComparison.OrdinalIgnoreCase)) {
+                throw new InvalidOperationException($"Static CT checkpoint origin '{checkpointOrigin}' did not match expected origin '{expected}'.");
+            }
+
+            if (!HasStaticCheckpointSignatureForOrigin(lines, expected)) {
+                throw new InvalidOperationException($"Static CT checkpoint did not include a note signature for expected origin '{expected}'.");
+            }
+        }
+
+        if (lines.Length < 2 ||
+            !long.TryParse(lines[1].Trim(), NumberStyles.Integer, CultureInfo.InvariantCulture, out long treeSize) ||
+            treeSize < 0) {
+            throw new InvalidOperationException("Static CT checkpoint did not include a tree size on the second line.");
+        }
+
+        return treeSize;
+    }
+
+    private static string? GetStaticCheckpointExpectedOrigin(string? logUrl, string? monitoringUrl, string? submissionUrl) {
+        string? normalizedMonitoringUrl = NormalizeLogUrl(monitoringUrl);
+        string? normalizedSubmissionUrl = NormalizeLogUrl(submissionUrl) ?? NormalizeLogUrl(logUrl);
+        if (string.IsNullOrWhiteSpace(normalizedSubmissionUrl) ||
+            string.Equals(normalizedSubmissionUrl, normalizedMonitoringUrl, StringComparison.OrdinalIgnoreCase)) {
+            return null;
+        }
+
+        return ToStaticCheckpointOrigin(normalizedSubmissionUrl);
+    }
+
+    private static string ToStaticCheckpointOrigin(string normalizedUrl) {
+        Uri uri = new(normalizedUrl, UriKind.Absolute);
+        string path = uri.AbsolutePath.Trim('/');
+        return path.Length == 0 ? uri.Host : uri.Host + "/" + path;
+    }
+
+    private static string NormalizeStaticCheckpointOrigin(string? origin)
+        => (origin ?? string.Empty).Trim().TrimEnd('/');
+
+    private static bool HasStaticCheckpointSignatureForOrigin(string[] checkpointLines, string expectedOrigin) {
+        string asciiExpectedPrefix = "- " + expectedOrigin + " ";
+        string noteExpectedPrefix = "\u2014 " + expectedOrigin + " ";
+        foreach (string line in checkpointLines) {
+            string trimmed = line.Trim();
+            if (trimmed.StartsWith(asciiExpectedPrefix, StringComparison.OrdinalIgnoreCase) ||
+                trimmed.StartsWith(noteExpectedPrefix, StringComparison.OrdinalIgnoreCase)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string EncodeStaticTileIndex(long tileIndex) {
+        if (tileIndex < 0) {
+            throw new ArgumentOutOfRangeException(nameof(tileIndex));
+        }
+
+        var parts = new Stack<string>();
+        do {
+            parts.Push((tileIndex % 1000).ToString("000", CultureInfo.InvariantCulture));
+            tileIndex /= 1000;
+        } while (tileIndex > 0);
+
+        string[] pathParts = parts.ToArray();
+        for (int i = 0; i < pathParts.Length - 1; i++) {
+            pathParts[i] = "x" + pathParts[i];
+        }
+
+        return string.Join("/", pathParts);
+    }
+
+    private static void AppendLogListEntries(
+        Dictionary<string, CtLogDescriptor> output,
+        JsonElement op,
+        string propertyName,
+        string? operatorName,
+        CtLogApiKind apiKind,
+        bool includeRetired,
+        bool includePending,
+        bool includeUnknownState) {
+        if (!op.TryGetProperty(propertyName, out JsonElement logs) || logs.ValueKind != JsonValueKind.Array) {
+            return;
+        }
+
+        foreach (JsonElement log in logs.EnumerateArray()) {
+            if (!ShouldIncludeLog(log, includeRetired, includePending, includeUnknownState)) {
+                continue;
+            }
+
+            string? submissionUrl = NormalizeLogUrl(
+                GetString(log, "submission_url") ??
+                GetString(log, "submissionUrl") ??
+                GetString(log, "url"));
+            string? monitoringUrl = apiKind == CtLogApiKind.StaticCt
+                ? NormalizeLogUrl(
+                    GetString(log, "monitoring_url") ??
+                    GetString(log, "monitoringUrl") ??
+                    GetString(log, "tile_url") ??
+                    GetString(log, "tileUrl") ??
+                    GetString(log, "url"))
+                : null;
+
+            string? identityUrl = submissionUrl ?? monitoringUrl;
+            if (identityUrl == null || (apiKind == CtLogApiKind.StaticCt && monitoringUrl == null)) {
+                continue;
+            }
+
+            TryGetTemporalInterval(log, out DateTimeOffset? startUtc, out DateTimeOffset? endUtc);
+            output[identityUrl] = new CtLogDescriptor {
+                Url = identityUrl,
+                LogId = GetString(log, "log_id") ?? GetString(log, "logId"),
+                PublicKey = GetString(log, "key"),
+                MaximumMergeDelaySeconds = TryGetInt32(log, "mmd", out int mmd) ? mmd : null,
+                ApiKind = apiKind,
+                MonitoringUrl = monitoringUrl,
+                SubmissionUrl = submissionUrl,
+                OperatorName = operatorName,
+                Description = GetString(log, "description"),
+                State = GetLogState(log),
+                IsRetired = IsRetiredLog(log),
+                TemporalStartUtc = startUtc,
+                TemporalEndUtc = endUtc
+            };
+        }
     }
 
     private static string? NormalizeLogUrl(string? rawUrl) {
@@ -624,20 +1083,21 @@ public sealed class CtLogIngestionClient {
         return normalized.EndsWith("/", StringComparison.Ordinal) ? normalized : normalized + "/";
     }
 
-    private static bool ShouldIncludeLog(JsonElement log, bool includeRetired, bool includePending) {
-        if (!log.TryGetProperty("state", out JsonElement state) || state.ValueKind != JsonValueKind.Object) {
-            return true;
+    private static bool ShouldIncludeLog(JsonElement log, bool includeRetired, bool includePending, bool includeUnknownState) {
+        if (!TryGetLogStateElement(log, out _)) {
+            return includeUnknownState;
         }
 
-        if (state.TryGetProperty("rejected", out _)) {
+        string? normalizedState = GetLogState(log);
+        if (string.Equals(normalizedState, "rejected", StringComparison.OrdinalIgnoreCase)) {
             return false;
         }
 
-        if (state.TryGetProperty("retired", out _)) {
+        if (string.Equals(normalizedState, "retired", StringComparison.OrdinalIgnoreCase)) {
             return includeRetired;
         }
 
-        if (state.TryGetProperty("pending", out _)) {
+        if (string.Equals(normalizedState, "pending", StringComparison.OrdinalIgnoreCase)) {
             return includePending;
         }
 
@@ -645,14 +1105,20 @@ public sealed class CtLogIngestionClient {
     }
 
     private static bool IsRetiredLog(JsonElement log) {
-        return log.TryGetProperty("state", out JsonElement state) &&
-               state.ValueKind == JsonValueKind.Object &&
-               state.TryGetProperty("retired", out _);
+        return string.Equals(GetLogState(log), "retired", StringComparison.OrdinalIgnoreCase);
     }
 
     private static string? GetLogState(JsonElement log) {
-        if (!log.TryGetProperty("state", out JsonElement state) || state.ValueKind != JsonValueKind.Object) {
+        if (!TryGetLogStateElement(log, out JsonElement state)) {
             return null;
+        }
+
+        if (state.ValueKind == JsonValueKind.String) {
+            return state.GetString();
+        }
+
+        if (state.ValueKind != JsonValueKind.Object) {
+            return state.ToString();
         }
 
         foreach (string name in new[] { "usable", "qualified", "pending", "retired", "rejected", "readonly" }) {
@@ -663,6 +1129,10 @@ public sealed class CtLogIngestionClient {
 
         return state.EnumerateObject().FirstOrDefault().Name;
     }
+
+    private static bool TryGetLogStateElement(JsonElement log, out JsonElement state)
+        => log.TryGetProperty("state", out state) &&
+           state.ValueKind is JsonValueKind.Object or JsonValueKind.String;
 
     private static void TryGetTemporalInterval(JsonElement log, out DateTimeOffset? temporalStartUtc, out DateTimeOffset? temporalEndUtc) {
         temporalStartUtc = null;
@@ -693,6 +1163,18 @@ public sealed class CtLogIngestionClient {
         return value.ValueKind == JsonValueKind.String ? value.GetString() : value.ToString();
     }
 
+    private static bool TryGetInt32(JsonElement obj, string propertyName, out int value) {
+        value = 0;
+        if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(propertyName, out JsonElement element)) {
+            return false;
+        }
+
+        return element.ValueKind == JsonValueKind.Number
+            ? element.TryGetInt32(out value)
+            : element.ValueKind == JsonValueKind.String &&
+              int.TryParse(element.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out value);
+    }
+
     private static bool TryGetInt64(JsonElement obj, string propertyName, out long value) {
         value = 0;
         if (obj.ValueKind != JsonValueKind.Object || !obj.TryGetProperty(propertyName, out JsonElement element)) {
@@ -706,4 +1188,9 @@ public sealed class CtLogIngestionClient {
     }
 
     private sealed record CachedSignedTreeHead(CtSignedTreeHead Value, DateTimeOffset ExpiresAtUtc);
+
+    private sealed record StaticCtTileEntry(
+        DateTimeOffset? TimestampUtc,
+        CtLogEntryType EntryType,
+        byte[] CertificateDer);
 }

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <PackageReference Include="MailKit" Version="4.16.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -17,7 +17,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MailKit" Version="4.15.1" />
+        <PackageReference Include="MailKit" Version="4.16.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/DomainDetective/Monitoring/NotificationSender.cs
+++ b/DomainDetective/Monitoring/NotificationSender.cs
@@ -78,9 +78,10 @@ public class EmailNotificationSender : INotificationSender
 
         using var client = CreateClient();
         await client.ConnectAsync(SmtpHost, Port, UseSsl, ct);
-        if (!string.IsNullOrEmpty(Username))
+        string? userName = Username;
+        if (!string.IsNullOrEmpty(userName))
         {
-            await client.AuthenticateAsync(Username, Password ?? string.Empty, ct);
+            await client.AuthenticateAsync(userName!, Password ?? string.Empty, ct);
         }
         await client.SendAsync(email, ct);
         await client.DisconnectAsync(true, ct);


### PR DESCRIPTION
## Summary
- add reusable Static CT log-list, checkpoint, and tiled data ingestion support to the shared CT client
- parse Static CT metadata, lifecycle state, temporal intervals, log IDs, public keys, MMD, monitoring URLs, and submission URLs
- validate Static CT checkpoints, note signatures, partial tile fallback, entry counts, retry-after propagation, and lifecycle filtering
- retain the existing names-only CT fingerprint preservation fix already on this branch

## Why
Let’s Encrypt has moved current writes to Static CT logs, so DDCT and future consumers need shared DomainDetective support for Static CT rather than service-local parsing.

## Validation
- `dotnet test C:\Support\GitHub\DomainDetective\DomainDetective.Tests\DomainDetective.Tests.csproj --framework net10.0 --filter FullyQualifiedName~TestCtLogIngestionClient --no-restore`
