### PR TITLE
Fix DomainDetective website sitemap discovery

### DIFF
--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -375,7 +375,7 @@
       "checkUtf8": true,
       "checkMetaCharset": true,
       "checkUnicodeReplacementChars": true,
-      "requiredRoutes": "/,/docs/,/tools/,/404.html,/search/,/sitemap/,/products/dnsclientx/,/docs/dnsclientx/"
+      "requiredRoutes": "/,/docs/,/tools/,/404.html,/search/,/sitemap/,/sitemap.xml,/products/dnsclientx/,/docs/dnsclientx/"
     }
   ]
 }

--- a/Website/static/robots.txt
+++ b/Website/static/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://domaindetective.dev/sitemap/sitemap.xml
+Sitemap: https://domaindetective.dev/sitemap.xml


### PR DESCRIPTION
## Summary
- correct the static robots sitemap URL from `/sitemap/sitemap.xml` to `/sitemap.xml`
- add `/sitemap.xml` to the website doctor required-route guard

## Root cause
DomainDetective had the same stale nested sitemap URL in `Website/static/robots.txt`, while the generated PowerForge sitemap is published at the root `/sitemap.xml` path.

## Validation
- `powerforge-web build --config .\site.json --out .\_site --clean`
- `powerforge-web sitemap --site-root .\_site --base-url https://domaindetective.dev ...`
- route-only `powerforge-web doctor` passed for `/sitemap.xml`
- checked generated `_site\robots.txt` advertises `https://domaindetective.dev/sitemap.xml`