### PR TITLE
Pin truthful Cloudflare verifier

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -68,7 +68,7 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
 }
 
 $deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
-$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@f2c4e9b4fc5bd624dcee64b2d766b471c4676387'
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977'
 $deployWorkflowUses = $null
 $guardrailValue = $null
 $inDeployJob = $false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -29,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
+      powerforge_ref: 01c8da4a9e9c5ab53b772e595c0abb514d36f977
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -17,6 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
   packages: read
 
@@ -52,13 +53,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
+      powerforge_ref: 01c8da4a9e9c5ab53b772e595c0abb514d36f977
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 8b7f06d1320a93bbdf0e0c5c7d7b164a27af9890
+      powerforge_ref: 01c8da4a9e9c5ab53b772e595c0abb514d36f977
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports


### PR DESCRIPTION
## Summary
- pin website deploy, CI, and maintenance workflows to immutable PowerForge merge `01c8da4a9e9c5ab53b772e595c0abb514d36f977`
- grant the website CI caller the `actions: read` ceiling required by the nested reusable workflow
- keep the deploy-contract source pin aligned with the real deployment workflow

## Why
The preceding deployment passed guardrails, build, Pages, and Cloudflare policy, but Bot Fight Mode challenged the synthetic Chromium readiness request. The owner fix now shares the truthful `powerforge-web-cloudflare-verify` identity already proven from the same GitHub runner, with no bypass or security weakening.

The previous pin PR's Website Build workflow was also a hidden `startup_failure`: GitHub did not expose it in the PR status rollup. This change corrects the reusable caller permission ceiling and aligns the repository's deploy-contract assertion so exact PR CI exercises the website path again.

## Validation
- YAML and JSON parse cleanly
- exact reusable workflows and inputs exist at the immutable owner merge
- deploy contract passes locally
- all six workflow `uses` / `powerforge_ref` values match
- seven-day edge TTL, incremental purge, Smart Tiered Cache, and `Hsts: false` are preserved

The decisive acceptance check is the post-merge GitHub-runner deployment behind Cloudflare Bot Fight Mode.