### PR TITLE
Detect direct Exchange Online header routes

### DIFF
--- a/DomainDetective.CLI/Commands/AnalyzeMessageHeaderCommand.cs
+++ b/DomainDetective.CLI/Commands/AnalyzeMessageHeaderCommand.cs
@@ -18,17 +18,21 @@ internal sealed class AnalyzeMessageHeaderSettings : CommandSettings {
     /// <summary>Output JSON results.</summary>
     [CommandOption("--json")]
     public bool Json { get; set; }
+
+    /// <summary>Expected public MX host. May be supplied multiple times.</summary>
+    [CommandOption("--expected-mx <HOST>")]
+    public string[]? ExpectedMx { get; set; }
 }
 
 /// <summary>
 /// Analyzes standard message headers for DMARC and authentication issues.
 /// </summary>
 internal sealed class AnalyzeMessageHeaderCommand : Command<AnalyzeMessageHeaderSettings> {
-    [RequiresDynamicCode("Calls DomainDetective.CLI.CommandUtilities.AnalyzeMessageHeader(FileInfo, String, Boolean)")]
-    [RequiresUnreferencedCode("Calls DomainDetective.CLI.CommandUtilities.AnalyzeMessageHeader(FileInfo, String, Boolean)")]
+    [RequiresDynamicCode("Calls DomainDetective.CLI.CommandUtilities.AnalyzeMessageHeader(FileInfo, String, Boolean, String[])")]
+    [RequiresUnreferencedCode("Calls DomainDetective.CLI.CommandUtilities.AnalyzeMessageHeader(FileInfo, String, Boolean, String[])")]
     /// <inheritdoc/>
     protected override int Execute(CommandContext context, AnalyzeMessageHeaderSettings settings, CancellationToken cancellationToken) {
-        CommandUtilities.AnalyzeMessageHeader(settings.File, settings.Header, settings.Json);
+        CommandUtilities.AnalyzeMessageHeader(settings.File, settings.Header, settings.Json, settings.ExpectedMx);
         return 0;
     }
 }

--- a/DomainDetective.CLI/Commands/CommandUtilities.cs
+++ b/DomainDetective.CLI/Commands/CommandUtilities.cs
@@ -100,7 +100,7 @@ internal static class CommandUtilities {
 
     [RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
     [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
-    internal static void AnalyzeMessageHeader(FileInfo? file, string? header, bool json) {
+    internal static void AnalyzeMessageHeader(FileInfo? file, string? header, bool json, string[]? expectedMx = null) {
         string? headerText = null;
         if (file != null) {
             if (!file.Exists) {
@@ -117,7 +117,9 @@ internal static class CommandUtilities {
         }
 
         var hc = new DomainHealthCheck();
-        var result = hc.CheckMessageHeaders(headerText);
+        var result = expectedMx != null && expectedMx.Length > 0
+            ? hc.CheckMessageHeaders(headerText, expectedMx)
+            : hc.CheckMessageHeaders(headerText);
 
         if (json) {
             var jsonText = JsonSerializer.Serialize(result, JsonOptions.Default);

--- a/DomainDetective.PowerShell/CmdletGetMailDomainClassification.cs
+++ b/DomainDetective.PowerShell/CmdletGetMailDomainClassification.cs
@@ -10,7 +10,7 @@ namespace DomainDetective.PowerShell;
 /// <example>
 ///   <summary>Classify a single domain</summary>
 ///   <prefix>PS&gt; </prefix>
-///   <code>Get-DDMailDomainClassification -DomainName example.com</code>
+///   <code>Test-DDMailDomainClassification -DomainName example.com</code>
 ///   <para>Returns category, confidence, signals, score, and RFC references.</para>
 /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDMailDomainClassification", DefaultParameterSetName = "ByName")]

--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -7,15 +7,19 @@ namespace DomainDetective.PowerShell {
     /// <para>Part of the DomainDetective project.</para>
     /// <example>
     ///   <summary>Analyze headers from a file.</summary>
-    ///   <code>Get-Content './headers.txt' -Raw | Get-DDEmailMessageHeaderInfo</code>
+    ///   <code>Get-Content './headers.txt' -Raw | Get-DDEmailMessageHeaderInfo -ExpectedMx 'mx1.gateway.example.net'</code>
     /// </example>
 [Cmdlet(VerbsCommon.Get, "DDEmailMessageHeaderInfo")]
 [Alias("Get-EmailHeaderInfo")]
     public sealed class CmdletTestMessageHeader : ExportableAsyncPSCmdlet {
         /// <summary>Raw header text.</summary>
-        [Parameter(Mandatory = true, Position = 0)]
+        [Parameter(Mandatory = true, Position = 0, ValueFromPipeline = true)]
         [ValidateNotNullOrEmpty]
         public string HeaderText = string.Empty;
+
+        /// <summary>Expected public MX hosts that should appear in the received path.</summary>
+        [Parameter]
+        public string[]? ExpectedMx { get; set; }
 
         private InternalLogger _logger = null!;
         private DomainHealthCheck _healthCheck = null!;
@@ -41,7 +45,7 @@ namespace DomainDetective.PowerShell {
         /// <summary>Executes the cmdlet operation.</summary>
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task ProcessRecordAsync() {
-            var result = _healthCheck.CheckMessageHeaders(HeaderText, CancelToken);
+            var result = _healthCheck.CheckMessageHeaders(HeaderText, ExpectedMx, CancelToken);
             WriteObject(result);
             if (IsExportRequested()) {
                 try {

--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -45,6 +45,7 @@ namespace DomainDetective.PowerShell {
         /// <summary>Executes the cmdlet operation.</summary>
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override Task ProcessRecordAsync() {
+            _logger.ClearLoggedMessages();
             var result = _healthCheck.CheckMessageHeaders(HeaderText, ExpectedMx, CancelToken);
             WriteObject(result);
             if (IsExportRequested()) {

--- a/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
+++ b/DomainDetective.PowerShell/CmdletTestMessageHeader.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using System.Collections.Generic;
 using System.Management.Automation;
 using System.Threading.Tasks;
 
@@ -23,6 +24,7 @@ namespace DomainDetective.PowerShell {
 
         private InternalLogger _logger = null!;
         private DomainHealthCheck _healthCheck = null!;
+        private readonly List<object> _items = new();
 
         /// <summary>Initializes logging and helper classes.</summary>
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
@@ -49,25 +51,37 @@ namespace DomainDetective.PowerShell {
             var result = _healthCheck.CheckMessageHeaders(HeaderText, ExpectedMx, CancelToken);
             WriteObject(result);
             if (IsExportRequested()) {
-                try {
-                    var hadUnsupportedFormats = false;
-                    CompositionExportHelper.WriteReports(
-                        new System.Collections.Generic.List<object> { result },
-                        GetRequestedFormatsOrDefault(ExportDefaults.Format),
-                        ExportPath,
-                        "message-header",
-                        DomainDetective.Reports.ReportScope.Normal,
-                        "Email Message Header Report",
-                        OpenInBrowser.IsPresent || ExportDefaults.OpenInBrowser,
-                        TryOpenReport,
-                        out hadUnsupportedFormats);
+                _items.Add(result);
+            }
+            return Task.CompletedTask;
+        }
 
-                    if (hadUnsupportedFormats) {
-                        return ExportNotImplementedAsync("Get-DDEmailMessageHeaderInfo");
-                    }
-                } catch (System.Exception ex) {
-                    WriteWarning($"Message header export failed: {ex.Message}");
+        /// <summary>Writes a single export for all piped message header results.</summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        protected override Task EndProcessingAsync() {
+            if (_items.Count == 0) {
+                return Task.CompletedTask;
+            }
+
+            var label = _items.Count == 1 ? "message-header" : "message-headers";
+            try {
+                var hadUnsupportedFormats = false;
+                CompositionExportHelper.WriteReports(
+                    _items,
+                    GetRequestedFormatsOrDefault(ExportDefaults.Format),
+                    ExportPath,
+                    label,
+                    DomainDetective.Reports.ReportScope.Normal,
+                    "Email Message Header Report",
+                    OpenInBrowser.IsPresent || ExportDefaults.OpenInBrowser,
+                    TryOpenReport,
+                    out hadUnsupportedFormats);
+
+                if (hadUnsupportedFormats) {
+                    return ExportNotImplementedAsync("Get-DDEmailMessageHeaderInfo");
                 }
+            } catch (System.Exception ex) {
+                WriteWarning($"Message header export failed: {ex.Message}");
             }
             return Task.CompletedTask;
         }

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -77,6 +77,124 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonIgnoresNonRouteHeaderMentions() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <mail-gateway.example.com@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: mail-gateway.example.com mentioned only in subject",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonNormalizesTrailingDotsAndSuppressesDirectEop() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-observed@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway observed",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from mail-gateway.example.com (mail-gateway.example.com [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com." });
+
+        Assert.True(analysis.ExpectedMxObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxBypassCheckAddsAssessment() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <mx-bypass-assessment@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Authorized validation",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var healthCheck = new DomainHealthCheck();
+        var analysis = healthCheck.CheckMessageHeaders(raw, new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed);
+    }
+
+    [Fact]
+    public void DkimMissingWithPassingSpfAndDmarcDoesNotReportFailedAuthentication() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <spf-authenticated@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: SPF authenticated",
+            "Authentication-Results: mx.example.com; dkim=none; spf=pass smtp.mailfrom=example.net; dmarc=pass header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.DkimMissingOrFailed);
+        Assert.False(analysis.AuthenticationFailedDeliveredToInbox);
+        Assert.DoesNotContain(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
+    public void SameDomainAuthenticatedInboxDeliveryIsNotSelfSpoof() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <internal@example.com>",
+            "From: user@example.com",
+            "To: colleague@example.com",
+            "Subject: Internal mail",
+            "Authentication-Results: mx.example.com; dkim=pass header.d=example.com; spf=pass smtp.mailfrom=example.com; dmarc=pass header.from=example.com",
+            "X-MS-Exchange-Organization-AuthAs: Internal",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "Received: from internal.example.com by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SameDomainSelfSpoof);
+        Assert.False(analysis.SelfSpoofDeliveredToInbox);
+        Assert.DoesNotContain(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
     public void GatewayLoopIsReported() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <loop-test@example.net>",
@@ -105,5 +223,30 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.GatewayLoopDetected);
         Assert.Contains(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
         Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.GatewayLoopDetected);
+    }
+
+    [Fact]
+    public void GatewayLoopIsReportedFromReceivedRoute() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <received-loop@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway loop",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:203.0.113.10;SCL:-1;SFV:SKN;H:sender.example.net",
+            "Received: from mx0a-00000000.pphosted.com by example-com.mail.protection.outlook.com with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
+            "Received: from example-com.mail.protection.outlook.com by mx0a-00000000.pphosted.com with ESMTPS id abc; Wed, 17 Jun 2026 12:00:30 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SeenMicrosoftEop);
+        Assert.True(analysis.SeenProofpoint);
+        Assert.True(analysis.GatewayLoopDetected);
+        Assert.Contains(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
     }
 }

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 
 namespace DomainDetective.Tests;
@@ -128,6 +129,91 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonRequiresHostBoundaryMatch() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-boundary@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway boundary",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from mail-gateway.example.com.evil.net (mail-gateway.example.com.evil.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonCanBeRepeatedWithDifferentHost() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-repeat@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway repeat",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from mail-gateway.example.com (mail-gateway.example.com [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.ExpectedMxObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+
+        analysis.CompareExpectedMx(new[] { "other-gateway.example.com" });
+
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonSuppressesDirectEopWarningForObservedGateway() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-logger@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway logger",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from mail-gateway.example.com (mail-gateway.example.com [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+        var logger = new InternalLogger();
+        var warnings = new List<LogEventArgs>();
+        logger.OnWarningMessage += (_, warning) => warnings.Add(warning);
+        var healthCheck = new DomainHealthCheck(internalLogger: logger);
+
+        var analysis = healthCheck.CheckMessageHeaders(raw, new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.ExpectedMxObserved);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(warnings, warning => warning.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+    }
+
+    [Fact]
     public void ExpectedMxBypassCheckAddsAssessment() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <mx-bypass-assessment@example.net>",
@@ -170,6 +256,30 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.DkimMissingOrFailed);
         Assert.False(analysis.AuthenticationFailedDeliveredToInbox);
         Assert.DoesNotContain(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
+    public void InboxAuthenticationWarningUsesTrustedAuthenticationResults() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <spoofed-auth-results@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Spoofed auth results",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "Authentication-Results: attacker.example.net; dkim=pass header.d=example.net; spf=pass smtp.mailfrom=example.net; dmarc=pass header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.Equal("pass header.from=example.net", analysis.DmarcResult);
+        Assert.True(analysis.AuthenticationFailedDeliveredToInbox);
+        Assert.Contains(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -752,6 +752,34 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxHealthCheckPreservesNonMxRouteAssessments() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <healthcheck-non-mx-route@example.com>",
+            "From: spoofed@example.com",
+            "To: target@example.com",
+            "Subject: Health check non MX route",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.com; dmarc=fail header.from=example.com",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:192.0.2.25;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [192.0.2.25]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var healthCheck = new DomainHealthCheck(internalLogger: new InternalLogger());
+
+        var analysis = healthCheck.CheckMessageHeaders(raw, new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.AuthenticationFailedDeliveredToInbox);
+        Assert.True(analysis.SelfSpoofDeliveredToInbox);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.AuthenticationFailedDeliveredToInbox);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.SelfSpoofDeliveredToInbox);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed);
+    }
+
+    [Fact]
     public void GatewayLoopIsReported() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <loop-test@example.net>",

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -214,6 +214,59 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonPreservesParseAssessments() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-auth-pass@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway auth pass",
+            "Authentication-Results: mx.example.com; dkim=pass; spf=pass; dmarc=pass; arc=pass",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from mail-gateway.example.com (mail-gateway.example.com [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+        var healthCheck = new DomainHealthCheck(internalLogger: new InternalLogger());
+
+        var analysis = healthCheck.CheckMessageHeaders(raw, new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.ExpectedMxObserved);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DkimPass);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.SpfPass);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DmarcPass);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ArcPass);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+    }
+
+    [Fact]
+    public void RouteDiagnosticsUseTopmostForefrontHeader() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <duplicate-forefront@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Duplicate Forefront",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "X-Forefront-Antispam-Report: SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.Equal("198.51.100.7", analysis.ForefrontSourceIp);
+        Assert.Equal("sender.example.net", analysis.ForefrontHost);
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+    }
+
+    [Fact]
     public void ExpectedMxBypassCheckAddsAssessment() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <mx-bypass-assessment@example.net>",

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -18,4 +18,92 @@ public class TestMessageHeaderIssues {
         analysis.Parse(raw, new InternalLogger());
         Assert.Contains(MessageHeaderIssue.InvalidDkim, analysis.Issues);
     }
+
+    [Fact]
+    public void DirectExchangeOnlineInboxDeliveryIsReported() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <direct-test@example.net>",
+            "From: user@example.com",
+            "To: user@example.com",
+            "Subject: Authorized validation",
+            "Authentication-Results: mx.example.com; dkim=none (message not signed) header.d=none; spf=fail smtp.mailfrom=example.com; dmarc=fail action=quarantine header.from=example.com",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-MS-Exchange-Organization-SCL: 1",
+            "X-Microsoft-Antispam-Mailbox-Delivery: ucf:0;jmr:0;auth:0;dest:I",
+            "X-Forefront-Antispam-Report: CIP:192.0.2.25;CTRY:ZZ;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [192.0.2.25]) by DB1PEPF00000001.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SeenMicrosoftEop);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+        Assert.True(analysis.DeliveredToInbox);
+        Assert.True(analysis.AuthenticationFailedDeliveredToInbox);
+        Assert.True(analysis.SelfSpoofDeliveredToInbox);
+        Assert.Equal("192.0.2.25", analysis.SourceIp);
+        Assert.Equal(1, analysis.Scl);
+        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.AuthenticationFailedDeliveredToInbox);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonReportsBypassedGateway() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <mx-bypass@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Authorized validation",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void GatewayLoopIsReported() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <loop-test@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway loop",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Example-O365-RedirectToProofpoint: true",
+            "X-Proofpoint-Spam-Details: rule=notspam policy=default score=0",
+            "X-Example-O365-EmailReceivedFromPP: true",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:203.0.113.10;SCL:-1;SFV:SKN;H:sender.example.net",
+            "Received: from mx0a-00000000.pphosted.com (mx0a-00000000.pphosted.com [203.0.113.20]) by example-com.mail.protection.outlook.com with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
+            "Received: from example-com.mail.protection.outlook.com by mx0a-00000000.pphosted.com with ESMTPS id abc; Wed, 17 Jun 2026 12:00:30 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SeenMicrosoftEop);
+        Assert.True(analysis.SeenProofpoint);
+        Assert.True(analysis.RedirectedToProofpoint);
+        Assert.True(analysis.ReceivedFromProofpoint);
+        Assert.True(analysis.GatewayLoopDetected);
+        Assert.Contains(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.GatewayLoopDetected);
+    }
 }

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -131,17 +131,16 @@ public class TestMessageHeaderIssues {
     [Fact]
     public void ExpectedMxComparisonRequiresGatewayAtMicrosoftIngress() {
         var raw = string.Join("\r\n", new[] {
-            "Message-ID: <gateway-late-hop@example.net>",
+            "Message-ID: <gateway-header-order@example.net>",
             "From: sender@example.net",
             "To: recipient@example.com",
-            "Subject: Gateway late hop",
+            "Subject: Gateway header order",
             "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
             "X-MS-Exchange-Organization-AuthAs: Anonymous",
             "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
             "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
-            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
-            "Received: from example-com.mail.protection.outlook.com by mail-gateway.example.com with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
-            "Received: from mail-gateway.example.com by example-com.mail.protection.outlook.com with ESMTPS id ghi; Wed, 17 Jun 2026 12:02:00 +0000",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:02:00 +0000",
+            "Received: from mail-gateway.example.com by example-com.mail.protection.outlook.com with ESMTPS id def; Wed, 17 Jun 2026 12:00:00 +0000",
             string.Empty
         });
 
@@ -154,6 +153,32 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.DirectToExchangeOnlineObserved);
         Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
         Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonTreatsExpectedExchangeOnlineMxAsObserved() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <expected-eop-mx@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Expected EOP MX",
+            "Authentication-Results: mx.example.com; dkim=none; spf=pass smtp.mailfrom=example.net; dmarc=pass header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "example-com.mail.protection.outlook.com" });
+
+        Assert.True(analysis.ExpectedMxObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
     }
 
     [Fact]
@@ -236,6 +261,42 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.DirectToExchangeOnlineObserved);
         Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
         Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonClearsBypassFindingsWhenExpectedMxCleared() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-clear@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway clear",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+        var logger = new InternalLogger();
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, logger);
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" }, logger);
+
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed);
+
+        analysis.CompareExpectedMx(null, logger);
+
+        Assert.Empty(analysis.ExpectedMxHosts);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -182,6 +182,32 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonSkipsMicrosoftInternalHopsForIngress() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-with-internal-eop@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway with internal EOP",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from EURP250MB0001.EURP250.PROD.OUTLOOK.COM by DB1PEPF00000001.mail.protection.outlook.com with ESMTPS id internal; Wed, 17 Jun 2026 12:02:00 +0000",
+            "Received: from mail-gateway.example.com (mail-gateway.example.com [198.51.100.7]) by example-com.mail.protection.outlook.com with ESMTPS id abc; Wed, 17 Jun 2026 12:01:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.ExpectedMxObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
     public void ExpectedMxComparisonRequiresHostBoundaryMatch() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <gateway-boundary@example.net>",
@@ -297,6 +323,32 @@ public class TestMessageHeaderIssues {
         Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
         Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
         Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonIgnoresSpoofedMicrosoftHeadersWithoutEopHop() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <spoofed-microsoft-headers@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Spoofed Microsoft headers",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by mail-gateway.example.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.SeenMicrosoftEop);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
     }
 
     [Fact]
@@ -600,5 +652,30 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.SeenProofpoint);
         Assert.True(analysis.GatewayLoopDetected);
         Assert.Contains(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
+    }
+
+    [Fact]
+    public void CrossTenantGatewayDeliveryIsNotReportedAsGatewayLoop() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <cross-tenant-gateway@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Cross tenant gateway",
+            "Authentication-Results: mx.example.com; dkim=pass; spf=pass smtp.mailfrom=example.net; dmarc=pass header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:203.0.113.20;SCL:1;SFV:NSPM;H:mx0a-00000000.pphosted.com",
+            "Received: from mx0a-00000000.pphosted.com by recipient-com.mail.protection.outlook.com with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
+            "Received: from sender-com.mail.protection.outlook.com by mx0a-00000000.pphosted.com with ESMTPS id abc; Wed, 17 Jun 2026 12:00:30 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SeenMicrosoftEop);
+        Assert.True(analysis.SeenProofpoint);
+        Assert.False(analysis.GatewayLoopDetected);
+        Assert.DoesNotContain(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
     }
 }

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -380,6 +380,32 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonRequiresMicrosoftIngressHopForDirectBypass() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <outbound-microsoft-hop@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Outbound Microsoft hop",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.mail.protection.outlook.com",
+            "Received: from sender.mail.protection.outlook.com by mail-gateway.example.com with ESMTPS id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.True(analysis.SeenMicrosoftEop);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
     public void ProviderDetectionUsesDnsBoundaryMatching() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <provider-boundary@example.net>",
@@ -405,6 +431,28 @@ public class TestMessageHeaderIssues {
         Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
         Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
         Assert.DoesNotContain(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
+    }
+
+    [Fact]
+    public void ProofpointDotComProviderHostIsDetected() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <proofpoint-dot-com@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Proofpoint dot com",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:203.0.113.10;SCL:-1;SFV:SKN;H:sender.example.net",
+            "Received: from mx.proofpoint.com by example-com.mail.protection.outlook.com with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
+            "Received: from example-com.mail.protection.outlook.com by mx.proofpoint.com with ESMTPS id abc; Wed, 17 Jun 2026 12:00:30 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SeenProofpoint);
     }
 
     [Fact]
@@ -675,6 +723,32 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.SameDomainSelfSpoof);
         Assert.True(analysis.SelfSpoofDeliveredToInbox);
         Assert.Contains(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonDoesNotDuplicateParseRouteAssessments() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <no-duplicate-route-assessment@example.com>",
+            "From: spoofed@example.com",
+            "To: target@example.com",
+            "Subject: No duplicate route assessment",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.com; dmarc=fail header.from=example.com",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:192.0.2.25;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [192.0.2.25]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+        var logger = new InternalLogger();
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, logger);
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" }, logger);
+
+        Assert.Equal(1, analysis.Assessments.Count(assessment => assessment.Code == MessageHeaderCodes.AuthenticationFailedDeliveredToInbox));
+        Assert.Equal(1, analysis.Assessments.Count(assessment => assessment.Code == MessageHeaderCodes.SelfSpoofDeliveredToInbox));
+        Assert.Equal(1, analysis.Assessments.Count(assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved));
+        Assert.Equal(1, analysis.Assessments.Count(assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed));
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -46,10 +46,10 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.SelfSpoofDeliveredToInbox);
         Assert.Equal("192.0.2.25", analysis.SourceIp);
         Assert.Equal(1, analysis.Scl);
-        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
         Assert.Contains(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
         Assert.Contains(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
-        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
         Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.AuthenticationFailedDeliveredToInbox);
     }
 
@@ -126,6 +126,34 @@ public class TestMessageHeaderIssues {
         Assert.False(analysis.ExpectedMxBypassed);
         Assert.False(analysis.DirectToExchangeOnlineObserved);
         Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+    }
+
+    [Fact]
+    public void ExpectedMxComparisonRequiresGatewayAtMicrosoftIngress() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-late-hop@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway late hop",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            "Received: from example-com.mail.protection.outlook.com by mail-gateway.example.com with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
+            "Received: from mail-gateway.example.com by example-com.mail.protection.outlook.com with ESMTPS id ghi; Wed, 17 Jun 2026 12:02:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
     }
 
     [Fact]
@@ -292,6 +320,31 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonDoesNotTrustForefrontHostAsGatewayEvidence() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <forefront-h-gateway@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Forefront H gateway",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:mail-gateway.example.com",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.Equal("mail-gateway.example.com", analysis.ForefrontHost);
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
     public void DirectExchangeOnlineUsesCrossTenantAuthAsFallback() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <cross-tenant-authas@example.net>",
@@ -358,6 +411,30 @@ public class TestMessageHeaderIssues {
         analysis.Parse(raw, new InternalLogger());
 
         Assert.True(analysis.DkimMissingOrFailed);
+        Assert.False(analysis.AuthenticationFailedDeliveredToInbox);
+        Assert.DoesNotContain(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
+    public void PassingDmarcDoesNotReportInboxAuthenticationFailureForSpfSoftFail() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <dmarc-pass-spf-softfail@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: DMARC pass SPF softfail",
+            "Authentication-Results: mx.example.com; dkim=pass header.d=example.net; spf=softfail smtp.mailfrom=example.net; dmarc=pass header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SpfFailedOrSoftFailed);
+        Assert.False(analysis.DmarcFailed);
         Assert.False(analysis.AuthenticationFailedDeliveredToInbox);
         Assert.DoesNotContain(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox, analysis.Issues);
     }

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -154,6 +154,31 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonIgnoresReceivedRawMentionsOutsideRouteHosts() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-raw-mention@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway raw mention",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com for <mail-gateway.example.com>; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.False(analysis.ExpectedMxObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
     public void ExpectedMxComparisonCanBeRepeatedWithDifferentHost() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <gateway-repeat@example.net>",
@@ -264,6 +289,32 @@ public class TestMessageHeaderIssues {
         Assert.False(analysis.ExpectedMxObserved);
         Assert.True(analysis.ExpectedMxBypassed);
         Assert.True(analysis.DirectToExchangeOnlineObserved);
+    }
+
+    [Fact]
+    public void DirectExchangeOnlineUsesCrossTenantAuthAsFallback() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <cross-tenant-authas@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: CrossTenant AuthAs",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-CrossTenant-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.Equal("Anonymous", analysis.CrossTenantAuthAs);
+        Assert.True(analysis.DirectToExchangeOnlineObserved);
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -326,6 +326,34 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void ExpectedMxComparisonPreservesAssessmentsWhenRepeatedWithSameLogger() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <gateway-repeat-assessments@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Gateway repeat assessments",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+        var logger = new InternalLogger();
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, logger);
+        analysis.CompareExpectedMx(new[] { "first-gateway.example.com" }, logger);
+        analysis.CompareExpectedMx(new[] { "second-gateway.example.com" }, logger);
+
+        Assert.True(analysis.ExpectedMxBypassed);
+        Assert.Contains(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.Contains(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.DirectToExchangeOnlineObserved);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == MessageHeaderCodes.ExpectedMxBypassed);
+    }
+
+    [Fact]
     public void ExpectedMxComparisonIgnoresSpoofedMicrosoftHeadersWithoutEopHop() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <spoofed-microsoft-headers@example.net>",
@@ -349,6 +377,34 @@ public class TestMessageHeaderIssues {
         Assert.False(analysis.ExpectedMxBypassed);
         Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
         Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+    }
+
+    [Fact]
+    public void ProviderDetectionUsesDnsBoundaryMatching() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <provider-boundary@example.net>",
+            "From: sender@example.net",
+            "To: recipient@example.com",
+            "Subject: Provider boundary",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.net; dmarc=fail header.from=example.net",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:198.51.100.7;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [198.51.100.7]) by example-com.mail.protection.outlook.com.evil.net with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            "Received: from sender.example.net by mx.pphosted.com.evil.net with ESMTPS id def; Wed, 17 Jun 2026 12:01:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+        analysis.CompareExpectedMx(new[] { "mail-gateway.example.com" });
+
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.False(analysis.ExpectedMxBypassed);
+        Assert.False(analysis.GatewayLoopDetected);
+        Assert.DoesNotContain(MessageHeaderIssue.DirectToExchangeOnline, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.ExpectedMxBypassed, analysis.Issues);
+        Assert.DoesNotContain(MessageHeaderIssue.GatewayLoopDetected, analysis.Issues);
     }
 
     [Fact]
@@ -596,6 +652,29 @@ public class TestMessageHeaderIssues {
         Assert.True(analysis.SameDomainSelfSpoof);
         Assert.False(analysis.SelfSpoofDeliveredToInbox);
         Assert.DoesNotContain(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
+    public void SameDomainSelfSpoofChecksAllRecipients() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <recipient-list@example.com>",
+            "From: spoofed@example.com",
+            "To: user@example.net, target@example.com",
+            "Subject: Recipient list",
+            "Authentication-Results: mx.example.com; dkim=none; spf=fail smtp.mailfrom=example.com; dmarc=fail header.from=example.com",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "X-Forefront-Antispam-Report: CIP:192.0.2.25;SCL:1;SFV:NSPM;H:sender.example.net",
+            "Received: from sender.example.net (sender.example.net [192.0.2.25]) by example-com.mail.protection.outlook.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SameDomainSelfSpoof);
+        Assert.True(analysis.SelfSpoofDeliveredToInbox);
+        Assert.Contains(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMessageHeaderIssues.cs
+++ b/DomainDetective.Tests/TestMessageHeaderIssues.cs
@@ -703,6 +703,30 @@ public class TestMessageHeaderIssues {
     }
 
     [Fact]
+    public void SameDomainAnonymousAuthenticatedDeliveryIsNotSelfSpoof() {
+        var raw = string.Join("\r\n", new[] {
+            "Message-ID: <anonymous-aligned@example.com>",
+            "From: user@example.com",
+            "To: colleague@example.com",
+            "Subject: External aligned sender",
+            "Authentication-Results: mx.example.com; dkim=pass header.d=example.com; spf=pass smtp.mailfrom=example.com; dmarc=pass header.from=example.com",
+            "X-MS-Exchange-Organization-AuthAs: Anonymous",
+            "X-Microsoft-Antispam-Mailbox-Delivery: dest:I",
+            "Received: from trusted-gateway.example.net by mx.example.com with SMTP id abc; Wed, 17 Jun 2026 12:00:00 +0000",
+            string.Empty
+        });
+
+        var analysis = new MessageHeaderAnalysis();
+        analysis.Parse(raw, new InternalLogger());
+
+        Assert.True(analysis.SameDomainSelfSpoof);
+        Assert.False(analysis.AuthenticationFailedDeliveredToInbox);
+        Assert.False(analysis.DirectToExchangeOnlineObserved);
+        Assert.False(analysis.SelfSpoofDeliveredToInbox);
+        Assert.DoesNotContain(MessageHeaderIssue.SelfSpoofDeliveredToInbox, analysis.Issues);
+    }
+
+    [Fact]
     public void SameDomainSelfSpoofChecksAllRecipients() {
         var raw = string.Join("\r\n", new[] {
             "Message-ID: <recipient-list@example.com>",

--- a/DomainDetective.Tests/TestMessageHeaderRecommendations.cs
+++ b/DomainDetective.Tests/TestMessageHeaderRecommendations.cs
@@ -16,6 +16,11 @@ public class TestMessageHeaderRecommendations
         Assert.Contains(MessageHeaderCodes.SpfPass, map.Keys);
         Assert.Contains(MessageHeaderCodes.DmarcPass, map.Keys);
         Assert.Contains(MessageHeaderCodes.ArcPass, map.Keys);
+        Assert.Contains(MessageHeaderCodes.DirectToExchangeOnlineObserved, map.Keys);
+        Assert.Contains(MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, map.Keys);
+        Assert.Contains(MessageHeaderCodes.SelfSpoofDeliveredToInbox, map.Keys);
+        Assert.Contains(MessageHeaderCodes.GatewayLoopDetected, map.Keys);
+        Assert.Contains(MessageHeaderCodes.ExpectedMxBypassed, map.Keys);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestMonitorScheduler.cs
+++ b/DomainDetective.Tests/TestMonitorScheduler.cs
@@ -30,7 +30,8 @@ public class TestMonitorScheduler
                 Expired = true,
                 ExpiryDate = System.DateTime.UtcNow.AddDays(-1),
                 Analysis = new CertificateAnalysis()
-            })
+            }),
+            BgpOverride = (_, _) => Task.FromResult(new System.Collections.Generic.Dictionary<string, int>())
         };
         scheduler.Domains.Add("example.com");
         await scheduler.RunAsync();
@@ -63,7 +64,8 @@ public class TestMonitorScheduler
                 Expired = true,
                 ExpiryDate = System.DateTime.UtcNow.AddDays(-1),
                 Analysis = new CertificateAnalysis()
-            })
+            }),
+            BgpOverride = (_, _) => Task.FromResult(new System.Collections.Generic.Dictionary<string, int>())
         };
         scheduler.Domains.Add("example.com");
 

--- a/DomainDetective/Diagnostics/Codes/MessageHeaderCodes.cs
+++ b/DomainDetective/Diagnostics/Codes/MessageHeaderCodes.cs
@@ -8,5 +8,10 @@ internal static class MessageHeaderCodes {
     public const string SpfPass = "HEADERS.SPF.Pass";
     public const string DmarcPass = "HEADERS.DMARC.Pass";
     public const string ArcPass = "HEADERS.ARC.Pass";
+    public const string DirectToExchangeOnlineObserved = "HEADERS.Route.DirectToExchangeOnline";
+    public const string AuthenticationFailedDeliveredToInbox = "HEADERS.Route.AuthFailedDeliveredToInbox";
+    public const string SelfSpoofDeliveredToInbox = "HEADERS.Route.SelfSpoofDeliveredToInbox";
+    public const string GatewayLoopDetected = "HEADERS.Route.GatewayLoopDetected";
+    public const string ExpectedMxBypassed = "HEADERS.Route.ExpectedMxBypassed";
 }
 

--- a/DomainDetective/Diagnostics/Recommendations/MessageHeaderRecommendations.cs
+++ b/DomainDetective/Diagnostics/Recommendations/MessageHeaderRecommendations.cs
@@ -46,5 +46,55 @@ internal sealed class MessageHeaderRecommendations : IRecommendationProvider
             Domain = RecommendationDomain.EmailAuth,
             Tags = new[] { "arc", "email", "authentication" }
         };
+        map[MessageHeaderCodes.DirectToExchangeOnlineObserved] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.DirectToExchangeOnlineObserved,
+            Title = "Direct Exchange Online ingress observed",
+            Why = "The message appears to have reached Exchange Online directly instead of first passing through the expected mail security gateway.",
+            How = "Restrict inbound Exchange Online connectors to the approved gateway source IPs or certificate identity, and verify direct MX/EOP delivery is rejected.",
+            Links = new[] { "https://learn.microsoft.com/exchange/mail-flow-best-practices/use-connectors-to-configure-mail-flow/inbound-connector" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "exchange-online", "mail-flow", "gateway", "headers" }
+        };
+        map[MessageHeaderCodes.AuthenticationFailedDeliveredToInbox] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.AuthenticationFailedDeliveredToInbox,
+            Title = "Authentication failed but message reached Inbox",
+            Why = "Inbox delivery with SPF, DKIM, or DMARC failure can make spoofed validation messages look normal to recipients.",
+            How = "Review anti-spam policy actions, DMARC handling, SCL overrides, safe sender bypasses, and inbound connector attribution.",
+            Links = new[] { "https://learn.microsoft.com/defender-office-365/email-authentication-about" },
+            Domain = RecommendationDomain.Dmarc,
+            Tags = new[] { "dmarc", "spf", "dkim", "inbox", "headers" }
+        };
+        map[MessageHeaderCodes.SelfSpoofDeliveredToInbox] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.SelfSpoofDeliveredToInbox,
+            Title = "Same-domain self-spoof reached Inbox",
+            Why = "A message using the recipient domain in the From header reached Inbox, which can undermine user trust cues and external tagging.",
+            How = "Block unauthenticated same-domain inbound mail unless it arrives from trusted gateways or authenticated internal systems.",
+            Links = new[] { "https://learn.microsoft.com/defender-office-365/anti-spoofing-protection-about" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "spoofing", "self-spoof", "exchange-online", "headers" }
+        };
+        map[MessageHeaderCodes.GatewayLoopDetected] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.GatewayLoopDetected,
+            Title = "Gateway loop detected in headers",
+            Why = "Headers show the message moving between Exchange Online and a third-party gateway, which may hide the original source or change authentication interpretation.",
+            How = "Validate connector ordering, Enhanced Filtering for Connectors, and gateway reinjection rules so the original external source remains visible.",
+            Links = new[] { "https://learn.microsoft.com/defender-office-365/enhanced-filtering-for-connectors" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "exchange-online", "gateway", "proofpoint", "headers" }
+        };
+        map[MessageHeaderCodes.ExpectedMxBypassed] = new RecommendationAdvice
+        {
+            Code = MessageHeaderCodes.ExpectedMxBypassed,
+            Title = "Expected MX path was bypassed",
+            Why = "The supplied public MX hosts were not observed in the message path while direct Exchange Online ingress was detected.",
+            How = "Compare public MX, accepted domains, connector restrictions, and direct EOP/onmicrosoft delivery behavior, then enforce gateway-only ingress.",
+            Links = new[] { "https://learn.microsoft.com/exchange/mail-flow-best-practices/use-connectors-to-configure-mail-flow/inbound-connector" },
+            Domain = RecommendationDomain.EmailAuth,
+            Tags = new[] { "mx", "gateway", "exchange-online", "headers" }
+        };
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.Arc.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Arc.cs
@@ -32,6 +32,9 @@ namespace DomainDetective {
             var analysis = new MessageHeaderAnalysis();
             analysis.Parse(rawHeaders, _logger, emitRouteDiagnostics: false);
             analysis.CompareExpectedMx(expectedMxHosts, _logger);
+            _logger.ClearLoggedMessages();
+            using var collector = AssessmentCollector.ForAnalysis(_logger, analysis, category: "HEADERS");
+            analysis.EmitNonMxRouteDiagnostics(_logger);
             return analysis;
         }
 

--- a/DomainDetective/DomainHealthCheck.Verification.Arc.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Arc.cs
@@ -29,7 +29,8 @@ namespace DomainDetective {
         public MessageHeaderAnalysis CheckMessageHeaders(string rawHeaders, IEnumerable<string>? expectedMxHosts, CancellationToken ct = default) {
             ct.ThrowIfCancellationRequested();
 
-            var analysis = CheckMessageHeaders(rawHeaders, ct);
+            var analysis = new MessageHeaderAnalysis();
+            analysis.Parse(rawHeaders);
             analysis.CompareExpectedMx(expectedMxHosts, _logger);
             return analysis;
         }

--- a/DomainDetective/DomainHealthCheck.Verification.Arc.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Arc.cs
@@ -30,10 +30,7 @@ namespace DomainDetective {
             ct.ThrowIfCancellationRequested();
 
             var analysis = CheckMessageHeaders(rawHeaders, ct);
-            analysis.CompareExpectedMx(expectedMxHosts);
-            if (analysis.ExpectedMxBypassed) {
-                _logger.WriteWarningCode(MessageHeaderCodes.ExpectedMxBypassed, "Expected public MX hosts were not observed in the message route.");
-            }
+            analysis.CompareExpectedMx(expectedMxHosts, _logger);
             return analysis;
         }
 

--- a/DomainDetective/DomainHealthCheck.Verification.Arc.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Arc.cs
@@ -30,7 +30,7 @@ namespace DomainDetective {
             ct.ThrowIfCancellationRequested();
 
             var analysis = new MessageHeaderAnalysis();
-            analysis.Parse(rawHeaders);
+            analysis.Parse(rawHeaders, _logger, emitRouteDiagnostics: false);
             analysis.CompareExpectedMx(expectedMxHosts, _logger);
             return analysis;
         }

--- a/DomainDetective/DomainHealthCheck.Verification.Arc.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.Arc.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -15,6 +16,24 @@ namespace DomainDetective {
 
             var analysis = new MessageHeaderAnalysis();
             analysis.Parse(rawHeaders, _logger);
+            return analysis;
+        }
+
+        /// <summary>
+        /// Parses raw message headers and compares the observed route with expected public MX hosts.
+        /// </summary>
+        /// <param name="rawHeaders">Unparsed header text.</param>
+        /// <param name="expectedMxHosts">Public MX hosts expected to process inbound mail.</param>
+        /// <param name="ct">Token to cancel the operation.</param>
+        /// <returns>Populated <see cref="MessageHeaderAnalysis"/> instance.</returns>
+        public MessageHeaderAnalysis CheckMessageHeaders(string rawHeaders, IEnumerable<string>? expectedMxHosts, CancellationToken ct = default) {
+            ct.ThrowIfCancellationRequested();
+
+            var analysis = CheckMessageHeaders(rawHeaders, ct);
+            analysis.CompareExpectedMx(expectedMxHosts);
+            if (analysis.ExpectedMxBypassed) {
+                _logger.WriteWarningCode(MessageHeaderCodes.ExpectedMxBypassed, "Expected public MX hosts were not observed in the message route.");
+            }
             return analysis;
         }
 

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -170,10 +170,11 @@ namespace DomainDetective {
                 Scl = forefrontScl;
             }
 
+            var hasMicrosoftEopReceivedHop = HasMicrosoftEopReceivedHop();
             SeenMicrosoftEop = HasHeaderPrefix("X-MS-Exchange-")
                 || HasHeaderPrefix("X-Microsoft-Antispam")
                 || HasHeaderPrefix("X-Forefront-")
-                || ReceivedHops.Any(static hop => ContainsProvider(hop.Raw, "protection.outlook.com") || ContainsProvider(hop.Raw, "prod.outlook.com"));
+                || hasMicrosoftEopReceivedHop;
             SeenProofpoint = HasHeaderPrefix("X-Proofpoint")
                 || HasHeaderContaining("Proofpoint")
                 || ReceivedHops.Any(static hop => ContainsProvider(hop.Raw, "pphosted.com") || ContainsProvider(hop.Raw, "proofpoint"));
@@ -181,7 +182,7 @@ namespace DomainDetective {
             RedirectedToProofpoint = HasHeaderContaining("RedirectToProofpoint");
             ReceivedFromProofpoint = HasHeaderContaining("EmailReceivedFromPP");
             GatewayLoopDetected = (RedirectedToProofpoint && ReceivedFromProofpoint) || HasGatewayLoopInReceivedRoute();
-            _rawDirectToExchangeOnlineObserved = SeenMicrosoftEop
+            _rawDirectToExchangeOnlineObserved = hasMicrosoftEopReceivedHop
                 && !string.IsNullOrWhiteSpace(ForefrontSourceIp)
                 && IsAnonymousExchangeAuth();
             DirectToExchangeOnlineObserved = _rawDirectToExchangeOnlineObserved;
@@ -239,13 +240,21 @@ namespace DomainDetective {
         }
 
         private bool IsHostObservedAtMicrosoftIngress(string host) {
-            var ingressHop = ReceivedHops
-                .Where(hop => IsMicrosoftEopHost(hop.ByHost))
-                .OrderBy(hop => hop.HeaderIndex)
-                .FirstOrDefault();
+            var ingressHop = GetExternalMicrosoftIngressHop();
             return ingressHop != null
                 && (IsSameHost(ingressHop.FromHost, host)
                     || (IsMicrosoftEopHost(host) && IsSameHost(ingressHop.ByHost, host)));
+        }
+
+        private bool HasMicrosoftEopReceivedHop() {
+            return ReceivedHops.Any(hop => IsMicrosoftEopHost(hop.FromHost) || IsMicrosoftEopHost(hop.ByHost));
+        }
+
+        private ReceivedHop? GetExternalMicrosoftIngressHop() {
+            return ReceivedHops
+                .Where(hop => IsMicrosoftEopHost(hop.ByHost) && !IsMicrosoftEopHost(hop.FromHost))
+                .OrderBy(hop => hop.HeaderIndex)
+                .FirstOrDefault();
         }
 
         private static string? ExtractToken(string? value, string key) {
@@ -261,19 +270,26 @@ namespace DomainDetective {
         }
 
         private bool HasGatewayLoopInReceivedRoute() {
-            var seenMicrosoftEopToGateway = false;
+            var microsoftEopToGatewayHosts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var hop in ReceivedHops) {
                 var fromMicrosoftEop = IsMicrosoftEopHost(hop.FromHost);
                 var byMicrosoftEop = IsMicrosoftEopHost(hop.ByHost);
                 var fromProofpoint = IsProofpointHost(hop.FromHost);
                 var byProofpoint = IsProofpointHost(hop.ByHost);
 
-                if (seenMicrosoftEopToGateway && fromProofpoint && byMicrosoftEop) {
-                    return true;
+                if (fromProofpoint && byMicrosoftEop) {
+                    var byHost = hop.ByHost;
+                    if (!string.IsNullOrWhiteSpace(byHost)
+                        && microsoftEopToGatewayHosts.Contains(NormalizeHost(byHost!))) {
+                        return true;
+                    }
                 }
 
                 if (fromMicrosoftEop && byProofpoint) {
-                    seenMicrosoftEopToGateway = true;
+                    var fromHost = hop.FromHost;
+                    if (!string.IsNullOrWhiteSpace(fromHost)) {
+                        microsoftEopToGatewayHosts.Add(NormalizeHost(fromHost!));
+                    }
                 }
             }
 

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 namespace DomainDetective {
     public partial class MessageHeaderAnalysis {
         private static readonly Regex SemicolonTokenRegex = new(@"(?<key>[A-Z0-9]+):(?<value>[^;]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private bool _rawDirectToExchangeOnlineObserved;
 
         /// <summary>Value of the <c>Message-ID</c> header.</summary>
         public string? MessageId { get; private set; }
@@ -75,8 +76,15 @@ namespace DomainDetective {
             ExpectedMxHosts.Clear();
             ExpectedMxObserved = false;
             ExpectedMxBypassed = false;
+            DirectToExchangeOnlineObserved = _rawDirectToExchangeOnlineObserved;
+            Issues.Remove(MessageHeaderIssue.ExpectedMxBypassed);
+            RemoveAssessment(MessageHeaderCodes.ExpectedMxBypassed);
 
             if (expectedMxHosts == null) {
+                if (DirectToExchangeOnlineObserved) {
+                    AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
+                }
+                EmitRouteDiagnostics(logger);
                 return;
             }
 
@@ -88,6 +96,10 @@ namespace DomainDetective {
             }
 
             if (ExpectedMxHosts.Count == 0) {
+                if (DirectToExchangeOnlineObserved) {
+                    AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
+                }
+                EmitRouteDiagnostics(logger);
                 return;
             }
 
@@ -95,14 +107,17 @@ namespace DomainDetective {
             if (ExpectedMxObserved) {
                 DirectToExchangeOnlineObserved = false;
                 Issues.Remove(MessageHeaderIssue.DirectToExchangeOnline);
-                Assessments.RemoveAll(static assessment => string.Equals(assessment.Code, MessageHeaderCodes.DirectToExchangeOnlineObserved, StringComparison.Ordinal));
+                RemoveAssessment(MessageHeaderCodes.DirectToExchangeOnlineObserved);
+            } else if (DirectToExchangeOnlineObserved) {
+                AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
             }
 
-            ExpectedMxBypassed = !ExpectedMxObserved && DirectToExchangeOnlineObserved;
+            ExpectedMxBypassed = !ExpectedMxObserved && _rawDirectToExchangeOnlineObserved;
             if (ExpectedMxBypassed) {
                 AddIssue(MessageHeaderIssue.ExpectedMxBypassed);
-                WriteRouteWarning(logger, MessageHeaderCodes.ExpectedMxBypassed, "Expected public MX hosts were not observed in the message route.");
             }
+
+            EmitRouteDiagnostics(logger);
         }
 
         private void ResetRouteDiagnostics() {
@@ -119,6 +134,7 @@ namespace DomainDetective {
             ExternalInOutlookResult = null;
             SeenMicrosoftEop = false;
             SeenProofpoint = false;
+            _rawDirectToExchangeOnlineObserved = false;
             DirectToExchangeOnlineObserved = false;
             DeliveredToInbox = false;
             DmarcFailed = false;
@@ -170,14 +186,15 @@ namespace DomainDetective {
             RedirectedToProofpoint = HasHeaderContaining("RedirectToProofpoint");
             ReceivedFromProofpoint = HasHeaderContaining("EmailReceivedFromPP");
             GatewayLoopDetected = (RedirectedToProofpoint && ReceivedFromProofpoint) || HasGatewayLoopInReceivedRoute();
-            DirectToExchangeOnlineObserved = SeenMicrosoftEop
+            _rawDirectToExchangeOnlineObserved = SeenMicrosoftEop
                 && !string.IsNullOrWhiteSpace(ForefrontSourceIp)
                 && string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase);
+            DirectToExchangeOnlineObserved = _rawDirectToExchangeOnlineObserved;
 
-            DmarcFailed = IsFailureResult(DmarcResult, treatMissingAsFailure: false);
-            DkimMissingOrFailed = IsFailureResult(DkimResult, treatMissingAsFailure: true);
-            SpfFailedOrSoftFailed = IsFailureResult(SpfResult, treatMissingAsFailure: false);
-            var dkimFailed = IsExplicitFailureResult(DkimResult);
+            DmarcFailed = IsFailureResult(TrustedDmarcResult, treatMissingAsFailure: false);
+            DkimMissingOrFailed = IsFailureResult(TrustedDkimResult, treatMissingAsFailure: true);
+            SpfFailedOrSoftFailed = IsFailureResult(TrustedSpfResult, treatMissingAsFailure: false);
+            var dkimFailed = IsExplicitFailureResult(TrustedDkimResult);
             SameDomainSelfSpoof = TryGetDomain(From, out var fromDomain)
                 && TryGetDomain(To, out var toDomain)
                 && string.Equals(fromDomain, toDomain, StringComparison.OrdinalIgnoreCase);
@@ -187,18 +204,6 @@ namespace DomainDetective {
                 && SameDomainSelfSpoof
                 && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox || string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase));
 
-            if (GatewayLoopDetected) {
-                logger?.WriteWarningCode(MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
-            }
-            if (DirectToExchangeOnlineObserved) {
-                logger?.WriteWarningCode(MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp);
-            }
-            if (AuthenticationFailedDeliveredToInbox) {
-                logger?.WriteWarningCode(MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
-            }
-            if (SelfSpoofDeliveredToInbox) {
-                logger?.WriteWarningCode(MessageHeaderCodes.SelfSpoofDeliveredToInbox, "Message appears to be same-domain self-spoofing and was delivered to Inbox.");
-            }
         }
 
         private void DetermineRouteIssues() {
@@ -232,10 +237,10 @@ namespace DomainDetective {
         }
 
         private bool IsHostObserved(string host) {
-            return ContainsProvider(ForefrontHost, host)
-                || ReceivedHops.Any(hop => ContainsProvider(hop.Raw, host)
-                    || ContainsProvider(hop.FromHost, host)
-                    || ContainsProvider(hop.ByHost, host));
+            return IsSameHost(ForefrontHost, host)
+                || ReceivedHops.Any(hop => ContainsHostWithBoundary(hop.Raw, host)
+                    || IsSameHost(hop.FromHost, host)
+                    || IsSameHost(hop.ByHost, host));
         }
 
         private static string? ExtractToken(string? value, string key) {
@@ -284,6 +289,24 @@ namespace DomainDetective {
             return host.Trim().TrimEnd('.');
         }
 
+        internal void EmitRouteDiagnostics(InternalLogger? logger = null) {
+            if (GatewayLoopDetected) {
+                WriteRouteWarning(logger, MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
+            }
+            if (DirectToExchangeOnlineObserved) {
+                WriteRouteWarning(logger, MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp);
+            }
+            if (AuthenticationFailedDeliveredToInbox) {
+                WriteRouteWarning(logger, MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
+            }
+            if (SelfSpoofDeliveredToInbox) {
+                WriteRouteWarning(logger, MessageHeaderCodes.SelfSpoofDeliveredToInbox, "Message appears to be same-domain self-spoofing and was delivered to Inbox.");
+            }
+            if (ExpectedMxBypassed) {
+                WriteRouteWarning(logger, MessageHeaderCodes.ExpectedMxBypassed, "Expected public MX hosts were not observed in the message route.");
+            }
+        }
+
         private void WriteRouteWarning(InternalLogger? logger, string code, string message) {
             if (logger != null) {
                 logger.WriteWarningCode(code, message);
@@ -302,6 +325,87 @@ namespace DomainDetective {
                 Timestamp = DateTimeOffset.UtcNow
             });
         }
+
+        private void WriteRouteWarning(InternalLogger? logger, string code, string message, params object?[] args) {
+            if (logger != null) {
+                logger.WriteWarningCode(code, message, args);
+                return;
+            }
+
+            var formatted = args != null && args.Length > 0 ? string.Format(message, args) : message;
+            if (Assessments.Any(assessment => string.Equals(assessment.Code, code, StringComparison.Ordinal))) {
+                return;
+            }
+
+            Assessments.Add(new Assessment {
+                Severity = AssessmentSeverity.Warning,
+                Category = "HEADERS",
+                Code = code,
+                Message = formatted,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+        }
+
+        private void RemoveAssessment(string code) {
+            Assessments.RemoveAll(assessment => string.Equals(assessment.Code, code, StringComparison.Ordinal));
+        }
+
+        private static bool IsSameHost(string? value, string host) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            return string.Equals(NormalizeHost(value!), host, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool ContainsHostWithBoundary(string? value, string host) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            var startIndex = 0;
+            while (startIndex < value!.Length) {
+                var index = value.IndexOf(host, startIndex, StringComparison.OrdinalIgnoreCase);
+                if (index < 0) {
+                    return false;
+                }
+
+                if (HasHostBoundary(value, index, host.Length)) {
+                    return true;
+                }
+
+                startIndex = index + host.Length;
+            }
+
+            return false;
+        }
+
+        private static bool HasHostBoundary(string value, int start, int length) {
+            if (start > 0 && IsDnsHostCharacter(value[start - 1])) {
+                return false;
+            }
+
+            var end = start + length;
+            if (end >= value.Length) {
+                return true;
+            }
+
+            if (value[end] == '.') {
+                return end == value.Length - 1 || !IsDnsHostCharacter(value[end + 1]);
+            }
+
+            return !IsDnsHostCharacter(value[end]);
+        }
+
+        private static bool IsDnsHostCharacter(char value) {
+            return char.IsLetterOrDigit(value) || value == '-' || value == '.';
+        }
+
+        private string? TrustedDkimResult => _hasTrustedAuthenticationResults ? _trustedDkimResult : DkimResult;
+
+        private string? TrustedSpfResult => _hasTrustedAuthenticationResults ? _trustedSpfResult : SpfResult;
+
+        private string? TrustedDmarcResult => _hasTrustedAuthenticationResults ? _trustedDmarcResult : DmarcResult;
 
         private static bool ContainsProvider(string? value, string provider) {
             if (string.IsNullOrWhiteSpace(value)) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -188,7 +188,7 @@ namespace DomainDetective {
             GatewayLoopDetected = (RedirectedToProofpoint && ReceivedFromProofpoint) || HasGatewayLoopInReceivedRoute();
             _rawDirectToExchangeOnlineObserved = SeenMicrosoftEop
                 && !string.IsNullOrWhiteSpace(ForefrontSourceIp)
-                && string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase);
+                && IsAnonymousExchangeAuth();
             DirectToExchangeOnlineObserved = _rawDirectToExchangeOnlineObserved;
 
             DmarcFailed = IsFailureResult(TrustedDmarcResult, treatMissingAsFailure: false);
@@ -202,7 +202,7 @@ namespace DomainDetective {
             AuthenticationFailedDeliveredToInbox = DeliveredToInbox && (DmarcFailed || dkimFailed || SpfFailedOrSoftFailed);
             SelfSpoofDeliveredToInbox = DeliveredToInbox
                 && SameDomainSelfSpoof
-                && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox || string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase));
+                && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox || IsAnonymousExchangeAuth());
 
         }
 
@@ -246,8 +246,7 @@ namespace DomainDetective {
 
         private bool IsHostObserved(string host) {
             return IsSameHost(ForefrontHost, host)
-                || ReceivedHops.Any(hop => ContainsHostWithBoundary(hop.Raw, host)
-                    || IsSameHost(hop.FromHost, host)
+                || ReceivedHops.Any(hop => IsSameHost(hop.FromHost, host)
                     || IsSameHost(hop.ByHost, host));
         }
 
@@ -291,6 +290,11 @@ namespace DomainDetective {
         private static bool IsProofpointHost(string? value) {
             return ContainsProvider(value, "pphosted.com")
                 || ContainsProvider(value, "proofpoint");
+        }
+
+        private bool IsAnonymousExchangeAuth() {
+            return string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase)
+                || string.Equals(CrossTenantAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase);
         }
 
         private static string NormalizeHost(string host) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -69,7 +69,9 @@ namespace DomainDetective {
         /// Compares the observed message path with expected public MX host names.
         /// </summary>
         /// <param name="expectedMxHosts">Public MX host names expected to process inbound mail first.</param>
-        public void CompareExpectedMx(IEnumerable<string>? expectedMxHosts) {
+        /// <param name="logger">Optional logger used to attach expected-MX route findings to assessments.</param>
+        public void CompareExpectedMx(IEnumerable<string>? expectedMxHosts, InternalLogger? logger = null) {
+            using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "HEADERS") : null;
             ExpectedMxHosts.Clear();
             ExpectedMxObserved = false;
             ExpectedMxBypassed = false;
@@ -78,9 +80,10 @@ namespace DomainDetective {
                 return;
             }
 
-            foreach (var host in expectedMxHosts) {
-                if (!string.IsNullOrWhiteSpace(host)) {
-                    ExpectedMxHosts.Add(host.Trim());
+            foreach (var host in expectedMxHosts.Where(static host => !string.IsNullOrWhiteSpace(host))) {
+                var normalized = NormalizeHost(host);
+                if (normalized.Length > 0 && !ExpectedMxHosts.Contains(normalized, StringComparer.OrdinalIgnoreCase)) {
+                    ExpectedMxHosts.Add(normalized);
                 }
             }
 
@@ -89,9 +92,16 @@ namespace DomainDetective {
             }
 
             ExpectedMxObserved = ExpectedMxHosts.Any(IsHostObserved);
+            if (ExpectedMxObserved) {
+                DirectToExchangeOnlineObserved = false;
+                Issues.Remove(MessageHeaderIssue.DirectToExchangeOnline);
+                Assessments.RemoveAll(static assessment => string.Equals(assessment.Code, MessageHeaderCodes.DirectToExchangeOnlineObserved, StringComparison.Ordinal));
+            }
+
             ExpectedMxBypassed = !ExpectedMxObserved && DirectToExchangeOnlineObserved;
             if (ExpectedMxBypassed) {
                 AddIssue(MessageHeaderIssue.ExpectedMxBypassed);
+                WriteRouteWarning(logger, MessageHeaderCodes.ExpectedMxBypassed, "Expected public MX hosts were not observed in the message route.");
             }
         }
 
@@ -159,7 +169,7 @@ namespace DomainDetective {
 
             RedirectedToProofpoint = HasHeaderContaining("RedirectToProofpoint");
             ReceivedFromProofpoint = HasHeaderContaining("EmailReceivedFromPP");
-            GatewayLoopDetected = RedirectedToProofpoint && ReceivedFromProofpoint;
+            GatewayLoopDetected = (RedirectedToProofpoint && ReceivedFromProofpoint) || HasGatewayLoopInReceivedRoute();
             DirectToExchangeOnlineObserved = SeenMicrosoftEop
                 && !string.IsNullOrWhiteSpace(ForefrontSourceIp)
                 && string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase);
@@ -167,18 +177,21 @@ namespace DomainDetective {
             DmarcFailed = IsFailureResult(DmarcResult, treatMissingAsFailure: false);
             DkimMissingOrFailed = IsFailureResult(DkimResult, treatMissingAsFailure: true);
             SpfFailedOrSoftFailed = IsFailureResult(SpfResult, treatMissingAsFailure: false);
+            var dkimFailed = IsExplicitFailureResult(DkimResult);
             SameDomainSelfSpoof = TryGetDomain(From, out var fromDomain)
                 && TryGetDomain(To, out var toDomain)
                 && string.Equals(fromDomain, toDomain, StringComparison.OrdinalIgnoreCase);
 
-            AuthenticationFailedDeliveredToInbox = DeliveredToInbox && (DmarcFailed || DkimMissingOrFailed || SpfFailedOrSoftFailed);
-            SelfSpoofDeliveredToInbox = DeliveredToInbox && SameDomainSelfSpoof;
+            AuthenticationFailedDeliveredToInbox = DeliveredToInbox && (DmarcFailed || dkimFailed || SpfFailedOrSoftFailed);
+            SelfSpoofDeliveredToInbox = DeliveredToInbox
+                && SameDomainSelfSpoof
+                && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox || string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase));
 
             if (GatewayLoopDetected) {
                 logger?.WriteWarningCode(MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
             }
             if (DirectToExchangeOnlineObserved) {
-                logger?.WriteWarningCode(MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp ?? "unknown source");
+                logger?.WriteWarningCode(MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp);
             }
             if (AuthenticationFailedDeliveredToInbox) {
                 logger?.WriteWarningCode(MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
@@ -219,8 +232,10 @@ namespace DomainDetective {
         }
 
         private bool IsHostObserved(string host) {
-            return Headers.Any(header => ContainsProvider(header.Value, host))
-                || ReceivedHops.Any(hop => ContainsProvider(hop.Raw, host));
+            return ContainsProvider(ForefrontHost, host)
+                || ReceivedHops.Any(hop => ContainsProvider(hop.Raw, host)
+                    || ContainsProvider(hop.FromHost, host)
+                    || ContainsProvider(hop.ByHost, host));
         }
 
         private static string? ExtractToken(string? value, string key) {
@@ -228,17 +243,72 @@ namespace DomainDetective {
                 return null;
             }
 
-            foreach (Match match in SemicolonTokenRegex.Matches(value)) {
-                if (string.Equals(match.Groups["key"].Value, key, StringComparison.OrdinalIgnoreCase)) {
-                    return match.Groups["value"].Value.Trim();
-                }
+            foreach (Match match in SemicolonTokenRegex.Matches(value).Cast<Match>().Where(match => string.Equals(match.Groups["key"].Value, key, StringComparison.OrdinalIgnoreCase))) {
+                return match.Groups["value"].Value.Trim();
             }
 
             return null;
         }
 
-        private static bool ContainsProvider(string value, string provider) {
-            return value.IndexOf(provider, StringComparison.OrdinalIgnoreCase) >= 0;
+        private bool HasGatewayLoopInReceivedRoute() {
+            var seenMicrosoftEopToGateway = false;
+            foreach (var hop in ReceivedHops) {
+                var fromMicrosoftEop = IsMicrosoftEopHost(hop.FromHost);
+                var byMicrosoftEop = IsMicrosoftEopHost(hop.ByHost);
+                var fromProofpoint = IsProofpointHost(hop.FromHost);
+                var byProofpoint = IsProofpointHost(hop.ByHost);
+
+                if (seenMicrosoftEopToGateway && fromProofpoint && byMicrosoftEop) {
+                    return true;
+                }
+
+                if (fromMicrosoftEop && byProofpoint) {
+                    seenMicrosoftEopToGateway = true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsMicrosoftEopHost(string? value) {
+            return ContainsProvider(value, "protection.outlook.com")
+                || ContainsProvider(value, "prod.outlook.com");
+        }
+
+        private static bool IsProofpointHost(string? value) {
+            return ContainsProvider(value, "pphosted.com")
+                || ContainsProvider(value, "proofpoint");
+        }
+
+        private static string NormalizeHost(string host) {
+            return host.Trim().TrimEnd('.');
+        }
+
+        private void WriteRouteWarning(InternalLogger? logger, string code, string message) {
+            if (logger != null) {
+                logger.WriteWarningCode(code, message);
+                return;
+            }
+
+            if (Assessments.Any(assessment => string.Equals(assessment.Code, code, StringComparison.Ordinal))) {
+                return;
+            }
+
+            Assessments.Add(new Assessment {
+                Severity = AssessmentSeverity.Warning,
+                Category = "HEADERS",
+                Code = code,
+                Message = message,
+                Timestamp = DateTimeOffset.UtcNow
+            });
+        }
+
+        private static bool ContainsProvider(string? value, string provider) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            return value!.IndexOf(provider, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private static bool IsFailureResult(string? result, bool treatMissingAsFailure) {
@@ -252,6 +322,18 @@ namespace DomainDetective {
                 || normalized.StartsWith("permerror", StringComparison.OrdinalIgnoreCase)
                 || normalized.StartsWith("temperror", StringComparison.OrdinalIgnoreCase)
                 || normalized.StartsWith("none", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsExplicitFailureResult(string? result) {
+            if (string.IsNullOrWhiteSpace(result)) {
+                return false;
+            }
+
+            var normalized = result!.Trim();
+            return normalized.StartsWith("fail", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("softfail", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("permerror", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("temperror", StringComparison.OrdinalIgnoreCase);
         }
 
         private static bool TryGetDomain(string? value, out string? domain) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -153,21 +153,21 @@ namespace DomainDetective {
 
         private void AnalyzeRouteHeaders(InternalLogger? logger) {
             MessageId = GetHeaderValue("Message-ID");
-            NetworkMessageId = GetHeaderValue("X-MS-Exchange-Organization-Network-Message-Id");
-            CrossTenantNetworkMessageId = GetHeaderValue("X-MS-Exchange-CrossTenant-Network-Message-Id");
-            ExchangeAuthAs = GetHeaderValue("X-MS-Exchange-Organization-AuthAs");
-            CrossTenantAuthAs = GetHeaderValue("X-MS-Exchange-CrossTenant-AuthAs");
-            ExternalInOutlookResult = GetHeaderValue("X-MS-Exchange-ExternalInOutlookResult");
+            NetworkMessageId = GetTrustedHeaderValue("X-MS-Exchange-Organization-Network-Message-Id");
+            CrossTenantNetworkMessageId = GetTrustedHeaderValue("X-MS-Exchange-CrossTenant-Network-Message-Id");
+            ExchangeAuthAs = GetTrustedHeaderValue("X-MS-Exchange-Organization-AuthAs");
+            CrossTenantAuthAs = GetTrustedHeaderValue("X-MS-Exchange-CrossTenant-AuthAs");
+            ExternalInOutlookResult = GetTrustedHeaderValue("X-MS-Exchange-ExternalInOutlookResult");
 
-            if (int.TryParse(GetHeaderValue("X-MS-Exchange-Organization-SCL"), out var scl)) {
+            if (int.TryParse(GetTrustedHeaderValue("X-MS-Exchange-Organization-SCL"), out var scl)) {
                 Scl = scl;
             }
 
-            var delivery = GetHeaderValue("X-Microsoft-Antispam-Mailbox-Delivery");
+            var delivery = GetTrustedHeaderValue("X-Microsoft-Antispam-Mailbox-Delivery");
             MailboxDestination = ExtractToken(delivery, "dest");
             DeliveredToInbox = string.Equals(MailboxDestination, "I", StringComparison.OrdinalIgnoreCase);
 
-            var forefront = GetHeaderValue("X-Forefront-Antispam-Report");
+            var forefront = GetTrustedHeaderValue("X-Forefront-Antispam-Report");
             ForefrontSourceIp = ExtractToken(forefront, "CIP");
             ForefrontHost = ExtractToken(forefront, "H");
             ForefrontSfv = ExtractToken(forefront, "SFV");
@@ -226,6 +226,14 @@ namespace DomainDetective {
 
         private string? GetHeaderValue(string name) {
             return Headers.TryGetValue(name, out var value) ? value : null;
+        }
+
+        private string? GetTrustedHeaderValue(string name) {
+            if (DuplicateHeaders.TryGetValue(name, out var values) && values.Count > 0) {
+                return values[0];
+            }
+
+            return GetHeaderValue(name);
         }
 
         private bool HasHeaderPrefix(string prefix) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -84,7 +84,7 @@ namespace DomainDetective {
             logger?.ClearLoggedMessages();
 
             if (expectedMxHosts == null) {
-                EmitRouteDiagnostics(logger);
+                EmitExpectedMxDiagnostics(logger);
                 return;
             }
 
@@ -96,7 +96,7 @@ namespace DomainDetective {
             }
 
             if (ExpectedMxHosts.Count == 0) {
-                EmitRouteDiagnostics(logger);
+                EmitExpectedMxDiagnostics(logger);
                 return;
             }
 
@@ -113,7 +113,7 @@ namespace DomainDetective {
                 AddIssue(MessageHeaderIssue.ExpectedMxBypassed);
             }
 
-            EmitRouteDiagnostics(logger);
+            EmitExpectedMxDiagnostics(logger);
         }
 
         private void ResetRouteDiagnostics() {
@@ -172,18 +172,19 @@ namespace DomainDetective {
             }
 
             var hasMicrosoftEopReceivedHop = HasMicrosoftEopReceivedHop();
+            var hasMicrosoftEopIngressHop = HasMicrosoftEopIngressHop();
             SeenMicrosoftEop = HasHeaderPrefix("X-MS-Exchange-")
                 || HasHeaderPrefix("X-Microsoft-Antispam")
                 || HasHeaderPrefix("X-Forefront-")
                 || hasMicrosoftEopReceivedHop;
             SeenProofpoint = HasHeaderPrefix("X-Proofpoint")
                 || HasHeaderContaining("Proofpoint")
-                || ReceivedHops.Any(static hop => ContainsProvider(hop.Raw, "pphosted.com") || ContainsProvider(hop.Raw, "proofpoint"));
+                || ReceivedHops.Any(hop => IsProofpointHost(hop.FromHost) || IsProofpointHost(hop.ByHost));
 
             RedirectedToProofpoint = HasHeaderContaining("RedirectToProofpoint");
             ReceivedFromProofpoint = HasHeaderContaining("EmailReceivedFromPP");
             GatewayLoopDetected = (RedirectedToProofpoint && ReceivedFromProofpoint) || HasGatewayLoopInReceivedRoute();
-            _rawDirectToExchangeOnlineObserved = hasMicrosoftEopReceivedHop
+            _rawDirectToExchangeOnlineObserved = hasMicrosoftEopIngressHop
                 && !string.IsNullOrWhiteSpace(ForefrontSourceIp)
                 && IsAnonymousExchangeAuth();
             DirectToExchangeOnlineObserved = _rawDirectToExchangeOnlineObserved;
@@ -250,6 +251,10 @@ namespace DomainDetective {
             return ReceivedHops.Any(hop => IsMicrosoftEopHost(hop.FromHost) || IsMicrosoftEopHost(hop.ByHost));
         }
 
+        private bool HasMicrosoftEopIngressHop() {
+            return ReceivedHops.Any(hop => IsMicrosoftEopHost(hop.ByHost));
+        }
+
         private ReceivedHop? GetExternalMicrosoftIngressHop() {
             return ReceivedHops
                 .Where(hop => IsMicrosoftEopHost(hop.ByHost) && !IsMicrosoftEopHost(hop.FromHost))
@@ -303,7 +308,7 @@ namespace DomainDetective {
 
         private static bool IsProofpointHost(string? value) {
             return ContainsProvider(value, "pphosted.com")
-                || ContainsProvider(value, "proofpoint");
+                || ContainsProvider(value, "proofpoint.com");
         }
 
         private bool IsAnonymousExchangeAuth() {
@@ -319,14 +324,18 @@ namespace DomainDetective {
             if (GatewayLoopDetected) {
                 WriteRouteWarning(logger, MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
             }
-            if (DirectToExchangeOnlineObserved && ExpectedMxBypassed) {
-                WriteRouteWarning(logger, MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp);
-            }
+            EmitExpectedMxDiagnostics(logger);
             if (AuthenticationFailedDeliveredToInbox) {
                 WriteRouteWarning(logger, MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
             }
             if (SelfSpoofDeliveredToInbox) {
                 WriteRouteWarning(logger, MessageHeaderCodes.SelfSpoofDeliveredToInbox, "Message appears to be same-domain self-spoofing and was delivered to Inbox.");
+            }
+        }
+
+        private void EmitExpectedMxDiagnostics(InternalLogger? logger = null) {
+            if (DirectToExchangeOnlineObserved && ExpectedMxBypassed) {
+                WriteRouteWarning(logger, MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp);
             }
             if (ExpectedMxBypassed) {
                 WriteRouteWarning(logger, MessageHeaderCodes.ExpectedMxBypassed, "Expected public MX hosts were not observed in the message route.");

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -116,6 +116,18 @@ namespace DomainDetective {
             EmitExpectedMxDiagnostics(logger);
         }
 
+        internal void EmitNonMxRouteDiagnostics(InternalLogger? logger = null) {
+            if (GatewayLoopDetected) {
+                WriteRouteWarning(logger, MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
+            }
+            if (AuthenticationFailedDeliveredToInbox) {
+                WriteRouteWarning(logger, MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
+            }
+            if (SelfSpoofDeliveredToInbox) {
+                WriteRouteWarning(logger, MessageHeaderCodes.SelfSpoofDeliveredToInbox, "Message appears to be same-domain self-spoofing and was delivered to Inbox.");
+            }
+        }
+
         private void ResetRouteDiagnostics() {
             MessageId = null;
             NetworkMessageId = null;
@@ -321,16 +333,8 @@ namespace DomainDetective {
         }
 
         internal void EmitRouteDiagnostics(InternalLogger? logger = null) {
-            if (GatewayLoopDetected) {
-                WriteRouteWarning(logger, MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
-            }
+            EmitNonMxRouteDiagnostics(logger);
             EmitExpectedMxDiagnostics(logger);
-            if (AuthenticationFailedDeliveredToInbox) {
-                WriteRouteWarning(logger, MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
-            }
-            if (SelfSpoofDeliveredToInbox) {
-                WriteRouteWarning(logger, MessageHeaderCodes.SelfSpoofDeliveredToInbox, "Message appears to be same-domain self-spoofing and was delivered to Inbox.");
-            }
         }
 
         private void EmitExpectedMxDiagnostics(InternalLogger? logger = null) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -210,7 +210,7 @@ namespace DomainDetective {
             AuthenticationFailedDeliveredToInbox = DeliveredToInbox && DmarcFailed;
             SelfSpoofDeliveredToInbox = DeliveredToInbox
                 && SameDomainSelfSpoof
-                && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox || IsAnonymousExchangeAuth());
+                && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox);
 
         }
 

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -81,6 +81,7 @@ namespace DomainDetective {
             Issues.Remove(MessageHeaderIssue.DirectToExchangeOnline);
             RemoveAssessment(MessageHeaderCodes.ExpectedMxBypassed);
             RemoveAssessment(MessageHeaderCodes.DirectToExchangeOnlineObserved);
+            logger?.ClearLoggedMessages();
 
             if (expectedMxHosts == null) {
                 EmitRouteDiagnostics(logger);
@@ -191,8 +192,7 @@ namespace DomainDetective {
             DkimMissingOrFailed = IsFailureResult(TrustedDkimResult, treatMissingAsFailure: true);
             SpfFailedOrSoftFailed = IsFailureResult(TrustedSpfResult, treatMissingAsFailure: false);
             SameDomainSelfSpoof = TryGetDomain(From, out var fromDomain)
-                && TryGetDomain(To, out var toDomain)
-                && string.Equals(fromDomain, toDomain, StringComparison.OrdinalIgnoreCase);
+                && HasRecipientDomain(To, fromDomain);
 
             AuthenticationFailedDeliveredToInbox = DeliveredToInbox && DmarcFailed;
             SelfSpoofDeliveredToInbox = DeliveredToInbox
@@ -407,7 +407,7 @@ namespace DomainDetective {
         }
 
         private static bool HasHostBoundary(string value, int start, int length) {
-            if (start > 0 && IsDnsHostCharacter(value[start - 1])) {
+            if (start > 0 && IsDnsHostCharacter(value[start - 1]) && value[start - 1] != '.') {
                 return false;
             }
 
@@ -434,11 +434,11 @@ namespace DomainDetective {
         private string? TrustedDmarcResult => _hasTrustedAuthenticationResults ? _trustedDmarcResult : DmarcResult;
 
         private static bool ContainsProvider(string? value, string provider) {
-            if (string.IsNullOrWhiteSpace(value)) {
+            if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(provider)) {
                 return false;
             }
 
-            return value!.IndexOf(provider, StringComparison.OrdinalIgnoreCase) >= 0;
+            return ContainsHostWithBoundary(value, NormalizeHost(provider));
         }
 
         private static bool IsFailureResult(string? result, bool treatMissingAsFailure) {
@@ -482,6 +482,39 @@ namespace DomainDetective {
             }
 
             domain = address.Address.Substring(at + 1);
+            return true;
+        }
+
+        private static bool HasRecipientDomain(string? value, string? domain) {
+            if (string.IsNullOrWhiteSpace(value) || string.IsNullOrWhiteSpace(domain)) {
+                return false;
+            }
+
+            if (InternetAddressList.TryParse(value, out var addresses)) {
+                foreach (var mailbox in addresses.Mailboxes) {
+                    if (TryGetAddressDomain(mailbox.Address, out var recipientDomain)
+                        && string.Equals(recipientDomain, domain, StringComparison.OrdinalIgnoreCase)) {
+                        return true;
+                    }
+                }
+            }
+
+            return TryGetDomain(value, out var singleDomain)
+                && string.Equals(singleDomain, domain, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryGetAddressDomain(string? address, out string? domain) {
+            domain = null;
+            if (string.IsNullOrWhiteSpace(address)) {
+                return false;
+            }
+
+            var at = address!.LastIndexOf('@');
+            if (at < 0 || at == address.Length - 1) {
+                return false;
+            }
+
+            domain = address.Substring(at + 1);
             return true;
         }
     }

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -78,7 +78,9 @@ namespace DomainDetective {
             ExpectedMxBypassed = false;
             DirectToExchangeOnlineObserved = _rawDirectToExchangeOnlineObserved;
             Issues.Remove(MessageHeaderIssue.ExpectedMxBypassed);
+            Issues.Remove(MessageHeaderIssue.DirectToExchangeOnline);
             RemoveAssessment(MessageHeaderCodes.ExpectedMxBypassed);
+            RemoveAssessment(MessageHeaderCodes.DirectToExchangeOnlineObserved);
 
             if (expectedMxHosts == null) {
                 EmitRouteDiagnostics(logger);
@@ -237,8 +239,13 @@ namespace DomainDetective {
         }
 
         private bool IsHostObservedAtMicrosoftIngress(string host) {
-            var ingressHop = ReceivedHops.FirstOrDefault(hop => IsMicrosoftEopHost(hop.ByHost));
-            return ingressHop != null && IsSameHost(ingressHop.FromHost, host);
+            var ingressHop = ReceivedHops
+                .Where(hop => IsMicrosoftEopHost(hop.ByHost))
+                .OrderBy(hop => hop.HeaderIndex)
+                .FirstOrDefault();
+            return ingressHop != null
+                && (IsSameHost(ingressHop.FromHost, host)
+                    || (IsMicrosoftEopHost(host) && IsSameHost(ingressHop.ByHost, host)));
         }
 
         private static string? ExtractToken(string? value, string key) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -81,9 +81,6 @@ namespace DomainDetective {
             RemoveAssessment(MessageHeaderCodes.ExpectedMxBypassed);
 
             if (expectedMxHosts == null) {
-                if (DirectToExchangeOnlineObserved) {
-                    AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
-                }
                 EmitRouteDiagnostics(logger);
                 return;
             }
@@ -96,24 +93,20 @@ namespace DomainDetective {
             }
 
             if (ExpectedMxHosts.Count == 0) {
-                if (DirectToExchangeOnlineObserved) {
-                    AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
-                }
                 EmitRouteDiagnostics(logger);
                 return;
             }
 
-            ExpectedMxObserved = ExpectedMxHosts.Any(IsHostObserved);
+            ExpectedMxObserved = ExpectedMxHosts.Any(IsHostObservedAtMicrosoftIngress);
             if (ExpectedMxObserved) {
                 DirectToExchangeOnlineObserved = false;
                 Issues.Remove(MessageHeaderIssue.DirectToExchangeOnline);
                 RemoveAssessment(MessageHeaderCodes.DirectToExchangeOnlineObserved);
-            } else if (DirectToExchangeOnlineObserved) {
-                AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
             }
 
             ExpectedMxBypassed = !ExpectedMxObserved && _rawDirectToExchangeOnlineObserved;
             if (ExpectedMxBypassed) {
+                AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
                 AddIssue(MessageHeaderIssue.ExpectedMxBypassed);
             }
 
@@ -194,12 +187,11 @@ namespace DomainDetective {
             DmarcFailed = IsFailureResult(TrustedDmarcResult, treatMissingAsFailure: false);
             DkimMissingOrFailed = IsFailureResult(TrustedDkimResult, treatMissingAsFailure: true);
             SpfFailedOrSoftFailed = IsFailureResult(TrustedSpfResult, treatMissingAsFailure: false);
-            var dkimFailed = IsExplicitFailureResult(TrustedDkimResult);
             SameDomainSelfSpoof = TryGetDomain(From, out var fromDomain)
                 && TryGetDomain(To, out var toDomain)
                 && string.Equals(fromDomain, toDomain, StringComparison.OrdinalIgnoreCase);
 
-            AuthenticationFailedDeliveredToInbox = DeliveredToInbox && (DmarcFailed || dkimFailed || SpfFailedOrSoftFailed);
+            AuthenticationFailedDeliveredToInbox = DeliveredToInbox && DmarcFailed;
             SelfSpoofDeliveredToInbox = DeliveredToInbox
                 && SameDomainSelfSpoof
                 && (DirectToExchangeOnlineObserved || AuthenticationFailedDeliveredToInbox || IsAnonymousExchangeAuth());
@@ -210,7 +202,7 @@ namespace DomainDetective {
             if (GatewayLoopDetected) {
                 AddIssue(MessageHeaderIssue.GatewayLoopDetected);
             }
-            if (DirectToExchangeOnlineObserved) {
+            if (DirectToExchangeOnlineObserved && ExpectedMxBypassed) {
                 AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
             }
             if (AuthenticationFailedDeliveredToInbox) {
@@ -244,10 +236,9 @@ namespace DomainDetective {
             return Headers.Keys.Any(key => key.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0);
         }
 
-        private bool IsHostObserved(string host) {
-            return IsSameHost(ForefrontHost, host)
-                || ReceivedHops.Any(hop => IsSameHost(hop.FromHost, host)
-                    || IsSameHost(hop.ByHost, host));
+        private bool IsHostObservedAtMicrosoftIngress(string host) {
+            var ingressHop = ReceivedHops.FirstOrDefault(hop => IsMicrosoftEopHost(hop.ByHost));
+            return ingressHop != null && IsSameHost(ingressHop.FromHost, host);
         }
 
         private static string? ExtractToken(string? value, string key) {
@@ -305,7 +296,7 @@ namespace DomainDetective {
             if (GatewayLoopDetected) {
                 WriteRouteWarning(logger, MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
             }
-            if (DirectToExchangeOnlineObserved) {
+            if (DirectToExchangeOnlineObserved && ExpectedMxBypassed) {
                 WriteRouteWarning(logger, MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp);
             }
             if (AuthenticationFailedDeliveredToInbox) {

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.Route.cs
@@ -1,0 +1,276 @@
+using MimeKit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace DomainDetective {
+    public partial class MessageHeaderAnalysis {
+        private static readonly Regex SemicolonTokenRegex = new(@"(?<key>[A-Z0-9]+):(?<value>[^;]+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        /// <summary>Value of the <c>Message-ID</c> header.</summary>
+        public string? MessageId { get; private set; }
+        /// <summary>Microsoft network message identifier when present.</summary>
+        public string? NetworkMessageId { get; private set; }
+        /// <summary>Microsoft cross-tenant network message identifier when present.</summary>
+        public string? CrossTenantNetworkMessageId { get; private set; }
+        /// <summary>Authentication attribution reported by Exchange Online.</summary>
+        public string? ExchangeAuthAs { get; private set; }
+        /// <summary>Cross-tenant authentication attribution reported by Exchange Online.</summary>
+        public string? CrossTenantAuthAs { get; private set; }
+        /// <summary>Spam confidence level reported by Exchange Online.</summary>
+        public int? Scl { get; private set; }
+        /// <summary>Mailbox destination parsed from Microsoft anti-spam delivery headers.</summary>
+        public string? MailboxDestination { get; private set; }
+        /// <summary>Connecting IP parsed from <c>X-Forefront-Antispam-Report</c>.</summary>
+        public string? ForefrontSourceIp { get; private set; }
+        /// <summary>Source host parsed from <c>X-Forefront-Antispam-Report</c>.</summary>
+        public string? ForefrontHost { get; private set; }
+        /// <summary>Spam filtering verdict parsed from <c>X-Forefront-Antispam-Report</c>.</summary>
+        public string? ForefrontSfv { get; private set; }
+        /// <summary>External sender tagging result reported by Outlook/Exchange Online.</summary>
+        public string? ExternalInOutlookResult { get; private set; }
+        /// <summary>Indicates that Microsoft Exchange Online Protection headers or hops were observed.</summary>
+        public bool SeenMicrosoftEop { get; private set; }
+        /// <summary>Indicates that Proofpoint headers or hops were observed.</summary>
+        public bool SeenProofpoint { get; private set; }
+        /// <summary>Indicates that the message appears to have entered Exchange Online directly.</summary>
+        public bool DirectToExchangeOnlineObserved { get; private set; }
+        /// <summary>Indicates that Microsoft classified the delivered destination as Inbox.</summary>
+        public bool DeliveredToInbox { get; private set; }
+        /// <summary>Indicates that DMARC failed or did not produce a pass result.</summary>
+        public bool DmarcFailed { get; private set; }
+        /// <summary>Indicates that DKIM was missing, failed, or did not produce a pass result.</summary>
+        public bool DkimMissingOrFailed { get; private set; }
+        /// <summary>Indicates that SPF failed, soft-failed, or did not produce a pass result.</summary>
+        public bool SpfFailedOrSoftFailed { get; private set; }
+        /// <summary>Indicates that From and To use the same address domain.</summary>
+        public bool SameDomainSelfSpoof { get; private set; }
+        /// <summary>Indicates that Microsoft headers show routing toward Proofpoint after Exchange Online.</summary>
+        public bool RedirectedToProofpoint { get; private set; }
+        /// <summary>Indicates that Microsoft headers show a message returning from Proofpoint.</summary>
+        public bool ReceivedFromProofpoint { get; private set; }
+        /// <summary>Indicates a likely EOP to gateway to EOP processing loop.</summary>
+        public bool GatewayLoopDetected { get; private set; }
+        /// <summary>Indicates failed authentication on a message that still reached Inbox.</summary>
+        public bool AuthenticationFailedDeliveredToInbox { get; private set; }
+        /// <summary>Indicates same-domain self-spoofing on a message that still reached Inbox.</summary>
+        public bool SelfSpoofDeliveredToInbox { get; private set; }
+        /// <summary>Expected public MX hosts supplied by the caller for route comparison.</summary>
+        public List<string> ExpectedMxHosts { get; } = new();
+        /// <summary>Indicates that at least one expected public MX host appears in the observed route.</summary>
+        public bool ExpectedMxObserved { get; private set; }
+        /// <summary>Indicates that expected MX hosts were not observed while direct Exchange Online ingress was observed.</summary>
+        public bool ExpectedMxBypassed { get; private set; }
+        /// <summary>First likely external source IP from structured Microsoft headers or Received hops.</summary>
+        public string? SourceIp => ForefrontSourceIp ?? ReceivedHops.FirstOrDefault(static hop => !string.IsNullOrWhiteSpace(hop.FromIp))?.FromIp;
+
+        /// <summary>
+        /// Compares the observed message path with expected public MX host names.
+        /// </summary>
+        /// <param name="expectedMxHosts">Public MX host names expected to process inbound mail first.</param>
+        public void CompareExpectedMx(IEnumerable<string>? expectedMxHosts) {
+            ExpectedMxHosts.Clear();
+            ExpectedMxObserved = false;
+            ExpectedMxBypassed = false;
+
+            if (expectedMxHosts == null) {
+                return;
+            }
+
+            foreach (var host in expectedMxHosts) {
+                if (!string.IsNullOrWhiteSpace(host)) {
+                    ExpectedMxHosts.Add(host.Trim());
+                }
+            }
+
+            if (ExpectedMxHosts.Count == 0) {
+                return;
+            }
+
+            ExpectedMxObserved = ExpectedMxHosts.Any(IsHostObserved);
+            ExpectedMxBypassed = !ExpectedMxObserved && DirectToExchangeOnlineObserved;
+            if (ExpectedMxBypassed) {
+                AddIssue(MessageHeaderIssue.ExpectedMxBypassed);
+            }
+        }
+
+        private void ResetRouteDiagnostics() {
+            MessageId = null;
+            NetworkMessageId = null;
+            CrossTenantNetworkMessageId = null;
+            ExchangeAuthAs = null;
+            CrossTenantAuthAs = null;
+            Scl = null;
+            MailboxDestination = null;
+            ForefrontSourceIp = null;
+            ForefrontHost = null;
+            ForefrontSfv = null;
+            ExternalInOutlookResult = null;
+            SeenMicrosoftEop = false;
+            SeenProofpoint = false;
+            DirectToExchangeOnlineObserved = false;
+            DeliveredToInbox = false;
+            DmarcFailed = false;
+            DkimMissingOrFailed = false;
+            SpfFailedOrSoftFailed = false;
+            SameDomainSelfSpoof = false;
+            RedirectedToProofpoint = false;
+            ReceivedFromProofpoint = false;
+            GatewayLoopDetected = false;
+            AuthenticationFailedDeliveredToInbox = false;
+            SelfSpoofDeliveredToInbox = false;
+            ExpectedMxHosts.Clear();
+            ExpectedMxObserved = false;
+            ExpectedMxBypassed = false;
+        }
+
+        private void AnalyzeRouteHeaders(InternalLogger? logger) {
+            MessageId = GetHeaderValue("Message-ID");
+            NetworkMessageId = GetHeaderValue("X-MS-Exchange-Organization-Network-Message-Id");
+            CrossTenantNetworkMessageId = GetHeaderValue("X-MS-Exchange-CrossTenant-Network-Message-Id");
+            ExchangeAuthAs = GetHeaderValue("X-MS-Exchange-Organization-AuthAs");
+            CrossTenantAuthAs = GetHeaderValue("X-MS-Exchange-CrossTenant-AuthAs");
+            ExternalInOutlookResult = GetHeaderValue("X-MS-Exchange-ExternalInOutlookResult");
+
+            if (int.TryParse(GetHeaderValue("X-MS-Exchange-Organization-SCL"), out var scl)) {
+                Scl = scl;
+            }
+
+            var delivery = GetHeaderValue("X-Microsoft-Antispam-Mailbox-Delivery");
+            MailboxDestination = ExtractToken(delivery, "dest");
+            DeliveredToInbox = string.Equals(MailboxDestination, "I", StringComparison.OrdinalIgnoreCase);
+
+            var forefront = GetHeaderValue("X-Forefront-Antispam-Report");
+            ForefrontSourceIp = ExtractToken(forefront, "CIP");
+            ForefrontHost = ExtractToken(forefront, "H");
+            ForefrontSfv = ExtractToken(forefront, "SFV");
+            if (!Scl.HasValue && int.TryParse(ExtractToken(forefront, "SCL"), out var forefrontScl)) {
+                Scl = forefrontScl;
+            }
+
+            SeenMicrosoftEop = HasHeaderPrefix("X-MS-Exchange-")
+                || HasHeaderPrefix("X-Microsoft-Antispam")
+                || HasHeaderPrefix("X-Forefront-")
+                || ReceivedHops.Any(static hop => ContainsProvider(hop.Raw, "protection.outlook.com") || ContainsProvider(hop.Raw, "prod.outlook.com"));
+            SeenProofpoint = HasHeaderPrefix("X-Proofpoint")
+                || HasHeaderContaining("Proofpoint")
+                || ReceivedHops.Any(static hop => ContainsProvider(hop.Raw, "pphosted.com") || ContainsProvider(hop.Raw, "proofpoint"));
+
+            RedirectedToProofpoint = HasHeaderContaining("RedirectToProofpoint");
+            ReceivedFromProofpoint = HasHeaderContaining("EmailReceivedFromPP");
+            GatewayLoopDetected = RedirectedToProofpoint && ReceivedFromProofpoint;
+            DirectToExchangeOnlineObserved = SeenMicrosoftEop
+                && !string.IsNullOrWhiteSpace(ForefrontSourceIp)
+                && string.Equals(ExchangeAuthAs, "Anonymous", StringComparison.OrdinalIgnoreCase);
+
+            DmarcFailed = IsFailureResult(DmarcResult, treatMissingAsFailure: false);
+            DkimMissingOrFailed = IsFailureResult(DkimResult, treatMissingAsFailure: true);
+            SpfFailedOrSoftFailed = IsFailureResult(SpfResult, treatMissingAsFailure: false);
+            SameDomainSelfSpoof = TryGetDomain(From, out var fromDomain)
+                && TryGetDomain(To, out var toDomain)
+                && string.Equals(fromDomain, toDomain, StringComparison.OrdinalIgnoreCase);
+
+            AuthenticationFailedDeliveredToInbox = DeliveredToInbox && (DmarcFailed || DkimMissingOrFailed || SpfFailedOrSoftFailed);
+            SelfSpoofDeliveredToInbox = DeliveredToInbox && SameDomainSelfSpoof;
+
+            if (GatewayLoopDetected) {
+                logger?.WriteWarningCode(MessageHeaderCodes.GatewayLoopDetected, "Message headers show Exchange Online routing to Proofpoint and returning to Exchange Online.");
+            }
+            if (DirectToExchangeOnlineObserved) {
+                logger?.WriteWarningCode(MessageHeaderCodes.DirectToExchangeOnlineObserved, "Message appears to have entered Exchange Online directly from {0}.", ForefrontSourceIp ?? "unknown source");
+            }
+            if (AuthenticationFailedDeliveredToInbox) {
+                logger?.WriteWarningCode(MessageHeaderCodes.AuthenticationFailedDeliveredToInbox, "Message reached Inbox even though SPF, DKIM, or DMARC did not pass.");
+            }
+            if (SelfSpoofDeliveredToInbox) {
+                logger?.WriteWarningCode(MessageHeaderCodes.SelfSpoofDeliveredToInbox, "Message appears to be same-domain self-spoofing and was delivered to Inbox.");
+            }
+        }
+
+        private void DetermineRouteIssues() {
+            if (GatewayLoopDetected) {
+                AddIssue(MessageHeaderIssue.GatewayLoopDetected);
+            }
+            if (DirectToExchangeOnlineObserved) {
+                AddIssue(MessageHeaderIssue.DirectToExchangeOnline);
+            }
+            if (AuthenticationFailedDeliveredToInbox) {
+                AddIssue(MessageHeaderIssue.AuthenticationFailedDeliveredToInbox);
+            }
+            if (SelfSpoofDeliveredToInbox) {
+                AddIssue(MessageHeaderIssue.SelfSpoofDeliveredToInbox);
+            }
+            if (ExpectedMxBypassed) {
+                AddIssue(MessageHeaderIssue.ExpectedMxBypassed);
+            }
+        }
+
+        private string? GetHeaderValue(string name) {
+            return Headers.TryGetValue(name, out var value) ? value : null;
+        }
+
+        private bool HasHeaderPrefix(string prefix) {
+            return Headers.Keys.Any(key => key.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private bool HasHeaderContaining(string text) {
+            return Headers.Keys.Any(key => key.IndexOf(text, StringComparison.OrdinalIgnoreCase) >= 0);
+        }
+
+        private bool IsHostObserved(string host) {
+            return Headers.Any(header => ContainsProvider(header.Value, host))
+                || ReceivedHops.Any(hop => ContainsProvider(hop.Raw, host));
+        }
+
+        private static string? ExtractToken(string? value, string key) {
+            if (string.IsNullOrWhiteSpace(value)) {
+                return null;
+            }
+
+            foreach (Match match in SemicolonTokenRegex.Matches(value)) {
+                if (string.Equals(match.Groups["key"].Value, key, StringComparison.OrdinalIgnoreCase)) {
+                    return match.Groups["value"].Value.Trim();
+                }
+            }
+
+            return null;
+        }
+
+        private static bool ContainsProvider(string value, string provider) {
+            return value.IndexOf(provider, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+
+        private static bool IsFailureResult(string? result, bool treatMissingAsFailure) {
+            if (string.IsNullOrWhiteSpace(result)) {
+                return treatMissingAsFailure;
+            }
+
+            var normalized = result!.Trim();
+            return normalized.StartsWith("fail", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("softfail", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("permerror", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("temperror", StringComparison.OrdinalIgnoreCase)
+                || normalized.StartsWith("none", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool TryGetDomain(string? value, out string? domain) {
+            domain = null;
+            if (string.IsNullOrWhiteSpace(value)) {
+                return false;
+            }
+
+            if (!MailboxAddress.TryParse(value, out var address) || string.IsNullOrWhiteSpace(address.Address)) {
+                return false;
+            }
+
+            var at = address.Address.LastIndexOf('@');
+            if (at < 0 || at == address.Address.Length - 1) {
+                return false;
+            }
+
+            domain = address.Address.Substring(at + 1);
+            return true;
+        }
+    }
+}

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -47,6 +47,11 @@ namespace DomainDetective {
         /// <summary>Ignored DKIM-Signature headers with invalid signature values.</summary>
         public List<string> InvalidDkimSignatures { get; } = new();
 
+        private bool _hasTrustedAuthenticationResults;
+        private string? _trustedDkimResult;
+        private string? _trustedSpfResult;
+        private string? _trustedDmarcResult;
+
         /// <summary>Collection of detected issues.</summary>
         public List<MessageHeaderIssue> Issues { get; } = new();
 
@@ -80,6 +85,10 @@ namespace DomainDetective {
             SpfResult = null;
             DmarcResult = null;
             ArcResult = null;
+            _hasTrustedAuthenticationResults = false;
+            _trustedDkimResult = null;
+            _trustedSpfResult = null;
+            _trustedDmarcResult = null;
             ResetRouteDiagnostics();
             if (string.IsNullOrWhiteSpace(rawHeaders)) {
                 logger?.WriteVerbose("No headers supplied for parsing.");
@@ -104,6 +113,7 @@ namespace DomainDetective {
                         ComputeTransitTime();
                         AnalyzeRouteHeaders(logger);
                         DetermineIssues();
+                        EmitRouteDiagnostics(logger);
                         return;
                     }
                 }
@@ -130,6 +140,7 @@ namespace DomainDetective {
 
             AnalyzeRouteHeaders(logger);
             DetermineIssues();
+            EmitRouteDiagnostics(logger);
         }
 
         private static readonly Regex FoldingWhitespace = new("\r?\n[ \t]+", RegexOptions.Compiled);
@@ -232,17 +243,42 @@ namespace DomainDetective {
         }
 
         private void ParseAuthenticationResults(string value) {
+            string? dkim = null;
+            string? spf = null;
+            string? dmarc = null;
+            string? arc = null;
+
             foreach (var part in value.Split(';')) {
                 var trimmed = part.Trim();
                 if (trimmed.StartsWith("dkim=", StringComparison.OrdinalIgnoreCase)) {
-                    DkimResult = trimmed.Substring(5).Trim();
+                    dkim = trimmed.Substring(5).Trim();
                 } else if (trimmed.StartsWith("spf=", StringComparison.OrdinalIgnoreCase)) {
-                    SpfResult = trimmed.Substring(4).Trim();
+                    spf = trimmed.Substring(4).Trim();
                 } else if (trimmed.StartsWith("dmarc=", StringComparison.OrdinalIgnoreCase)) {
-                    DmarcResult = trimmed.Substring(6).Trim();
+                    dmarc = trimmed.Substring(6).Trim();
                 } else if (trimmed.StartsWith("arc=", StringComparison.OrdinalIgnoreCase)) {
-                    ArcResult = trimmed.Substring(4).Trim();
+                    arc = trimmed.Substring(4).Trim();
                 }
+            }
+
+            if (dkim != null) {
+                DkimResult = dkim;
+            }
+            if (spf != null) {
+                SpfResult = spf;
+            }
+            if (dmarc != null) {
+                DmarcResult = dmarc;
+            }
+            if (arc != null) {
+                ArcResult = arc;
+            }
+
+            if (!_hasTrustedAuthenticationResults && (dkim != null || spf != null || dmarc != null || arc != null)) {
+                _hasTrustedAuthenticationResults = true;
+                _trustedDkimResult = dkim;
+                _trustedSpfResult = spf;
+                _trustedDmarcResult = dmarc;
             }
         }
 

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -11,7 +11,7 @@ namespace DomainDetective {
     /// Represents the results from parsing message headers.
     /// </summary>
     /// <para>Part of the DomainDetective project.</para>
-    public class MessageHeaderAnalysis : IHasAssessments {
+    public partial class MessageHeaderAnalysis : IHasAssessments {
         /// <summary>Raw headers supplied for parsing.</summary>
         public string? RawHeaders { get; private set; }
         /// <summary>All parsed headers keyed by header name.</summary>
@@ -80,6 +80,7 @@ namespace DomainDetective {
             SpfResult = null;
             DmarcResult = null;
             ArcResult = null;
+            ResetRouteDiagnostics();
             if (string.IsNullOrWhiteSpace(rawHeaders)) {
                 logger?.WriteVerbose("No headers supplied for parsing.");
                 return;
@@ -101,6 +102,7 @@ namespace DomainDetective {
                         logger?.WriteErrorCode(MessageHeaderCodes.MimeParseFailed, "MimeKit failed to parse headers: {0}", ex.Message);
                         ParseManually(rawHeaders, logger);
                         ComputeTransitTime();
+                        AnalyzeRouteHeaders(logger);
                         DetermineIssues();
                         return;
                     }
@@ -126,6 +128,7 @@ namespace DomainDetective {
                 logger?.WriteInformationCode(MessageHeaderCodes.ArcPass, "ARC authentication passed");
             }
 
+            AnalyzeRouteHeaders(logger);
             DetermineIssues();
         }
 
@@ -342,6 +345,8 @@ namespace DomainDetective {
             } else if (!string.Equals(arcResult, "pass", StringComparison.OrdinalIgnoreCase)) {
                 AddIssue(MessageHeaderIssue.InvalidArc);
             }
+
+            DetermineRouteIssues();
         }
     }
 }

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -66,6 +66,10 @@ namespace DomainDetective {
         /// <param name="rawHeaders">Unparsed header text.</param>
         /// <param name="logger">Logger used for diagnostics.</param>
         public void Parse(string rawHeaders, InternalLogger? logger = null) {
+            Parse(rawHeaders, logger, emitRouteDiagnostics: true);
+        }
+
+        internal void Parse(string rawHeaders, InternalLogger? logger, bool emitRouteDiagnostics) {
             using var _collector = logger != null ? AssessmentCollector.ForAnalysis(logger, this, category: "HEADERS") : null;
             RawHeaders = rawHeaders;
             Headers.Clear();
@@ -113,7 +117,9 @@ namespace DomainDetective {
                         ComputeTransitTime();
                         AnalyzeRouteHeaders(logger);
                         DetermineIssues();
-                        EmitRouteDiagnostics(logger);
+                        if (emitRouteDiagnostics) {
+                            EmitRouteDiagnostics(logger);
+                        }
                         return;
                     }
                 }
@@ -140,7 +146,9 @@ namespace DomainDetective {
 
             AnalyzeRouteHeaders(logger);
             DetermineIssues();
-            EmitRouteDiagnostics(logger);
+            if (emitRouteDiagnostics) {
+                EmitRouteDiagnostics(logger);
+            }
         }
 
         private static readonly Regex FoldingWhitespace = new("\r?\n[ \t]+", RegexOptions.Compiled);

--- a/DomainDetective/Protocols/MessageHeaderAnalysis.cs
+++ b/DomainDetective/Protocols/MessageHeaderAnalysis.cs
@@ -18,7 +18,7 @@ namespace DomainDetective {
         public Dictionary<string, string> Headers { get; } = new(StringComparer.OrdinalIgnoreCase);
         /// <summary>Duplicate header values keyed by header name.</summary>
         public Dictionary<string, List<string>> DuplicateHeaders { get; } = new(StringComparer.OrdinalIgnoreCase);
-        /// <summary>List of parsed <c>Received</c> header hops in order.</summary>
+        /// <summary>List of parsed <c>Received</c> header hops. Use <see cref="ReceivedHop.HeaderIndex"/> for original header order.</summary>
         public List<ReceivedHop> ReceivedHops { get; } = new();
         /// <summary>Total message transit time across all hops.</summary>
         public TimeSpan? TotalTransitTime { get; private set; }
@@ -181,7 +181,9 @@ namespace DomainDetective {
 
             switch (lower) {
                 case "received":
-                    ReceivedHops.Add(ReceivedHop.Parse(value));
+                    var hop = ReceivedHop.Parse(value);
+                    hop.HeaderIndex = ReceivedHops.Count;
+                    ReceivedHops.Add(hop);
                     break;
                 case "from":
                     From = value;

--- a/DomainDetective/Protocols/MessageHeaderIssue.cs
+++ b/DomainDetective/Protocols/MessageHeaderIssue.cs
@@ -9,5 +9,15 @@ public enum MessageHeaderIssue {
     /// <summary>The ARC chain exists but failed validation.</summary>
     InvalidArc,
     /// <summary>One or more DKIM signatures were invalid.</summary>
-    InvalidDkim
+    InvalidDkim,
+    /// <summary>The message appears to have entered Exchange Online directly.</summary>
+    DirectToExchangeOnline,
+    /// <summary>The message was delivered to Inbox despite failed authentication.</summary>
+    AuthenticationFailedDeliveredToInbox,
+    /// <summary>The message appears to be same-domain self-spoofing and reached Inbox.</summary>
+    SelfSpoofDeliveredToInbox,
+    /// <summary>The message appears to have looped between Exchange Online and a third-party gateway.</summary>
+    GatewayLoopDetected,
+    /// <summary>The expected public MX path was not observed while direct Exchange Online ingress was observed.</summary>
+    ExpectedMxBypassed
 }

--- a/DomainDetective/Protocols/ReceivedHop.cs
+++ b/DomainDetective/Protocols/ReceivedHop.cs
@@ -24,6 +24,8 @@ public class ReceivedHop {
     public DateTimeOffset? Timestamp { get; set; }
     /// <summary>Delay since the previous hop.</summary>
     public TimeSpan? HopDelay { get; set; }
+    /// <summary>Zero-based order in which the header appeared in the message.</summary>
+    public int HeaderIndex { get; set; }
     /// <summary>Raw header value.</summary>
     public string Raw { get; set; } = string.Empty;
 


### PR DESCRIPTION
## Summary
- detect direct Exchange Online ingress, expected MX bypass, failed-auth Inbox delivery, self-spoof delivery, and gateway loop evidence from message headers
- expose expected MX comparison through CLI and PowerShell `Get-DDEmailMessageHeaderInfo -ExpectedMx`
- add recommendations and focused message-header coverage

## Tests
- `dotnet test DomainDetective.Tests\DomainDetective.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~TestMessageHeader" --no-restore`
- `dotnet test DomainDetective.Tests\DomainDetective.Tests.csproj --framework net472 --filter "FullyQualifiedName~TestMessageHeader" --no-restore`
- `dotnet build DomainDetective.CLI\DomainDetective.CLI.csproj --framework net8.0 --no-restore`
- `dotnet build DomainDetective.CLI\DomainDetective.CLI.csproj --framework net10.0 --no-restore`
- `dotnet build DomainDetective.PowerShell\DomainDetective.PowerShell.csproj --framework net8.0 --no-restore`
- `dotnet build DomainDetective.PowerShell\DomainDetective.PowerShell.csproj --framework net472 --no-restore`
- PowerShell smoke: imported built module and confirmed `Get-DDEmailMessageHeaderInfo -ExpectedMx` returns direct EOP and expected MX bypass flags