### PR TITLE
Use browser identity for website readiness checks

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@531676159febd177704c5b3663c03089fce28c90
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@07f1573afd91fd5727f9704b3fccba240381e150
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -29,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 531676159febd177704c5b3663c03089fce28c90
+      powerforge_ref: 07f1573afd91fd5727f9704b3fccba240381e150
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@531676159febd177704c5b3663c03089fce28c90
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@07f1573afd91fd5727f9704b3fccba240381e150
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 531676159febd177704c5b3663c03089fce28c90
+      powerforge_ref: 07f1573afd91fd5727f9704b3fccba240381e150
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@531676159febd177704c5b3663c03089fce28c90
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@07f1573afd91fd5727f9704b3fccba240381e150
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 531676159febd177704c5b3663c03089fce28c90
+      powerforge_ref: 07f1573afd91fd5727f9704b3fccba240381e150
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary

- pin deployment, CI, and maintenance website workflows to the immutable PowerForge merge containing browser-identity readiness requests
- preserve the existing seven-day edge cache, incremental purge, Smart Tiered Cache, and HSTS-disabled configuration
- keep the consumer change limited to exact reusable-workflow and `powerforge_ref` pairs

Cloudflare Bot Fight Mode challenged the prior crawler-style readiness identities from GitHub-hosted runners. The shared fix keeps all artifact, discovery, security, CORS, media, and content validation intact while making remote availability checks look like ordinary browser traffic; it does not weaken Cloudflare security or add a bypass.

## Validation

- all three workflow files parse as YAML
- all pinned reusable workflows exist at the exact immutable owner merge and declare `powerforge_ref`
- the pinned owner source contains the synthetic browser identity
- Cloudflare configuration remains `EdgeTtlSeconds: 604800`, `PurgeMode: incremental`, `SmartTieredCache: true`, and `Hsts: false`
- `git diff --check` passes