### PR TITLE
Ignore ImageSharp major Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
               update-types:
                   - minor
                   - patch
+      ignore:
+          # SixLabors.ImageSharp 4.x has a license change; keep 3.x updates flowing.
+          - dependency-name: "SixLabors.ImageSharp"
+            update-types:
+                - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- Ignore semver-major Dependabot version updates for `SixLabors.ImageSharp`
- Keep minor/patch ImageSharp 3.x updates eligible for Dependabot

## Why
ImageSharp 4.x changes licensing, so the 4.0.0 bump should be treated as a policy/licensing decision rather than a routine dependency update.

## Validation
- `git diff --check`