### PR TITLE
Use incremental Cloudflare cache deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -29,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -13,13 +13,14 @@ on:
 permissions:
   actions: write
   contents: read
+  deployments: read
   packages: read
   pages: write
   id-token: write
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -28,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: f2c4e9b4fc5bd624dcee64b2d766b471c4676387
+      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 7ed77bb8e6728e362bc906eb4fbf1585dcd47693
+      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports

--- a/Website/pipeline.cloudflare.json
+++ b/Website/pipeline.cloudflare.json
@@ -3,16 +3,7 @@
   "steps": [
     {
       "task": "cloudflare",
-      "id": "purge-cache",
-      "operation": "purge",
-      "siteConfig": "./site.json",
-      "zoneIdEnv": "CLOUDFLARE_ZONE_ID",
-      "tokenEnv": "CLOUDFLARE_API_TOKEN"
-    },
-    {
-      "task": "cloudflare",
       "id": "verify-cache",
-      "dependsOn": "purge-cache",
       "operation": "verify",
       "siteConfig": "./site.json",
       "warmupRequests": 1,
@@ -35,6 +26,14 @@
       "allowStatuses": "HIT,REVALIDATED,EXPIRED,STALE",
       "reportPath": "./_reports/cloudflare-cache.json",
       "summaryPath": "./_reports/cloudflare-cache.md"
+    },
+    {
+      "task": "agent-ready",
+      "id": "verify-agent-readiness-live",
+      "dependsOn": "verify-cache",
+      "operation": "scan",
+      "config": "./site.json",
+      "failOnFailures": true
     }
   ]
 }

--- a/Website/site.json
+++ b/Website/site.json
@@ -173,7 +173,7 @@
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
     "WebMcp": false,
-    "MarkdownNegotiation": true
+    "MarkdownNegotiation": false
   },
   "Cloudflare": {
     "Cache": {

--- a/Website/site.json
+++ b/Website/site.json
@@ -179,7 +179,8 @@
     "Cache": {
       "EdgeTtlSeconds": 604800
     },
-    "PurgeMode": "hostname"
+    "PurgeMode": "incremental",
+    "SmartTieredCache": true
   },
   "EditLinks": {
     "Enabled": true,


### PR DESCRIPTION
## Summary

- grant the reusable deployment workflow read access to GitHub Pages deployment records
- switch the managed static-site policy to incremental cache purge and record Smart Tiered Cache
- pin deployment, CI, and maintenance to the current shared PowerForge owner
- leave post-deploy verification cache- and security-focused; the deployment job alone owns manifest-backed invalidation
- stop advertising unsupported Markdown negotiation on static GitHub Pages

Browser caching remains origin-controlled and HSTS remains disabled for the GitHub Pages recovery path.