### PR TITLE
fix: repin website workflows to secure PowerForge

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -68,7 +68,7 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
 }
 
 $deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
-$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700'
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b'
 $deployWorkflowUses = $null
 $guardrailValue = $null
 $inDeployJob = $false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
+      powerforge_ref: 0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@dd88fcac5f50143a774cbe47a6705a83d400bfe1
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: dd88fcac5f50143a774cbe47a6705a83d400bfe1
+      powerforge_ref: 0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 9d9f2d2c0fde07aaeb76518a787b52b49fbe5700
+      powerforge_ref: 0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
Repins DomainDetective's reusable PowerForge website workflows and source reference to shared commit `0b17dd8626a0164c922bfb0580e4f7f0b8b2857b`, replacing audit-vulnerable pinned source revisions.

The repository contract check now verifies the deployment workflow against the same immutable shared revision.