### PR TITLE
Add Google sitemap extension detection

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -67,17 +67,72 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
     throw "Deploy workflow not found: $DeployWorkflowPath"
 }
 
-$deployWorkflow = Get-Content -LiteralPath $DeployWorkflowPath -Raw
-if ($deployWorkflow -notmatch 'powerforge-website-deploy\.yml@') {
-    throw "Deploy workflow must call the PowerForge website deploy reusable workflow."
+$deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@3c671c874bb90ad83741f42d6ad6106320c52502'
+$deployWorkflowUses = $null
+$guardrailValue = $null
+$inDeployJob = $false
+$deployJobIndent = -1
+$inDeployWith = $false
+$deployWithIndent = -1
+
+for ($lineIndex = 0; $lineIndex -lt $deployWorkflowLines.Count; $lineIndex++) {
+    $line = $deployWorkflowLines[$lineIndex]
+
+    if ($line -match '^\s*(#.*)?$') {
+        continue
+    }
+
+    if (-not $inDeployJob) {
+        $jobMatch = [regex]::Match($line, '^(?<indent>\s*)website-deploy:\s*(?:#.*)?$')
+        if ($jobMatch.Success) {
+            $inDeployJob = $true
+            $deployJobIndent = $jobMatch.Groups['indent'].Value.Length
+        }
+
+        continue
+    }
+
+    $keyMatch = [regex]::Match($line, '^(?<indent>\s*)(?<key>[A-Za-z0-9_-]+):')
+    if ($keyMatch.Success -and $keyMatch.Groups['indent'].Value.Length -le $deployJobIndent) {
+        break
+    }
+
+    $usesMatch = [regex]::Match($line, '^\s*uses:\s*(?<value>\S+)\s*(?:#.*)?$')
+    if ($usesMatch.Success) {
+        $deployWorkflowUses = $usesMatch.Groups['value'].Value
+        continue
+    }
+
+    $withMatch = [regex]::Match($line, '^(?<indent>\s*)with:\s*(?:#.*)?$')
+    if ($withMatch.Success) {
+        $inDeployWith = $true
+        $deployWithIndent = $withMatch.Groups['indent'].Value.Length
+        continue
+    }
+
+    if ($inDeployWith) {
+        if ($keyMatch.Success -and $keyMatch.Groups['indent'].Value.Length -le $deployWithIndent) {
+            $inDeployWith = $false
+            continue
+        }
+
+        $guardrailMatch = [regex]::Match($line, '^\s*require_seo_doctor_guardrail:\s*(?<value>true|false)\s*(?:#.*)?$', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        if ($guardrailMatch.Success) {
+            $guardrailValue = $guardrailMatch.Groups['value'].Value
+        }
+    }
 }
 
-$guardrailMatch = [regex]::Match($deployWorkflow, '(?m)^\s*require_seo_doctor_guardrail:\s*(true|false)\s*(?:#.*)?$')
-$requiresSeoDoctorGuardrail = $true
-if ($guardrailMatch.Success) {
-    $requiresSeoDoctorGuardrail = [bool]::Parse($guardrailMatch.Groups[1].Value)
+if (-not [string]::Equals($deployWorkflowUses, $expectedDeployWorkflowUses, [System.StringComparison]::Ordinal)) {
+    throw "Deploy workflow must call $expectedDeployWorkflowUses from the website-deploy job."
 }
 
+if ([string]::IsNullOrWhiteSpace($guardrailValue)) {
+    throw "Deploy workflow website-deploy job must explicitly set require_seo_doctor_guardrail to true or false."
+}
+
+$requiresSeoDoctorGuardrail = [bool]::Parse($guardrailValue)
 $visited = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $steps = @(Get-ResolvedPipelineSteps -PipelinePath $PipelinePath -Visited $visited)
 $pipelineMode = 'ci'

--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -36,7 +36,7 @@ function Get-ResolvedPipelineSteps {
 
     $resolvedPath = [System.IO.Path]::GetFullPath($PipelinePath)
     if (-not $Visited.Add($resolvedPath)) {
-        @()
+        throw "Pipeline config inheritance cycle detected: $resolvedPath"
     } else {
         if (-not (Test-Path -LiteralPath $resolvedPath)) {
             throw "Pipeline config not found: $resolvedPath"
@@ -80,8 +80,35 @@ if ($guardrailMatch.Success) {
 
 $visited = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
 $steps = @(Get-ResolvedPipelineSteps -PipelinePath $PipelinePath -Visited $visited)
+$pipelineMode = 'ci'
 
-[array] $seoDoctorSteps = foreach ($step in $steps) {
+[array] $activeSteps = foreach ($step in $steps) {
+    $stepProperties = @($step.PSObject.Properties.Name)
+    $runsInMode = $true
+
+    if ($stepProperties -contains 'modes' -and $null -ne $step.modes) {
+        $runsInMode = $false
+        foreach ($mode in @($step.modes)) {
+            if ([string]::Equals([string] $mode, $pipelineMode, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $runsInMode = $true
+            }
+        }
+    }
+
+    if ($runsInMode -and $stepProperties -contains 'skipModes' -and $null -ne $step.skipModes) {
+        foreach ($mode in @($step.skipModes)) {
+            if ([string]::Equals([string] $mode, $pipelineMode, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $runsInMode = $false
+            }
+        }
+    }
+
+    if ($runsInMode) {
+        $step
+    }
+}
+
+[array] $seoDoctorSteps = foreach ($step in $activeSteps) {
     $stepProperties = @($step.PSObject.Properties.Name)
     if ($stepProperties -contains 'task' -and
         [string]::Equals([string] $step.task, 'seo-doctor', [System.StringComparison]::OrdinalIgnoreCase)) {
@@ -115,7 +142,7 @@ if ($requiresSeoDoctorGuardrail) {
 
     Write-Host "Deploy contract validated with $($fullyConfiguredSeoDoctorSteps.Count) fully configured seo-doctor step(s)."
 } else {
-    [array] $doctorSteps = foreach ($step in $steps) {
+    [array] $doctorSteps = foreach ($step in $activeSteps) {
         $stepProperties = @($step.PSObject.Properties.Name)
         if ($stepProperties -contains 'task' -and
             [string]::Equals([string] $step.task, 'doctor', [System.StringComparison]::OrdinalIgnoreCase)) {

--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $DeployWorkflowPath,
+
+    [Parameter(Mandatory = $true)]
+    [string] $PipelinePath
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-ResolvedPipelineSteps {
+    <#
+    .SYNOPSIS
+    Resolves PowerForge pipeline steps, including inherited parent pipeline files.
+
+    .DESCRIPTION
+    Reads a PowerForge pipeline JSON file and returns the combined parent and local step list so deployment guardrails can be validated against the effective pipeline.
+
+    .PARAMETER PipelinePath
+    Path to the pipeline JSON file.
+
+    .PARAMETER Visited
+    Tracks visited pipeline files and prevents recursion loops.
+
+    .EXAMPLE
+    Get-ResolvedPipelineSteps -PipelinePath 'Website/pipeline.json' -Visited ([System.Collections.Generic.HashSet[string]]::new())
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $PipelinePath,
+
+        [System.Collections.Generic.HashSet[string]] $Visited
+    )
+
+    $resolvedPath = [System.IO.Path]::GetFullPath($PipelinePath)
+    if (-not $Visited.Add($resolvedPath)) {
+        @()
+    } else {
+        if (-not (Test-Path -LiteralPath $resolvedPath)) {
+            throw "Pipeline config not found: $resolvedPath"
+        }
+
+        $document = Get-Content -LiteralPath $resolvedPath -Raw | ConvertFrom-Json
+        $documentProperties = @($document.PSObject.Properties.Name)
+        $steps = [System.Collections.Generic.List[object]]::new()
+
+        if ($documentProperties -contains 'extends' -and -not [string]::IsNullOrWhiteSpace([string] $document.extends)) {
+            $parentPath = Join-Path -Path ([System.IO.Path]::GetDirectoryName($resolvedPath)) -ChildPath ([string] $document.extends)
+            foreach ($parentStep in @(Get-ResolvedPipelineSteps -PipelinePath $parentPath -Visited $Visited)) {
+                $steps.Add($parentStep)
+            }
+        }
+
+        if ($documentProperties -contains 'steps' -and $null -ne $document.steps) {
+            foreach ($step in @($document.steps)) {
+                $steps.Add($step)
+            }
+        }
+
+        $steps.ToArray()
+    }
+}
+
+if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
+    throw "Deploy workflow not found: $DeployWorkflowPath"
+}
+
+$deployWorkflow = Get-Content -LiteralPath $DeployWorkflowPath -Raw
+if ($deployWorkflow -notmatch 'powerforge-website-deploy\.yml@') {
+    throw "Deploy workflow must call the PowerForge website deploy reusable workflow."
+}
+
+$guardrailMatch = [regex]::Match($deployWorkflow, '(?m)^\s*require_seo_doctor_guardrail:\s*(true|false)\s*(?:#.*)?$')
+$requiresSeoDoctorGuardrail = $true
+if ($guardrailMatch.Success) {
+    $requiresSeoDoctorGuardrail = [bool]::Parse($guardrailMatch.Groups[1].Value)
+}
+
+$visited = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+$steps = @(Get-ResolvedPipelineSteps -PipelinePath $PipelinePath -Visited $visited)
+
+[array] $seoDoctorSteps = foreach ($step in $steps) {
+    $stepProperties = @($step.PSObject.Properties.Name)
+    if ($stepProperties -contains 'task' -and
+        [string]::Equals([string] $step.task, 'seo-doctor', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $step
+    }
+}
+
+[array] $gatingSeoDoctorSteps = foreach ($step in $seoDoctorSteps) {
+    $stepProperties = @($step.PSObject.Properties.Name)
+    if (($stepProperties -contains 'failOnWarnings' -and $step.failOnWarnings -eq $true) -or
+        ($stepProperties -contains 'failOnNewIssues' -and $step.failOnNewIssues -eq $true) -or
+        ($stepProperties -contains 'failOnNew' -and $step.failOnNew -eq $true)) {
+        $step
+    }
+}
+
+[array] $fullyConfiguredSeoDoctorSteps = foreach ($step in $gatingSeoDoctorSteps) {
+    $stepProperties = @($step.PSObject.Properties.Name)
+    if ($stepProperties -contains 'checkContentLeaks' -and $step.checkContentLeaks -eq $true -and
+        $stepProperties -contains 'requireCanonical' -and $step.requireCanonical -eq $true -and
+        $stepProperties -contains 'requireHreflang' -and $step.requireHreflang -eq $true -and
+        $stepProperties -contains 'requireHreflangXDefault' -and $step.requireHreflangXDefault -eq $true) {
+        $step
+    }
+}
+
+if ($requiresSeoDoctorGuardrail) {
+    if ($fullyConfiguredSeoDoctorSteps.Count -eq 0) {
+        throw "Deploy workflow enables require_seo_doctor_guardrail, but the effective pipeline does not contain a gating seo-doctor step with checkContentLeaks, canonical, hreflang, and x-default checks."
+    }
+
+    Write-Host "Deploy contract validated with $($fullyConfiguredSeoDoctorSteps.Count) fully configured seo-doctor step(s)."
+} else {
+    [array] $doctorSteps = foreach ($step in $steps) {
+        $stepProperties = @($step.PSObject.Properties.Name)
+        if ($stepProperties -contains 'task' -and
+            [string]::Equals([string] $step.task, 'doctor', [System.StringComparison]::OrdinalIgnoreCase)) {
+            $step
+        }
+    }
+
+    [array] $gatingDoctorSteps = foreach ($step in $doctorSteps) {
+        $stepProperties = @($step.PSObject.Properties.Name)
+        if (($stepProperties -contains 'failOnWarnings' -and $step.failOnWarnings -eq $true) -or
+            ($stepProperties -contains 'failOnNewIssues' -and $step.failOnNewIssues -eq $true) -or
+            ($stepProperties -contains 'failOnNew' -and $step.failOnNew -eq $true)) {
+            $step
+        }
+    }
+
+    if ($gatingDoctorSteps.Count -eq 0) {
+        throw "Deploy workflow opts out of seo-doctor guardrails, but the effective pipeline does not contain a gating doctor audit step."
+    }
+
+    Write-Host "Deploy contract validated with seo-doctor guardrail intentionally disabled and $($gatingDoctorSteps.Count) gating doctor audit step(s)."
+}

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -28,5 +28,7 @@ jobs:
       powerforge_repository: EvotecIT/PSPublishModule
       powerforge_ref: 3c671c874bb90ad83741f42d6ad6106320c52502
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
+      # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
+      require_seo_doctor_guardrail: false
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -7,6 +7,8 @@ on:
       - "DomainDetective.Website/**"
       - "DomainDetective.Toolbox/**"
       - "DomainDetective.Website.Tests/**"
+      - ".github/scripts/Test-WebsiteDeployContract.ps1"
+      - ".github/workflows/deploy-website.yml"
       - ".github/workflows/website-ci.yml"
   workflow_dispatch:
 
@@ -35,8 +37,20 @@ jobs:
       - name: Run website regression tests
         run: dotnet test DomainDetective.Website.Tests/DomainDetective.Website.Tests.csproj --configuration ${{ env.BUILD_CONFIGURATION }} --framework net10.0 --verbosity minimal --logger "console;verbosity=minimal" --logger trx --collect:"XPlat Code Coverage"
 
+  deploy-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Validate deploy contract
+        shell: pwsh
+        run: ./.github/scripts/Test-WebsiteDeployContract.ps1 -DeployWorkflowPath .github/workflows/deploy-website.yml -PipelinePath Website/pipeline.json
+
   website-build:
-    needs: website-tests
+    needs:
+      - website-tests
+      - deploy-contract
     uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@3c671c874bb90ad83741f42d6ad6106320c52502
     with:
       website_root: Website

--- a/Docs/SITEMAP.MD
+++ b/Docs/SITEMAP.MD
@@ -9,6 +9,7 @@ The sitemap check validates XML sitemap discovery, sitemap protocol shape, and t
 | Discovery | `robots.txt` `Sitemap:` directives, conventional `/sitemap.xml`, sitemap indexes, nested sitemap documents |
 | XML shape | well-formed XML, expected sitemap namespace, sitemap.org XSD validation, `urlset` vs `sitemapindex`, missing or invalid `loc` |
 | Entry metadata | invalid `lastmod`, invalid `changefreq`, invalid `priority`, duplicate `loc` values |
+| Extensions | `xhtml:link` alternate/hreflang entries and common Google image/news/video sitemap extensions counted separately from strict XSD validity |
 | URL probes | redirect chains, redirect loops, HTTP 4xx/5xx, failed fetches |
 | Indexing signals | `X-Robots-Tag` and HTML meta robots `noindex` |
 | Canonical signals | HTML `rel=canonical` mismatches against the final URL |
@@ -45,4 +46,4 @@ Useful tuning options:
 
 The analysis is intentionally bounded by default. Large sites should raise `MaxEntries` and `MaxUrlProbes` deliberately, especially when probing URL reachability, because every probed sitemap URL results in an HTTP request.
 
-The sitemap.org schema permits extension elements from other namespaces through strict XML Schema wildcards. In practice, that means documents with `xhtml:link` alternates can be well-formed XML and accepted by Google for hreflang purposes while still failing strict sitemap.org XSD validation unless the extension schema is available to the validator. DomainDetective keeps those signals separate: XML well-formedness, sitemap XSD validity, and XHTML alternate counts are reported independently so callers can decide how strict a site should be.
+The sitemap.org schema permits extension elements from other namespaces through strict XML Schema wildcards. In practice, that means documents with `xhtml:link`, Google image, Google News, or Google video sitemap extensions can be well-formed XML and accepted by specific crawlers while still failing strict sitemap.org XSD validation unless the extension schema is available to the validator. DomainDetective keeps those signals separate: XML well-formedness, sitemap XSD validity, and known extension counts are reported independently so callers can decide how strict a site should be.

--- a/DomainDetective.Tests/TestSitemapAnalysis.cs
+++ b/DomainDetective.Tests/TestSitemapAnalysis.cs
@@ -128,6 +128,41 @@ public class TestSitemapAnalysis {
     }
 
     [Fact]
+    public async Task AnalyzeAsyncDoesNotReportGoogleExtensionWarningsForSitemapIndex() {
+        var sitemapIndex = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                           "<sitemapindex xmlns:image=\"http://www.google.com/schemas/sitemap-image/1.1\" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                           "<sitemap><loc>https://index-extension.example/child.xml</loc><image:image><image:loc>https://index-extension.example/image.jpg</image:loc></image:image></sitemap>" +
+                           "</sitemapindex>";
+        var analysis = new SitemapAnalysis {
+            HttpHandlerFactory = () => new HttpStubMessageHandler((request, cancellationToken) => {
+                var url = request.RequestUri?.AbsoluteUri ?? string.Empty;
+                if (url.Equals("https://index-extension.example/robots.txt", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("text/plain", "User-agent: *\nAllow: /\nSitemap: https://index-extension.example/sitemap.xml\n");
+                }
+
+                if (url.Equals("https://index-extension.example/sitemap.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", sitemapIndex);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })
+        };
+
+        await analysis.AnalyzeAsync(
+            "index-extension.example",
+            options: new SitemapAnalysisOptions {
+                AllowHttpFallback = false,
+                ProbeUrls = false,
+                MaxSitemapDocuments = 1
+            });
+
+        Assert.Single(analysis.Documents);
+        Assert.Equal(SitemapDocumentKind.SitemapIndex, analysis.Documents[0].Kind);
+        Assert.Equal(0, analysis.Documents[0].ImageExtensionElementCount);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == SitemapCodes.ImageExtension);
+    }
+
+    [Fact]
     public async Task AnalyzeAsyncSchemaValidatesSitemapIndexes() {
         var sitemapIndex = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                            "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +

--- a/DomainDetective.Tests/TestSitemapAnalysis.cs
+++ b/DomainDetective.Tests/TestSitemapAnalysis.cs
@@ -87,6 +87,46 @@ public class TestSitemapAnalysis {
         Assert.Contains(analysis.Recommendations, recommendation => recommendation.Code == SitemapCodes.XhtmlAlternateExtension);
     }
 
+    [Theory]
+    [InlineData("image", "http://www.google.com/schemas/sitemap-image/1.1", "image", "loc", "https://image.example/photo.jpg", SitemapCodes.ImageExtension)]
+    [InlineData("news", "http://www.google.com/schemas/sitemap-news/0.9", "news", "title", "Example title", SitemapCodes.NewsExtension)]
+    [InlineData("video", "http://www.google.com/schemas/sitemap-video/1.1", "video", "title", "Example video", SitemapCodes.VideoExtension)]
+    public async Task AnalyzeAsyncReportsKnownGoogleSitemapExtensionsSeparately(string prefix, string extensionNamespace, string wrapperElement, string childElement, string childValue, string expectedCode) {
+        var sitemap = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                      "<urlset xmlns:" + prefix + "=\"" + extensionNamespace + "\" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                      "<url><loc>https://extension.example/</loc><" + prefix + ":" + wrapperElement + "><" + prefix + ":" + childElement + ">" + childValue + "</" + prefix + ":" + childElement + "></" + prefix + ":" + wrapperElement + "></url>" +
+                      "</urlset>";
+        var analysis = new SitemapAnalysis {
+            HttpHandlerFactory = () => new HttpStubMessageHandler((request, cancellationToken) => {
+                var url = request.RequestUri?.AbsoluteUri ?? string.Empty;
+                if (url.Equals("https://extension.example/robots.txt", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("text/plain", "User-agent: *\nAllow: /\nSitemap: https://extension.example/sitemap.xml\n");
+                }
+
+                if (url.Equals("https://extension.example/sitemap.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", sitemap);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })
+        };
+
+        await analysis.AnalyzeAsync(
+            "extension.example",
+            options: new SitemapAnalysisOptions {
+                AllowHttpFallback = false,
+                ProbeUrls = false
+            });
+
+        Assert.Single(analysis.Documents);
+        Assert.True(analysis.Documents[0].XmlValid);
+        Assert.False(analysis.Documents[0].SchemaValid);
+        Assert.Equal(1, GetGoogleExtensionCount(analysis.Documents[0], expectedCode));
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaInvalid && assessment.Severity == AssessmentSeverity.Error);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == expectedCode && assessment.Severity == AssessmentSeverity.Warning);
+        Assert.Contains(analysis.Recommendations, recommendation => recommendation.Code == expectedCode);
+    }
+
     [Fact]
     public async Task AnalyzeAsyncSchemaValidatesSitemapIndexes() {
         var sitemapIndex = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
@@ -164,6 +204,14 @@ public class TestSitemapAnalysis {
         Assert.Equal(1, analysis.Documents[0].SchemaValidationErrorCount);
         Assert.Contains("loc", analysis.Documents[0].SchemaValidationError, StringComparison.OrdinalIgnoreCase);
         Assert.Contains(analysis.Assessments, assessment => assessment.Code == SitemapCodes.SchemaInvalid && assessment.Severity == AssessmentSeverity.Error);
+    }
+
+    [Fact]
+    public void SitemapProtocolSchemasAreEmbeddedResources() {
+        var resourceNames = typeof(SitemapAnalysis).Assembly.GetManifestResourceNames();
+
+        Assert.Contains("DomainDetective.Definitions.SitemapProtocol_0_9.xsd", resourceNames);
+        Assert.Contains("DomainDetective.Definitions.SitemapIndexProtocol_0_9.xsd", resourceNames);
     }
 
     [Fact]
@@ -674,6 +722,22 @@ public class TestSitemapAnalysis {
             gzip.Write(bytes, 0, bytes.Length);
         }
         return output.ToArray();
+    }
+
+    private static int GetGoogleExtensionCount(SitemapDocument document, string code) {
+        if (code == SitemapCodes.ImageExtension) {
+            return document.ImageExtensionElementCount;
+        }
+
+        if (code == SitemapCodes.NewsExtension) {
+            return document.NewsExtensionElementCount;
+        }
+
+        if (code == SitemapCodes.VideoExtension) {
+            return document.VideoExtensionElementCount;
+        }
+
+        return 0;
     }
 
     private static async Task Write(HttpListenerContext ctx, string content) {

--- a/DomainDetective.Tests/TestSitemapAnalysis.cs
+++ b/DomainDetective.Tests/TestSitemapAnalysis.cs
@@ -91,6 +91,9 @@ public class TestSitemapAnalysis {
     [InlineData("image", "http://www.google.com/schemas/sitemap-image/1.1", "image", "loc", "https://image.example/photo.jpg", SitemapCodes.ImageExtension)]
     [InlineData("news", "http://www.google.com/schemas/sitemap-news/0.9", "news", "title", "Example title", SitemapCodes.NewsExtension)]
     [InlineData("video", "http://www.google.com/schemas/sitemap-video/1.1", "video", "title", "Example video", SitemapCodes.VideoExtension)]
+    [InlineData("image", "https://www.google.com/schemas/sitemap-image/1.1", "image", "loc", "https://image.example/photo.jpg", SitemapCodes.ImageExtension)]
+    [InlineData("news", "https://www.google.com/schemas/sitemap-news/0.9", "news", "title", "Example title", SitemapCodes.NewsExtension)]
+    [InlineData("video", "https://www.google.com/schemas/sitemap-video/1.1", "video", "title", "Example video", SitemapCodes.VideoExtension)]
     public async Task AnalyzeAsyncReportsKnownGoogleSitemapExtensionsSeparately(string prefix, string extensionNamespace, string wrapperElement, string childElement, string childValue, string expectedCode) {
         var sitemap = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
                       "<urlset xmlns:" + prefix + "=\"" + extensionNamespace + "\" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
@@ -158,6 +161,42 @@ public class TestSitemapAnalysis {
 
         Assert.Single(analysis.Documents);
         Assert.Equal(SitemapDocumentKind.SitemapIndex, analysis.Documents[0].Kind);
+        Assert.Equal(0, analysis.Documents[0].ImageExtensionElementCount);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == SitemapCodes.ImageExtension);
+    }
+
+    [Fact]
+    public async Task AnalyzeAsyncCountsGoogleExtensionsOnlyForParsedUrlEntries() {
+        var sitemap = "<?xml version=\"1.0\" encoding=\"utf-8\"?>" +
+                      "<urlset xmlns:image=\"http://www.google.com/schemas/sitemap-image/1.1\" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">" +
+                      "<url><loc>https://entry-limit.example/first/</loc></url>" +
+                      "<url><loc>https://entry-limit.example/second/</loc><image:image><image:loc>https://entry-limit.example/image.jpg</image:loc></image:image></url>" +
+                      "</urlset>";
+        var analysis = new SitemapAnalysis {
+            HttpHandlerFactory = () => new HttpStubMessageHandler((request, cancellationToken) => {
+                var url = request.RequestUri?.AbsoluteUri ?? string.Empty;
+                if (url.Equals("https://entry-limit.example/robots.txt", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("text/plain", "User-agent: *\nAllow: /\nSitemap: https://entry-limit.example/sitemap.xml\n");
+                }
+
+                if (url.Equals("https://entry-limit.example/sitemap.xml", StringComparison.OrdinalIgnoreCase)) {
+                    return CreateResponse("application/xml", sitemap);
+                }
+
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            })
+        };
+
+        await analysis.AnalyzeAsync(
+            "entry-limit.example",
+            options: new SitemapAnalysisOptions {
+                AllowHttpFallback = false,
+                MaxEntries = 1,
+                ProbeUrls = false
+            });
+
+        Assert.Single(analysis.Documents);
+        Assert.Equal(1, analysis.Documents[0].UrlCount);
         Assert.Equal(0, analysis.Documents[0].ImageExtensionElementCount);
         Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == SitemapCodes.ImageExtension);
     }

--- a/DomainDetective.Toolbox/Components/Tools/WebDiscovery/SitemapTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/WebDiscovery/SitemapTool.razor
@@ -98,6 +98,15 @@
                             @if (document.XhtmlAlternateLinkCount > 0) {
                                 <span class="tool-chip">@document.XhtmlAlternateLinkCount.ToString(CultureInfo.InvariantCulture) xhtml alternate(s)</span>
                             }
+                            @if (document.ImageExtensionElementCount > 0) {
+                                <span class="tool-chip">@document.ImageExtensionElementCount.ToString(CultureInfo.InvariantCulture) image extension(s)</span>
+                            }
+                            @if (document.NewsExtensionElementCount > 0) {
+                                <span class="tool-chip">@document.NewsExtensionElementCount.ToString(CultureInfo.InvariantCulture) news extension(s)</span>
+                            }
+                            @if (document.VideoExtensionElementCount > 0) {
+                                <span class="tool-chip">@document.VideoExtensionElementCount.ToString(CultureInfo.InvariantCulture) video extension(s)</span>
+                            }
                             <span class="tool-chip">@document.UrlCount.ToString(CultureInfo.InvariantCulture) URLs</span>
                             <span class="tool-chip">@document.SitemapCount.ToString(CultureInfo.InvariantCulture) child sitemaps</span>
                             @if (IsCrossHost(document.Url, view.Subject ?? Domain)) {

--- a/DomainDetective/Diagnostics/Codes/SitemapCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/SitemapCodes.cs
@@ -9,6 +9,9 @@ internal static class SitemapCodes {
     public const string SchemaValid = "SITEMAP.Schema.Valid";
     public const string SchemaInvalid = "SITEMAP.Schema.Invalid";
     public const string XhtmlAlternateExtension = "SITEMAP.Extension.XhtmlAlternate";
+    public const string ImageExtension = "SITEMAP.Extension.Image";
+    public const string NewsExtension = "SITEMAP.Extension.News";
+    public const string VideoExtension = "SITEMAP.Extension.Video";
     public const string RootInvalid = "SITEMAP.Root.Invalid";
     public const string NamespaceInvalid = "SITEMAP.Namespace.Invalid";
     public const string UrlEntryPresent = "SITEMAP.UrlEntry.Present";

--- a/DomainDetective/Diagnostics/Recommendations/SitemapRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/SitemapRecommendations.cs
@@ -48,6 +48,39 @@ internal sealed class SitemapRecommendations : IRecommendationProvider {
             Effort = RecommendationEffort.Low,
             Verify = "Compare strict sitemap schema validation with Google Search Central hreflang sitemap guidance."
         };
+        map[SitemapCodes.ImageExtension] = new RecommendationAdvice {
+            Code = SitemapCodes.ImageExtension,
+            Title = "Image sitemap extension affects strict validation",
+            Why = "Google image sitemap elements are crawler-specific extensions. They are useful for Google discovery, but a strict base Sitemap protocol schema validation pass reports them separately from plain sitemap validity.",
+            How = "Keep image sitemap extensions when Google image discovery is intentional, and validate image metadata against Google Search Central guidance. Publish a separate plain sitemap if a consumer requires only the base Sitemap protocol schema.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "sitemap", "image-sitemap", "xml-schema", "seo" },
+            Impact = "Strict schema validation can fail even though Google can consume the image extension.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Check image sitemap entries against Google Search Central image sitemap guidance."
+        };
+        map[SitemapCodes.NewsExtension] = new RecommendationAdvice {
+            Code = SitemapCodes.NewsExtension,
+            Title = "News sitemap extension affects strict validation",
+            Why = "Google News sitemap elements are crawler-specific extensions. They should be distinguished from generic schema failures so operators can tell extension usage from malformed base sitemap XML.",
+            How = "Keep news sitemap extensions when Google News discovery is intentional, and validate publication metadata against Google Search Central guidance. Publish a separate plain sitemap if a consumer requires only the base Sitemap protocol schema.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "sitemap", "news-sitemap", "xml-schema", "seo" },
+            Impact = "Strict schema validation can fail even though Google can consume the news extension.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Check news sitemap entries against Google Search Central news sitemap guidance."
+        };
+        map[SitemapCodes.VideoExtension] = new RecommendationAdvice {
+            Code = SitemapCodes.VideoExtension,
+            Title = "Video sitemap extension affects strict validation",
+            Why = "Google video sitemap elements are crawler-specific extensions. They should be reported as extension usage rather than leaving the operator with only a generic schema error.",
+            How = "Keep video sitemap extensions when Google video discovery is intentional, and validate video metadata against Google Search Central guidance. Publish a separate plain sitemap if a consumer requires only the base Sitemap protocol schema.",
+            Domain = RecommendationDomain.Infrastructure,
+            Tags = new[] { "sitemap", "video-sitemap", "xml-schema", "seo" },
+            Impact = "Strict schema validation can fail even though Google can consume the video extension.",
+            Effort = RecommendationEffort.Low,
+            Verify = "Check video sitemap entries against Google Search Central video sitemap guidance."
+        };
         map[SitemapCodes.CrossHostSitemap] = new RecommendationAdvice {
             Code = SitemapCodes.CrossHostSitemap,
             Title = "Cross-host sitemap advertised",

--- a/DomainDetective/Protocols/SitemapAnalysis.cs
+++ b/DomainDetective/Protocols/SitemapAnalysis.cs
@@ -309,8 +309,6 @@ public sealed class SitemapAnalysis : IHasAssessments {
             AddAssessment(AssessmentSeverity.Warning, SitemapCodes.NamespaceInvalid, "Sitemap root namespace is not the standard sitemap namespace.", sitemapUri.AbsoluteUri);
         }
 
-        RecordGoogleExtensionCounts(root, docInfo, sitemapUri);
-
         var schemaErrors = ValidateProtocolSchema(response.Body!, Math.Max(1024, options.MaxSitemapBodyCharacters));
         docInfo.SchemaValidationErrorCount = schemaErrors.Count;
         if (schemaErrors.Count == 0) {
@@ -327,6 +325,7 @@ public sealed class SitemapAnalysis : IHasAssessments {
 
         if (root.Name.LocalName.Equals("urlset", StringComparison.OrdinalIgnoreCase)) {
             docInfo.Kind = SitemapDocumentKind.UrlSet;
+            RecordGoogleExtensionCounts(root, docInfo, sitemapUri);
             ParseUrlSet(root, sitemapUri, docInfo, options);
             if (docInfo.XhtmlAlternateLinkCount > 0) {
                 AddAssessment(

--- a/DomainDetective/Protocols/SitemapAnalysis.cs
+++ b/DomainDetective/Protocols/SitemapAnalysis.cs
@@ -25,12 +25,18 @@ public sealed class SitemapAnalysis : IHasAssessments {
     private static readonly Lazy<XmlSchemaSet> _protocolSchemas = new(LoadProtocolSchemas);
     private static readonly XNamespace _sitemapNs = SitemapNamespace;
     private static readonly XNamespace _xhtmlNs = "http://www.w3.org/1999/xhtml";
-    private static readonly XNamespace _imageNs = "http://www.google.com/schemas/sitemap-image/1.1";
-    private static readonly XNamespace _newsNs = "http://www.google.com/schemas/sitemap-news/0.9";
-    private static readonly XNamespace _videoNs = "http://www.google.com/schemas/sitemap-video/1.1";
-    private static readonly XName _imageElementName = _imageNs + "image";
-    private static readonly XName _newsElementName = _newsNs + "news";
-    private static readonly XName _videoElementName = _videoNs + "video";
+    private static readonly HashSet<string> _imageNamespaces = new(StringComparer.OrdinalIgnoreCase) {
+        "http://www.google.com/schemas/sitemap-image/1.1",
+        "https://www.google.com/schemas/sitemap-image/1.1"
+    };
+    private static readonly HashSet<string> _newsNamespaces = new(StringComparer.OrdinalIgnoreCase) {
+        "http://www.google.com/schemas/sitemap-news/0.9",
+        "https://www.google.com/schemas/sitemap-news/0.9"
+    };
+    private static readonly HashSet<string> _videoNamespaces = new(StringComparer.OrdinalIgnoreCase) {
+        "http://www.google.com/schemas/sitemap-video/1.1",
+        "https://www.google.com/schemas/sitemap-video/1.1"
+    };
     private static readonly HashSet<string> _validChangeFrequencies = new(StringComparer.OrdinalIgnoreCase) {
         "always",
         "hourly",
@@ -325,8 +331,8 @@ public sealed class SitemapAnalysis : IHasAssessments {
 
         if (root.Name.LocalName.Equals("urlset", StringComparison.OrdinalIgnoreCase)) {
             docInfo.Kind = SitemapDocumentKind.UrlSet;
-            RecordGoogleExtensionCounts(root, docInfo, sitemapUri);
             ParseUrlSet(root, sitemapUri, docInfo, options);
+            AddGoogleExtensionAssessments(docInfo, sitemapUri);
             if (docInfo.XhtmlAlternateLinkCount > 0) {
                 AddAssessment(
                     AssessmentSeverity.Warning,
@@ -455,22 +461,30 @@ public sealed class SitemapAnalysis : IHasAssessments {
             }
 
             docInfo.XhtmlAlternateLinkCount += entry.Alternates.Count;
+            RecordGoogleExtensionCounts(urlElement, docInfo);
             Entries.Add(entry);
             docInfo.UrlCount++;
         }
     }
 
-    private void RecordGoogleExtensionCounts(XElement root, SitemapDocument docInfo, Uri sitemapUri) {
-        foreach (var element in root.Descendants()) {
-            if (element.Name == _imageElementName) {
+    private static void RecordGoogleExtensionCounts(XElement urlElement, SitemapDocument docInfo) {
+        foreach (var element in urlElement.Descendants()) {
+            if (IsGoogleExtensionElement(element, "image", _imageNamespaces)) {
                 docInfo.ImageExtensionElementCount++;
-            } else if (element.Name == _newsElementName) {
+            } else if (IsGoogleExtensionElement(element, "news", _newsNamespaces)) {
                 docInfo.NewsExtensionElementCount++;
-            } else if (element.Name == _videoElementName) {
+            } else if (IsGoogleExtensionElement(element, "video", _videoNamespaces)) {
                 docInfo.VideoExtensionElementCount++;
             }
         }
+    }
 
+    private static bool IsGoogleExtensionElement(XElement element, string localName, HashSet<string> namespaces) {
+        return element.Name.LocalName.Equals(localName, StringComparison.OrdinalIgnoreCase) &&
+               namespaces.Contains(element.Name.NamespaceName);
+    }
+
+    private void AddGoogleExtensionAssessments(SitemapDocument docInfo, Uri sitemapUri) {
         if (docInfo.ImageExtensionElementCount > 0) {
             AddAssessment(
                 AssessmentSeverity.Warning,

--- a/DomainDetective/Protocols/SitemapAnalysis.cs
+++ b/DomainDetective/Protocols/SitemapAnalysis.cs
@@ -25,6 +25,12 @@ public sealed class SitemapAnalysis : IHasAssessments {
     private static readonly Lazy<XmlSchemaSet> _protocolSchemas = new(LoadProtocolSchemas);
     private static readonly XNamespace _sitemapNs = SitemapNamespace;
     private static readonly XNamespace _xhtmlNs = "http://www.w3.org/1999/xhtml";
+    private static readonly XNamespace _imageNs = "http://www.google.com/schemas/sitemap-image/1.1";
+    private static readonly XNamespace _newsNs = "http://www.google.com/schemas/sitemap-news/0.9";
+    private static readonly XNamespace _videoNs = "http://www.google.com/schemas/sitemap-video/1.1";
+    private static readonly XName _imageElementName = _imageNs + "image";
+    private static readonly XName _newsElementName = _newsNs + "news";
+    private static readonly XName _videoElementName = _videoNs + "video";
     private static readonly HashSet<string> _validChangeFrequencies = new(StringComparer.OrdinalIgnoreCase) {
         "always",
         "hourly",
@@ -303,6 +309,8 @@ public sealed class SitemapAnalysis : IHasAssessments {
             AddAssessment(AssessmentSeverity.Warning, SitemapCodes.NamespaceInvalid, "Sitemap root namespace is not the standard sitemap namespace.", sitemapUri.AbsoluteUri);
         }
 
+        RecordGoogleExtensionCounts(root, docInfo, sitemapUri);
+
         var schemaErrors = ValidateProtocolSchema(response.Body!, Math.Max(1024, options.MaxSitemapBodyCharacters));
         docInfo.SchemaValidationErrorCount = schemaErrors.Count;
         if (schemaErrors.Count == 0) {
@@ -450,6 +458,42 @@ public sealed class SitemapAnalysis : IHasAssessments {
             docInfo.XhtmlAlternateLinkCount += entry.Alternates.Count;
             Entries.Add(entry);
             docInfo.UrlCount++;
+        }
+    }
+
+    private void RecordGoogleExtensionCounts(XElement root, SitemapDocument docInfo, Uri sitemapUri) {
+        foreach (var element in root.Descendants()) {
+            if (element.Name == _imageElementName) {
+                docInfo.ImageExtensionElementCount++;
+            } else if (element.Name == _newsElementName) {
+                docInfo.NewsExtensionElementCount++;
+            } else if (element.Name == _videoElementName) {
+                docInfo.VideoExtensionElementCount++;
+            }
+        }
+
+        if (docInfo.ImageExtensionElementCount > 0) {
+            AddAssessment(
+                AssessmentSeverity.Warning,
+                SitemapCodes.ImageExtension,
+                "Sitemap contains " + docInfo.ImageExtensionElementCount.ToString(CultureInfo.InvariantCulture) + " Google image sitemap extension element(s). Strict base sitemap schema validation may report these separately from Google crawler support.",
+                sitemapUri.AbsoluteUri);
+        }
+
+        if (docInfo.NewsExtensionElementCount > 0) {
+            AddAssessment(
+                AssessmentSeverity.Warning,
+                SitemapCodes.NewsExtension,
+                "Sitemap contains " + docInfo.NewsExtensionElementCount.ToString(CultureInfo.InvariantCulture) + " Google News sitemap extension element(s). Strict base sitemap schema validation may report these separately from Google crawler support.",
+                sitemapUri.AbsoluteUri);
+        }
+
+        if (docInfo.VideoExtensionElementCount > 0) {
+            AddAssessment(
+                AssessmentSeverity.Warning,
+                SitemapCodes.VideoExtension,
+                "Sitemap contains " + docInfo.VideoExtensionElementCount.ToString(CultureInfo.InvariantCulture) + " Google video sitemap extension element(s). Strict base sitemap schema validation may report these separately from Google crawler support.",
+                sitemapUri.AbsoluteUri);
         }
     }
 

--- a/DomainDetective/Protocols/SitemapModels.cs
+++ b/DomainDetective/Protocols/SitemapModels.cs
@@ -43,6 +43,12 @@ public sealed class SitemapDocument {
     public int SitemapCount { get; set; }
     /// <summary>Number of XHTML alternate links parsed from this document.</summary>
     public int XhtmlAlternateLinkCount { get; set; }
+    /// <summary>Number of Google image sitemap extension elements parsed from this document.</summary>
+    public int ImageExtensionElementCount { get; set; }
+    /// <summary>Number of Google news sitemap extension elements parsed from this document.</summary>
+    public int NewsExtensionElementCount { get; set; }
+    /// <summary>Number of Google video sitemap extension elements parsed from this document.</summary>
+    public int VideoExtensionElementCount { get; set; }
 }
 
 /// <summary>Represents one URL entry from a sitemap urlset.</summary>

--- a/DomainDetective/Views/Converters.Sitemap.cs
+++ b/DomainDetective/Views/Converters.Sitemap.cs
@@ -49,6 +49,9 @@ public static partial class Converters {
                     UrlCount = document.UrlCount,
                     SitemapCount = document.SitemapCount,
                     XhtmlAlternateLinkCount = document.XhtmlAlternateLinkCount,
+                    ImageExtensionElementCount = document.ImageExtensionElementCount,
+                    NewsExtensionElementCount = document.NewsExtensionElementCount,
+                    VideoExtensionElementCount = document.VideoExtensionElementCount,
                     Error = document.Error
                 })
                 .ToArray(),
@@ -167,6 +170,12 @@ public sealed class SitemapDocumentInfo {
     public int SitemapCount { get; set; }
     /// <summary>Number of XHTML alternate links in this document.</summary>
     public int XhtmlAlternateLinkCount { get; set; }
+    /// <summary>Number of Google image sitemap extension elements in this document.</summary>
+    public int ImageExtensionElementCount { get; set; }
+    /// <summary>Number of Google news sitemap extension elements in this document.</summary>
+    public int NewsExtensionElementCount { get; set; }
+    /// <summary>Number of Google video sitemap extension elements in this document.</summary>
+    public int VideoExtensionElementCount { get; set; }
     /// <summary>Fetch or parse error when available.</summary>
     public string? Error { get; set; }
 }


### PR DESCRIPTION
## Summary
- detect Google image, news, and video sitemap extension namespaces separately from generic strict XSD failures
- surface extension counts in sitemap view models and Toolbox chips
- add regression coverage for image sitemap extension detection and embedded XSD resources

## Validation
- dotnet test .\DomainDetective.Tests\DomainDetective.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~TestSitemapAnalysis" --no-restore
- dotnet build .\DomainDetective\DomainDetective.csproj --framework net472 --no-restore -m:1 -nr:false
- dotnet build .\DomainDetective.Toolbox\DomainDetective.Toolbox.csproj --no-restore -m:1 -nr:false
- git diff --check