### PR TITLE
Restore DNSSEC trust-anchor package compatibility

### DIFF
--- a/DomainDetective/DomainDetective.csproj
+++ b/DomainDetective/DomainDetective.csproj
@@ -14,7 +14,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DnsClientX" Version="2.0.0" />
+        <PackageReference Include="DnsClientX" Version="2.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- update DomainDetective from DnsClientX 2.0.0 to the public 2.1.0 release
- restore the DNSSEC trust-anchor APIs consumed by DomainDetective
- keep the repaired System.Security.Cryptography.Xml 10.0.10 audit pin already present on `master`

## Why
DomainDetective source consumes trust-anchor types added after DnsClientX 2.0.0. DnsClientX 2.1.0 is now published and carries that API, so clean restores no longer depend on an older source checkout or a local package bridge.

## Validation
- public NuGet.org package verified with author and repository signatures
- public package exports all seven trust-anchor types
- clean-cache NuGet.org restore succeeded
- focused DNSSEC tests: 21/21 on .NET 10 and 21/21 on .NET 8
- full .NET 10 suite: 1,918 passed, 16 skipped

## Release
- DnsClientX 2.1.0: https://www.nuget.org/packages/DnsClientX/2.1.0
- GitHub release: https://github.com/EvotecIT/DnsClientX/releases/tag/DnsClientX-v20260724095714