### PR TITLE
fix(ci): repin PowerForge website workflows

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -68,7 +68,7 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
 }
 
 $deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
-$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b'
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037'
 $deployWorkflowUses = $null
 $guardrailValue = $null
 $inDeployJob = $false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 0b17dd8626a0164c922bfb0580e4f7f0b8b2857b
+      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
Repins the website CI, deployment, and maintenance callers to the verified PowerForge commit c6451c9d264a81c7f179b38f6e4d2b62f0784037.\n\nThis shared revision resolves the Magick.NET 14.14.0 audit failures seen in the scheduled website maintenance run, while keeping the existing workflow configuration intact.