### PR TITLE
build(module): Enable packaged AssemblyLoadContext

### DIFF
--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -165,6 +165,7 @@ jobs:
                 Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
                 Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                 Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
+                Install-Module -Name PSPublishModule -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
               shell: pwsh
 
 
@@ -205,6 +206,13 @@ jobs:
 
                   exit $exitCode
                 }
+
+            - name: Build packaged module for ALC tests
+              env:
+                RefreshPSD1Only: 'false'
+              run: .\Module\Build\Build-Module.ps1
+              shell: pwsh
+
             - name: Run PowerShell tests
               run: ./Module/DomainDetective.Tests.ps1
               shell: pwsh

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -81,6 +81,7 @@ Build-Module -ModuleName 'DomainDetective' {
         NETAssemblyTypeAcceleratorMode       = 'Assembly'
         NETAssemblyTypeAcceleratorAssemblies = @(
             'DomainDetective'
+            'DomainDetective.PowerShell'
         )
         DotSourceLibraries                   = $true
         DotSourceClasses                     = $true

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -64,24 +64,29 @@ Build-Module -ModuleName 'DomainDetective' {
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
-        Enable                            = $true
-        SignModule                        = if ($Env:COMPUTERNAME -eq 'EVOMAGIC') { $true } else { $false }
-        MergeModuleOnBuild                = $true
-        MergeFunctionsFromApprovedModules = $true
-        CertificateThumbprint             = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
-        NETProjectPath                    = "$PSScriptRoot\..\..\DomainDetective.PowerShell"
-        ResolveBinaryConflicts            = $true
-        ResolveBinaryConflictsName        = 'DomainDetective.PowerShell'
-        NETProjectName                    = 'DomainDetective.PowerShell'
-        NETBinaryModule                   = 'DomainDetective.PowerShell.dll'
-        NETConfiguration                  = 'Release'
-        NETFramework                      = 'net8.0', 'net472'
-        NETHandleAssemblyWithSameName     = $true
-        DotSourceLibraries                = $true
-        DotSourceClasses                  = $true
-        DeleteTargetModuleBeforeBuild     = $true
-        RefreshPSD1Only                   = $true
-        NETBinaryModuleDocumenation       = $true
+        Enable                               = $true
+        SignModule                           = if ($Env:COMPUTERNAME -eq 'EVOMAGIC') { $true } else { $false }
+        MergeModuleOnBuild                   = $true
+        MergeFunctionsFromApprovedModules    = $true
+        CertificateThumbprint                = '483292C9E317AA13B07BB7A96AE9D1A5ED9E7703'
+        NETProjectPath                       = "$PSScriptRoot\..\..\DomainDetective.PowerShell"
+        ResolveBinaryConflicts               = $true
+        ResolveBinaryConflictsName           = 'DomainDetective.PowerShell'
+        NETProjectName                       = 'DomainDetective.PowerShell'
+        NETBinaryModule                      = 'DomainDetective.PowerShell.dll'
+        NETConfiguration                     = 'Release'
+        NETFramework                         = 'net8.0', 'net472'
+        NETHandleAssemblyWithSameName        = $true
+        NETAssemblyLoadContext               = $true
+        NETAssemblyTypeAcceleratorMode       = 'Assembly'
+        NETAssemblyTypeAcceleratorAssemblies = @(
+            'DomainDetective'
+        )
+        DotSourceLibraries                   = $true
+        DotSourceClasses                     = $true
+        DeleteTargetModuleBeforeBuild        = $true
+        RefreshPSD1Only                      = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $true } else { [bool]::Parse($Env:RefreshPSD1Only) }
+        NETBinaryModuleDocumenation          = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -78,11 +78,6 @@ Build-Module -ModuleName 'DomainDetective' {
         NETFramework                         = 'net8.0', 'net472'
         NETHandleAssemblyWithSameName        = $true
         NETAssemblyLoadContext               = $true
-        NETAssemblyTypeAcceleratorMode       = 'Assembly'
-        NETAssemblyTypeAcceleratorAssemblies = @(
-            'DomainDetective'
-            'DomainDetective.PowerShell'
-        )
         DotSourceLibraries                   = $true
         DotSourceClasses                     = $true
         DeleteTargetModuleBeforeBuild        = $true

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -25,13 +25,21 @@ Import-Module DomainDetective -Force
 `$command = Get-Command Test-DDEmailSpfRecord -Module DomainDetective -ErrorAction Stop
 `$commandAssembly = `$command.ImplementingType.Assembly
 `$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
-`$healthCheckAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.DomainHealthCheck].Assembly)
-`$captureOptionsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.CertificateInventoryCaptureOptions].Assembly)
-`$exportDefaultsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.PowerShell.ExportDefaults].Assembly)
-`$spfCmdletAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.PowerShell.CmdletTestSpfRecord].Assembly)
-`$healthCheck = [DomainDetective.DomainHealthCheck]::new()
-`$captureOptions = [DomainDetective.CertificateInventoryCaptureOptions]::new()
-`$spfCmdlet = [DomainDetective.PowerShell.CmdletTestSpfRecord]::new()
+`$coreAssembly = `$commandAlc.Assemblies | Where-Object { `$_.GetName().Name -eq 'DomainDetective' } | Select-Object -First 1
+if (`$null -eq `$coreAssembly) {
+    throw 'DomainDetective core assembly was not loaded in the module AssemblyLoadContext.'
+}
+
+`$healthCheckType = `$coreAssembly.GetType('DomainDetective.DomainHealthCheck', `$true)
+`$captureOptionsType = `$coreAssembly.GetType('DomainDetective.CertificateInventoryCaptureOptions', `$true)
+`$exportDefaultsType = `$commandAssembly.GetType('DomainDetective.PowerShell.ExportDefaults', `$true)
+`$spfCmdletType = `$commandAssembly.GetType('DomainDetective.PowerShell.CmdletTestSpfRecord', `$true)
+`$healthCheckAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$healthCheckType.Assembly)
+`$captureOptionsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$captureOptionsType.Assembly)
+`$exportDefaultsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$exportDefaultsType.Assembly)
+`$spfCmdletAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$spfCmdletType.Assembly)
+`$captureOptions = [Activator]::CreateInstance(`$captureOptionsType)
+`$spfCmdlet = [Activator]::CreateInstance(`$spfCmdletType)
 
 [pscustomobject]@{
     CommandName = `$command.Name
@@ -39,19 +47,20 @@ Import-Module DomainDetective -Force
     CommandAssemblyPath = `$commandAssembly.Location
     CommandALC = `$commandAlc.Name
     CommandALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
-    HealthCheckType = [DomainDetective.DomainHealthCheck].FullName
+    CoreAssembly = `$coreAssembly.GetName().Name
+    CoreAssemblyPath = `$coreAssembly.Location
+    HealthCheckType = `$healthCheckType.FullName
     HealthCheckALC = `$healthCheckAlc.Name
     HealthCheckALCIsDefault = [object]::ReferenceEquals(`$healthCheckAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
-    CaptureOptionsType = [DomainDetective.CertificateInventoryCaptureOptions].FullName
+    CaptureOptionsType = `$captureOptionsType.FullName
     CaptureOptionsALC = `$captureOptionsAlc.Name
     CaptureOptionsALCIsDefault = [object]::ReferenceEquals(`$captureOptionsAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
-    ExportDefaultsType = [DomainDetective.PowerShell.ExportDefaults].FullName
+    ExportDefaultsType = `$exportDefaultsType.FullName
     ExportDefaultsALC = `$exportDefaultsAlc.Name
     ExportDefaultsALCIsDefault = [object]::ReferenceEquals(`$exportDefaultsAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
-    SpfCmdletType = [DomainDetective.PowerShell.CmdletTestSpfRecord].FullName
+    SpfCmdletType = `$spfCmdletType.FullName
     SpfCmdletALC = `$spfCmdletAlc.Name
     SpfCmdletALCIsDefault = [object]::ReferenceEquals(`$spfCmdletAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
-    HealthCheckCreated = `$null -ne `$healthCheck
     CaptureOptionsCreated = `$null -ne `$captureOptions
     SpfCmdletCreated = `$null -ne `$spfCmdlet
 } | ConvertTo-Json -Compress
@@ -69,6 +78,8 @@ Import-Module DomainDetective -Force
         ($result.CommandAssemblyPath -replace '\\', '/') | Should -BeLike '*/Artefacts/Unpacked/Modules/DomainDetective/Lib/Core/DomainDetective.PowerShell.dll'
         $result.CommandALC | Should -Be 'DomainDetective'
         $result.CommandALCIsDefault | Should -BeFalse
+        $result.CoreAssembly | Should -Be 'DomainDetective'
+        ($result.CoreAssemblyPath -replace '\\', '/') | Should -BeLike '*/Artefacts/Unpacked/Modules/DomainDetective/Lib/Core/DomainDetective.dll'
         $result.HealthCheckType | Should -Be 'DomainDetective.DomainHealthCheck'
         $result.HealthCheckALC | Should -Be 'DomainDetective'
         $result.HealthCheckALCIsDefault | Should -BeFalse
@@ -81,7 +92,6 @@ Import-Module DomainDetective -Force
         $result.SpfCmdletType | Should -Be 'DomainDetective.PowerShell.CmdletTestSpfRecord'
         $result.SpfCmdletALC | Should -Be 'DomainDetective'
         $result.SpfCmdletALCIsDefault | Should -BeFalse
-        $result.HealthCheckCreated | Should -BeTrue
         $result.CaptureOptionsCreated | Should -BeTrue
         $result.SpfCmdletCreated | Should -BeTrue
     }

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -1,0 +1,71 @@
+Describe 'Packaged AssemblyLoadContext isolation' {
+    It 'loads binary cmdlets and core types from the module ALC' {
+        $packagedModuleRoot = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Modules'
+        $packagedModule = Join-Path $packagedModuleRoot 'DomainDetective'
+        $packagedLoader = Join-Path $packagedModule 'Lib\Core\DomainDetective.ModuleLoadContext.dll'
+        if ($PSVersionTable.PSEdition -ne 'Core') {
+            Set-ItResult -Skipped -Because 'module-scoped AssemblyLoadContext is PowerShell Core-only'
+            return
+        }
+
+        if (-not (Test-Path -LiteralPath $packagedLoader)) {
+            Set-ItResult -Skipped -Because 'packaged ALC artifact is not present; run Module\Build\Build-Module.ps1 with RefreshPSD1Only=false before this regression'
+            return
+        }
+
+        $moduleRootLiteral = $packagedModuleRoot.Replace("'", "''")
+        $script = @"
+`$ErrorActionPreference = 'Stop'
+`$WarningPreference = 'SilentlyContinue'
+`$moduleRoot = '$moduleRootLiteral'
+`$env:PSModulePath = `$moduleRoot + [IO.Path]::PathSeparator + `$env:PSModulePath
+
+Import-Module DomainDetective -Force
+
+`$command = Get-Command Test-DDEmailSpfRecord -Module DomainDetective -ErrorAction Stop
+`$commandAssembly = `$command.ImplementingType.Assembly
+`$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
+`$healthCheckAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.DomainHealthCheck].Assembly)
+`$captureOptionsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.CertificateInventoryCaptureOptions].Assembly)
+`$healthCheck = [DomainDetective.DomainHealthCheck]::new()
+`$captureOptions = [DomainDetective.CertificateInventoryCaptureOptions]::new()
+
+[pscustomobject]@{
+    CommandName = `$command.Name
+    CommandAssembly = `$commandAssembly.GetName().Name
+    CommandAssemblyPath = `$commandAssembly.Location
+    CommandALC = `$commandAlc.Name
+    CommandALCIsDefault = [object]::ReferenceEquals(`$commandAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    HealthCheckType = [DomainDetective.DomainHealthCheck].FullName
+    HealthCheckALC = `$healthCheckAlc.Name
+    HealthCheckALCIsDefault = [object]::ReferenceEquals(`$healthCheckAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    CaptureOptionsType = [DomainDetective.CertificateInventoryCaptureOptions].FullName
+    CaptureOptionsALC = `$captureOptionsAlc.Name
+    CaptureOptionsALCIsDefault = [object]::ReferenceEquals(`$captureOptionsAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    HealthCheckCreated = `$null -ne `$healthCheck
+    CaptureOptionsCreated = `$null -ne `$captureOptions
+} | ConvertTo-Json -Compress
+"@
+        $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
+        $output = pwsh -NoProfile -ExecutionPolicy Bypass -EncodedCommand $encoded 2>&1
+        $LASTEXITCODE | Should -Be 0 -Because ($output -join [Environment]::NewLine)
+
+        $json = $output | Where-Object { $_ -is [string] -and $_.TrimStart().StartsWith('{') } | Select-Object -Last 1
+        $json | Should -Not -BeNullOrEmpty -Because ($output -join [Environment]::NewLine)
+        $result = $json | ConvertFrom-Json
+
+        $result.CommandName | Should -Be 'Test-DDEmailSpfRecord'
+        $result.CommandAssembly | Should -Be 'DomainDetective.PowerShell'
+        ($result.CommandAssemblyPath -replace '\\', '/') | Should -BeLike '*/Artefacts/Unpacked/Modules/DomainDetective/Lib/Core/DomainDetective.PowerShell.dll'
+        $result.CommandALC | Should -Be 'DomainDetective'
+        $result.CommandALCIsDefault | Should -BeFalse
+        $result.HealthCheckType | Should -Be 'DomainDetective.DomainHealthCheck'
+        $result.HealthCheckALC | Should -Be 'DomainDetective'
+        $result.HealthCheckALCIsDefault | Should -BeFalse
+        $result.CaptureOptionsType | Should -Be 'DomainDetective.CertificateInventoryCaptureOptions'
+        $result.CaptureOptionsALC | Should -Be 'DomainDetective'
+        $result.CaptureOptionsALCIsDefault | Should -BeFalse
+        $result.HealthCheckCreated | Should -BeTrue
+        $result.CaptureOptionsCreated | Should -BeTrue
+    }
+}

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -27,8 +27,11 @@ Import-Module DomainDetective -Force
 `$commandAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext(`$commandAssembly)
 `$healthCheckAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.DomainHealthCheck].Assembly)
 `$captureOptionsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.CertificateInventoryCaptureOptions].Assembly)
+`$exportDefaultsAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.PowerShell.ExportDefaults].Assembly)
+`$spfCmdletAlc = [System.Runtime.Loader.AssemblyLoadContext]::GetLoadContext([DomainDetective.PowerShell.CmdletTestSpfRecord].Assembly)
 `$healthCheck = [DomainDetective.DomainHealthCheck]::new()
 `$captureOptions = [DomainDetective.CertificateInventoryCaptureOptions]::new()
+`$spfCmdlet = [DomainDetective.PowerShell.CmdletTestSpfRecord]::new()
 
 [pscustomobject]@{
     CommandName = `$command.Name
@@ -42,8 +45,15 @@ Import-Module DomainDetective -Force
     CaptureOptionsType = [DomainDetective.CertificateInventoryCaptureOptions].FullName
     CaptureOptionsALC = `$captureOptionsAlc.Name
     CaptureOptionsALCIsDefault = [object]::ReferenceEquals(`$captureOptionsAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    ExportDefaultsType = [DomainDetective.PowerShell.ExportDefaults].FullName
+    ExportDefaultsALC = `$exportDefaultsAlc.Name
+    ExportDefaultsALCIsDefault = [object]::ReferenceEquals(`$exportDefaultsAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
+    SpfCmdletType = [DomainDetective.PowerShell.CmdletTestSpfRecord].FullName
+    SpfCmdletALC = `$spfCmdletAlc.Name
+    SpfCmdletALCIsDefault = [object]::ReferenceEquals(`$spfCmdletAlc, [System.Runtime.Loader.AssemblyLoadContext]::Default)
     HealthCheckCreated = `$null -ne `$healthCheck
     CaptureOptionsCreated = `$null -ne `$captureOptions
+    SpfCmdletCreated = `$null -ne `$spfCmdlet
 } | ConvertTo-Json -Compress
 "@
         $encoded = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($script))
@@ -65,7 +75,14 @@ Import-Module DomainDetective -Force
         $result.CaptureOptionsType | Should -Be 'DomainDetective.CertificateInventoryCaptureOptions'
         $result.CaptureOptionsALC | Should -Be 'DomainDetective'
         $result.CaptureOptionsALCIsDefault | Should -BeFalse
+        $result.ExportDefaultsType | Should -Be 'DomainDetective.PowerShell.ExportDefaults'
+        $result.ExportDefaultsALC | Should -Be 'DomainDetective'
+        $result.ExportDefaultsALCIsDefault | Should -BeFalse
+        $result.SpfCmdletType | Should -Be 'DomainDetective.PowerShell.CmdletTestSpfRecord'
+        $result.SpfCmdletALC | Should -Be 'DomainDetective'
+        $result.SpfCmdletALCIsDefault | Should -BeFalse
         $result.HealthCheckCreated | Should -BeTrue
         $result.CaptureOptionsCreated | Should -BeTrue
+        $result.SpfCmdletCreated | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary
- enable PSPublishModule module-scoped AssemblyLoadContext packaging for DomainDetective binary module builds
- align `RefreshPSD1Only` with Mailozaurr so full packaging can be forced with `RefreshPSD1Only=false`
- add a packaged-module ALC regression for PowerShell Core that validates the binary cmdlet assembly and core DomainDetective types load from the `DomainDetective` ALC

## Validation
- `$env:PSModulePath = 'C:\Support\GitHub\PSPublishModule\Module' + [IO.Path]::PathSeparator + $env:PSModulePath; $env:RefreshPSD1Only = 'false'; pwsh -NoProfile -ExecutionPolicy Bypass -File .\Module\Build\Build-Module.ps1`
- `pwsh -NoProfile -ExecutionPolicy Bypass -Command "Import-Module Pester -Force; Invoke-Pester -Path '.\Module\Tests\AssemblyLoadContext.Tests.ps1' -Output Detailed"`
- `dotnet restore .\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj /nr:false`
- `dotnet build .\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj -c Debug --framework net8.0 --no-restore /nr:false`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\Module\DomainDetective.Tests.ps1`
- `git diff --check`

## Notes
- Full package build produced `Module\Artefacts\Unpacked\Modules\DomainDetective\Lib\Core\DomainDetective.ModuleLoadContext.dll` and `Module\Artefacts\Packed\DomainDetective.v0.2.0.zip`.
- PSPublishModule binary conflict reports flagged installed-module assembly overlap on Desktop/Core, which is the collision class this ALC packaging is meant to isolate.