### PR TITLE
Fetch Static CT tiles concurrently

### DIFF
--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -641,6 +641,64 @@ public sealed class TestCtLogIngestionClient {
     }
 
     [Fact]
+    public async Task ReadBatchAsync_FetchesStaticCtDataTilesConcurrently_WhenConfigured() {
+        byte[] certificateDer = LoadCertificateDer("multi.pem");
+        byte[] firstTile = CreateStaticCtTile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:05Z"), 256);
+        byte[] secondTile = CreateStaticCtTile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:08:21Z"), 256);
+        var firstTileMayComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        int activeTileFetches = 0;
+        int maxActiveTileFetches = 0;
+        List<string> requestedUrls = [];
+        var client = new CtLogIngestionClient {
+            SendOverride = async (request, cancellationToken) => {
+                string url = request.RequestUri?.ToString() ?? string.Empty;
+                requestedUrls.Add(url);
+                int active = Interlocked.Increment(ref activeTileFetches);
+                UpdateMaxActive(ref maxActiveTileFetches, active);
+                try {
+                    if (url.EndsWith("/tile/data/000", StringComparison.Ordinal)) {
+                        await WaitForSignalAsync(firstTileMayComplete.Task, TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+                        return CreateBinaryResponse(firstTile);
+                    }
+
+                    if (url.EndsWith("/tile/data/001", StringComparison.Ordinal)) {
+                        firstTileMayComplete.TrySetResult(true);
+                        return CreateBinaryResponse(secondTile);
+                    }
+
+                    throw new InvalidOperationException("Unexpected URL: " + url);
+                } finally {
+                    Interlocked.Decrement(ref activeTileFetches);
+                }
+            }
+        };
+
+        CtLogIngestionBatch batch = await client.ReadBatchAsync(
+            new CtLogIngestionBatchRequest {
+                LogUrl = "https://log.ct.example.test/2026h1/",
+                ApiKind = CtLogApiKind.StaticCt,
+                MonitoringUrl = "https://mon.ct.example.test/2026h1/",
+                StartIndex = 0,
+                BatchSize = 512,
+                KnownTreeSize = 512,
+                RequestTimeout = TimeSpan.FromSeconds(5),
+                StaticTileFetchConcurrency = 2,
+                CertificateDetailLevel = CtCertificateRecordDetailLevel.NamesOnly
+            },
+            CancellationToken.None);
+
+        Assert.Equal(512, batch.Entries.Count);
+        Assert.Equal(0L, batch.Entries[0].EntryIndex);
+        Assert.Equal(255L, batch.Entries[255].EntryIndex);
+        Assert.Equal(256L, batch.Entries[256].EntryIndex);
+        Assert.True(maxActiveTileFetches >= 2);
+        Assert.Equal([
+            "https://mon.ct.example.test/2026h1/tile/data/000",
+            "https://mon.ct.example.test/2026h1/tile/data/001"
+        ], requestedUrls.OrderBy(static item => item, StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
     public async Task ReadBatchAsync_RejectsStaticCtDataTileWithUnexpectedEntryCount() {
         byte[] certificateDer = LoadCertificateDer("multi.pem");
         byte[] first = CreateStaticCtX509Tile(certificateDer, DateTimeOffset.Parse("2026-01-02T03:04:05Z"));
@@ -796,6 +854,31 @@ public sealed class TestCtLogIngestionClient {
         WriteVector16(stream, Array.Empty<byte>());
         WriteVector16(stream, Array.Empty<byte>());
         return stream.ToArray();
+    }
+
+    private static byte[] CreateStaticCtTile(byte[] certificateDer, DateTimeOffset firstTimestampUtc, int count)
+        => Enumerable
+            .Range(0, count)
+            .SelectMany(index => CreateStaticCtX509Tile(certificateDer, firstTimestampUtc.AddSeconds(index)))
+            .ToArray();
+
+    private static void UpdateMaxActive(ref int maxActive, int observed) {
+        int snapshot;
+        do {
+            snapshot = Volatile.Read(ref maxActive);
+            if (observed <= snapshot) {
+                return;
+            }
+        } while (Interlocked.CompareExchange(ref maxActive, observed, snapshot) != snapshot);
+    }
+
+    private static async Task WaitForSignalAsync(Task signal, TimeSpan timeout, CancellationToken cancellationToken) {
+        Task completed = await Task.WhenAny(signal, Task.Delay(timeout, cancellationToken)).ConfigureAwait(false);
+        if (!ReferenceEquals(completed, signal)) {
+            throw new TimeoutException("The expected concurrent Static CT tile request did not start.");
+        }
+
+        await signal.ConfigureAwait(false);
     }
 
     private static byte[] CreateStaticCtPrecertificateTile(byte[] certificateDer, DateTimeOffset timestampUtc) {

--- a/DomainDetective.Tests/TestCtLogIngestionClient.cs
+++ b/DomainDetective.Tests/TestCtLogIngestionClient.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -648,11 +649,11 @@ public sealed class TestCtLogIngestionClient {
         var firstTileMayComplete = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         int activeTileFetches = 0;
         int maxActiveTileFetches = 0;
-        List<string> requestedUrls = [];
+        var requestedUrls = new ConcurrentQueue<string>();
         var client = new CtLogIngestionClient {
             SendOverride = async (request, cancellationToken) => {
                 string url = request.RequestUri?.ToString() ?? string.Empty;
-                requestedUrls.Add(url);
+                requestedUrls.Enqueue(url);
                 int active = Interlocked.Increment(ref activeTileFetches);
                 UpdateMaxActive(ref maxActiveTileFetches, active);
                 try {

--- a/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
+++ b/DomainDetective/CertificateTransparency/CtLogIngestionClient.cs
@@ -162,6 +162,8 @@ public sealed class CtLogIngestionBatchRequest {
     public long? KnownTreeSize { get; init; }
     /// <summary>HTTP request timeout.</summary>
     public TimeSpan RequestTimeout { get; init; } = TimeSpan.FromSeconds(30);
+    /// <summary>Maximum number of Static CT data tiles to fetch concurrently for one batch.</summary>
+    public int StaticTileFetchConcurrency { get; init; } = 1;
     /// <summary>How much certificate metadata to decode for each entry.</summary>
     public CtCertificateRecordDetailLevel CertificateDetailLevel { get; init; } = CtCertificateRecordDetailLevel.Full;
 }
@@ -440,22 +442,24 @@ public sealed class CtLogIngestionClient {
         long end = Math.Min(treeSize - 1, start + batchSize - 1);
         var entries = new List<CtLogIngestionEntry>();
         var diagnostics = new List<string>();
-        for (long tileIndex = start / StaticCtTileWidth; tileIndex <= end / StaticCtTileWidth; tileIndex++) {
+        IReadOnlyList<StaticCtDataTile> tiles = await GetStaticDataTilesAsync(
+            monitoringUrl,
+            start / StaticCtTileWidth,
+            end / StaticCtTileWidth,
+            treeSize,
+            timeout,
+            Math.Max(1, request.StaticTileFetchConcurrency),
+            cancellationToken).ConfigureAwait(false);
+        foreach (StaticCtDataTile tile in tiles) {
             cancellationToken.ThrowIfCancellationRequested();
-            IReadOnlyList<StaticCtTileEntry> tileEntries = await GetStaticDataTileEntriesAsync(
-                monitoringUrl,
-                tileIndex,
-                treeSize,
-                timeout,
-                cancellationToken).ConfigureAwait(false);
-            long tileStartIndex = tileIndex * StaticCtTileWidth;
-            for (int tileOffset = 0; tileOffset < tileEntries.Count; tileOffset++) {
+            long tileStartIndex = tile.TileIndex * StaticCtTileWidth;
+            for (int tileOffset = 0; tileOffset < tile.Entries.Count; tileOffset++) {
                 long entryIndex = tileStartIndex + tileOffset;
                 if (entryIndex < start || entryIndex > end) {
                     continue;
                 }
 
-                StaticCtTileEntry tileEntry = tileEntries[tileOffset];
+                StaticCtTileEntry tileEntry = tile.Entries[tileOffset];
                 try {
                     entries.Add(new CtLogIngestionEntry {
                         LogUrl = submissionUrl,
@@ -485,6 +489,55 @@ public sealed class CtLogIngestionClient {
             Entries = entries,
             Diagnostics = diagnostics
         };
+    }
+
+    private async Task<IReadOnlyList<StaticCtDataTile>> GetStaticDataTilesAsync(
+        string monitoringUrl,
+        long firstTileIndex,
+        long lastTileIndex,
+        long treeSize,
+        TimeSpan timeout,
+        int fetchConcurrency,
+        CancellationToken cancellationToken) {
+        if (lastTileIndex < firstTileIndex) {
+            return Array.Empty<StaticCtDataTile>();
+        }
+
+        int tileCount = checked((int)(lastTileIndex - firstTileIndex + 1));
+        int concurrency = Math.Max(1, Math.Min(fetchConcurrency, tileCount));
+        var tiles = new StaticCtDataTile[tileCount];
+        if (concurrency == 1) {
+            for (int offset = 0; offset < tileCount; offset++) {
+                long tileIndex = firstTileIndex + offset;
+                tiles[offset] = new StaticCtDataTile(
+                    tileIndex,
+                    await GetStaticDataTileEntriesAsync(monitoringUrl, tileIndex, treeSize, timeout, cancellationToken).ConfigureAwait(false));
+            }
+
+            return tiles;
+        }
+
+        using var gate = new SemaphoreSlim(concurrency);
+        var tasks = new List<Task>(tileCount);
+        for (int offset = 0; offset < tileCount; offset++) {
+            int tileOffset = offset;
+            long tileIndex = firstTileIndex + offset;
+            tasks.Add(FetchTileAsync(tileOffset, tileIndex));
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        return tiles;
+
+        async Task FetchTileAsync(int tileOffset, long tileIndex) {
+            await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try {
+                tiles[tileOffset] = new StaticCtDataTile(
+                    tileIndex,
+                    await GetStaticDataTileEntriesAsync(monitoringUrl, tileIndex, treeSize, timeout, cancellationToken).ConfigureAwait(false));
+            } finally {
+                gate.Release();
+            }
+        }
     }
 
     private async Task<CtSignedTreeHead> GetStaticSignedTreeHeadAsync(
@@ -587,7 +640,7 @@ public sealed class CtLogIngestionClient {
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         using HttpResponseMessage response = SendOverride != null
             ? await SendOverride(request, effectiveToken).ConfigureAwait(false)
-            : await GetHttpClient().SendAsync(request, effectiveToken).ConfigureAwait(false);
+            : await GetHttpClient().SendAsync(request, HttpCompletionOption.ResponseHeadersRead, effectiveToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) {
             throw CreateRequestFailure(response);
         }
@@ -611,7 +664,7 @@ public sealed class CtLogIngestionClient {
         request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("identity"));
         using HttpResponseMessage response = SendOverride != null
             ? await SendOverride(request, effectiveToken).ConfigureAwait(false)
-            : await GetHttpClient().SendAsync(request, effectiveToken).ConfigureAwait(false);
+            : await GetHttpClient().SendAsync(request, HttpCompletionOption.ResponseHeadersRead, effectiveToken).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode) {
             throw CreateRequestFailure(response);
         }
@@ -1262,4 +1315,8 @@ public sealed class CtLogIngestionClient {
         DateTimeOffset? TimestampUtc,
         CtLogEntryType EntryType,
         byte[] CertificateDer);
+
+    private sealed record StaticCtDataTile(
+        long TileIndex,
+        IReadOnlyList<StaticCtTileEntry> Entries);
 }


### PR DESCRIPTION
## Summary
- add a configurable Static CT tile fetch concurrency knob to `CtLogIngestionBatchRequest`
- fetch Static CT data tiles concurrently while preserving entry order in the returned batch
- use `ResponseHeadersRead` for CT HTTP reads to reduce response buffering pressure

## Validation
- `dotnet test DomainDetective.Tests\DomainDetective.Tests.csproj --filter TestCtLogIngestionClient`
