### PR TITLE
Harden crt.sh PostgreSQL transport handling

### DIFF
--- a/DomainDetective.CtSql.Tests/TestCrtShPostgreSqlCertificateTransparencyProvider.cs
+++ b/DomainDetective.CtSql.Tests/TestCrtShPostgreSqlCertificateTransparencyProvider.cs
@@ -273,6 +273,25 @@ public sealed class TestCrtShPostgreSqlCertificateTransparencyProvider {
     }
 
     [Fact]
+    public async Task QueryAsync_MapsTransientConnectFailureWithoutSocketCode() {
+        using var provider = new CrtShPostgreSqlCertificateTransparencyProvider(
+            new CertificateInventoryCaptureOptions(),
+            new FakeCrtShPostgreSqlQueryClient(new DbaQueryExecutionException(
+                "failed",
+                "SELECT 1",
+                new FakeTransientConnectException(
+                    "Failed to connect to crt.sh PostgreSQL endpoint",
+                    new InvalidOperationException("transport failed before socket classification")))));
+
+        CtProviderQueryException exception = await Assert.ThrowsAsync<CtProviderQueryException>(
+            () => provider.QueryAsync(CtCertificateQuery.ForExactHostLatest("api.example.test")));
+
+        Assert.Equal(CtProviderOutcomeKind.TransientFailure, exception.OutcomeKind);
+        Assert.Equal("connect-failure", exception.ProviderErrorCode);
+        Assert.True(exception.RetryAfter.HasValue);
+    }
+
+    [Fact]
     public void BuildCrtShPostgreSqlConnectionString_PrefersResolvedIpv4Address() {
         string connectionString = CrtShPostgreSqlCertificateTransparencyProvider.BuildCrtShPostgreSqlConnectionString(
             new CertificateInventoryCaptureOptions {

--- a/DomainDetective.CtSql.Tests/TestCrtShPostgreSqlCertificateTransparencyProvider.cs
+++ b/DomainDetective.CtSql.Tests/TestCrtShPostgreSqlCertificateTransparencyProvider.cs
@@ -1,7 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Data.Common;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
@@ -177,17 +180,22 @@ public sealed class TestCrtShPostgreSqlCertificateTransparencyProvider {
     public void QueryBuilders_UseSupportedCertificateFtsPath() {
         string expansion = CrtShPostgreSqlCertificateTransparencyProvider.BuildDomainExpansionNamesQuery();
         string domainTree = CrtShPostgreSqlCertificateTransparencyProvider.BuildDomainTreeCertificateQuery();
+        string exact = CrtShPostgreSqlCertificateTransparencyProvider.BuildExactHostCertificateQuery();
 
         Assert.Contains("identities(c.certificate)", expansion, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("identities(c.certificate)", domainTree, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("identities(c.certificate)", CrtShPostgreSqlCertificateTransparencyProvider.BuildExactHostCertificateQuery(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("identities(c.certificate)", exact, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("LIMIT @limit", expansion, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("LIMIT @limit", domainTree, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("LIMIT @limit", CrtShPostgreSqlCertificateTransparencyProvider.BuildExactHostCertificateQuery(), StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("@wildcardHost", CrtShPostgreSqlCertificateTransparencyProvider.BuildExactHostCertificateQuery(), StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("LIMIT @limit", exact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("@wildcardHost", exact, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("certificate_identity", expansion, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("certificate_identity", domainTree, StringComparison.OrdinalIgnoreCase);
-        Assert.DoesNotContain("certificate_identity", CrtShPostgreSqlCertificateTransparencyProvider.BuildExactHostCertificateQuery(), StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("certificate_identity", exact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WITH ranked_certificates AS", domainTree, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("WITH ranked_certificates AS", exact, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("FROM ranked_certificates rc", domainTree, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("FROM ranked_certificates rc", exact, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -226,6 +234,75 @@ public sealed class TestCrtShPostgreSqlCertificateTransparencyProvider {
         Assert.Equal(expectedRetryAfter, exception.RetryAfter.HasValue);
     }
 
+    [Fact]
+    public async Task QueryAsync_MapsNetworkUnreachableToTransientFailure() {
+        using var provider = new CrtShPostgreSqlCertificateTransparencyProvider(
+            new CertificateInventoryCaptureOptions(),
+            new FakeCrtShPostgreSqlQueryClient(new DbaQueryExecutionException(
+                "failed",
+                "SELECT 1",
+                new FakeTransientConnectException(
+                    "Failed to connect to [2a0e:ac00:c7:d449::5bc7:d449]:5432",
+                    new SocketException((int)SocketError.NetworkUnreachable)))));
+
+        CtProviderQueryException exception = await Assert.ThrowsAsync<CtProviderQueryException>(
+            () => provider.QueryAsync(CtCertificateQuery.ForExactHostLatest("api.example.test")));
+
+        Assert.Equal(CtProviderOutcomeKind.TransientFailure, exception.OutcomeKind);
+        Assert.Equal("network-unreachable", exception.ProviderErrorCode);
+        Assert.True(exception.RetryAfter.HasValue);
+    }
+
+    [Fact]
+    public async Task QueryAsync_MapsConnectTimeoutToTransientFailure() {
+        using var provider = new CrtShPostgreSqlCertificateTransparencyProvider(
+            new CertificateInventoryCaptureOptions(),
+            new FakeCrtShPostgreSqlQueryClient(new DbaQueryExecutionException(
+                "failed",
+                "SELECT 1",
+                new FakeTransientConnectException(
+                    "Failed to connect to 91.199.212.73:5432",
+                    new TimeoutException("Timeout during connection attempt")))));
+
+        CtProviderQueryException exception = await Assert.ThrowsAsync<CtProviderQueryException>(
+            () => provider.QueryAsync(CtCertificateQuery.ForExactHostLatest("api.example.test")));
+
+        Assert.Equal(CtProviderOutcomeKind.TransientFailure, exception.OutcomeKind);
+        Assert.Equal("connect-timeout", exception.ProviderErrorCode);
+        Assert.True(exception.RetryAfter.HasValue);
+    }
+
+    [Fact]
+    public void BuildCrtShPostgreSqlConnectionString_PrefersResolvedIpv4Address() {
+        string connectionString = CrtShPostgreSqlCertificateTransparencyProvider.BuildCrtShPostgreSqlConnectionString(
+            new CertificateInventoryCaptureOptions {
+                CrtShPostgreSqlCommandTimeoutSeconds = 9
+            },
+            _ => new[] {
+                IPAddress.Parse("2a0e:ac00:c7:d449::5bc7:d449"),
+                IPAddress.Parse("91.199.212.73")
+            });
+        var builder = new DbConnectionStringBuilder {
+            ConnectionString = connectionString
+        };
+
+        Assert.Equal("91.199.212.73", builder["Host"]);
+        Assert.Equal("9", builder["Timeout"].ToString());
+        Assert.Equal("9", builder["Command Timeout"].ToString());
+    }
+
+    [Fact]
+    public void BuildCrtShPostgreSqlConnectionString_FallsBackToPinnedIpv4WhenDnsFails() {
+        string connectionString = CrtShPostgreSqlCertificateTransparencyProvider.BuildCrtShPostgreSqlConnectionString(
+            new CertificateInventoryCaptureOptions(),
+            _ => throw new SocketException((int)SocketError.HostNotFound));
+        var builder = new DbConnectionStringBuilder {
+            ConnectionString = connectionString
+        };
+
+        Assert.Equal(CrtShPostgreSqlCertificateTransparencyProvider.DefaultCrtShPostgreSqlPinnedIpv4Address, builder["Host"]);
+    }
+
     private static byte[] CreateCertificate(string commonName, out X509Certificate2 certificate) {
         RSA rsa = RSA.Create(2048);
         try {
@@ -255,6 +332,14 @@ public sealed class TestCrtShPostgreSqlCertificateTransparencyProvider {
         }
 
         public string SqlState { get; }
+    }
+
+    private sealed class FakeTransientConnectException : Exception {
+        public FakeTransientConnectException(string message, Exception innerException)
+            : base(message, innerException) {
+        }
+
+        public bool IsTransient => true;
     }
 
     private sealed class FakeCrtShPostgreSqlQueryClient : ICrtShPostgreSqlQueryClient {

--- a/DomainDetective.CtSql.Tests/TestCrtShPostgreSqlCertificateTransparencyProvider.cs
+++ b/DomainDetective.CtSql.Tests/TestCrtShPostgreSqlCertificateTransparencyProvider.cs
@@ -322,6 +322,20 @@ public sealed class TestCrtShPostgreSqlCertificateTransparencyProvider {
         Assert.Equal(CrtShPostgreSqlCertificateTransparencyProvider.DefaultCrtShPostgreSqlPinnedIpv4Address, builder["Host"]);
     }
 
+    [Fact]
+    public void BuildCrtShPostgreSqlConnectionString_PreservesHostnameWhenDnsReturnsOnlyIpv6() {
+        string connectionString = CrtShPostgreSqlCertificateTransparencyProvider.BuildCrtShPostgreSqlConnectionString(
+            new CertificateInventoryCaptureOptions(),
+            _ => new[] {
+                IPAddress.Parse("2a0e:ac00:c7:d449::5bc7:d449")
+            });
+        var builder = new DbConnectionStringBuilder {
+            ConnectionString = connectionString
+        };
+
+        Assert.Equal(CrtShPostgreSqlCertificateTransparencyProvider.DefaultCrtShPostgreSqlHostName, builder["Host"]);
+    }
+
     private static byte[] CreateCertificate(string commonName, out X509Certificate2 certificate) {
         RSA rsa = RSA.Create(2048);
         try {

--- a/DomainDetective.CtSql/CrtShPostgreSqlCertificateTransparencyProvider.cs
+++ b/DomainDetective.CtSql/CrtShPostgreSqlCertificateTransparencyProvider.cs
@@ -666,6 +666,12 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
             if (ipv4Address != null) {
                 return ipv4Address.ToString();
             }
+
+            if (addresses.Any(static address => address.AddressFamily == AddressFamily.InterNetworkV6)) {
+                // Preserve the hostname path when only IPv6 answers are available so IPv6-only
+                // environments can still connect instead of forcing the pinned IPv4 fallback.
+                return DefaultCrtShPostgreSqlHostName;
+            }
         } catch (SocketException) {
             // Fall back to the pinned public IPv4 endpoint when DNS resolution is unavailable.
         } catch (ArgumentException) {

--- a/DomainDetective.CtSql/CrtShPostgreSqlCertificateTransparencyProvider.cs
+++ b/DomainDetective.CtSql/CrtShPostgreSqlCertificateTransparencyProvider.cs
@@ -4,6 +4,8 @@ using System.Data;
 using System.Data.Common;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using DBAClientX;
@@ -20,6 +22,8 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
     private const int DefaultHistoryLimit = 100;
     private const int DefaultExpansionLimit = 500;
     private const int DefaultDomainTreeLimit = 100;
+    internal const string DefaultCrtShPostgreSqlHostName = "crt.sh";
+    internal const string DefaultCrtShPostgreSqlPinnedIpv4Address = "91.199.212.73";
 
     private readonly ICrtShPostgreSqlQueryClient _client;
     private readonly CertificateInventoryCaptureOptions _options;
@@ -221,45 +225,55 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
     public static string BuildDomainTreeCertificateQuery() {
         return
             """
+            WITH ranked_certificates AS (
+                SELECT
+                    c.id,
+                    c.certificate,
+                    (
+                        SELECT MAX(ctle.entry_timestamp)
+                        FROM ct_log_entry ctle
+                        WHERE ctle.certificate_id = c.id
+                    ) AS entry_timestamp,
+                    x509_notBefore(c.certificate) AS not_before
+                FROM certificate c
+                WHERE identities(c.certificate) @@ plainto_tsquery('simple', @domain)
+                  AND EXISTS (
+                        SELECT 1
+                        FROM (
+                            SELECT lower(COALESCE(x509_commonName(c.certificate), '')) AS candidate_name
+                            UNION
+                            SELECT lower(alt_name)
+                            FROM x509_altnames(c.certificate) AS alt_name
+                        ) AS candidate_names
+                        WHERE candidate_name = lower(@domain)
+                           OR candidate_name LIKE lower(@domainSuffix)
+                    )
+                ORDER BY entry_timestamp DESC NULLS LAST,
+                         not_before DESC NULLS LAST
+                LIMIT @limit
+            )
             SELECT
-                c.certificate,
-                (
-                    SELECT MAX(ctle.entry_timestamp)
-                    FROM ct_log_entry ctle
-                    WHERE ctle.certificate_id = c.id
-                ) AS entry_timestamp,
-                x509_commonName(c.certificate) AS common_name,
-                x509_issuerName(c.certificate) AS issuer_name,
-                encode(x509_serialNumber(c.certificate), 'hex') AS serial_number,
-                x509_notBefore(c.certificate) AS not_before,
-                x509_notAfter(c.certificate) AS not_after,
+                rc.certificate,
+                rc.entry_timestamp,
+                x509_commonName(rc.certificate) AS common_name,
+                x509_issuerName(rc.certificate) AS issuer_name,
+                encode(x509_serialNumber(rc.certificate), 'hex') AS serial_number,
+                rc.not_before,
+                x509_notAfter(rc.certificate) AS not_after,
                 ARRAY(
                     SELECT candidate_name
                     FROM (
-                        SELECT x509_commonName(c.certificate) AS candidate_name
+                        SELECT x509_commonName(rc.certificate) AS candidate_name
                         UNION
                         SELECT alt_name
-                        FROM x509_altnames(c.certificate) AS alt_name
+                        FROM x509_altnames(rc.certificate) AS alt_name
                     ) AS candidate_names
                     WHERE candidate_name IS NOT NULL
                     ORDER BY lower(candidate_name)
                 ) AS dns_names
-            FROM certificate c
-            WHERE identities(c.certificate) @@ plainto_tsquery('simple', @domain)
-              AND EXISTS (
-                    SELECT 1
-                    FROM (
-                        SELECT lower(COALESCE(x509_commonName(c.certificate), '')) AS candidate_name
-                        UNION
-                        SELECT lower(alt_name)
-                        FROM x509_altnames(c.certificate) AS alt_name
-                    ) AS candidate_names
-                    WHERE candidate_name = lower(@domain)
-                       OR candidate_name LIKE lower(@domainSuffix)
-                )
-            ORDER BY entry_timestamp DESC NULLS LAST,
-                     x509_notBefore(c.certificate) DESC NULLS LAST
-            LIMIT @limit;
+            FROM ranked_certificates rc
+            ORDER BY rc.entry_timestamp DESC NULLS LAST,
+                     rc.not_before DESC NULLS LAST;
             """;
     }
 
@@ -269,48 +283,58 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
     public static string BuildExactHostCertificateQuery() {
         return
             """
+            WITH ranked_certificates AS (
+                SELECT
+                    c.id,
+                    c.certificate,
+                    (
+                        SELECT MAX(ctle.entry_timestamp)
+                        FROM ct_log_entry ctle
+                        WHERE ctle.certificate_id = c.id
+                    ) AS entry_timestamp,
+                    x509_notBefore(c.certificate) AS not_before
+                FROM certificate c
+                WHERE (
+                        identities(c.certificate) @@ plainto_tsquery('simple', @host)
+                     OR identities(c.certificate) @@ plainto_tsquery('simple', @wildcardHost)
+                      )
+                  AND EXISTS (
+                        SELECT 1
+                        FROM (
+                            SELECT lower(COALESCE(x509_commonName(c.certificate), '')) AS candidate_name
+                            UNION
+                            SELECT lower(alt_name)
+                            FROM x509_altnames(c.certificate) AS alt_name
+                        ) AS candidate_names
+                        WHERE candidate_name = lower(@host)
+                           OR candidate_name = lower(@wildcardHost)
+                    )
+                ORDER BY entry_timestamp DESC NULLS LAST,
+                         not_before DESC NULLS LAST
+                LIMIT @limit
+            )
             SELECT
-                c.certificate,
-                (
-                    SELECT MAX(ctle.entry_timestamp)
-                    FROM ct_log_entry ctle
-                    WHERE ctle.certificate_id = c.id
-                ) AS entry_timestamp,
-                x509_commonName(c.certificate) AS common_name,
-                x509_issuerName(c.certificate) AS issuer_name,
-                encode(x509_serialNumber(c.certificate), 'hex') AS serial_number,
-                x509_notBefore(c.certificate) AS not_before,
-                x509_notAfter(c.certificate) AS not_after,
+                rc.certificate,
+                rc.entry_timestamp,
+                x509_commonName(rc.certificate) AS common_name,
+                x509_issuerName(rc.certificate) AS issuer_name,
+                encode(x509_serialNumber(rc.certificate), 'hex') AS serial_number,
+                rc.not_before,
+                x509_notAfter(rc.certificate) AS not_after,
                 ARRAY(
                     SELECT candidate_name
                     FROM (
-                        SELECT x509_commonName(c.certificate) AS candidate_name
+                        SELECT x509_commonName(rc.certificate) AS candidate_name
                         UNION
                         SELECT alt_name
-                        FROM x509_altnames(c.certificate) AS alt_name
+                        FROM x509_altnames(rc.certificate) AS alt_name
                     ) AS candidate_names
                     WHERE candidate_name IS NOT NULL
                     ORDER BY lower(candidate_name)
                 ) AS dns_names
-            FROM certificate c
-            WHERE (
-                    identities(c.certificate) @@ plainto_tsquery('simple', @host)
-                 OR identities(c.certificate) @@ plainto_tsquery('simple', @wildcardHost)
-                  )
-              AND EXISTS (
-                    SELECT 1
-                    FROM (
-                        SELECT lower(COALESCE(x509_commonName(c.certificate), '')) AS candidate_name
-                        UNION
-                        SELECT lower(alt_name)
-                        FROM x509_altnames(c.certificate) AS alt_name
-                    ) AS candidate_names
-                    WHERE candidate_name = lower(@host)
-                       OR candidate_name = lower(@wildcardHost)
-                )
-            ORDER BY entry_timestamp DESC NULLS LAST,
-                     x509_notBefore(c.certificate) DESC NULLS LAST
-            LIMIT @limit;
+            FROM ranked_certificates rc
+            ORDER BY rc.entry_timestamp DESC NULLS LAST,
+                     rc.not_before DESC NULLS LAST;
             """;
     }
 
@@ -467,27 +491,35 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
 
     private CtProviderQueryException CreateProviderQueryException(DbaQueryExecutionException exception) {
         string? providerErrorCode = TryGetProviderErrorCode(exception);
-        CtProviderOutcomeKind outcomeKind = providerErrorCode switch {
+        string? transportFailureCode = TryGetTransportFailureCode(exception);
+        string? effectiveErrorCode = providerErrorCode ?? transportFailureCode;
+        CtProviderOutcomeKind outcomeKind = effectiveErrorCode switch {
             "40001" => CtProviderOutcomeKind.TransientFailure,
             "57014" => CtProviderOutcomeKind.Timeout,
             "57P03" => CtProviderOutcomeKind.TransientFailure,
             "53300" => CtProviderOutcomeKind.TransientFailure,
+            "connect-timeout" => CtProviderOutcomeKind.TransientFailure,
+            "network-unreachable" => CtProviderOutcomeKind.TransientFailure,
+            "host-unreachable" => CtProviderOutcomeKind.TransientFailure,
+            "connection-refused" => CtProviderOutcomeKind.TransientFailure,
+            "host-not-found" => CtProviderOutcomeKind.TransientFailure,
+            "connect-failure" => CtProviderOutcomeKind.TransientFailure,
             _ => CtProviderOutcomeKind.PermanentFailure
         };
         TimeSpan? retryAfter = outcomeKind == CtProviderOutcomeKind.RateLimited ||
                                outcomeKind == CtProviderOutcomeKind.TransientFailure
             ? Profile.RateLimit.Normalize().CooldownAfterRateLimit
             : null;
-        string suffix = string.IsNullOrWhiteSpace(providerErrorCode)
+        string suffix = string.IsNullOrWhiteSpace(effectiveErrorCode)
             ? string.Empty
-            : $" Provider code: {providerErrorCode}.";
+            : $" Provider code: {effectiveErrorCode}.";
 
         return new CtProviderQueryException(
             ProviderId,
             outcomeKind,
             "crt.sh PostgreSQL CT query failed." + suffix,
             exception,
-            providerErrorCode,
+            effectiveErrorCode,
             retryAfter);
     }
 
@@ -496,6 +528,37 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
             object? sqlState = current.GetType().GetProperty("SqlState")?.GetValue(current);
             if (sqlState is string value && !string.IsNullOrWhiteSpace(value)) {
                 return value;
+            }
+        }
+
+        return null;
+    }
+
+    private static string? TryGetTransportFailureCode(Exception exception) {
+        for (Exception? current = exception; current != null; current = current.InnerException) {
+            if (current is TimeoutException) {
+                return "connect-timeout";
+            }
+
+            if (current is SocketException socketException) {
+                return socketException.SocketErrorCode switch {
+                    SocketError.NetworkUnreachable => "network-unreachable",
+                    SocketError.HostUnreachable => "host-unreachable",
+                    SocketError.ConnectionRefused => "connection-refused",
+                    SocketError.HostNotFound => "host-not-found",
+                    _ => null
+                };
+            }
+
+        }
+
+        for (Exception? current = exception; current != null; current = current.InnerException) {
+            object? isTransient = current.GetType().GetProperty("IsTransient")?.GetValue(current);
+            if (isTransient is true) {
+                string message = current.Message ?? string.Empty;
+                if (message.IndexOf("Failed to connect", StringComparison.OrdinalIgnoreCase) >= 0) {
+                    return "connect-failure";
+                }
             }
         }
 
@@ -565,6 +628,12 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
         => row.IsDBNull(0) ? string.Empty : row.GetString(0);
 
     private static string BuildCrtShPostgreSqlConnectionString(CertificateInventoryCaptureOptions options) {
+        return BuildCrtShPostgreSqlConnectionString(options, null);
+    }
+
+    internal static string BuildCrtShPostgreSqlConnectionString(
+        CertificateInventoryCaptureOptions? options,
+        Func<string, IPAddress[]>? dnsResolver) {
         if (!string.IsNullOrWhiteSpace(options?.CrtShPostgreSqlConnectionString)) {
             return options!.CrtShPostgreSqlConnectionString!;
         }
@@ -572,7 +641,7 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
         int timeoutSeconds = Math.Max(1, options?.CrtShPostgreSqlCommandTimeoutSeconds ?? 15);
         var builder = new DbConnectionStringBuilder {
             ConnectionString = PostgreSql.BuildConnectionString(
-                host: "crt.sh",
+                host: ResolveCrtShPostgreSqlHost(dnsResolver),
                 database: "certwatch",
                 username: "guest",
                 password: string.Empty,
@@ -582,6 +651,20 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
         builder["Timeout"] = timeoutSeconds;
         builder["Command Timeout"] = timeoutSeconds;
         return builder.ConnectionString;
+    }
+
+    internal static string ResolveCrtShPostgreSqlHost(Func<string, IPAddress[]>? dnsResolver = null) {
+        try {
+            IPAddress[] addresses = (dnsResolver ?? Dns.GetHostAddresses)(DefaultCrtShPostgreSqlHostName);
+            IPAddress? ipv4Address = addresses.FirstOrDefault(static address => address.AddressFamily == AddressFamily.InterNetwork);
+            if (ipv4Address != null) {
+                return ipv4Address.ToString();
+            }
+        } catch {
+            // Fall back to the pinned public IPv4 endpoint when DNS resolution is unavailable.
+        }
+
+        return DefaultCrtShPostgreSqlPinnedIpv4Address;
     }
 
     private static DateTimeOffset? ReadDateTimeOffset(object? value) {

--- a/DomainDetective.CtSql/CrtShPostgreSqlCertificateTransparencyProvider.cs
+++ b/DomainDetective.CtSql/CrtShPostgreSqlCertificateTransparencyProvider.cs
@@ -23,6 +23,7 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
     private const int DefaultExpansionLimit = 500;
     private const int DefaultDomainTreeLimit = 100;
     internal const string DefaultCrtShPostgreSqlHostName = "crt.sh";
+    // Last verified against crt.sh DNS in April 2026. Update this fallback if crt.sh moves.
     internal const string DefaultCrtShPostgreSqlPinnedIpv4Address = "91.199.212.73";
 
     private readonly ICrtShPostgreSqlQueryClient _client;
@@ -541,21 +542,26 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
             }
 
             if (current is SocketException socketException) {
-                return socketException.SocketErrorCode switch {
+                string? code = socketException.SocketErrorCode switch {
                     SocketError.NetworkUnreachable => "network-unreachable",
                     SocketError.HostUnreachable => "host-unreachable",
                     SocketError.ConnectionRefused => "connection-refused",
                     SocketError.HostNotFound => "host-not-found",
+                    SocketError.TimedOut => "connect-timeout",
                     _ => null
                 };
+                if (code != null) {
+                    return code;
+                }
             }
-
         }
 
         for (Exception? current = exception; current != null; current = current.InnerException) {
+            // Keep this duck-typed so we can recognize transient connect failures from provider-specific
+            // exceptions (for example Npgsql) without taking an additional package dependency here.
             object? isTransient = current.GetType().GetProperty("IsTransient")?.GetValue(current);
             if (isTransient is true) {
-                string message = current.Message ?? string.Empty;
+                string message = current.Message;
                 if (message.IndexOf("Failed to connect", StringComparison.OrdinalIgnoreCase) >= 0) {
                     return "connect-failure";
                 }
@@ -660,7 +666,9 @@ public sealed class CrtShPostgreSqlCertificateTransparencyProvider : ICtCertific
             if (ipv4Address != null) {
                 return ipv4Address.ToString();
             }
-        } catch {
+        } catch (SocketException) {
+            // Fall back to the pinned public IPv4 endpoint when DNS resolution is unavailable.
+        } catch (ArgumentException) {
             // Fall back to the pinned public IPv4 endpoint when DNS resolution is unavailable.
         }
 


### PR DESCRIPTION
## Summary
- harden the crt.sh PostgreSQL provider against transport and connection failures
- pin IPv4 resolution for crt.sh PostgreSQL connectivity when required
- extend tests around timeout handling and IPv4 endpoint selection

## Validation
- dotnet test DomainDetective.CtSql.Tests/DomainDetective.CtSql.Tests.csproj -c Release