### PR TITLE
Add strict sitemap validation

### DIFF
--- a/Docs/SITEMAP.MD
+++ b/Docs/SITEMAP.MD
@@ -7,7 +7,7 @@ The sitemap check validates XML sitemap discovery, sitemap protocol shape, and t
 | Area | Checks |
 | --- | --- |
 | Discovery | `robots.txt` `Sitemap:` directives, conventional `/sitemap.xml`, sitemap indexes, nested sitemap documents |
-| XML shape | well-formed XML, expected sitemap namespace, `urlset` vs `sitemapindex`, missing or invalid `loc` |
+| XML shape | well-formed XML, expected sitemap namespace, sitemap.org XSD validation, `urlset` vs `sitemapindex`, missing or invalid `loc` |
 | Entry metadata | invalid `lastmod`, invalid `changefreq`, invalid `priority`, duplicate `loc` values |
 | URL probes | redirect chains, redirect loops, HTTP 4xx/5xx, failed fetches |
 | Indexing signals | `X-Robots-Tag` and HTML meta robots `noindex` |
@@ -44,3 +44,5 @@ Useful tuning options:
 ## Notes
 
 The analysis is intentionally bounded by default. Large sites should raise `MaxEntries` and `MaxUrlProbes` deliberately, especially when probing URL reachability, because every probed sitemap URL results in an HTTP request.
+
+The sitemap.org schema permits extension elements from other namespaces through strict XML Schema wildcards. In practice, that means documents with `xhtml:link` alternates can be well-formed XML and accepted by Google for hreflang purposes while still failing strict sitemap.org XSD validation unless the extension schema is available to the validator. DomainDetective keeps those signals separate: XML well-formedness, sitemap XSD validity, and XHTML alternate counts are reported independently so callers can decide how strict a site should be.

--- a/DomainDetective.Tests/TestSitemapAnalysis.cs
+++ b/DomainDetective.Tests/TestSitemapAnalysis.cs
@@ -161,7 +161,7 @@ public class TestSitemapAnalysis {
         Assert.True(analysis.Documents[0].XmlValid);
         Assert.False(analysis.Documents[0].SchemaValid);
         Assert.Equal(SitemapDocumentKind.SitemapIndex, analysis.Documents[0].Kind);
-        Assert.True(analysis.Documents[0].SchemaValidationErrorCount > 0);
+        Assert.Equal(1, analysis.Documents[0].SchemaValidationErrorCount);
         Assert.Contains("loc", analysis.Documents[0].SchemaValidationError, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaInvalid && assessment.Severity == AssessmentSeverity.Error);
     }

--- a/DomainDetective.Tests/TestSitemapAnalysis.cs
+++ b/DomainDetective.Tests/TestSitemapAnalysis.cs
@@ -130,6 +130,43 @@ public class TestSitemapAnalysis {
     }
 
     [Fact]
+    public async Task AnalyzeAsyncReportsSchemaInvalidForMalformedSitemapIndex() {
+        var sitemapIndex = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                           "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                           "<sitemap><lastmod>2026-05-07</lastmod></sitemap>" +
+                           "</sitemapindex>";
+        var analysis = new SitemapAnalysis {
+            HttpHandlerFactory = () => new HttpStubMessageHandler((request, cancellationToken) => {
+                var url = request.RequestUri?.AbsoluteUri ?? string.Empty;
+                if (url.Equals("https://invalid-index.example/robots.txt", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("text/plain", "User-agent: *\nAllow: /\nSitemap: https://invalid-index.example/sitemap.xml\n");
+                }
+
+                if (url.Equals("https://invalid-index.example/sitemap.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", sitemapIndex);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })
+        };
+
+        await analysis.AnalyzeAsync(
+            "invalid-index.example",
+            options: new SitemapAnalysisOptions {
+                AllowHttpFallback = false,
+                ProbeUrls = false
+            });
+
+        Assert.Single(analysis.Documents);
+        Assert.True(analysis.Documents[0].XmlValid);
+        Assert.False(analysis.Documents[0].SchemaValid);
+        Assert.Equal(SitemapDocumentKind.SitemapIndex, analysis.Documents[0].Kind);
+        Assert.True(analysis.Documents[0].SchemaValidationErrorCount > 0);
+        Assert.Contains("loc", analysis.Documents[0].SchemaValidationError, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaInvalid && assessment.Severity == AssessmentSeverity.Error);
+    }
+
+    [Fact]
     public async Task VerifyIncludesSitemapAssessmentsInAggregateRecommendations() {
         using var listener = StartListener(out var prefix);
         using var cts = new CancellationTokenSource();

--- a/DomainDetective.Tests/TestSitemapAnalysis.cs
+++ b/DomainDetective.Tests/TestSitemapAnalysis.cs
@@ -27,6 +27,7 @@ public class TestSitemapAnalysis {
 
             Assert.Single(analysis.Documents);
             Assert.True(analysis.Documents[0].XmlValid);
+            Assert.True(analysis.Documents[0].SchemaValid);
             Assert.Equal(SitemapDocumentKind.UrlSet, analysis.Documents[0].Kind);
             Assert.Equal(6, analysis.Entries.Count);
             Assert.Equal(1, analysis.DuplicateLocationCount);
@@ -44,6 +45,88 @@ public class TestSitemapAnalysis {
             listener.Stop();
             await serverTask;
         }
+    }
+
+    [Fact]
+    public async Task AnalyzeAsyncReportsSchemaInvalidForUndeclaredExtensionElements() {
+        var sitemap = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                      "<urlset xmlns:xhtml=\"http://www.w3.org/1999/xhtml\" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                      "<url><loc>https://schema.example/</loc><xhtml:link rel=\"alternate\" hreflang=\"de\" href=\"https://schema.example/de/\" /></url>" +
+                      "</urlset>";
+        var analysis = new SitemapAnalysis {
+            HttpHandlerFactory = () => new HttpStubMessageHandler((request, cancellationToken) => {
+                var url = request.RequestUri?.AbsoluteUri ?? string.Empty;
+                if (url.Equals("https://schema.example/robots.txt", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("text/plain", "User-agent: *\nAllow: /\nSitemap: https://schema.example/sitemap.xml\n");
+                }
+
+                if (url.Equals("https://schema.example/sitemap.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", sitemap);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })
+        };
+
+        await analysis.AnalyzeAsync(
+            "schema.example",
+            options: new SitemapAnalysisOptions {
+                AllowHttpFallback = false,
+                ProbeUrls = false
+            });
+
+        Assert.Single(analysis.Documents);
+        Assert.True(analysis.Documents[0].XmlValid);
+        Assert.False(analysis.Documents[0].SchemaValid);
+        Assert.Equal(1, analysis.Documents[0].SchemaValidationErrorCount);
+        Assert.Equal(1, analysis.Documents[0].XhtmlAlternateLinkCount);
+        Assert.Contains("xhtml", analysis.Documents[0].SchemaValidationError, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaInvalid && assessment.Severity == AssessmentSeverity.Error);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.XhtmlAlternateExtension && assessment.Severity == AssessmentSeverity.Warning);
+        Assert.Contains(analysis.Recommendations, recommendation => recommendation.Code == SitemapCodes.SchemaInvalid);
+        Assert.Contains(analysis.Recommendations, recommendation => recommendation.Code == SitemapCodes.XhtmlAlternateExtension);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsyncSchemaValidatesSitemapIndexes() {
+        var sitemapIndex = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                           "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                           "<sitemap><loc>https://index.example/child.xml</loc><lastmod>2026-05-07</lastmod></sitemap>" +
+                           "</sitemapindex>";
+        var childSitemap = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                           "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                           "<url><loc>https://index.example/</loc></url>" +
+                           "</urlset>";
+        var analysis = new SitemapAnalysis {
+            HttpHandlerFactory = () => new HttpStubMessageHandler((request, cancellationToken) => {
+                var url = request.RequestUri?.AbsoluteUri ?? string.Empty;
+                if (url.Equals("https://index.example/robots.txt", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("text/plain", "User-agent: *\nAllow: /\nSitemap: https://index.example/sitemap.xml\n");
+                }
+
+                if (url.Equals("https://index.example/sitemap.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", sitemapIndex);
+                }
+
+                if (url.Equals("https://index.example/child.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", childSitemap);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })
+        };
+
+        await analysis.AnalyzeAsync(
+            "index.example",
+            options: new SitemapAnalysisOptions {
+                AllowHttpFallback = false,
+                ProbeUrls = false
+            });
+
+        Assert.Equal(2, analysis.Documents.Count);
+        Assert.All(analysis.Documents, document => Assert.True(document.SchemaValid));
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaValid);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaInvalid);
     }
 
     [Fact]

--- a/DomainDetective.Toolbox/Components/Tools/WebDiscovery/SitemapTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/WebDiscovery/SitemapTool.razor
@@ -52,7 +52,7 @@
             <div class="tool-summary-card">
                 <span class="tool-summary-label">Document health</span>
                 <strong class="tool-summary-value">@GetValidDocumentCount(view).ToString(CultureInfo.InvariantCulture) / @view.DocumentCount.ToString(CultureInfo.InvariantCulture)</strong>
-                <p class="tool-summary-note">Well-formed XML documents. @GetInvalidDocumentCount(view).ToString(CultureInfo.InvariantCulture) document(s) need review.</p>
+                <p class="tool-summary-note">XML, namespace, and schema-valid documents. @GetInvalidDocumentCount(view).ToString(CultureInfo.InvariantCulture) document(s) need review.</p>
             </div>
             <div class="tool-summary-card">
                 <span class="tool-summary-label">URL hygiene</span>
@@ -89,6 +89,13 @@
                             <span class="tool-chip">HTTP @FormatStatusCode(document.StatusCode)</span>
                             <span class="tool-chip">XML @FormatBool(document.XmlValid)</span>
                             <span class="tool-chip">Namespace @FormatBool(document.NamespaceValid)</span>
+                            <span class="tool-chip">Schema @FormatBool(document.SchemaValid)</span>
+                            @if (document.SchemaValidationErrorCount > 0) {
+                                <span class="tool-chip">@document.SchemaValidationErrorCount.ToString(CultureInfo.InvariantCulture) schema error(s)</span>
+                            }
+                            @if (document.XhtmlAlternateLinkCount > 0) {
+                                <span class="tool-chip">@document.XhtmlAlternateLinkCount.ToString(CultureInfo.InvariantCulture) xhtml alternate(s)</span>
+                            }
                             <span class="tool-chip">@document.UrlCount.ToString(CultureInfo.InvariantCulture) URLs</span>
                             <span class="tool-chip">@document.SitemapCount.ToString(CultureInfo.InvariantCulture) child sitemaps</span>
                             @if (IsCrossHost(document.Url, view.Subject ?? Domain)) {
@@ -97,6 +104,9 @@
                         </div>
                         @if (!string.IsNullOrWhiteSpace(document.Error)) {
                             <p class="sitemap-error-text">@document.Error</p>
+                        }
+                        @if (!string.IsNullOrWhiteSpace(document.SchemaValidationError)) {
+                            <p class="sitemap-error-text">@document.SchemaValidationError</p>
                         }
                     </article>
                 }
@@ -209,8 +219,12 @@
             return $"Sitemap XML parsed successfully across {GetValidDocumentCount(view).ToString(CultureInfo.InvariantCulture)} document(s), but sampled URL probes found {view.ErrorCount.ToString(CultureInfo.InvariantCulture)} blocking fetch issue(s).";
         }
 
+        if (GetSchemaInvalidDocumentCount(view) > 0) {
+            return $"Sitemap XML parsed, but {GetSchemaInvalidDocumentCount(view).ToString(CultureInfo.InvariantCulture)} document(s) failed official Sitemap protocol schema validation.";
+        }
+
         if (view.ErrorCount > 0) {
-            return $"DD found {view.ErrorCount.ToString(CultureInfo.InvariantCulture)} sitemap error(s), including XML, redirect-loop, or HTTP failure findings.";
+            return $"DD found {view.ErrorCount.ToString(CultureInfo.InvariantCulture)} sitemap error(s), including XML, schema, redirect-loop, or HTTP failure findings.";
         }
 
         if (view.WarningCount > 0) {
@@ -274,11 +288,15 @@
     }
 
     private static int GetValidDocumentCount(SitemapInfo view) {
-        return view.Documents.Count(static document => document.XmlValid && document.NamespaceValid);
+        return view.Documents.Count(static document => document.XmlValid && document.NamespaceValid && document.SchemaValid);
     }
 
     private static int GetInvalidDocumentCount(SitemapInfo view) {
-        return view.Documents.Count(static document => !document.XmlValid || !document.NamespaceValid);
+        return view.Documents.Count(static document => !document.XmlValid || !document.NamespaceValid || !document.SchemaValid);
+    }
+
+    private static int GetSchemaInvalidDocumentCount(SitemapInfo view) {
+        return view.Documents.Count(static document => document.XmlValid && !document.SchemaValid);
     }
 
     private static int GetCrossHostDocumentCount(SitemapInfo view) {

--- a/DomainDetective.Toolbox/Components/Tools/WebDiscovery/SitemapTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/WebDiscovery/SitemapTool.razor
@@ -89,7 +89,9 @@
                             <span class="tool-chip">HTTP @FormatStatusCode(document.StatusCode)</span>
                             <span class="tool-chip">XML @FormatBool(document.XmlValid)</span>
                             <span class="tool-chip">Namespace @FormatBool(document.NamespaceValid)</span>
-                            <span class="tool-chip">Schema @FormatBool(document.SchemaValid)</span>
+                            @if (document.XmlValid) {
+                                <span class="tool-chip">Schema @FormatBool(document.SchemaValid)</span>
+                            }
                             @if (document.SchemaValidationErrorCount > 0) {
                                 <span class="tool-chip">@document.SchemaValidationErrorCount.ToString(CultureInfo.InvariantCulture) schema error(s)</span>
                             }
@@ -219,8 +221,9 @@
             return $"Sitemap XML parsed successfully across {GetValidDocumentCount(view).ToString(CultureInfo.InvariantCulture)} document(s), but sampled URL probes found {view.ErrorCount.ToString(CultureInfo.InvariantCulture)} blocking fetch issue(s).";
         }
 
-        if (GetSchemaInvalidDocumentCount(view) > 0) {
-            return $"Sitemap XML parsed, but {GetSchemaInvalidDocumentCount(view).ToString(CultureInfo.InvariantCulture)} document(s) failed official Sitemap protocol schema validation.";
+        var schemaInvalidCount = GetSchemaInvalidDocumentCount(view);
+        if (schemaInvalidCount > 0) {
+            return $"Sitemap XML parsed, but {schemaInvalidCount.ToString(CultureInfo.InvariantCulture)} document(s) failed official Sitemap protocol schema validation.";
         }
 
         if (view.ErrorCount > 0) {

--- a/DomainDetective/Definitions/SitemapIndexProtocol_0_9.xsd
+++ b/DomainDetective/Definitions/SitemapIndexProtocol_0_9.xsd
@@ -6,6 +6,7 @@
   <xsd:element name="sitemapindex">
     <xsd:complexType>
       <xsd:sequence>
+        <!-- Mirrors the published sitemaps.org siteindex.xsd wildcard ordering and strict extension processing. -->
         <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
         <xsd:element name="sitemap" type="tSitemap" maxOccurs="unbounded"/>
       </xsd:sequence>
@@ -16,6 +17,7 @@
     <xsd:sequence>
       <xsd:element name="loc" type="tLocSitemap"/>
       <xsd:element name="lastmod" type="tLastmodSitemap" minOccurs="0"/>
+      <!-- Mirrors the published sitemaps.org siteindex.xsd strict extension processing. -->
       <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
     </xsd:sequence>
   </xsd:complexType>

--- a/DomainDetective/Definitions/SitemapIndexProtocol_0_9.xsd
+++ b/DomainDetective/Definitions/SitemapIndexProtocol_0_9.xsd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+            elementFormDefault="qualified">
+  <xsd:element name="sitemapindex">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+        <xsd:element name="sitemap" type="tSitemap" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="tSitemap">
+    <xsd:sequence>
+      <xsd:element name="loc" type="tLocSitemap"/>
+      <xsd:element name="lastmod" type="tLastmodSitemap" minOccurs="0"/>
+      <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="tLocSitemap">
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tLastmodSitemap">
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:date"/>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:dateTime"/>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+</xsd:schema>

--- a/DomainDetective/Definitions/SitemapProtocol_0_9.xsd
+++ b/DomainDetective/Definitions/SitemapProtocol_0_9.xsd
@@ -6,6 +6,7 @@
   <xsd:element name="urlset">
     <xsd:complexType>
       <xsd:sequence>
+        <!-- Mirrors the published sitemaps.org sitemap.xsd wildcard ordering and strict extension processing. -->
         <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
         <xsd:element name="url" type="tUrl" maxOccurs="unbounded"/>
       </xsd:sequence>
@@ -18,6 +19,7 @@
       <xsd:element name="lastmod" type="tLastmod" minOccurs="0"/>
       <xsd:element name="changefreq" type="tChangeFreq" minOccurs="0"/>
       <xsd:element name="priority" type="tPriority" minOccurs="0"/>
+      <!-- Mirrors the published sitemaps.org sitemap.xsd strict extension processing. -->
       <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
     </xsd:sequence>
   </xsd:complexType>

--- a/DomainDetective/Definitions/SitemapProtocol_0_9.xsd
+++ b/DomainDetective/Definitions/SitemapProtocol_0_9.xsd
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://www.sitemaps.org/schemas/sitemap/0.9"
+            xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+            elementFormDefault="qualified">
+  <xsd:element name="urlset">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+        <xsd:element name="url" type="tUrl" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="tUrl">
+    <xsd:sequence>
+      <xsd:element name="loc" type="tLoc"/>
+      <xsd:element name="lastmod" type="tLastmod" minOccurs="0"/>
+      <xsd:element name="changefreq" type="tChangeFreq" minOccurs="0"/>
+      <xsd:element name="priority" type="tPriority" minOccurs="0"/>
+      <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="tLoc">
+    <xsd:restriction base="xsd:anyURI">
+      <xsd:minLength value="12"/>
+      <xsd:maxLength value="2048"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tLastmod">
+    <xsd:union>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:date"/>
+      </xsd:simpleType>
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:dateTime"/>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tChangeFreq">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="always"/>
+      <xsd:enumeration value="hourly"/>
+      <xsd:enumeration value="daily"/>
+      <xsd:enumeration value="weekly"/>
+      <xsd:enumeration value="monthly"/>
+      <xsd:enumeration value="yearly"/>
+      <xsd:enumeration value="never"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="tPriority">
+    <xsd:restriction base="xsd:decimal">
+      <xsd:minInclusive value="0.0"/>
+      <xsd:maxInclusive value="1.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+</xsd:schema>

--- a/DomainDetective/Diagnostics/Codes/SitemapCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SitemapCodes.cs
@@ -6,6 +6,9 @@ internal static class SitemapCodes {
     public const string DownloadFailed = "SITEMAP.Download.Failed";
     public const string XmlValid = "SITEMAP.Xml.Valid";
     public const string XmlInvalid = "SITEMAP.Xml.Invalid";
+    public const string SchemaValid = "SITEMAP.Schema.Valid";
+    public const string SchemaInvalid = "SITEMAP.Schema.Invalid";
+    public const string XhtmlAlternateExtension = "SITEMAP.Extension.XhtmlAlternate";
     public const string RootInvalid = "SITEMAP.Root.Invalid";
     public const string NamespaceInvalid = "SITEMAP.Namespace.Invalid";
     public const string UrlEntryPresent = "SITEMAP.UrlEntry.Present";

--- a/DomainDetective/Diagnostics/Recommendations/SitemapRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SitemapRecommendations.cs
@@ -26,6 +26,28 @@ internal sealed class SitemapRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Medium,
             Verify = "Parse the sitemap with an XML parser and confirm the root is urlset or sitemapindex."
         };
+        map[SitemapCodes.SchemaInvalid] = new RecommendationAdvice {
+            Code = SitemapCodes.SchemaInvalid,
+            Title = "Sitemap does not match the protocol schema",
+            Why = "A sitemap can be well-formed XML but still violate the official Sitemap protocol schema. Schema-level issues can cause search tools to classify or consume the sitemap inconsistently.",
+            How = "Validate the document against sitemap.xsd or siteindex.xsd, then fix unsupported elements, element ordering, required loc entries, lastmod values, priority values, and extension namespaces.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "sitemap", "xml-schema", "seo", "crawl" },
+            Impact = "Search engines may ignore entries, report stale discovery counts, or treat the sitemap differently than a simple XML parser.",
+            Effort = RecommendationEffort.Medium,
+            Verify = "Validate the sitemap against the official schema from https://www.sitemaps.org/schemas/sitemap/0.9/."
+        };
+        map[SitemapCodes.XhtmlAlternateExtension] = new RecommendationAdvice {
+            Code = SitemapCodes.XhtmlAlternateExtension,
+            Title = "XHTML alternate links affect strict sitemap validation",
+            Why = "Google supports xhtml:link hreflang annotations in sitemaps, but the base sitemaps.org schema does not declare the XHTML extension. Generic XML schema validators and Chrome's XML tree viewer can therefore treat the document differently than a plain sitemap.",
+            How = "Decide whether this sitemap is meant to be a strict generic sitemap or a Google hreflang sitemap. For strict sitemap consumers, remove xhtml:link entries or publish a separate plain sitemap. For Google hreflang, validate reciprocal/self-referencing hreflang rules and monitor Search Console.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "sitemap", "hreflang", "xhtml", "xml-schema", "seo" },
+            Impact = "Diagnostics may report strict schema failures even though Google supports the hreflang extension; separating the signals makes the crawler behavior easier to explain.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Compare strict sitemap schema validation with Google Search Central hreflang sitemap guidance."
+        };
         map[SitemapCodes.CrossHostSitemap] = new RecommendationAdvice {
             Code = SitemapCodes.CrossHostSitemap,
             Title = "Cross-host sitemap advertised",

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -69,6 +69,8 @@
     <ItemGroup>
         <EmbeddedResource Include="Definitions\DmarcAggregateReport_v1.xsd" />  
         <EmbeddedResource Include="Definitions\DmarcAggregateReport_v2.xsd" />  
+        <EmbeddedResource Include="Definitions\SitemapProtocol_0_9.xsd" />
+        <EmbeddedResource Include="Definitions\SitemapIndexProtocol_0_9.xsd" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DomainDetective/Protocols/SitemapAnalysis.cs
+++ b/DomainDetective/Protocols/SitemapAnalysis.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
+using System.Xml.Schema;
 using DomainDetective.Helpers;
 
 namespace DomainDetective;
@@ -21,6 +22,7 @@ namespace DomainDetective;
 /// </summary>
 public sealed class SitemapAnalysis : IHasAssessments {
     private const string SitemapNamespace = "http://www.sitemaps.org/schemas/sitemap/0.9";
+    private static readonly Lazy<XmlSchemaSet> _protocolSchemas = new(LoadProtocolSchemas);
     private static readonly XNamespace _sitemapNs = SitemapNamespace;
     private static readonly XNamespace _xhtmlNs = "http://www.w3.org/1999/xhtml";
     private static readonly HashSet<string> _validChangeFrequencies = new(StringComparer.OrdinalIgnoreCase) {
@@ -301,9 +303,30 @@ public sealed class SitemapAnalysis : IHasAssessments {
             AddAssessment(AssessmentSeverity.Warning, SitemapCodes.NamespaceInvalid, "Sitemap root namespace is not the standard sitemap namespace.", sitemapUri.AbsoluteUri);
         }
 
+        var schemaErrors = ValidateProtocolSchema(response.Body!, Math.Max(1024, options.MaxSitemapBodyCharacters));
+        docInfo.SchemaValidationErrorCount = schemaErrors.Count;
+        if (schemaErrors.Count == 0) {
+            docInfo.SchemaValid = true;
+            AddAssessment(AssessmentSeverity.Info, SitemapCodes.SchemaValid, "Sitemap XML matches the official Sitemap protocol schema.", sitemapUri.AbsoluteUri);
+        } else {
+            docInfo.SchemaValidationError = schemaErrors[0];
+            AddAssessment(
+                AssessmentSeverity.Error,
+                SitemapCodes.SchemaInvalid,
+                "Sitemap XML does not match the official Sitemap protocol schema: " + schemaErrors[0] + " (" + schemaErrors.Count.ToString(CultureInfo.InvariantCulture) + " validation error(s)).",
+                sitemapUri.AbsoluteUri);
+        }
+
         if (root.Name.LocalName.Equals("urlset", StringComparison.OrdinalIgnoreCase)) {
             docInfo.Kind = SitemapDocumentKind.UrlSet;
             ParseUrlSet(root, sitemapUri, docInfo, options);
+            if (docInfo.XhtmlAlternateLinkCount > 0) {
+                AddAssessment(
+                    AssessmentSeverity.Warning,
+                    SitemapCodes.XhtmlAlternateExtension,
+                    "Sitemap contains " + docInfo.XhtmlAlternateLinkCount.ToString(CultureInfo.InvariantCulture) + " xhtml:link alternate entries. Google supports hreflang sitemap extensions, but the base sitemaps.org schema and Chrome XML tree rendering may not treat this as a plain sitemap.",
+                    sitemapUri.AbsoluteUri);
+            }
         } else if (root.Name.LocalName.Equals("sitemapindex", StringComparison.OrdinalIgnoreCase)) {
             docInfo.Kind = SitemapDocumentKind.SitemapIndex;
             ParseSitemapIndex(root, sitemapUri, docInfo, result.NestedSitemaps);
@@ -325,6 +348,41 @@ public sealed class SitemapAnalysis : IHasAssessments {
         using var reader = new StringReader(body.TrimStart('\uFEFF'));
         using var xmlReader = XmlReader.Create(reader, settings);
         return XDocument.Load(xmlReader, LoadOptions.None);
+    }
+
+    private static List<string> ValidateProtocolSchema(string body, int maxCharactersInDocument) {
+        var errors = new List<string>();
+        var settings = new XmlReaderSettings {
+            DtdProcessing = DtdProcessing.Prohibit,
+            XmlResolver = null,
+            MaxCharactersInDocument = maxCharactersInDocument,
+            ValidationType = ValidationType.Schema,
+            Schemas = _protocolSchemas.Value
+        };
+        settings.ValidationEventHandler += (_, e) => errors.Add(e.Message);
+
+        using var reader = new StringReader(body.TrimStart('\uFEFF'));
+        using var xmlReader = XmlReader.Create(reader, settings);
+        while (xmlReader.Read()) {
+        }
+
+        return errors;
+    }
+
+    private static XmlSchemaSet LoadProtocolSchemas() {
+        var schemas = new XmlSchemaSet();
+        AddProtocolSchema(schemas, "DomainDetective.Definitions.SitemapProtocol_0_9.xsd");
+        AddProtocolSchema(schemas, "DomainDetective.Definitions.SitemapIndexProtocol_0_9.xsd");
+        schemas.Compile();
+        return schemas;
+    }
+
+    private static void AddProtocolSchema(XmlSchemaSet schemas, string resourceName) {
+        var assembly = typeof(SitemapAnalysis).Assembly;
+        using var stream = assembly.GetManifestResourceStream(resourceName) ??
+            throw new InvalidOperationException("Schema resource '" + resourceName + "' not found.");
+        using var reader = XmlReader.Create(stream);
+        schemas.Add(SitemapNamespace, reader);
     }
 
     private void ParseUrlSet(XElement root, Uri sitemapUri, SitemapDocument docInfo, SitemapAnalysisOptions options) {
@@ -384,6 +442,7 @@ public sealed class SitemapAnalysis : IHasAssessments {
                 });
             }
 
+            docInfo.XhtmlAlternateLinkCount += entry.Alternates.Count;
             Entries.Add(entry);
             docInfo.UrlCount++;
         }

--- a/DomainDetective/Protocols/SitemapAnalysis.cs
+++ b/DomainDetective/Protocols/SitemapAnalysis.cs
@@ -361,10 +361,14 @@ public sealed class SitemapAnalysis : IHasAssessments {
         };
         settings.ValidationEventHandler += (_, e) => errors.Add(e.Message);
 
-        using var reader = new StringReader(body.TrimStart('\uFEFF'));
-        using var xmlReader = XmlReader.Create(reader, settings);
-        while (xmlReader.Read()) {
-            // Reading the full document drives XmlReader schema validation events.
+        try {
+            using var reader = new StringReader(body.TrimStart('\uFEFF'));
+            using var xmlReader = XmlReader.Create(reader, settings);
+            while (xmlReader.Read()) {
+                // Reading the full document drives XmlReader schema validation events.
+            }
+        } catch (XmlException ex) {
+            errors.Add(ex.Message);
         }
 
         return errors;

--- a/DomainDetective/Protocols/SitemapAnalysis.cs
+++ b/DomainDetective/Protocols/SitemapAnalysis.cs
@@ -364,6 +364,7 @@ public sealed class SitemapAnalysis : IHasAssessments {
         using var reader = new StringReader(body.TrimStart('\uFEFF'));
         using var xmlReader = XmlReader.Create(reader, settings);
         while (xmlReader.Read()) {
+            // Reading the full document drives XmlReader schema validation events.
         }
 
         return errors;

--- a/DomainDetective/Protocols/SitemapModels.cs
+++ b/DomainDetective/Protocols/SitemapModels.cs
@@ -25,6 +25,12 @@ public sealed class SitemapDocument {
     public bool Present { get; set; }
     /// <summary>True when the sitemap document is well-formed XML.</summary>
     public bool XmlValid { get; set; }
+    /// <summary>True when the sitemap document validates against the official Sitemap protocol XML schema.</summary>
+    public bool SchemaValid { get; set; }
+    /// <summary>Number of Sitemap protocol XML schema validation errors.</summary>
+    public int SchemaValidationErrorCount { get; set; }
+    /// <summary>First Sitemap protocol XML schema validation error, when available.</summary>
+    public string? SchemaValidationError { get; set; }
     /// <summary>True when the root element uses the standard sitemap namespace.</summary>
     public bool NamespaceValid { get; set; }
     /// <summary>Detected sitemap document kind.</summary>
@@ -35,6 +41,8 @@ public sealed class SitemapDocument {
     public int UrlCount { get; set; }
     /// <summary>Number of nested sitemap entries parsed from this document.</summary>
     public int SitemapCount { get; set; }
+    /// <summary>Number of XHTML alternate links parsed from this document.</summary>
+    public int XhtmlAlternateLinkCount { get; set; }
 }
 
 /// <summary>Represents one URL entry from a sitemap urlset.</summary>

--- a/DomainDetective/Views/Converters.Sitemap.cs
+++ b/DomainDetective/Views/Converters.Sitemap.cs
@@ -41,10 +41,14 @@ public static partial class Converters {
                     ContentType = document.ContentType,
                     Present = document.Present,
                     XmlValid = document.XmlValid,
+                    SchemaValid = document.SchemaValid,
+                    SchemaValidationErrorCount = document.SchemaValidationErrorCount,
+                    SchemaValidationError = document.SchemaValidationError,
                     NamespaceValid = document.NamespaceValid,
                     Kind = document.Kind.ToString(),
                     UrlCount = document.UrlCount,
                     SitemapCount = document.SitemapCount,
+                    XhtmlAlternateLinkCount = document.XhtmlAlternateLinkCount,
                     Error = document.Error
                 })
                 .ToArray(),
@@ -147,6 +151,12 @@ public sealed class SitemapDocumentInfo {
     public bool Present { get; set; }
     /// <summary>True when the sitemap XML was well formed.</summary>
     public bool XmlValid { get; set; }
+    /// <summary>True when the sitemap XML validates against the official Sitemap protocol schema.</summary>
+    public bool SchemaValid { get; set; }
+    /// <summary>Number of Sitemap protocol schema validation errors.</summary>
+    public int SchemaValidationErrorCount { get; set; }
+    /// <summary>First Sitemap protocol schema validation error, when available.</summary>
+    public string? SchemaValidationError { get; set; }
     /// <summary>True when the root namespace matches the sitemap protocol namespace.</summary>
     public bool NamespaceValid { get; set; }
     /// <summary>Detected root document kind.</summary>
@@ -155,6 +165,8 @@ public sealed class SitemapDocumentInfo {
     public int UrlCount { get; set; }
     /// <summary>Number of nested sitemap entries in this document.</summary>
     public int SitemapCount { get; set; }
+    /// <summary>Number of XHTML alternate links in this document.</summary>
+    public int XhtmlAlternateLinkCount { get; set; }
     /// <summary>Fetch or parse error when available.</summary>
     public string? Error { get; set; }
 }


### PR DESCRIPTION
## Summary
- add strict sitemap.org XSD validation for sitemap urlset and sitemapindex documents
- expose schema validity, schema error count, first schema error, and XHTML alternate counts in sitemap view output
- show strict schema evidence in the Sitemap Toolbox UI and document the distinction from XML well-formedness

## Validation
- `dotnet restore .\DomainDetective.sln` (completed project restores; parent process exited without additional output)
- `dotnet test .\DomainDetective.Tests\DomainDetective.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~TestSitemapAnalysis" --no-restore`
- `dotnet build .\DomainDetective\DomainDetective.csproj --framework net472 --no-restore -m:1 -nr:false`
- `dotnet build .\DomainDetective.Toolbox\DomainDetective.Toolbox.csproj --no-restore -m:1 -nr:false`
- `git diff --cached --check`