### PR TITLE
Pin website workflows to readiness user-agent fix

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@531676159febd177704c5b3663c03089fce28c90
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -29,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 531676159febd177704c5b3663c03089fce28c90
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@531676159febd177704c5b3663c03089fce28c90
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 531676159febd177704c5b3663c03089fce28c90
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@531676159febd177704c5b3663c03089fce28c90
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 1dbcec06df408947ee5f0dad3f71a11b0d31b0b6
+      powerforge_ref: 531676159febd177704c5b3663c03089fce28c90
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary

- pin DomainDetective website deployment, CI, and maintenance workflows to the immutable PowerForge merge containing the stable readiness user-agent correction
- keep each reusable workflow `uses` reference aligned with its `powerforge_ref`
- preserve the existing seven-day incremental Cloudflare profile, Smart Tiered Cache, and `Hsts: false`

The previous post-deploy failures were traced to Cloudflare Bot Fight challenging the task-specific `PowerForge.Web.AgentReady/1.0` user agent while the established `PowerForge.Web/1.0` identity was allowed. The shared fix changes only that request identity; no Cloudflare security bypass is introduced.

## Validation

- all three workflow YAML files parse successfully
- all three pinned reusable workflows exist at the immutable PowerForge revision and expose `powerforge_ref`
- the pinned PowerForge source contains the stable readiness identity and no longer contains the challenged identity
- site configuration remains `EdgeTtlSeconds: 604800`, `PurgeMode: incremental`, `SmartTieredCache: true`, and `Hsts: false`
- `git diff --check` passes