### PR TITLE
Repin PowerForge website workflows

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -68,7 +68,7 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
 }
 
 $deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
-$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@69190d5ee56c844210e69cd3b2b3a7e128148360'
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700'
 $deployWorkflowUses = $null
 $guardrailValue = $null
 $inDeployJob = $false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@69190d5ee56c844210e69cd3b2b3a7e128148360
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -26,7 +26,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 69190d5ee56c844210e69cd3b2b3a7e128148360
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   actions: write
   contents: read
+  packages: read
   pages: write
   id-token: write
 

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -51,13 +51,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@69190d5ee56c844210e69cd3b2b3a7e128148360
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 69190d5ee56c844210e69cd3b2b3a7e128148360
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -18,6 +18,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: read
 
 env:
   BUILD_CONFIGURATION: 'Release'

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   actions: write
   contents: read
+  packages: read
 
 concurrency:
   group: website-maintenance-${{ github.ref }}

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -15,13 +15,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@69190d5ee56c844210e69cd3b2b3a7e128148360
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 69190d5ee56c844210e69cd3b2b3a7e128148360
+      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## What changed
- Repins the website reusable workflows to PSPublishModule `9d9f2d2c0fde07aaeb76518a787b52b49fbe5700`.
- Keeps the change scoped to workflow references and `powerforge_ref` values.
- Picks up the shared Magick.NET and Scriban package-audit fixes already merged in PSPublishModule.

## Notes
No product code changed. This is the downstream pin update for the scheduled Website Maintenance package-audit failures.