### PR TITLE
Add managed Cloudflare security, discovery, and static caching

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -23,6 +23,7 @@ jobs:
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
+      post_deploy_pipeline_config: Website/pipeline.cloudflare.json
       site_output_path: Website/_site
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
@@ -31,5 +32,8 @@ jobs:
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false
+      manage_cloudflare_site_policy: true
     secrets:
       indexnow_key: ${{ secrets.INDEXNOW_KEY }}
+      cloudflare_api_token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      cloudflare_zone_id: ${{ secrets.CLOUDFLARE_ZONE_ID_DOMAINDETECTIVE }}

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://raw.githubusercontent.com/EvotecIT/PSPublishModule/main/Schemas/powerforge.web.pipelinespec.schema.json",
+  "steps": [
+    {
+      "task": "cloudflare",
+      "id": "purge-cache",
+      "operation": "purge",
+      "siteConfig": "./site.json",
+      "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
+      "tokenEnv": "CLOUDFLARE_API_TOKEN"
+    },
+    {
+      "task": "cloudflare",
+      "id": "verify-cache",
+      "dependsOn": "purge-cache",
+      "operation": "verify",
+      "siteConfig": "./site.json",
+      "warmupRequests": 1,
+      "paths": [
+        "/",
+        "/docs/",
+        "/api/",
+        "/api/index.json",
+        "/api/powershell/",
+        "/api/powershell/index.json",
+        "/api/dnsclientx/",
+        "/api/dnsclientx/index.json",
+        "/api/dnsclientx-powershell/",
+        "/api/dnsclientx-powershell/index.json",
+        "/agents.json",
+        "/.well-known/api-catalog",
+        "/llms.txt",
+        "/favicon.svg"
+      ],
+      "allowStatuses": "HIT,REVALIDATED,EXPIRED,STALE",
+      "reportPath": "./_reports/cloudflare-cache.json",
+      "summaryPath": "./_reports/cloudflare-cache.md"
+    }
+  ]
+}

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -370,9 +370,20 @@
       "reportPath": "./_reports/optimize-report.json"
     },
     {
+      "task": "agent-ready",
+      "id": "agent-ready",
+      "dependsOn": "optimize-site",
+      "skipModes": ["dev"],
+      "operation": "prepare",
+      "config": "./site.json",
+      "siteRoot": "./_site",
+      "output": "./_reports/agent-ready.json",
+      "failOnFailures": true
+    },
+    {
       "task": "doctor",
       "id": "doctor-site",
-      "dependsOn": "optimize-site",
+      "dependsOn": "agent-ready",
       "skipModes": ["dev"],
       "config": "./site.json",
       "siteRoot": "./_site",

--- a/Website/site.json
+++ b/Website/site.json
@@ -122,7 +122,7 @@
     "SecurityHeaders": {
       "Enabled": true,
       "Hsts": false,
-      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://dns.google https://cloudflare-dns.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     },
     "ContentSignals": {
       "Enabled": true,
@@ -131,19 +131,19 @@
       "AiTrain": false
     },
     "BotRules": [
-      { "UserAgent": "GPTBot", "Allow": "/" },
+      { "UserAgent": "GPTBot", "Disallow": "/" },
       { "UserAgent": "ChatGPT-User", "Allow": "/" },
       { "UserAgent": "OAI-SearchBot", "Allow": "/" },
-      { "UserAgent": "ClaudeBot", "Allow": "/" },
+      { "UserAgent": "ClaudeBot", "Disallow": "/" },
       { "UserAgent": "Claude-SearchBot", "Allow": "/" },
       { "UserAgent": "Claude-User", "Allow": "/" },
       { "UserAgent": "PerplexityBot", "Allow": "/" },
       { "UserAgent": "Perplexity-User", "Allow": "/" },
-      { "UserAgent": "Google-Extended", "Allow": "/" },
-      { "UserAgent": "Applebot-Extended", "Allow": "/" },
-      { "UserAgent": "Meta-ExternalAgent", "Allow": "/" },
-      { "UserAgent": "Amazonbot", "Allow": "/" },
-      { "UserAgent": "CCBot", "Allow": "/" }
+      { "UserAgent": "Google-Extended", "Disallow": "/" },
+      { "UserAgent": "Applebot-Extended", "Disallow": "/" },
+      { "UserAgent": "Meta-ExternalAgent", "Disallow": "/" },
+      { "UserAgent": "Amazonbot", "Disallow": "/" },
+      { "UserAgent": "CCBot", "Disallow": "/" }
     ],
     "ApiCatalog": {
       "Enabled": true,
@@ -169,21 +169,7 @@
       "Enabled": true,
       "Description": "Agent-facing discovery metadata for DomainDetective documentation, DNS tools, API references, and support resources."
     },
-    "A2AAgentCard": {
-      "Enabled": true,
-      "Name": "DomainDetective Documentation Discovery",
-      "Description": "Discover DomainDetective and DnsClientX documentation, API references, llms summaries, sitemap, and project resources.",
-      "Url": "/",
-      "DocumentationUrl": "/docs/",
-      "Skills": [
-        {
-          "Id": "documentation-discovery",
-          "Name": "Documentation discovery",
-          "Description": "Find DomainDetective and DnsClientX product documentation, API references, DNS tools, and support pages.",
-          "Tags": ["documentation", "api-reference", "dns", "sitemap", "llms"]
-        }
-      ]
-    },
+    "A2AAgentCard": { "Enabled": false },
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
     "WebMcp": false,

--- a/Website/site.json
+++ b/Website/site.json
@@ -114,6 +114,87 @@
       "DefaultRobots": "index,follow"
     }
   },
+  "AgentReadiness": {
+    "Enabled": true,
+    "HeadersPath": "_headers",
+    "LinkHeaders": true,
+    "Robots": true,
+    "SecurityHeaders": {
+      "Enabled": true,
+      "Hsts": false,
+      "ContentSecurityPolicyValue": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    },
+    "ContentSignals": {
+      "Enabled": true,
+      "Search": true,
+      "AiInput": true,
+      "AiTrain": false
+    },
+    "BotRules": [
+      { "UserAgent": "GPTBot", "Allow": "/" },
+      { "UserAgent": "ChatGPT-User", "Allow": "/" },
+      { "UserAgent": "OAI-SearchBot", "Allow": "/" },
+      { "UserAgent": "ClaudeBot", "Allow": "/" },
+      { "UserAgent": "Claude-SearchBot", "Allow": "/" },
+      { "UserAgent": "Claude-User", "Allow": "/" },
+      { "UserAgent": "PerplexityBot", "Allow": "/" },
+      { "UserAgent": "Perplexity-User", "Allow": "/" },
+      { "UserAgent": "Google-Extended", "Allow": "/" },
+      { "UserAgent": "Applebot-Extended", "Allow": "/" },
+      { "UserAgent": "Meta-ExternalAgent", "Allow": "/" },
+      { "UserAgent": "Amazonbot", "Allow": "/" },
+      { "UserAgent": "CCBot", "Allow": "/" }
+    ],
+    "ApiCatalog": {
+      "Enabled": true,
+      "Entries": [
+        { "Anchor": "/api/", "ServiceDesc": "/api/index.json", "ServiceDoc": "/api/", "Title": "DomainDetective API Reference" },
+        { "Anchor": "/api/powershell/", "ServiceDesc": "/api/powershell/index.json", "ServiceDoc": "/api/powershell/", "Title": "DomainDetective PowerShell Cmdlet Reference" },
+        { "Anchor": "/api/dnsclientx/", "ServiceDesc": "/api/dnsclientx/index.json", "ServiceDoc": "/api/dnsclientx/", "Title": "DnsClientX API Reference" },
+        { "Anchor": "/api/dnsclientx-powershell/", "ServiceDesc": "/api/dnsclientx-powershell/index.json", "ServiceDoc": "/api/dnsclientx-powershell/", "Title": "DnsClientX PowerShell Cmdlet Reference" }
+      ]
+    },
+    "AgentSkills": {
+      "Enabled": true,
+      "Skills": [
+        {
+          "Name": "domaindetective-site-assistant",
+          "Type": "skill-md",
+          "Description": "Use DomainDetective documentation, API references, DNS tools, sitemap, and llms files.",
+          "Content": "---\nname: domaindetective-site-assistant\ndescription: Use DomainDetective documentation, API references, DNS tools, sitemap, and llms resources.\n---\n\n# DomainDetective Site Assistant\n\nUse this skill when answering questions about DomainDetective and DnsClientX.\n\n- Prefer canonical pages from https://domaindetective.dev.\n- Use `/docs/` for product and workflow guidance.\n- Use `/api/` routes for DomainDetective API references and `/api/dnsclientx/` routes for DnsClientX API references.\n- Check `/llms.txt`, `/llms.json`, and `/llms-full.txt` when present for agent-readable summaries.\n- Check `/.well-known/api-catalog` before assuming API documentation paths.\n- Respect `/robots.txt` and Content-Signal preferences.\n"
+        }
+      ]
+    },
+    "AgentsJson": {
+      "Enabled": true,
+      "Description": "Agent-facing discovery metadata for DomainDetective documentation, DNS tools, API references, and support resources."
+    },
+    "A2AAgentCard": {
+      "Enabled": true,
+      "Name": "DomainDetective Documentation Discovery",
+      "Description": "Discover DomainDetective and DnsClientX documentation, API references, llms summaries, sitemap, and project resources.",
+      "Url": "/",
+      "DocumentationUrl": "/docs/",
+      "Skills": [
+        {
+          "Id": "documentation-discovery",
+          "Name": "Documentation discovery",
+          "Description": "Find DomainDetective and DnsClientX product documentation, API references, DNS tools, and support pages.",
+          "Tags": ["documentation", "api-reference", "dns", "sitemap", "llms"]
+        }
+      ]
+    },
+    "McpServerCard": { "Enabled": false },
+    "OpenApi": { "Enabled": false },
+    "WebMcp": false,
+    "MarkdownNegotiation": true
+  },
+  "Cloudflare": {
+    "Cache": {
+      "EdgeTtlSeconds": 604800
+    },
+    "PurgeMode": "hostname"
+  },
   "EditLinks": {
     "Enabled": true,
     "Template": "https://github.com/EvotecIT/DomainDetective/edit/master/{path}",


### PR DESCRIPTION
## Summary

- add the standard PowerForge agent-readiness and discovery contract for DomainDetective and DnsClientX
- enable managed Cloudflare security headers and seven-day edge caching while respecting origin browser caching
- allow Blazor WebAssembly execution and the two DNS-over-HTTPS resolvers used by the browser tools
- align crawler rules with the declared no-training preference and stop advertising an A2A service that is not hosted
- purge by hostname on deployment and verify representative HTML, API, discovery, and static paths afterward
- keep HSTS explicitly disabled while the site remains on GitHub Pages

## Validation

- PowerForge site planning and the full 27-step website pipeline passed
- generated agent artifacts block training crawlers, preserve search/user agents, and omit the A2A card
- the corrected Cloudflare policy is active; the live Blazor app loaded without console errors and a real Google DNS-over-HTTPS query returned NOERROR