### PR TITLE
fix(website): Link DNS lookup to query playground

### DIFF
--- a/DomainDetective.Toolbox/Components/Tools/Dns/DnsLookupTool.razor
+++ b/DomainDetective.Toolbox/Components/Tools/Dns/DnsLookupTool.razor
@@ -84,6 +84,7 @@
         }
 
         <div class="tool-link-row">
+            <a href="/tools/dns-query-playground/" class="tool-inline-link">DNS query playground</a>
             <a href="/docs/dnsclientx/" class="tool-inline-link">DnsClientX toolkit</a>
             <a href="/docs/dns-workspace/" class="tool-inline-link">DnsClientX guide</a>
             <a href="/docs/dns-resolvers/" class="tool-inline-link">Resolver guide</a>
@@ -232,8 +233,9 @@
             <div class="tool-summary-card">
                 <span class="tool-summary-label">Docs and API lane</span>
                 <strong class="tool-summary-value">Keep DNS guidance together</strong>
-                <p class="tool-summary-note">Use the DnsClientX toolkit page as the DNS landing area today, then grow this into fuller DNS docs and API references later.</p>
+                <p class="tool-summary-note">Move between the DNS workspace, the direct query playground, and the DnsClientX docs without leaving the tools flow.</p>
                 <div class="tool-link-row tool-link-row-left">
+                    <a href="/tools/dns-query-playground/" class="tool-inline-link">DNS query playground</a>
                     <a href="/docs/dnsclientx/" class="tool-inline-link">DnsClientX toolkit</a>
                     <a href="/docs/dns-workspace/" class="tool-inline-link">Workspace guide</a>
                     <a href="/docs/dns-resolvers/" class="tool-inline-link">Resolver guide</a>

--- a/DomainDetective.Website.Tests/ToolPageComponentTests.cs
+++ b/DomainDetective.Website.Tests/ToolPageComponentTests.cs
@@ -50,6 +50,7 @@ public sealed class ToolPageComponentTests : TestContext {
             Assert.Equal("contoso.com", domainInput.GetAttribute("value"));
             Assert.Contains("Need raw record-by-record queries?", cut.Markup);
             Assert.Contains("Use <a href=\"/tools/raw-dns-query/\">Raw DNS Query</a>", cut.Markup);
+            Assert.Contains("/tools/dns-query-playground/", cut.Markup);
             Assert.Contains("Analyze", cut.Markup);
             Assert.DoesNotContain("Tool not found", cut.Markup);
             Assert.Contains(_dnsHandler.RequestUris, uri => uri.Host.Equals("cloudflare-dns.com", StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
## Summary
- add the DNS query playground to the DNS lookup tool link rows
- update the DNS lookup component test so the playground route remains visible from the tool page

## Validation
- dotnet test .\DomainDetective.Website.Tests\DomainDetective.Website.Tests.csproj -c Debug --no-restore --filter FullyQualifiedName~ToolPageComponentTests
- git diff --check