### PR TITLE
Share certificate transparency name matching helpers

### DIFF
--- a/DomainDetective.Tests/TestCertificateTransparencyNameUtility.cs
+++ b/DomainDetective.Tests/TestCertificateTransparencyNameUtility.cs
@@ -14,6 +14,26 @@ public sealed class TestCertificateTransparencyNameUtility
     }
 
     [Theory]
+    [InlineData("*.example.com", true)]
+    [InlineData("*.*.example.com", true)]
+    [InlineData("www.example.com", false)]
+    [InlineData(" ", false)]
+    public void IsWildcard_DetectsLeadingWildcardLabel(string name, bool expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.IsWildcard(name));
+    }
+
+    [Theory]
+    [InlineData("*.example.com", "example.com")]
+    [InlineData("*.*.example.com", "example.com")]
+    [InlineData("WWW.Example.COM.", "www.example.com")]
+    [InlineData(" ", "")]
+    public void StripWildcard_RemovesAllLeadingWildcardLabels(string name, string expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.StripWildcard(name));
+    }
+
+    [Theory]
     [InlineData("*.example.com", "*.example.com", null)]
     [InlineData("www.example.com.", "www.example.com", "*.example.com")]
     [InlineData("example.com", "example.com", null)]
@@ -35,10 +55,29 @@ public sealed class TestCertificateTransparencyNameUtility
     }
 
     [Theory]
+    [InlineData("api.example.com", "com.example.api")]
+    [InlineData("*.www.example.com", "com.example.www")]
+    [InlineData("Example.COM.", "com.example")]
+    [InlineData(" ", "")]
+    public void ReverseLabels_NormalizesStripsWildcardsAndReverses(string name, string expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.ReverseLabels(name));
+    }
+
+    [Theory]
+    [InlineData("api.example.com", "com.example.api")]
+    [InlineData("*.api.example.com", "com.example.api")]
+    public void BuildReversedExactMatch_UsesReversedLabels(string name, string expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.BuildReversedExactMatch(name));
+    }
+
+    [Theory]
     [InlineData("api.example.com", "com.example.api.%")]
     [InlineData("foo_bar.example.com", "com.example.foo\\_bar.%")]
     [InlineData("sales%25.example.com", "com.example.sales\\%25.%")]
-    [InlineData("weird[host].example.com", "com.example.weird\\[host].%")]
+    [InlineData("weird[host].example.com", "com.example.weird\\[host\\].%")]
+    [InlineData("weird]host.example.com", "com.example.weird\\]host.%")]
     public void BuildReversedPrefixMatch_EscapesSqlLikeWildcards(string name, string expected)
     {
         Assert.Equal(expected, CertificateTransparencyNameUtility.BuildReversedPrefixMatch(name));
@@ -53,5 +92,14 @@ public sealed class TestCertificateTransparencyNameUtility
     public void CertificateNameMatchesHost_UsesSingleLabelWildcardCoverage(string hostName, string certificateName, bool expected)
     {
         Assert.Equal(expected, CertificateTransparencyNameUtility.CertificateNameMatchesHost(hostName, certificateName));
+    }
+
+    [Theory]
+    [InlineData("www.example.com", "example.com")]
+    [InlineData("example.com", "example.com")]
+    [InlineData("localhost", "localhost")]
+    public void GetRegistrableDomainOrSelf_ReturnsRegistrableDomainWhenAvailable(string name, string expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.GetRegistrableDomainOrSelf(name));
     }
 }

--- a/DomainDetective.Tests/TestCertificateTransparencyNameUtility.cs
+++ b/DomainDetective.Tests/TestCertificateTransparencyNameUtility.cs
@@ -1,0 +1,57 @@
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public sealed class TestCertificateTransparencyNameUtility
+{
+    [Theory]
+    [InlineData("WWW.Example.COM.", "www.example.com")]
+    [InlineData("*.Example.COM.", "*.example.com")]
+    [InlineData(" ", "")]
+    public void Normalize_LowercasesAndTrimsRootDot(string name, string expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.Normalize(name));
+    }
+
+    [Theory]
+    [InlineData("*.example.com", "*.example.com", null)]
+    [InlineData("www.example.com.", "www.example.com", "*.example.com")]
+    [InlineData("example.com", "example.com", null)]
+    public void SearchNameHelpers_PreserveLiteralWildcardsOnlyForExactPredicate(string name, string expectedExactName, string? expectedImplicitWildcard)
+    {
+        Assert.Equal(expectedExactName, CertificateTransparencyNameUtility.BuildExactSearchName(name));
+        Assert.Equal(expectedImplicitWildcard, CertificateTransparencyNameUtility.BuildImplicitWildcardCandidateName(name));
+    }
+
+    [Theory]
+    [InlineData("www.example.com", "*.example.com")]
+    [InlineData("login.eu.example.com", "*.eu.example.com")]
+    [InlineData("*.www.example.com", "*.example.com")]
+    [InlineData("example.com", null)]
+    [InlineData("localhost", null)]
+    public void BuildImmediateWildcardName_ReturnsOnlyCoveringWildcard(string name, string? expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.BuildImmediateWildcardName(name));
+    }
+
+    [Theory]
+    [InlineData("api.example.com", "com.example.api.%")]
+    [InlineData("foo_bar.example.com", "com.example.foo\\_bar.%")]
+    [InlineData("sales%25.example.com", "com.example.sales\\%25.%")]
+    [InlineData("weird[host].example.com", "com.example.weird\\[host].%")]
+    public void BuildReversedPrefixMatch_EscapesSqlLikeWildcards(string name, string expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.BuildReversedPrefixMatch(name));
+    }
+
+    [Theory]
+    [InlineData("www.example.com", "www.example.com", true)]
+    [InlineData("www.example.com", "*.example.com", true)]
+    [InlineData("api.www.example.com", "*.example.com", false)]
+    [InlineData("example.com", "*.example.com", false)]
+    [InlineData("www.example.com", "*.www.example.com", false)]
+    public void CertificateNameMatchesHost_UsesSingleLabelWildcardCoverage(string hostName, string certificateName, bool expected)
+    {
+        Assert.Equal(expected, CertificateTransparencyNameUtility.CertificateNameMatchesHost(hostName, certificateName));
+    }
+}

--- a/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
@@ -18,24 +18,20 @@ public class TestDdctApiCertificateTransparencyProvider
         var handler = new HttpStubMessageHandler((request, _) =>
         {
             string pathAndQuery = request.RequestUri!.PathAndQuery;
-            if (pathAndQuery.StartsWith("/api/v1/search/domain?", StringComparison.Ordinal))
+            if (pathAndQuery.StartsWith("/api/v1/certificates?", StringComparison.Ordinal))
             {
                 Assert.Equal("secret", string.Join(",", request.Headers.GetValues("X-DDCT-Api-Key")));
-                return Json(HttpStatusCode.OK, new
+                return Json(HttpStatusCode.OK, new[]
                 {
-                    certificates = new[]
+                    new
                     {
-                        new
-                        {
-                            sha256Fingerprint = "abc123",
-                            matchedName = "www.example.test",
-                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
-                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
-                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
-                            notAfterUtc = "2027-04-12T12:00:00Z"
-                        }
-                    },
-                    observations = Array.Empty<object>()
+                        sha256Fingerprint = "abc123",
+                        matchedName = "www.example.test",
+                        firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                        ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                        lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
+                        notAfterUtc = "2027-04-12T12:00:00Z"
+                    }
                 });
             }
 
@@ -81,28 +77,31 @@ public class TestDdctApiCertificateTransparencyProvider
         {
             requestCount++;
             string pathAndQuery = request.RequestUri!.PathAndQuery;
-            if (pathAndQuery.Contains("offset=2", StringComparison.Ordinal))
+            if (pathAndQuery.StartsWith("/api/v1/observations/paged?", StringComparison.Ordinal)
+                && pathAndQuery.Contains("continuation=page-2", StringComparison.Ordinal))
             {
                 return Json(HttpStatusCode.OK, new
                 {
-                    observations = new[]
+                    items = new[]
                     {
                         new { matchedName = "mail.example.test" }
                     },
                     limit = 2,
-                    offset = 2
+                    hasMore = false
                 });
             }
 
+            Assert.StartsWith("/api/v1/observations/paged?", pathAndQuery, StringComparison.Ordinal);
             return Json(HttpStatusCode.OK, new
             {
-                observations = new[]
+                items = new[]
                 {
                     new { matchedName = "api.example.test" },
                     new { matchedName = "www.example.test" }
                 },
                 limit = 2,
-                offset = 0
+                nextContinuation = "page-2",
+                hasMore = true
             });
         });
         using var httpClient = new HttpClient(handler);
@@ -122,7 +121,7 @@ public class TestDdctApiCertificateTransparencyProvider
             new[] { "api.example.test", "www.example.test" },
             result.DiscoveredNames);
         Assert.True(result.HasMore);
-        Assert.Equal("2", result.ContinuationToken);
+        Assert.Equal("page-2", result.ContinuationToken);
 
         CtCertificateQueryResult nextPage = await provider.QueryAsync(
             new CtCertificateQuery
@@ -170,24 +169,25 @@ public class TestDdctApiCertificateTransparencyProvider
         var handler = new HttpStubMessageHandler((request, _) =>
         {
             string pathAndQuery = request.RequestUri!.PathAndQuery;
-            if (pathAndQuery.StartsWith("/api/v1/search/domain/timeline?", StringComparison.Ordinal))
+            if (pathAndQuery.StartsWith("/api/v1/certificates/paged?", StringComparison.Ordinal))
             {
                 page++;
                 return Json(HttpStatusCode.OK, new
                 {
-                    observations = new[]
+                    items = new[]
                     {
                         new
                         {
                             sha256Fingerprint = "cert-" + page,
                             matchedName = "www.example.test",
-                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
                             notAfterUtc = "2027-04-12T12:00:00Z"
                         }
                     },
                     limit = 1,
-                    offset = page - 1,
-                    returnedObservations = 1
+                    nextContinuation = "next-page",
+                    hasMore = true
                 });
             }
 
@@ -229,23 +229,19 @@ public class TestDdctApiCertificateTransparencyProvider
             Assert.Equal("secret", request.Headers.Authorization?.Parameter);
 
             string pathAndQuery = request.RequestUri!.PathAndQuery;
-            if (pathAndQuery.StartsWith("/api/v1/search/domain?", StringComparison.Ordinal))
+            if (pathAndQuery.StartsWith("/api/v1/certificates?", StringComparison.Ordinal))
             {
-                return Json(HttpStatusCode.OK, new
+                return Json(HttpStatusCode.OK, new[]
                 {
-                    certificates = new[]
+                    new
                     {
-                        new
-                        {
-                            sha256Fingerprint = "bearer123",
-                            matchedName = "www.example.test",
-                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
-                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
-                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
-                            notAfterUtc = "2027-04-12T12:00:00Z"
-                        }
-                    },
-                    observations = Array.Empty<object>()
+                        sha256Fingerprint = "bearer123",
+                        matchedName = "www.example.test",
+                        firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                        ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                        lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
+                        notAfterUtc = "2027-04-12T12:00:00Z"
+                    }
                 });
             }
 
@@ -294,6 +290,125 @@ public class TestDdctApiCertificateTransparencyProvider
     }
 
     [Fact]
+    public async Task QueryAsyncFallsBackToRegistrableDomainTimelineForWildcardLatest()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+        int searchCalls = 0;
+        int observationPageCalls = 0;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates?", StringComparison.Ordinal))
+            {
+                searchCalls++;
+                Assert.Contains("name=www.example.test", pathAndQuery, StringComparison.Ordinal);
+                Assert.Contains("includeSubdomains=false", pathAndQuery, StringComparison.Ordinal);
+                return Json(HttpStatusCode.OK, Array.Empty<object>());
+            }
+
+            if (pathAndQuery.StartsWith("/api/v1/observations/paged?", StringComparison.Ordinal))
+            {
+                observationPageCalls++;
+                Assert.Contains("name=example.test", pathAndQuery, StringComparison.Ordinal);
+                Assert.Contains("includeSubdomains=true", pathAndQuery, StringComparison.Ordinal);
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[] {
+                        new {
+                            sha256Fingerprint = "wildcard-123",
+                            matchedName = "*.example.test",
+                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 100,
+                    hasMore = false
+                });
+            }
+
+            if (pathAndQuery == "/api/v1/certificates/wildcard-123/der")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(der)
+                };
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                QueryPageSize = 100,
+                MaxPagesPerQuery = 5
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForExactHostLatest("www.example.test"));
+
+        CtCertificateRecord record = Assert.Single(result.Certificates);
+        Assert.Equal("wildcard-123", record.ProviderCertificateId);
+        Assert.Contains("*.example.test", result.DiscoveredNames);
+        Assert.Equal(1, searchCalls);
+        Assert.Equal(1, observationPageCalls);
+    }
+
+    [Fact]
+    public async Task QueryAsyncDoesNotTreatWildcardAsApexLatest()
+    {
+        int searchCalls = 0;
+        int observationPageCalls = 0;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates?", StringComparison.Ordinal))
+            {
+                searchCalls++;
+                return Json(HttpStatusCode.OK, Array.Empty<object>());
+            }
+
+            if (pathAndQuery.StartsWith("/api/v1/observations/paged?", StringComparison.Ordinal))
+            {
+                observationPageCalls++;
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[] {
+                        new {
+                            sha256Fingerprint = "wildcard-apex",
+                            matchedName = "*.example.test",
+                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 100,
+                    hasMore = false
+                });
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                QueryPageSize = 100,
+                MaxPagesPerQuery = 5
+            });
+
+        CtCertificateQueryResult result = await provider.QueryAsync(
+            CtCertificateQuery.ForExactHostLatest("example.test"));
+
+        Assert.Empty(result.Certificates);
+        Assert.Equal(1, searchCalls);
+        Assert.Equal(0, observationPageCalls);
+    }
+
+    [Fact]
     public async Task QueryAsyncRejectsEmptyQueryNames()
     {
         using var httpClient = new HttpClient(new HttpStubMessageHandler((_, _) => throw new InvalidOperationException("HTTP should not be called for empty names.")));
@@ -316,24 +431,25 @@ public class TestDdctApiCertificateTransparencyProvider
         var handler = new HttpStubMessageHandler((request, _) =>
         {
             string pathAndQuery = request.RequestUri!.PathAndQuery;
-            if (pathAndQuery.StartsWith("/api/v1/search/domain/timeline?", StringComparison.Ordinal))
+            if (pathAndQuery.StartsWith("/api/v1/certificates/paged?", StringComparison.Ordinal))
             {
                 pageRequestCount++;
                 Assert.Contains("limit=500", pathAndQuery, StringComparison.Ordinal);
                 return Json(HttpStatusCode.OK, new
                 {
-                    observations = new[]
+                    items = new[]
                     {
                         new
                         {
                             sha256Fingerprint = "oversized-page",
                             matchedName = "www.example.test",
-                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                            firstCtObservedAtUtc = "2026-04-12T10:00:00Z",
+                            lastCtObservedAtUtc = "2026-04-12T12:00:00Z",
                             notAfterUtc = "2027-04-12T12:00:00Z"
                         }
                     },
                     limit = 500,
-                    offset = 0
+                    hasMore = false
                 });
             }
 

--- a/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective.Tests/TestDdctApiCertificateTransparencyProvider.cs
@@ -357,6 +357,117 @@ public class TestDdctApiCertificateTransparencyProvider
     }
 
     [Fact]
+    public async Task QueryAsyncContinuesRegistrableDomainFallbackFromCallerToken()
+    {
+        byte[] der = LoadPemCertificateDer("multi.pem");
+        int searchCalls = 0;
+        int observationPageCalls = 0;
+        bool sawContinuedFallback = false;
+        var handler = new HttpStubMessageHandler((request, _) =>
+        {
+            string pathAndQuery = request.RequestUri!.PathAndQuery;
+            if (pathAndQuery.StartsWith("/api/v1/certificates?", StringComparison.Ordinal))
+            {
+                searchCalls++;
+                Assert.Contains("name=www.example.test", pathAndQuery, StringComparison.Ordinal);
+                return Json(HttpStatusCode.OK, Array.Empty<object>());
+            }
+
+            if (pathAndQuery.StartsWith("/api/v1/observations/paged?", StringComparison.Ordinal)
+                && pathAndQuery.Contains("continuation=page-2", StringComparison.Ordinal))
+            {
+                sawContinuedFallback = true;
+                observationPageCalls++;
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[] {
+                        new {
+                            sha256Fingerprint = "wildcard-123",
+                            matchedName = "*.example.test",
+                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 1,
+                    hasMore = false
+                });
+            }
+
+            if (pathAndQuery.StartsWith("/api/v1/observations/paged?", StringComparison.Ordinal))
+            {
+                observationPageCalls++;
+                Assert.DoesNotContain("continuation=", pathAndQuery, StringComparison.Ordinal);
+                return Json(HttpStatusCode.OK, new
+                {
+                    items = new[] {
+                        new {
+                            sha256Fingerprint = "other-123",
+                            matchedName = "other.example.test",
+                            ctObservedAtUtc = "2026-04-12T12:00:00Z",
+                            notAfterUtc = "2027-04-12T12:00:00Z"
+                        }
+                    },
+                    limit = 1,
+                    nextContinuation = "page-2",
+                    hasMore = true
+                });
+            }
+
+            if (pathAndQuery == "/api/v1/certificates/wildcard-123/der")
+            {
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new ByteArrayContent(der)
+                };
+            }
+
+            throw new InvalidOperationException("Unexpected URL: " + request.RequestUri);
+        });
+        using var httpClient = new HttpClient(handler);
+        var provider = new DdctApiCertificateTransparencyProvider(
+            httpClient,
+            new DdctApiCertificateTransparencyProviderOptions
+            {
+                EndpointUrl = "http://127.0.0.1:8080",
+                QueryPageSize = 1,
+                MaxPagesPerQuery = 1
+            });
+
+        var firstQuery = new CtCertificateQuery
+        {
+            Name = "www.example.test",
+            QueryKind = CtCertificateQueryKind.ExactHostLatest,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = true,
+            PageSize = 1
+        };
+        CtCertificateQueryResult firstPage = await provider.QueryAsync(firstQuery);
+
+        Assert.Empty(firstPage.Certificates);
+        Assert.True(firstPage.HasMore);
+        Assert.Equal("page-2", firstPage.ContinuationToken);
+
+        var secondQuery = new CtCertificateQuery
+        {
+            Name = "www.example.test",
+            QueryKind = CtCertificateQueryKind.ExactHostLatest,
+            Operations = CtIngestionOperation.GetLatestCertificate,
+            RequireFullCertificate = true,
+            ContinuationToken = firstPage.ContinuationToken,
+            PageSize = 1
+        };
+        CtCertificateQueryResult secondPage = await provider.QueryAsync(secondQuery);
+
+        CtCertificateRecord record = Assert.Single(secondPage.Certificates);
+        Assert.Equal("wildcard-123", record.ProviderCertificateId);
+        Assert.Contains("*.example.test", secondPage.DiscoveredNames);
+        Assert.False(secondPage.HasMore);
+        Assert.True(sawContinuedFallback);
+        Assert.Equal(2, searchCalls);
+        Assert.Equal(2, observationPageCalls);
+    }
+
+    [Fact]
     public async Task QueryAsyncDoesNotTreatWildcardAsApexLatest()
     {
         int searchCalls = 0;

--- a/DomainDetective/CertificateTransparency/CertificateTransparencyNameUtility.cs
+++ b/DomainDetective/CertificateTransparency/CertificateTransparencyNameUtility.cs
@@ -1,0 +1,226 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace DomainDetective;
+
+/// <summary>
+/// DNS-name normalization and matching helpers shared by certificate transparency providers.
+/// </summary>
+public static class CertificateTransparencyNameUtility
+{
+    private static readonly Lazy<PublicSuffixList> EmbeddedPublicSuffixList = new(LoadPublicSuffixList);
+
+    /// <summary>
+    /// Normalizes a DNS name for certificate transparency matching.
+    /// </summary>
+    /// <param name="name">The input DNS name.</param>
+    /// <returns>A lower-case DNS name without a trailing root dot, or an empty string.</returns>
+    public static string Normalize(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return string.Empty;
+        }
+
+        return (name ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Determines whether a DNS name starts with a wildcard label.
+    /// </summary>
+    /// <param name="name">The DNS name to inspect.</param>
+    /// <returns><see langword="true"/> when the normalized name starts with <c>*.</c>.</returns>
+    public static bool IsWildcard(string? name)
+    {
+        string normalized = Normalize(name);
+        return normalized.StartsWith("*.", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Removes one or more leading wildcard labels from a DNS name.
+    /// </summary>
+    /// <param name="name">The DNS name to normalize.</param>
+    /// <returns>The normalized DNS name without leading wildcard labels.</returns>
+    public static string StripWildcard(string? name)
+    {
+        string normalized = Normalize(name);
+        while (normalized.StartsWith("*.", StringComparison.Ordinal))
+        {
+            normalized = normalized.Substring(2);
+        }
+
+        return normalized;
+    }
+
+    /// <summary>
+    /// Normalizes a search name while preserving an explicit leading wildcard label.
+    /// </summary>
+    /// <param name="name">The DNS name to normalize for an exact storage predicate.</param>
+    /// <returns>The normalized exact search name.</returns>
+    public static string BuildExactSearchName(string? name)
+    {
+        string normalized = Normalize(name);
+        return IsWildcard(normalized) ? normalized : StripWildcard(normalized);
+    }
+
+    /// <summary>
+    /// Builds the wildcard DNS name that can cover exactly one left-most label of a host.
+    /// </summary>
+    /// <param name="name">The DNS host name to inspect.</param>
+    /// <returns>The immediate wildcard name, or <see langword="null"/> when the input is not a multi-label host.</returns>
+    public static string? BuildImmediateWildcardName(string? name)
+    {
+        string normalized = StripWildcard(name);
+        string[] labels = normalized.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+        if (labels.Length < 3)
+        {
+            return null;
+        }
+
+        return "*." + string.Join(".", labels.Skip(1));
+    }
+
+    /// <summary>
+    /// Builds an implicit wildcard candidate for a host lookup, but not for literal wildcard searches.
+    /// </summary>
+    /// <param name="name">The DNS name to inspect.</param>
+    /// <returns>The immediate wildcard name, or <see langword="null"/> when no implicit candidate applies.</returns>
+    public static string? BuildImplicitWildcardCandidateName(string? name)
+        => IsWildcard(name) ? null : BuildImmediateWildcardName(name);
+
+    /// <summary>
+    /// Reverses DNS labels so suffix queries can use prefix-like indexes.
+    /// </summary>
+    /// <param name="name">The DNS name to normalize and reverse.</param>
+    /// <returns>The reversed-label DNS name.</returns>
+    public static string ReverseLabels(string? name)
+    {
+        string normalized = StripWildcard(name);
+        if (normalized.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        string[] labels = normalized.Split(new[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+        Array.Reverse(labels);
+        return string.Join(".", labels);
+    }
+
+    /// <summary>
+    /// Builds the reversed-label exact match used by suffix-aware storage queries.
+    /// </summary>
+    /// <param name="name">The DNS name to normalize and reverse.</param>
+    /// <returns>The reversed-label exact match value.</returns>
+    public static string BuildReversedExactMatch(string? name)
+        => ReverseLabels(name);
+
+    /// <summary>
+    /// Builds the reversed-label prefix match used by suffix-aware storage queries.
+    /// </summary>
+    /// <param name="name">The DNS name to normalize and reverse.</param>
+    /// <returns>The escaped reversed-label prefix match value.</returns>
+    public static string BuildReversedPrefixMatch(string? name)
+    {
+        string reversed = ReverseLabels(name);
+        return reversed.Length == 0 ? string.Empty : EscapeLikePattern(reversed) + ".%";
+    }
+
+    /// <summary>
+    /// Determines whether a certificate DNS name covers a host using exact and single-label wildcard semantics.
+    /// </summary>
+    /// <param name="hostName">The concrete host being queried.</param>
+    /// <param name="certificateName">The certificate DNS name.</param>
+    /// <returns><see langword="true"/> when the certificate name covers the host.</returns>
+    public static bool CertificateNameMatchesHost(string? hostName, string? certificateName)
+    {
+        string normalizedHost = Normalize(hostName);
+        if (normalizedHost.Length == 0 || string.IsNullOrWhiteSpace(certificateName))
+        {
+            return false;
+        }
+
+        string normalizedCandidate = Normalize(certificateName);
+        if (string.Equals(normalizedCandidate, normalizedHost, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        if (!normalizedCandidate.StartsWith("*.", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        string suffix = normalizedCandidate.Substring(2);
+        if (string.IsNullOrWhiteSpace(suffix) ||
+            normalizedHost.Length <= suffix.Length + 1 ||
+            !normalizedHost.EndsWith("." + suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        string wildcardLabel = normalizedHost.Substring(0, normalizedHost.Length - suffix.Length - 1);
+        return wildcardLabel.Length > 0 && wildcardLabel.IndexOf('.') < 0;
+    }
+
+    /// <summary>
+    /// Resolves a host to its registrable domain when the embedded public suffix list is available.
+    /// </summary>
+    /// <param name="candidate">The host name to inspect.</param>
+    /// <returns>The registrable domain, or a conservative last-two-label fallback.</returns>
+    public static string GetRegistrableDomainOrSelf(string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+        {
+            return candidate;
+        }
+
+        try
+        {
+            return EmbeddedPublicSuffixList.Value.GetRegistrableDomain(candidate);
+        }
+        catch
+        {
+            string[] labels = candidate.Split('.');
+            if (labels.Length <= 2)
+            {
+                return candidate;
+            }
+
+            return string.Join(".", labels.Skip(labels.Length - 2));
+        }
+    }
+
+    private static string EscapeLikePattern(string value)
+    {
+        if (value.Length == 0)
+        {
+            return value;
+        }
+
+        return value
+            .Replace(@"\", @"\\")
+            .Replace("%", @"\%")
+            .Replace("_", @"\_")
+            .Replace("[", @"\[");
+    }
+
+    private static PublicSuffixList LoadPublicSuffixList()
+    {
+        try
+        {
+            using Stream? stream = typeof(CertificateTransparencyNameUtility).Assembly
+                .GetManifestResourceStream("DomainDetective.public_suffix_list.dat");
+            if (stream != null)
+            {
+                return PublicSuffixList.Load(stream);
+            }
+        }
+        catch
+        {
+            // Best-effort only; fallback callers still preserve host-level behavior.
+        }
+
+        return new PublicSuffixList();
+    }
+}

--- a/DomainDetective/CertificateTransparency/CertificateTransparencyNameUtility.cs
+++ b/DomainDetective/CertificateTransparency/CertificateTransparencyNameUtility.cs
@@ -23,7 +23,8 @@ public static class CertificateTransparencyNameUtility
             return string.Empty;
         }
 
-        return (name ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+        string normalized = name!;
+        return normalized.Trim().TrimEnd('.').ToLowerInvariant();
     }
 
     /// <summary>
@@ -179,7 +180,12 @@ public static class CertificateTransparencyNameUtility
         {
             return EmbeddedPublicSuffixList.Value.GetRegistrableDomain(candidate);
         }
-        catch
+        catch (Exception ex) when (
+            ex is InvalidOperationException ||
+            ex is ArgumentException ||
+            ex is IOException ||
+            ex is ObjectDisposedException ||
+            ex is FormatException)
         {
             string[] labels = candidate.Split('.');
             if (labels.Length <= 2)
@@ -202,7 +208,8 @@ public static class CertificateTransparencyNameUtility
             .Replace(@"\", @"\\")
             .Replace("%", @"\%")
             .Replace("_", @"\_")
-            .Replace("[", @"\[");
+            .Replace("[", @"\[")
+            .Replace("]", @"\]");
     }
 
     private static PublicSuffixList LoadPublicSuffixList()
@@ -216,7 +223,12 @@ public static class CertificateTransparencyNameUtility
                 return PublicSuffixList.Load(stream);
             }
         }
-        catch
+        catch (Exception ex) when (
+            ex is IOException ||
+            ex is UnauthorizedAccessException ||
+            ex is InvalidDataException ||
+            ex is ArgumentException ||
+            ex is FormatException)
         {
             // Best-effort only; fallback callers still preserve host-level behavior.
         }

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -21,7 +21,6 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
     {
         PropertyNameCaseInsensitive = true
     };
-
     private readonly HttpClient _httpClient;
     private readonly string _endpointUrl;
     private readonly string? _apiKey;
@@ -105,28 +104,21 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
 
     private async Task<CtCertificateQueryResult> QueryLatestCertificateAsync(CtCertificateQuery query, CancellationToken cancellationToken)
     {
-        DdctDomainSearchResponseDto response = await QueryDomainSearchAsync(query.Name, includeSubdomains: false, 1, 1, cancellationToken).ConfigureAwait(false);
-        DdctCertificateSearchDto? latest = response.Certificates
+        IReadOnlyList<DdctCertificateSearchDto> certificates = await QueryLatestCertificateCandidatesAsync(query.Name, cancellationToken).ConfigureAwait(false);
+        DdctCertificateSearchDto? latest = certificates
             .OrderByDescending(static item => item.LastCtObservedAtUtc ?? item.FirstCtObservedAtUtc ?? item.LastIngestedByDdctAtUtc ?? DateTimeOffset.MinValue)
             .ThenByDescending(static item => item.NotAfterUtc ?? DateTimeOffset.MinValue)
             .FirstOrDefault();
 
         if (latest == null)
         {
-            return new CtCertificateQueryResult
+            CtCertificateQueryResult? fallback = await TryQueryLatestCertificateViaDomainTreeAsync(query, cancellationToken).ConfigureAwait(false);
+            if (fallback != null)
             {
-                ProviderId = ProviderId,
-                Certificates = Array.Empty<CtCertificateRecord>(),
-                DiscoveredNames = response.Observations
-                    .Select(static item => NormalizeHostName(item.MatchedName))
-                    .Where(static name => name.Length > 0)
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
-                    .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
-                    .ToArray(),
-                HasMore = false,
-                ContinuationToken = null,
-                Diagnostics = Array.Empty<string>()
-            };
+                return fallback;
+            }
+
+            return CreateEmptyLatestResult();
         }
 
         byte[] der = await DownloadCertificateDerAsync(latest.Sha256Fingerprint, cancellationToken).ConfigureAwait(false);
@@ -140,9 +132,8 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
                     providerCertificateId: latest.Sha256Fingerprint,
                     entryTimestampUtc: latest.LastCtObservedAtUtc ?? latest.FirstCtObservedAtUtc)
             ],
-            DiscoveredNames = response.Certificates
-                .Select(static item => NormalizeHostName(item.MatchedName))
-                .Concat(response.Observations.Select(static item => NormalizeHostName(item.MatchedName)))
+            DiscoveredNames = certificates
+                .Select(static item => CertificateTransparencyNameUtility.Normalize(item.MatchedName))
                 .Where(static name => name.Length > 0)
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
@@ -153,32 +144,129 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         };
     }
 
+    private async Task<CtCertificateQueryResult?> TryQueryLatestCertificateViaDomainTreeAsync(CtCertificateQuery query, CancellationToken cancellationToken)
+    {
+        string fallbackDomain = CertificateTransparencyNameUtility.GetRegistrableDomainOrSelf(query.Name);
+        if (string.IsNullOrWhiteSpace(fallbackDomain) ||
+            string.Equals(fallbackDomain, query.Name, StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        int pageSize = ResolvePageSize(query.PageSize);
+        string? continuation = null;
+        bool truncated = false;
+        var matchingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        DdctObservationDto? latestMatch = null;
+
+        for (int pageIndex = 0; pageIndex < _maxPagesPerQuery; pageIndex++)
+        {
+            DdctObservationPageDto page = await QueryObservationPageAsync(
+                fallbackDomain,
+                includeSubdomains: true,
+                pageSize,
+                continuation,
+                cancellationToken).ConfigureAwait(false);
+
+            if (page.Items.Count == 0)
+            {
+                break;
+            }
+
+            foreach (DdctObservationDto observation in page.Items)
+            {
+                string matchedName = CertificateTransparencyNameUtility.Normalize(observation.MatchedName);
+                if (!CertificateTransparencyNameUtility.CertificateNameMatchesHost(query.Name, matchedName))
+                {
+                    continue;
+                }
+
+                if (matchedName.Length > 0)
+                {
+                    matchingNames.Add(matchedName);
+                }
+
+                latestMatch ??= observation;
+            }
+
+            if (latestMatch != null)
+            {
+                break;
+            }
+
+            bool pageHasMore = HasMore(page);
+            if (!pageHasMore)
+            {
+                break;
+            }
+
+            continuation = page.NextContinuation;
+            if (pageIndex == _maxPagesPerQuery - 1)
+            {
+                truncated = true;
+            }
+        }
+
+        if (latestMatch == null)
+        {
+            return truncated
+                ? new CtCertificateQueryResult
+                {
+                    ProviderId = ProviderId,
+                    Certificates = Array.Empty<CtCertificateRecord>(),
+                    DiscoveredNames = Array.Empty<string>(),
+                    HasMore = false,
+                    ContinuationToken = null,
+                    Diagnostics = BuildDiagnostics(truncated)
+                }
+                : null;
+        }
+
+        byte[] der = await DownloadCertificateDerAsync(latestMatch.Sha256Fingerprint, cancellationToken).ConfigureAwait(false);
+        return new CtCertificateQueryResult
+        {
+            ProviderId = ProviderId,
+            Certificates = [
+                CtCertificateRecord.FromDer(
+                    ProviderId,
+                    der,
+                    providerCertificateId: latestMatch.Sha256Fingerprint,
+                    entryTimestampUtc: latestMatch.CtObservedAtUtc)
+            ],
+            DiscoveredNames = matchingNames
+                .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+                .ToArray(),
+            HasMore = false,
+            ContinuationToken = null,
+            Diagnostics = BuildDiagnostics(truncated)
+        };
+    }
+
     private async Task<CtCertificateQueryResult> QueryDomainExpansionAsync(CtCertificateQuery query, CancellationToken cancellationToken)
     {
         int pageSize = ResolvePageSize(query.PageSize);
-        int offset = DecodeOffsetContinuation(query.ContinuationToken);
-        DdctTimelineResponseDto page = await QueryTimelineAsync(
+        DdctObservationPageDto page = await QueryObservationPageAsync(
             query.Name,
             includeSubdomains: true,
             pageSize,
-            offset,
+            query.ContinuationToken,
             cancellationToken).ConfigureAwait(false);
 
-        string[] names = page.Observations
-            .Select(static item => NormalizeHostName(item.MatchedName))
+        string[] names = page.Items
+            .Select(static item => CertificateTransparencyNameUtility.Normalize(item.MatchedName))
             .Where(static name => name.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-        bool hasMore = page.Observations.Count >= page.Limit && page.Limit > 0;
+        bool hasMore = HasMore(page);
 
         return new CtCertificateQueryResult
         {
             ProviderId = ProviderId,
             DiscoveredNames = names,
             HasMore = hasMore,
-            ContinuationToken = hasMore ? EncodeOffsetContinuation(offset + page.Observations.Count) : null,
+            ContinuationToken = hasMore ? page.NextContinuation : null,
             Diagnostics = Array.Empty<string>()
         };
     }
@@ -186,65 +274,65 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
     private async Task<CtCertificateQueryResult> QueryCertificatesAsync(CtCertificateQuery query, bool includeSubdomains, int maxCertificates, CancellationToken cancellationToken)
     {
         int pageSize = ResolvePageSize(query.PageSize);
-        int offset = DecodeOffsetContinuation(query.ContinuationToken);
-        int currentOffset = offset;
+        string? continuation = query.ContinuationToken;
+        string? nextContinuation = null;
         int maxPages = ResolveMaximumPageCount(pageSize, maxCertificates);
         bool hasMore = false;
         bool truncated = false;
         var discoveredNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var selectedObservations = new List<DdctObservationDto>(maxCertificates);
+        var selectedCertificates = new List<DdctCertificateSearchDto>(maxCertificates);
         var seenFingerprints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         for (int pageIndex = 0; pageIndex < maxPages; pageIndex++)
         {
-            DdctTimelineResponseDto page = await QueryTimelineAsync(
+            DdctCertificatePageDto page = await QueryCertificatePageAsync(
                 query.Name,
                 includeSubdomains,
                 pageSize,
-                currentOffset,
+                continuation,
                 cancellationToken).ConfigureAwait(false);
-            if (page.Observations.Count == 0)
+            if (page.Items.Count == 0)
             {
                 hasMore = false;
                 break;
             }
 
-            foreach (DdctObservationDto item in page.Observations)
+            foreach (DdctCertificateSearchDto item in page.Items)
             {
-                string normalizedName = NormalizeHostName(item.MatchedName);
+                string normalizedName = CertificateTransparencyNameUtility.Normalize(item.MatchedName);
                 if (normalizedName.Length > 0)
                 {
                     discoveredNames.Add(normalizedName);
                 }
             }
 
-            foreach (DdctObservationDto item in page.Observations)
+            foreach (DdctCertificateSearchDto item in page.Items)
             {
                 if (seenFingerprints.Add(item.Sha256Fingerprint))
                 {
-                    selectedObservations.Add(item);
-                    if (selectedObservations.Count >= maxCertificates)
+                    selectedCertificates.Add(item);
+                    if (selectedCertificates.Count >= maxCertificates)
                     {
                         break;
                     }
                 }
             }
 
-            currentOffset += page.Observations.Count;
-            bool pageHasMore = page.Observations.Count >= page.Limit && page.Limit > 0;
-            hasMore = pageHasMore;
+            hasMore = HasMore(page);
+            nextContinuation = hasMore ? page.NextContinuation : null;
 
-            if (selectedObservations.Count >= maxCertificates)
+            if (selectedCertificates.Count >= maxCertificates)
             {
-                truncated = pageHasMore;
+                truncated = hasMore;
                 break;
             }
 
-            if (!pageHasMore)
+            if (!hasMore)
             {
                 break;
             }
 
+            continuation = page.NextContinuation;
             if (pageIndex == maxPages - 1)
             {
                 truncated = true;
@@ -252,15 +340,15 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
             }
         }
 
-        var certificates = new List<CtCertificateRecord>(selectedObservations.Count);
-        foreach (DdctObservationDto item in selectedObservations)
+        var certificates = new List<CtCertificateRecord>(selectedCertificates.Count);
+        foreach (DdctCertificateSearchDto item in selectedCertificates)
         {
             byte[] der = await DownloadCertificateDerAsync(item.Sha256Fingerprint, cancellationToken).ConfigureAwait(false);
             certificates.Add(CtCertificateRecord.FromDer(
                 ProviderId,
                 der,
                 providerCertificateId: item.Sha256Fingerprint,
-                entryTimestampUtc: item.CtObservedAtUtc));
+                entryTimestampUtc: item.LastCtObservedAtUtc ?? item.FirstCtObservedAtUtc));
         }
 
         return new CtCertificateQueryResult
@@ -271,50 +359,66 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
                 .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
                 .ToArray(),
             HasMore = hasMore,
-            ContinuationToken = hasMore ? EncodeOffsetContinuation(currentOffset) : null,
+            ContinuationToken = hasMore ? nextContinuation : null,
             Diagnostics = BuildDiagnostics(truncated)
         };
     }
 
-    private async Task<DdctTimelineResponseDto> QueryTimelineAsync(
+    private async Task<DdctObservationPageDto> QueryObservationPageAsync(
         string name,
         bool includeSubdomains,
         int pageSize,
-        int offset,
+        string? continuation,
         CancellationToken cancellationToken)
     {
-        string url = BuildTimelineUrl(name, includeSubdomains, pageSize, offset);
+        string url = BuildObservationsPagedUrl(name, includeSubdomains, pageSize, continuation);
         using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url, acceptJson: false);
         using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            return new DdctTimelineResponseDto
+            return new DdctObservationPageDto
             {
-                Observations = Array.Empty<DdctObservationDto>(),
-                Limit = pageSize,
-                Offset = offset
+                Items = Array.Empty<DdctObservationDto>(),
+                Limit = pageSize
             };
         }
 
-        return await DeserializeJsonAsync<DdctTimelineResponseDto>(response, cancellationToken).ConfigureAwait(false);
+        return await DeserializeJsonAsync<DdctObservationPageDto>(response, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<DdctDomainSearchResponseDto> QueryDomainSearchAsync(
+    private async Task<DdctCertificatePageDto> QueryCertificatePageAsync(
         string name,
         bool includeSubdomains,
-        int certificateLimit,
-        int observationLimit,
+        int pageSize,
+        string? continuation,
         CancellationToken cancellationToken)
     {
-        string url = BuildDomainSearchUrl(name, includeSubdomains, certificateLimit, observationLimit);
+        string url = BuildCertificatesPagedUrl(name, includeSubdomains, pageSize, continuation);
         using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url, acceptJson: false);
         using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            return new DdctDomainSearchResponseDto();
+            return new DdctCertificatePageDto
+            {
+                Items = Array.Empty<DdctCertificateSearchDto>(),
+                Limit = pageSize
+            };
         }
 
-        return await DeserializeJsonAsync<DdctDomainSearchResponseDto>(response, cancellationToken).ConfigureAwait(false);
+        return await DeserializeJsonAsync<DdctCertificatePageDto>(response, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<DdctCertificateSearchDto>> QueryLatestCertificateCandidatesAsync(string name, CancellationToken cancellationToken)
+    {
+        string url = BuildCertificatesUrl(name, includeSubdomains: false, limit: 1);
+        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, url, acceptJson: false);
+        using HttpResponseMessage response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return Array.Empty<DdctCertificateSearchDto>();
+        }
+
+        return await DeserializeJsonAsync<DdctCertificateSearchDto[]>(response, cancellationToken).ConfigureAwait(false);
     }
 
     private static async Task<T> DeserializeJsonAsync<T>(HttpResponseMessage response, CancellationToken cancellationToken)
@@ -370,38 +474,62 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         return request;
     }
 
-    private string BuildTimelineUrl(string name, bool includeSubdomains, int limit, int offset)
+    private string BuildCertificatesPagedUrl(string name, bool includeSubdomains, int limit, string? continuation)
     {
         var query = new List<string>
         {
             "name=" + Uri.EscapeDataString(name),
             "includeSubdomains=" + (includeSubdomains ? "true" : "false"),
-            "limit=" + limit.ToString(CultureInfo.InvariantCulture),
-            "offset=" + offset.ToString(CultureInfo.InvariantCulture)
+            "limit=" + limit.ToString(CultureInfo.InvariantCulture)
         };
         if (!string.IsNullOrWhiteSpace(_scopeName))
         {
             query.Add("scope=" + Uri.EscapeDataString(_scopeName));
         }
 
-        return BuildPath("/api/v1/search/domain/timeline?" + string.Join("&", query));
+        if (!string.IsNullOrWhiteSpace(continuation))
+        {
+            query.Add("continuation=" + Uri.EscapeDataString(continuation));
+        }
+
+        return BuildPath("/api/v1/certificates/paged?" + string.Join("&", query));
     }
 
-    private string BuildDomainSearchUrl(string name, bool includeSubdomains, int certificateLimit, int observationLimit)
+    private string BuildCertificatesUrl(string name, bool includeSubdomains, int limit)
     {
         var query = new List<string>
         {
             "name=" + Uri.EscapeDataString(name),
             "includeSubdomains=" + (includeSubdomains ? "true" : "false"),
-            "certificateLimit=" + certificateLimit.ToString(CultureInfo.InvariantCulture),
-            "observationLimit=" + observationLimit.ToString(CultureInfo.InvariantCulture)
+            "limit=" + limit.ToString(CultureInfo.InvariantCulture)
         };
         if (!string.IsNullOrWhiteSpace(_scopeName))
         {
             query.Add("scope=" + Uri.EscapeDataString(_scopeName));
         }
 
-        return BuildPath("/api/v1/search/domain?" + string.Join("&", query));
+        return BuildPath("/api/v1/certificates?" + string.Join("&", query));
+    }
+
+    private string BuildObservationsPagedUrl(string name, bool includeSubdomains, int limit, string? continuation)
+    {
+        var query = new List<string>
+        {
+            "name=" + Uri.EscapeDataString(name),
+            "includeSubdomains=" + (includeSubdomains ? "true" : "false"),
+            "limit=" + limit.ToString(CultureInfo.InvariantCulture)
+        };
+        if (!string.IsNullOrWhiteSpace(_scopeName))
+        {
+            query.Add("scope=" + Uri.EscapeDataString(_scopeName));
+        }
+
+        if (!string.IsNullOrWhiteSpace(continuation))
+        {
+            query.Add("continuation=" + Uri.EscapeDataString(continuation));
+        }
+
+        return BuildPath("/api/v1/observations/paged?" + string.Join("&", query));
     }
 
     private string BuildPath(string relativePath)
@@ -421,7 +549,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
 
     private static string NormalizeQueryName(string? value)
     {
-        string normalized = NormalizeHostName(value);
+        string normalized = CertificateTransparencyNameUtility.Normalize(value);
         if (normalized.Length == 0)
         {
             throw new ArgumentException("CT query name must not be empty.", nameof(value));
@@ -448,36 +576,26 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         return ClampInt(pagesNeeded, 1, _maxPagesPerQuery);
     }
 
-    private static string EncodeOffsetContinuation(int offset)
-        => Math.Max(0, offset).ToString(CultureInfo.InvariantCulture);
-
-    private static int DecodeOffsetContinuation(string? continuation)
-    {
-        if (continuation == null)
-        {
-            return 0;
-        }
-
-        string trimmed = continuation.Trim();
-        if (trimmed.Length == 0)
-        {
-            return 0;
-        }
-
-        return int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out int value) && value > 0
-            ? value
-            : 0;
-    }
-
     private static string NormalizeEndpointUrl(string? value)
         => string.IsNullOrWhiteSpace(value)
             ? DdctApiCertificateTransparencyProviderOptions.DefaultEndpointUrl
             : value!.Trim().TrimEnd('/');
 
-    private static string NormalizeHostName(string? value)
-        => string.IsNullOrWhiteSpace(value)
-            ? string.Empty
-            : value!.Trim().TrimEnd('.').ToLowerInvariant();
+    private static CtCertificateQueryResult CreateEmptyLatestResult()
+        => new()
+        {
+            ProviderId = ProviderIdStatic,
+            Certificates = Array.Empty<CtCertificateRecord>(),
+            DiscoveredNames = Array.Empty<string>(),
+            HasMore = false,
+            ContinuationToken = null,
+            Diagnostics = Array.Empty<string>()
+        };
+
+    private const string ProviderIdStatic = CtProviderProfiles.DdctApiProviderId;
+
+    private static bool HasMore<TItem>(DdctPageDto<TItem> page)
+        => page.HasMore && !string.IsNullOrWhiteSpace(page.NextContinuation);
 
     private static int ClampInt(int value, int minimum, int maximum)
         => value < minimum ? minimum : (value > maximum ? maximum : value);
@@ -505,17 +623,21 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
 #endif
     }
 
-    private sealed class DdctTimelineResponseDto
+    private abstract class DdctPageDto<TItem>
     {
-        public IReadOnlyList<DdctObservationDto> Observations { get; init; } = Array.Empty<DdctObservationDto>();
+        public IReadOnlyList<TItem> Items { get; init; } = Array.Empty<TItem>();
         public int Limit { get; init; }
         public int Offset { get; init; }
+        public string? NextContinuation { get; init; }
+        public bool HasMore { get; init; }
     }
 
-    private sealed class DdctDomainSearchResponseDto
+    private sealed class DdctCertificatePageDto : DdctPageDto<DdctCertificateSearchDto>
     {
-        public IReadOnlyList<DdctCertificateSearchDto> Certificates { get; init; } = Array.Empty<DdctCertificateSearchDto>();
-        public IReadOnlyList<DdctObservationDto> Observations { get; init; } = Array.Empty<DdctObservationDto>();
+    }
+
+    private sealed class DdctObservationPageDto : DdctPageDto<DdctObservationDto>
+    {
     }
 
     private sealed class DdctCertificateSearchDto

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -154,7 +154,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
         }
 
         int pageSize = ResolvePageSize(query.PageSize);
-        string? continuation = null;
+        string? continuation = query.ContinuationToken;
         bool truncated = false;
         var matchingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         DdctObservationDto? latestMatch = null;

--- a/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
+++ b/DomainDetective/CertificateTransparency/DdctApiCertificateTransparencyProvider.cs
@@ -186,6 +186,7 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
                     matchingNames.Add(matchedName);
                 }
 
+                // DDCT observation pages are ordered newest-first, so the first matching observation is the latest match.
                 latestMatch ??= observation;
             }
 
@@ -215,8 +216,8 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
                     ProviderId = ProviderId,
                     Certificates = Array.Empty<CtCertificateRecord>(),
                     DiscoveredNames = Array.Empty<string>(),
-                    HasMore = false,
-                    ContinuationToken = null,
+                    HasMore = HasMore(continuation),
+                    ContinuationToken = continuation,
                     Diagnostics = BuildDiagnostics(truncated)
                 }
                 : null;
@@ -597,6 +598,9 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
     private static bool HasMore<TItem>(DdctPageDto<TItem> page)
         => page.HasMore && !string.IsNullOrWhiteSpace(page.NextContinuation);
 
+    private static bool HasMore(string? continuation)
+        => !string.IsNullOrWhiteSpace(continuation);
+
     private static int ClampInt(int value, int minimum, int maximum)
         => value < minimum ? minimum : (value > maximum ? maximum : value);
 
@@ -627,7 +631,6 @@ public sealed class DdctApiCertificateTransparencyProvider : ICtCertificateTrans
     {
         public IReadOnlyList<TItem> Items { get; init; } = Array.Empty<TItem>();
         public int Limit { get; init; }
-        public int Offset { get; init; }
         public string? NextContinuation { get; init; }
         public bool HasMore { get; init; }
     }


### PR DESCRIPTION
## Summary
- Add a reusable `CertificateTransparencyNameUtility` for CT DNS normalization, wildcard coverage, reversed-label SQL matching patterns, and registrable-domain fallback.
- Update the DDCT API provider to use the shared CT name semantics while continuing to consume DDCT cursor-paged endpoints.
- Add multi-target tests for wildcard coverage and helper behavior.

## Validation
- `dotnet test DomainDetective.Tests\DomainDetective.Tests.csproj -c Release --no-restore --filter "TestCertificateTransparencyNameUtility|TestDdctApiCertificateTransparencyProvider"`