### PR TITLE
Verify website LLMS installation metadata

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -68,7 +68,7 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
 }
 
 $deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
-$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037'
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@683531aed9652851a03b1301624b9c769ce62d52'
 $deployWorkflowUses = $null
 $guardrailValue = $null
 $inDeployJob = $false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@683531aed9652851a03b1301624b9c769ce62d52
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -27,7 +27,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
+      powerforge_ref: 683531aed9652851a03b1301624b9c769ce62d52
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@683531aed9652851a03b1301624b9c769ce62d52
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
+      powerforge_ref: 683531aed9652851a03b1301624b9c769ce62d52
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@c6451c9d264a81c7f179b38f6e4d2b62f0784037
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@683531aed9652851a03b1301624b9c769ce62d52
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: c6451c9d264a81c7f179b38f6e4d2b62f0784037
+      powerforge_ref: 683531aed9652851a03b1301624b9c769ce62d52
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/llms-quickstart.cs
+++ b/Website/llms-quickstart.cs
@@ -1,0 +1,6 @@
+using DomainDetective;
+
+var healthCheck = new DomainHealthCheck();
+await healthCheck.Verify("example.com");
+
+Console.WriteLine(healthCheck.ToJson());

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -277,18 +277,39 @@
       "errorPreviewCount": 10
     },
     {
+      "task": "ecosystem-stats",
+      "id": "build-llms-publication-catalog",
+      "dependsOn": "verify-ci-final",
+      "out": "./_temp/llms-publication-catalog.json",
+      "publishPath": "",
+      "summaryPath": "./_temp/llms-publication-catalog-summary.json",
+      "nugetOwner": "Evotec",
+      "psgalleryOwner": "Przemyslaw.Klys",
+      "timeoutSeconds": 120,
+      "preserveOnWarnings": false,
+      "strict": true
+    },
+    {
       "task": "llms",
       "id": "build-llms",
-      "dependsOn": "verify-ci-final",
+      "dependsOn": "build-llms-publication-catalog",
       "siteRoot": "./_site",
+      "contentKind": "Package",
+      "project": "../DomainDetective/DomainDetective.csproj",
+      "packageFiles": ["../DomainDetective/DomainDetective.csproj", "../Module/DomainDetective.psd1"],
+      "installPolicy": "VerifiedCatalog",
+      "publicationCatalog": "./_temp/llms-publication-catalog.json",
+      "nugetOwner": "Evotec",
+      "powerShellGalleryOwner": "Przemyslaw.Klys",
+      "publicationCatalogMaxAgeHours": 24,
       "apiIndex": "./_site/api/index.json",
       "apiBase": "/api",
+      "apiLevel": "Summary",
       "name": "DomainDetective",
-      "package": "DomainDetective",
       "overview": "DomainDetective is a comprehensive domain analysis toolkit supporting 115+ protocols for DNS, email security, TLS, web security, and threat intelligence analysis.",
       "license": "MIT",
       "targets": ".NET 8+, .NET 10+, PowerShell 5.1+",
-      "quickstart": "./llms-quickstart.txt"
+      "quickstart": "./llms-quickstart.cs"
     },
     {
       "task": "sitemap",


### PR DESCRIPTION
## Summary

- generate a fresh owner-scoped publication catalog before LLMS output
- emit NuGet and PowerShell Gallery install commands only when the exact package version is verified for the configured Evotec owner
- use explicit Package mode, retain both package manifests, and add a curated C# quickstart
- pin website build and deploy workflows to the landed PowerForge engine

## Validation

- exact landed engine generated NuGet 0.2.0 and PowerShell Gallery 1.0.0 channel metadata without unverified installs
- website deploy contract passed
- changed pipeline JSON parses successfully

This consumes public registry metadata; it does not publish packages.