### PR TITLE
chore(deps): ⬆️ consolidate dependency updates

### DIFF
--- a/DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj
+++ b/DomainDetective.CLI.Tests/DomainDetective.CLI.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/DomainDetective.CtSql.Tests/DomainDetective.CtSql.Tests.csproj
+++ b/DomainDetective.CtSql.Tests/DomainDetective.CtSql.Tests.csproj
@@ -16,7 +16,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/DomainDetective.Pgp/DomainDetective.Pgp.csproj
+++ b/DomainDetective.Pgp/DomainDetective.Pgp.csproj
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.IO.Compression.FileSystem" />
         <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/DomainDetective.Tests/DomainDetective.Tests.csproj
+++ b/DomainDetective.Tests/DomainDetective.Tests.csproj
@@ -26,7 +26,7 @@
         </PackageReference>
         <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/DomainDetective.Toolbox/DomainDetective.Toolbox.csproj
+++ b/DomainDetective.Toolbox/DomainDetective.Toolbox.csproj
@@ -12,7 +12,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.5" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="10.0.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DomainDetective.Visual/DomainDetective.Visual.csproj
+++ b/DomainDetective.Visual/DomainDetective.Visual.csproj
@@ -29,7 +29,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.IO.Compression.FileSystem" />
         <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/DomainDetective.Website.Tests/DomainDetective.Website.Tests.csproj
+++ b/DomainDetective.Website.Tests/DomainDetective.Website.Tests.csproj
@@ -17,7 +17,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/DomainDetective.Website/DomainDetective.Website.csproj
+++ b/DomainDetective.Website/DomainDetective.Website.csproj
@@ -8,8 +8,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.6" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DnsClientX" Version="1.0.7" />
+        <PackageReference Include="DnsClientX" Version="1.0.8" />
     </ItemGroup>
 
     <ItemGroup>
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
+        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.6.3" />
         <Reference Include="System.IO.Compression" />
         <Reference Include="System.IO.Compression.FileSystem" />
         <Reference Include="System.ComponentModel.DataAnnotations" />


### PR DESCRIPTION
## Summary
- consolidate the stale Dependabot dependency bumps into one branch
- bump DnsClientX to 1.0.8 and align System.Threading.Tasks.Extensions to 4.6.3 for net472 restore compatibility
- bump ASP.NET Core Web/WebAssembly packages to 10.0.6 and coverlet.collector to 10.0.0

## Validation
- dotnet restore .\DomainDetective.sln --disable-parallel -v:m -p:RestoreUseStaticGraphEvaluation=true /nr:false
- dotnet build .\DomainDetective.sln --no-restore -m:1 -nr:false
- dotnet test .\DomainDetective.sln --no-build --no-restore -m:1 -nr:false
- pwsh -NoProfile -File .\Module\DomainDetective.Tests.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File .\Module\DomainDetective.Tests.ps1
- RefreshPSD1Only=true .\Module\Build\Build-Module.ps1
- git diff --check