### PR TITLE
Group minor and patch NuGet Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,11 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
+      groups:
+          nuget-minor-patch:
+              applies-to: version-updates
+              patterns:
+                  - "*"
+              update-types:
+                  - minor
+                  - patch


### PR DESCRIPTION
## Summary
- group NuGet minor/patch Dependabot version updates into one weekly PR
- keep major updates separate for easier risk review

## Why
Today multiple independent NuGet PRs in this repo repeated the same CI/build-script fix and ran the full matrix several times. Grouping minor/patch version updates should reduce PR and CI churn while preserving separate major-version decisions.

## Validation
- `git diff --check`
- compared against GitHub Dependabot `groups` documentation for `patterns` + `update-types`