### PR TITLE
Pin paced agent readiness checks

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@07f1573afd91fd5727f9704b3fccba240381e150
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -29,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 07f1573afd91fd5727f9704b3fccba240381e150
+      powerforge_ref: 8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -52,13 +52,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@07f1573afd91fd5727f9704b3fccba240381e150
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 07f1573afd91fd5727f9704b3fccba240381e150
+      powerforge_ref: 8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@07f1573afd91fd5727f9704b3fccba240381e150
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 07f1573afd91fd5727f9704b3fccba240381e150
+      powerforge_ref: 8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- pin DomainDetective website deployment, CI, and maintenance workflows to the immutable PowerForge merge that paces live agent-readiness requests
- preserve the current seven-day edge TTL, incremental purge, Smart Tiered Cache, and HSTS-disabled GitHub Pages policy

## Why
DomainDetective's prior post-deploy run completed its build, Pages deployment, Cloudflare policy, and cache verification, but Cloudflare Bot Fight Mode challenged the rapid readiness scan from the GitHub runner. The shared owner now spaces live requests and removes one duplicate homepage fetch without relaxing validation or Cloudflare security.

## Validation
- all three workflow files parse as YAML
- exact remote reusable workflows and `powerforge_ref` inputs exist at the immutable owner merge
- the pinned merge contains reviewed PowerForge head `1fe1e92f696aa174e4324a2c590963e6db819003`
- site policy remains edge TTL 604800, incremental purge, Smart Tiered Cache enabled, and HSTS disabled
- `git diff --check` passes

## Operational proof
The decisive proof is the exact post-merge DomainDetective deployment and post-deploy readiness scan from GitHub-hosted infrastructure.