### PR TITLE
Add targeted mail transport diagnostics

### DIFF
--- a/DomainDetective.PowerShell/CmdletTestEmailProtocolTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestEmailProtocolTls.cs
@@ -39,6 +39,10 @@ public sealed class CmdletTestEmailProtocolTls : ExportableAsyncPSCmdlet {
     [ValidateSet("Smtp", "Imap", "Pop3")]
     public string[] Protocol = new[] { "Smtp", "Imap", "Pop3" };
 
+    /// <summary>Network address family used when connecting to discovered mail hosts.</summary>
+    [Parameter(Mandatory = false)]
+    public MailTransportAddressFamily AddressFamily = MailTransportAddressFamily.Any;
+
     private readonly List<object> _items = new();
     private readonly List<string> _subjects = new();
     private readonly object _exportLock = new();
@@ -80,6 +84,9 @@ public sealed class CmdletTestEmailProtocolTls : ExportableAsyncPSCmdlet {
             internalLoggerPowerShell.ResetActivityIdCounter();
             var healthCheck = new DomainHealthCheck(DnsEndpoint, logger);
             ApplyExecutionOptions(healthCheck);
+            healthCheck.SmtpTlsAnalysis.AddressFamily = AddressFamily;
+            healthCheck.ImapTlsAnalysis.AddressFamily = AddressFamily;
+            healthCheck.Pop3TlsAnalysis.AddressFamily = AddressFamily;
 
             logger.WriteVerbose("Checking mail protocol TLS for domain: {0}", domain);
             await healthCheck.Verify(domain, checkTypes.ToArray(), cancellationToken: CancelToken);

--- a/DomainDetective.PowerShell/CmdletTestImapTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestImapTls.cs
@@ -9,6 +9,10 @@ namespace DomainDetective.PowerShell {
     ///   <summary>Test IMAP TLS.</summary>
     ///   <code>Test-DDEmailImapTls -HostName mail.example.com -Port 993</code>
     /// </example>
+    /// <example>
+    ///   <summary>Test only the IPv6 path for an IMAP host.</summary>
+    ///   <code>Test-DDEmailImapTls -HostName mail.example.com -Port 993 -AddressFamily IPv6</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DDEmailImapTls", DefaultParameterSetName = "ServerName")]
     [Alias("Test-EmailImapTls", "Test-ImapTls")]
     public sealed class CmdletTestImapTls : ExportableAsyncPSCmdlet {
@@ -22,6 +26,14 @@ namespace DomainDetective.PowerShell {
         /// <summary>IMAP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 143;
+
+        /// <summary>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</summary>
+        [Parameter(Mandatory = false)]
+        public System.Net.IPAddress? ConnectAddress;
+
+        /// <summary>Network address family used by the connection.</summary>
+        [Parameter(Mandatory = false)]
+        public MailTransportAddressFamily AddressFamily = MailTransportAddressFamily.Any;
 
         /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
@@ -45,11 +57,15 @@ namespace DomainDetective.PowerShell {
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking IMAP TLS for {0}:{1}", HostName, Port);
-            await _healthCheck.CheckImapTlsHost(HostName, Port);
+            var endpoint = new MailTransportEndpoint(HostName, Port) {
+                ConnectAddress = ConnectAddress,
+                AddressFamily = AddressFamily
+            };
+            await _healthCheck.CheckImapTlsHost(endpoint, CancelToken);
             _healthCheck.ImapTlsAnalysis.Subject = HostName;
             var analysis = _healthCheck.ImapTlsAnalysis;
             var view = DomainDetective.Views.Converters.Convert(analysis);
-            var result = analysis.ServerResults[$"{HostName}:{Port}"];
+            var result = analysis.ServerResults[endpoint.Key];
             WriteObject(view);
             if (ShowChain && result.Chain.Count > 0) {
                 WriteObject(result.Chain, true);

--- a/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
+++ b/DomainDetective.PowerShell/CmdletTestPop3Tls.cs
@@ -9,6 +9,10 @@ namespace DomainDetective.PowerShell {
     ///   <summary>Test POP3 TLS.</summary>
     ///   <code>Test-DDEmailPop3Tls -HostName mail.example.com -Port 995</code>
     /// </example>
+    /// <example>
+    ///   <summary>Test a specific POP3 backend without changing the certificate hostname.</summary>
+    ///   <code>Test-DDEmailPop3Tls -HostName mail.example.com -Port 995 -ConnectAddress 192.0.2.10</code>
+    /// </example>
     [Cmdlet(VerbsDiagnostic.Test, "DDEmailPop3Tls", DefaultParameterSetName = "ServerName")]
     [Alias("Test-EmailPop3Tls", "Test-Pop3Tls")]
     public sealed class CmdletTestPop3Tls : ExportableAsyncPSCmdlet {
@@ -22,6 +26,14 @@ namespace DomainDetective.PowerShell {
         /// <summary>POP3 port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 110;
+
+        /// <summary>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</summary>
+        [Parameter(Mandatory = false)]
+        public System.Net.IPAddress? ConnectAddress;
+
+        /// <summary>Network address family used by the connection.</summary>
+        [Parameter(Mandatory = false)]
+        public MailTransportAddressFamily AddressFamily = MailTransportAddressFamily.Any;
 
         /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
@@ -45,11 +57,15 @@ namespace DomainDetective.PowerShell {
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking POP3 TLS for {0}:{1}", HostName, Port);
-            await _healthCheck.CheckPop3TlsHost(HostName, Port);
+            var endpoint = new MailTransportEndpoint(HostName, Port) {
+                ConnectAddress = ConnectAddress,
+                AddressFamily = AddressFamily
+            };
+            await _healthCheck.CheckPop3TlsHost(endpoint, CancelToken);
             _healthCheck.Pop3TlsAnalysis.Subject = HostName;
             var analysis = _healthCheck.Pop3TlsAnalysis;
             var view = DomainDetective.Views.Converters.Convert(analysis);
-            var result = analysis.ServerResults[$"{HostName}:{Port}"];
+            var result = analysis.ServerResults[endpoint.Key];
             WriteObject(view);
             if (ShowChain && result.Chain.Count > 0) {
                 WriteObject(result.Chain, true);

--- a/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestSmtpTls.cs
@@ -10,6 +10,10 @@ namespace DomainDetective.PowerShell {
     ///   <summary>Test mail server TLS.</summary>
     ///   <code>Test-DDEmailSmtpTls -HostName mail.example.com -Port 587</code>
     /// </example>
+    /// <example>
+    ///   <summary>Test a specific backend while preserving the public SMTP hostname for TLS validation.</summary>
+    ///   <code>Test-DDEmailSmtpTls -HostName mail.example.com -Port 587 -ConnectAddress 192.0.2.10 -AddressFamily IPv4</code>
+    /// </example>
 [Cmdlet(VerbsDiagnostic.Test, "DDEmailSmtpTls", DefaultParameterSetName = "ServerName")]
 [Alias("Test-EmailSmtpTls")]
     public sealed class CmdletTestSmtpTls : ExportableAsyncPSCmdlet {
@@ -23,6 +27,14 @@ namespace DomainDetective.PowerShell {
         /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
         public int Port = 25;
+
+        /// <summary>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</summary>
+        [Parameter(Mandatory = false)]
+        public System.Net.IPAddress? ConnectAddress;
+
+        /// <summary>Network address family used by the connection.</summary>
+        [Parameter(Mandatory = false)]
+        public MailTransportAddressFamily AddressFamily = MailTransportAddressFamily.Any;
 
         /// <summary>Output certificate chain information.</summary>
         [Parameter(Mandatory = false)]
@@ -50,14 +62,18 @@ namespace DomainDetective.PowerShell {
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
             _logger.WriteVerbose("Checking SMTP TLS for {0}:{1}", HostName, Port);
-            await _healthCheck.CheckSmtpTlsHost(HostName, Port);
+            var endpoint = new MailTransportEndpoint(HostName, Port) {
+                ConnectAddress = ConnectAddress,
+                AddressFamily = AddressFamily
+            };
+            await _healthCheck.CheckSmtpTlsHost(endpoint, CancelToken);
             _healthCheck.SmtpTlsAnalysis.Subject = HostName;
             var analysis = _healthCheck.SmtpTlsAnalysis;
             var view = DomainDetective.Views.Converters.Convert(analysis);
             // View-by-default design: exposes full Raw analysis on view.Raw
             WriteObject(FullResponse.IsPresent ? (object)analysis : view);
             if (ShowChain) {
-                if (analysis.ServerResults != null && analysis.ServerResults.TryGetValue($"{HostName}:{Port}", out var tls) && tls.Chain.Count > 0) {
+                if (analysis.ServerResults != null && analysis.ServerResults.TryGetValue(endpoint.Key, out var tls) && tls.Chain.Count > 0) {
                     WriteObject(tls.Chain, true);
                 }
             }

--- a/DomainDetective.PowerShell/CmdletTestStartTls.cs
+++ b/DomainDetective.PowerShell/CmdletTestStartTls.cs
@@ -9,22 +9,42 @@ namespace DomainDetective.PowerShell {
     ///   <summary>Verify STARTTLS.</summary>
     ///   <code>Test-DDEmailStartTls -DomainName example.com -Port 587</code>
     /// </example>
-    [Cmdlet(VerbsDiagnostic.Test, "DDEmailStartTls", DefaultParameterSetName = "ServerName")]
+    /// <example>
+    ///   <summary>Test STARTTLS advertisement on a specific SMTP backend and retain the logical hostname in the evidence.</summary>
+    ///   <code>Test-DDEmailStartTls -HostName mail.example.com -Port 587 -ConnectAddress 192.0.2.10 -AddressFamily IPv4</code>
+    /// </example>
+    [Cmdlet(VerbsDiagnostic.Test, "DDEmailStartTls", DefaultParameterSetName = "DomainName")]
     [Alias("Test-EmailStartTls")]
     public sealed class CmdletTestStartTls : ExportableAsyncPSCmdlet {
+        private const string DomainSet = "DomainName";
+        private const string ServerSet = "ServerName";
+
         /// <summary>Domain(s) to test.</summary>
-        [Parameter(Mandatory = true, Position = 0, ParameterSetName = "ServerName", ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = DomainSet, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
         [ValidateNotNullOrEmpty]
         [ValidateDomainName]
         public string[] DomainName = System.Array.Empty<string>();
 
+        /// <summary>Logical SMTP hostname to test directly.</summary>
+        [Parameter(Mandatory = true, Position = 0, ParameterSetName = ServerSet)]
+        [ValidateNotNullOrEmpty]
+        public string HostName = string.Empty;
+
         /// <summary>DNS server used for queries.</summary>
-        [Parameter(Mandatory = false, Position = 1, ParameterSetName = "ServerName")]
+        [Parameter(Mandatory = false, Position = 1)]
         public DnsEndpoint DnsEndpoint = DnsEndpoint.System;
 
         /// <summary>SMTP port number.</summary>
         [Parameter(Mandatory = false)]
         public int Port = 25;
+
+        /// <summary>Optional concrete address used for the TCP connection while HostName remains the reported logical endpoint.</summary>
+        [Parameter(Mandatory = false, ParameterSetName = ServerSet)]
+        public System.Net.IPAddress? ConnectAddress;
+
+        /// <summary>Network address family used by the connection.</summary>
+        [Parameter(Mandatory = false)]
+        public MailTransportAddressFamily AddressFamily = MailTransportAddressFamily.Any;
 
         /// <summary>Return the full analysis object instead of per-server details.</summary>
         [Parameter(Mandatory = false)]
@@ -33,6 +53,53 @@ namespace DomainDetective.PowerShell {
         /// <summary>Executes the cmdlet operation.</summary>
         /// <returns>A <see cref="System.Threading.Tasks.Task"/> representing the asynchronous operation.</returns>
         protected override async Task ProcessRecordAsync() {
+            if (ParameterSetName == ServerSet) {
+                var logger = new InternalLogger(false);
+                var loggerPowerShell = new InternalLoggerPowerShell(
+                    logger,
+                    WriteVerbose,
+                    WriteWarning,
+                    WriteDebug,
+                    WriteError,
+                    WriteProgress,
+                    WriteInformation);
+                loggerPowerShell.ResetActivityIdCounter();
+                var healthCheck = new DomainHealthCheck(DnsEndpoint, logger);
+                ApplyExecutionOptions(healthCheck);
+                var endpoint = new MailTransportEndpoint(HostName, Port) {
+                    ConnectAddress = ConnectAddress,
+                    AddressFamily = AddressFamily
+                };
+
+                logger.WriteVerbose("Querying STARTTLS for host: {0} on port {1}", HostName, Port);
+                await healthCheck.CheckStartTlsHost(endpoint, CancelToken);
+                healthCheck.StartTlsAnalysis.Subject = HostName;
+                var directView = DomainDetective.Views.Converters.Convert(healthCheck.StartTlsAnalysis);
+                WriteObject(FullResponse.IsPresent ? (object)healthCheck.StartTlsAnalysis : directView);
+                if (IsExportRequested()) {
+                    try {
+                        var hadUnsupportedFormats = false;
+                        CompositionExportHelper.WriteReports(
+                            new System.Collections.Generic.List<object> { directView },
+                            GetRequestedFormatsOrDefault(ExportDefaults.Format),
+                            ExportPath,
+                            $"{HostName}-{Port}",
+                            DomainDetective.Reports.ReportScope.Normal,
+                            $"STARTTLS Report - {HostName}:{Port}",
+                            OpenInBrowser.IsPresent || ExportDefaults.OpenInBrowser,
+                            TryOpenReport,
+                            out hadUnsupportedFormats);
+
+                        if (hadUnsupportedFormats) {
+                            await ExportNotImplementedAsync("Test-DDEmailStartTls");
+                        }
+                    } catch (System.Exception ex) {
+                        WriteWarning($"STARTTLS export failed: {ex.Message}");
+                    }
+                }
+                return;
+            }
+
             async Task ProcessDomainAsync(string domain) {
                 var logger = new InternalLogger(false);
                 var internalLoggerPowerShell = new InternalLoggerPowerShell(
@@ -46,6 +113,7 @@ namespace DomainDetective.PowerShell {
                 internalLoggerPowerShell.ResetActivityIdCounter();
                 var healthCheck = new DomainHealthCheck(DnsEndpoint, logger);
                 ApplyExecutionOptions(healthCheck);
+                healthCheck.StartTlsAnalysis.AddressFamily = AddressFamily;
 
                 logger.WriteVerbose("Querying STARTTLS for domain: {0} on port {1}", domain, Port);
                 await healthCheck.VerifySTARTTLS(domain, Port, cancellationToken: CancelToken);

--- a/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
+++ b/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
@@ -43,4 +43,71 @@ public class TestConstrainedOutboundConnections {
             listener.Stop();
         }
     }
+
+    [Fact]
+    public async Task MailConnectorFiltersApprovedAddressesByRequestedFamily() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var endpoint = new MailTransportEndpoint("intentionally-unresolvable.invalid", port) {
+                AddressFamily = MailTransportAddressFamily.IPv4
+            };
+
+            var connect = MailTransportConnector.ConnectAsync(
+                endpoint,
+                (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.IPv6Loopback, IPAddress.Loopback }),
+                CancellationToken.None);
+            using var accepted = await listener.AcceptTcpClientAsync();
+            using var client = await connect;
+
+            Assert.True(client.Connected);
+            var remote = Assert.IsType<IPEndPoint>(client.Client.RemoteEndPoint);
+            Assert.Equal(System.Net.Sockets.AddressFamily.InterNetwork, remote.AddressFamily);
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task MailConnectorRejectsPinnedAddressFromWrongFamily() {
+        var endpoint = new MailTransportEndpoint("mail.example.com", 25) {
+            ConnectAddress = IPAddress.IPv6Loopback,
+            AddressFamily = MailTransportAddressFamily.IPv4
+        };
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            MailTransportConnector.ConnectAsync(endpoint, null, CancellationToken.None));
+
+        Assert.Contains("does not match", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MailConnectorRejectsPinnedAddressOutsideApprovedSet() {
+        var endpoint = new MailTransportEndpoint("mail.example.com", 25) {
+            ConnectAddress = IPAddress.Loopback
+        };
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            MailTransportConnector.ConnectAsync(
+                endpoint,
+                (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Parse("192.0.2.10") }),
+                CancellationToken.None));
+
+        Assert.Contains("was not approved", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AwaitConnectDisposesSocketWhenCanceled() {
+        using var client = new TcpClient();
+        var socket = client.Client;
+        var pendingConnect = new TaskCompletionSource<object?>();
+        using var cancellation = new CancellationTokenSource();
+
+        var connect = MailTransportConnector.AwaitConnectAsync(client, pendingConnect.Task, cancellation.Token);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => connect);
+        Assert.Throws<ObjectDisposedException>(() => socket.Poll(0, SelectMode.SelectRead));
+    }
 }

--- a/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
+++ b/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
@@ -5,6 +5,30 @@ namespace DomainDetective.Tests;
 
 public class TestConstrainedOutboundConnections {
     [Fact]
+    public async Task HealthCheckHostProbesPreserveAnalysisResolversWhenTopLevelResolverIsUnset() {
+        var healthCheck = new DomainHealthCheck();
+        Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>> resolver =
+            (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Loopback });
+        healthCheck.StartTlsAnalysis.OutboundAddressResolver = resolver;
+        healthCheck.SmtpTlsAnalysis.OutboundAddressResolver = resolver;
+        healthCheck.ImapTlsAnalysis.OutboundAddressResolver = resolver;
+        healthCheck.Pop3TlsAnalysis.OutboundAddressResolver = resolver;
+        var endpoint = new MailTransportEndpoint("mail.example.com", 1) {
+            ConnectAddress = IPAddress.Loopback
+        };
+
+        await healthCheck.CheckStartTlsHost(endpoint);
+        await healthCheck.CheckSmtpTlsHost(endpoint);
+        await healthCheck.CheckImapTlsHost(endpoint);
+        await healthCheck.CheckPop3TlsHost(endpoint);
+
+        Assert.Same(resolver, healthCheck.StartTlsAnalysis.OutboundAddressResolver);
+        Assert.Same(resolver, healthCheck.SmtpTlsAnalysis.OutboundAddressResolver);
+        Assert.Same(resolver, healthCheck.ImapTlsAnalysis.OutboundAddressResolver);
+        Assert.Same(resolver, healthCheck.Pop3TlsAnalysis.OutboundAddressResolver);
+    }
+
+    [Fact]
     public async Task CertificateConnectorUsesApprovedAddressWithoutResolvingHostAgain() {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();

--- a/DomainDetective.Tests/TestExecutionCache.cs
+++ b/DomainDetective.Tests/TestExecutionCache.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using DnsClientX;
@@ -35,6 +36,64 @@ namespace DomainDetective.Tests {
             } catch {
                 // Ignore DNS/network failures; we only validate caching behavior.
             }
+        }
+
+        [Fact]
+        public async Task VerifySmtpTls_CacheIncludesAddressFamilyAndResolver() {
+            var mxRecords = new TaskCompletionSource<DnsAnswer[]>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var healthCheck = new DomainHealthCheck {
+                DnsConfiguration = new DnsConfiguration {
+                    QueryDnsOverride = (_, _) => mxRecords.Task
+                }
+            };
+            Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>> firstResolver =
+                (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Loopback });
+            Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>> secondResolver =
+                (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Loopback });
+            healthCheck.SmtpTlsAnalysis.AddressFamily = MailTransportAddressFamily.IPv4;
+            healthCheck.SmtpTlsAnalysis.OutboundAddressResolver = firstResolver;
+
+            var first = healthCheck.VerifySMTPTLS("example.com", 25);
+            var repeated = healthCheck.VerifySMTPTLS("example.com", 25);
+            healthCheck.SmtpTlsAnalysis.AddressFamily = MailTransportAddressFamily.IPv6;
+            var differentFamily = healthCheck.VerifySMTPTLS("example.com", 25);
+            healthCheck.SmtpTlsAnalysis.OutboundAddressResolver = secondResolver;
+            var differentResolver = healthCheck.VerifySMTPTLS("example.com", 25);
+
+            Assert.Same(first, repeated);
+            Assert.NotSame(first, differentFamily);
+            Assert.NotSame(differentFamily, differentResolver);
+            mxRecords.SetResult(Array.Empty<DnsAnswer>());
+            await Task.WhenAll(first, differentFamily, differentResolver);
+        }
+
+        [Fact]
+        public async Task MxMailProbesPreserveAnalysisResolversWhenTopLevelResolverIsUnset() {
+            var healthCheck = CreateHealthCheckWithEmptyMx();
+            Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>> resolver =
+                (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Loopback });
+            healthCheck.StartTlsAnalysis.OutboundAddressResolver = resolver;
+            healthCheck.SmtpTlsAnalysis.OutboundAddressResolver = resolver;
+            healthCheck.ImapTlsAnalysis.OutboundAddressResolver = resolver;
+            healthCheck.Pop3TlsAnalysis.OutboundAddressResolver = resolver;
+
+            await healthCheck.VerifySTARTTLS("example.com");
+            await healthCheck.VerifySMTPTLS("example.com");
+            await healthCheck.VerifyIMAPTLS("example.com");
+            await healthCheck.VerifyPOP3TLS("example.com");
+
+            Assert.Same(resolver, healthCheck.StartTlsAnalysis.OutboundAddressResolver);
+            Assert.Same(resolver, healthCheck.SmtpTlsAnalysis.OutboundAddressResolver);
+            Assert.Same(resolver, healthCheck.ImapTlsAnalysis.OutboundAddressResolver);
+            Assert.Same(resolver, healthCheck.Pop3TlsAnalysis.OutboundAddressResolver);
+        }
+
+        private static DomainHealthCheck CreateHealthCheckWithEmptyMx() {
+            var healthCheck = new DomainHealthCheck();
+            healthCheck.DnsConfiguration = new DnsConfiguration {
+                QueryDnsOverride = (_, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+            };
+            return healthCheck;
         }
     }
 }

--- a/DomainDetective.Tests/TestMailTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestMailTlsAnalysis.cs
@@ -15,6 +15,23 @@ namespace DomainDetective.Tests;
 public class TestMailTlsAnalysis
 {
     [Fact]
+    public async Task ExplicitEndpointCollectionRejectsDuplicateLogicalKeysBeforeConnecting()
+    {
+        var endpoints = new[]
+        {
+            new MailTransportEndpoint("mail.example.com", 995) { ConnectAddress = IPAddress.Loopback },
+            new MailTransportEndpoint("MAIL.EXAMPLE.COM", 995) { ConnectAddress = IPAddress.IPv6Loopback }
+        };
+        var analysis = new MailTlsAnalysis();
+
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            analysis.AnalyzeServers(MailTlsAnalysis.MailProtocol.Pop3, endpoints, new InternalLogger()));
+
+        Assert.Contains("duplicate logical result key", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Empty(analysis.ServerResults);
+    }
+
+    [Fact]
     public async Task ImapTlsWorks()
     {
         using var cert = CreateSelfSigned();
@@ -80,6 +97,40 @@ public class TestMailTlsAnalysis
             await analysis.AnalyzeServer("localhost", port, new InternalLogger());
             var result = analysis.ServerResults[$"localhost:{port}"];
             Assert.False(result.StartTlsAdvertised);
+        }
+        finally
+        {
+            cts.Cancel();
+            listener.Stop();
+            await serverTask;
+        }
+    }
+
+    [Fact]
+    public async Task Pop3TlsUsesPinnedAddressAndKeepsLogicalResultKey()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        using var cts = new CancellationTokenSource();
+        var serverTask = Task.Run(() => RunPop3ServerNoTls(listener, cts.Token), cts.Token);
+        const string logicalHost = "pop-intentionally-unresolvable.invalid";
+
+        try
+        {
+            var endpoint = new MailTransportEndpoint(logicalHost, port) {
+                ConnectAddress = IPAddress.Loopback,
+                AddressFamily = MailTransportAddressFamily.IPv4
+            };
+            var analysis = new POP3TLSAnalysis();
+
+            await analysis.AnalyzeServer(endpoint, new InternalLogger());
+
+            var result = analysis.ServerResults[endpoint.Key];
+            Assert.Equal(logicalHost, result.Connection.HostName);
+            Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.ConnectAddress);
+            Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.RemoteAddress);
+            Assert.Equal(MailTransportAddressFamily.IPv4, result.Connection.RemoteAddressFamily);
         }
         finally
         {

--- a/DomainDetective.Tests/TestMailTlsView.cs
+++ b/DomainDetective.Tests/TestMailTlsView.cs
@@ -14,6 +14,14 @@ public class TestMailTlsView
         var until = new DateTime(2025, 12, 31, 0, 0, 0, DateTimeKind.Utc);
         tls.ServerResults["smtp.example.com:25"] = new MailTlsAnalysis.TlsResult
         {
+            Connection = new MailTransportConnectionEvidence {
+                HostName = "smtp.example.com",
+                Port = 25,
+                ConnectAddress = "192.0.2.10",
+                RequestedAddressFamily = MailTransportAddressFamily.IPv4,
+                RemoteAddress = "192.0.2.10",
+                RemoteAddressFamily = MailTransportAddressFamily.IPv4
+            },
             StartTlsAdvertised = true,
             CertificateValid = true,
             HostnameMatch = true,
@@ -30,6 +38,12 @@ public class TestMailTlsView
         Assert.Equal(when, server.ValidFrom);
         Assert.Equal(until, server.ValidTo);
         Assert.Equal("ABCDEF123456", server.Thumbprint);
+        Assert.Equal("smtp.example.com", server.HostName);
+        Assert.Equal(25, server.Port);
+        Assert.Equal("192.0.2.10", server.ConnectAddress);
+        Assert.Equal("192.0.2.10", server.RemoteAddress);
+        Assert.Equal(MailTransportAddressFamily.IPv4, server.RequestedAddressFamily);
+        Assert.Equal(MailTransportAddressFamily.IPv4, server.RemoteAddressFamily);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
+++ b/DomainDetective.Tests/TestSTARTTLSAnalysis.cs
@@ -89,6 +89,46 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task PinnedAddressPreservesLogicalHostAndCapturesRemoteEndpoint() {
+            var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+            listener.Start();
+            var port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+            var serverTask = System.Threading.Tasks.Task.Run(async () => {
+                using var client = await listener.AcceptTcpClientAsync();
+                using var stream = client.GetStream();
+                using var reader = new System.IO.StreamReader(stream);
+                using var writer = new System.IO.StreamWriter(stream) { AutoFlush = true, NewLine = "\r\n" };
+                await writer.WriteLineAsync("220 local ESMTP");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("250-localhost\r\n250-STARTTLS\r\n250 OK");
+                await reader.ReadLineAsync();
+                await writer.WriteLineAsync("221 bye");
+            });
+
+            const string logicalHost = "mail-intentionally-unresolvable.invalid";
+            try {
+                var endpoint = new MailTransportEndpoint(logicalHost, port) {
+                    ConnectAddress = System.Net.IPAddress.Loopback,
+                    AddressFamily = MailTransportAddressFamily.IPv4
+                };
+                var analysis = new STARTTLSAnalysis();
+
+                await analysis.AnalyzeServer(endpoint, new InternalLogger());
+
+                var detail = analysis.ServerDetails[endpoint.Key];
+                Assert.True(detail.StartTlsAdvertised);
+                Assert.Equal(logicalHost, detail.Connection.HostName);
+                Assert.Equal(System.Net.IPAddress.Loopback.ToString(), detail.Connection.ConnectAddress);
+                Assert.Equal(System.Net.IPAddress.Loopback.ToString(), detail.Connection.RemoteAddress);
+                Assert.Equal(MailTransportAddressFamily.IPv4, detail.Connection.RequestedAddressFamily);
+                Assert.Equal(MailTransportAddressFamily.IPv4, detail.Connection.RemoteAddressFamily);
+            } finally {
+                listener.Stop();
+                await serverTask;
+            }
+        }
+
+        [Fact]
         public async Task StartTlsNotAdvertisedReturnsFalse() {
             var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
             listener.Start();

--- a/DomainDetective/DomainHealthCheck.ExecutionCache.cs
+++ b/DomainDetective/DomainHealthCheck.ExecutionCache.cs
@@ -2,6 +2,7 @@ using DnsClientX;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,7 +13,7 @@ public partial class DomainHealthCheck {
     private Task? _spfTask;
     private Task<DnsAnswer[]>? _mxRecordsTask;
     private Task<string[]>? _mxHostsTask;
-    private Dictionary<int, Task>? _smtpTlsTasks;
+    private Dictionary<SmtpTlsExecutionKey, Task>? _smtpTlsTasks;
     private Task? _reverseDnsTask;
     private Task? _daneTask;
     private string? _daneKey;
@@ -92,12 +93,41 @@ public partial class DomainHealthCheck {
     private Task EnsureSmtpTlsAsync(string domainName, int port, CancellationToken cancellationToken) {
         lock (_executionLock) {
             EnsureCacheDomainLocked(domainName);
-            _smtpTlsTasks ??= new Dictionary<int, Task>();
-            if (!_smtpTlsTasks.TryGetValue(port, out var task)) {
+            _smtpTlsTasks ??= new Dictionary<SmtpTlsExecutionKey, Task>();
+            var resolver = OutboundAddressResolver ?? SmtpTlsAnalysis.OutboundAddressResolver;
+            var key = new SmtpTlsExecutionKey(port, SmtpTlsAnalysis.AddressFamily, resolver);
+            if (!_smtpTlsTasks.TryGetValue(key, out var task)) {
                 task = VerifySmtpTlsInternal(domainName, port, cancellationToken);
-                _smtpTlsTasks[port] = task;
+                _smtpTlsTasks[key] = task;
             }
             return task;
+        }
+    }
+
+    private readonly struct SmtpTlsExecutionKey : IEquatable<SmtpTlsExecutionKey> {
+        private readonly int _port;
+        private readonly MailTransportAddressFamily _addressFamily;
+        private readonly Delegate? _resolver;
+
+        public SmtpTlsExecutionKey(int port, MailTransportAddressFamily addressFamily, Delegate? resolver) {
+            _port = port;
+            _addressFamily = addressFamily;
+            _resolver = resolver;
+        }
+
+        public bool Equals(SmtpTlsExecutionKey other) =>
+            _port == other._port &&
+            _addressFamily == other._addressFamily &&
+            ReferenceEquals(_resolver, other._resolver);
+
+        public override bool Equals(object? obj) =>
+            obj is SmtpTlsExecutionKey other && Equals(other);
+
+        public override int GetHashCode() {
+            unchecked {
+                var hash = (_port * 397) ^ (int)_addressFamily;
+                return (hash * 397) ^ (_resolver == null ? 0 : RuntimeHelpers.GetHashCode(_resolver));
+            }
         }
     }
 

--- a/DomainDetective/DomainHealthCheck.Verification.HostChecks.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.HostChecks.cs
@@ -33,7 +33,7 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckStartTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
             ValidatePort(port);
-            StartTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(StartTlsAnalysis);
             await StartTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
@@ -45,7 +45,7 @@ namespace DomainDetective {
                 throw new System.ArgumentNullException(nameof(endpoint));
             }
             ValidatePort(endpoint.Port);
-            StartTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(StartTlsAnalysis);
             await StartTlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
@@ -54,7 +54,7 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckSmtpTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
             ValidatePort(port);
-            SmtpTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(SmtpTlsAnalysis);
             await SmtpTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
@@ -66,7 +66,7 @@ namespace DomainDetective {
                 throw new System.ArgumentNullException(nameof(endpoint));
             }
             ValidatePort(endpoint.Port);
-            SmtpTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(SmtpTlsAnalysis);
             await SmtpTlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
@@ -75,7 +75,7 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckImapTlsHost(string host, int port = 143, CancellationToken cancellationToken = default) {
             ValidatePort(port);
-            ImapTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(ImapTlsAnalysis);
             await ImapTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
@@ -87,7 +87,7 @@ namespace DomainDetective {
                 throw new System.ArgumentNullException(nameof(endpoint));
             }
             ValidatePort(endpoint.Port);
-            ImapTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(ImapTlsAnalysis);
             await ImapTlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
@@ -96,7 +96,7 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckPop3TlsHost(string host, int port = 110, CancellationToken cancellationToken = default) {
             ValidatePort(port);
-            Pop3TlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(Pop3TlsAnalysis);
             await Pop3TlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
         }
 
@@ -108,7 +108,7 @@ namespace DomainDetective {
                 throw new System.ArgumentNullException(nameof(endpoint));
             }
             ValidatePort(endpoint.Port);
-            Pop3TlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(Pop3TlsAnalysis);
             await Pop3TlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
@@ -174,6 +174,18 @@ namespace DomainDetective {
         /// <summary>Queries neighbors for IPs used by MX hosts of <paramref name="domainName"/>.</summary>
         public async Task CheckMailIPNeighbors(string domainName, CancellationToken cancellationToken = default) {
             await IPNeighborAnalysis.AnalyzeMx(domainName, _logger, cancellationToken);
+        }
+
+        private void ApplyOutboundAddressResolver(STARTTLSAnalysis analysis) {
+            if (OutboundAddressResolver != null) {
+                analysis.OutboundAddressResolver = OutboundAddressResolver;
+            }
+        }
+
+        private void ApplyOutboundAddressResolver(MailTlsAnalysis analysis) {
+            if (OutboundAddressResolver != null) {
+                analysis.OutboundAddressResolver = OutboundAddressResolver;
+            }
         }
     }
 }

--- a/DomainDetective/DomainHealthCheck.Verification.HostChecks.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.HostChecks.cs
@@ -33,7 +33,20 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckStartTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
             ValidatePort(port);
+            StartTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await StartTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks an explicitly targeted host for STARTTLS support while preserving the logical hostname.
+        /// </summary>
+        public async Task CheckStartTlsHost(MailTransportEndpoint endpoint, CancellationToken cancellationToken = default) {
+            if (endpoint == null) {
+                throw new System.ArgumentNullException(nameof(endpoint));
+            }
+            ValidatePort(endpoint.Port);
+            StartTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            await StartTlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -41,7 +54,20 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckSmtpTlsHost(string host, int port = 25, CancellationToken cancellationToken = default) {
             ValidatePort(port);
+            SmtpTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await SmtpTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks an explicitly targeted host for SMTP TLS capabilities while preserving the logical hostname.
+        /// </summary>
+        public async Task CheckSmtpTlsHost(MailTransportEndpoint endpoint, CancellationToken cancellationToken = default) {
+            if (endpoint == null) {
+                throw new System.ArgumentNullException(nameof(endpoint));
+            }
+            ValidatePort(endpoint.Port);
+            SmtpTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            await SmtpTlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -49,7 +75,20 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckImapTlsHost(string host, int port = 143, CancellationToken cancellationToken = default) {
             ValidatePort(port);
+            ImapTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await ImapTlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks an explicitly targeted host for IMAP TLS capabilities while preserving the logical hostname.
+        /// </summary>
+        public async Task CheckImapTlsHost(MailTransportEndpoint endpoint, CancellationToken cancellationToken = default) {
+            if (endpoint == null) {
+                throw new System.ArgumentNullException(nameof(endpoint));
+            }
+            ValidatePort(endpoint.Port);
+            ImapTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            await ImapTlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
         /// <summary>
@@ -57,7 +96,20 @@ namespace DomainDetective {
         /// </summary>
         public async Task CheckPop3TlsHost(string host, int port = 110, CancellationToken cancellationToken = default) {
             ValidatePort(port);
+            Pop3TlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await Pop3TlsAnalysis.AnalyzeServer(host, port, _logger, cancellationToken);
+        }
+
+        /// <summary>
+        /// Checks an explicitly targeted host for POP3 TLS capabilities while preserving the logical hostname.
+        /// </summary>
+        public async Task CheckPop3TlsHost(MailTransportEndpoint endpoint, CancellationToken cancellationToken = default) {
+            if (endpoint == null) {
+                throw new System.ArgumentNullException(nameof(endpoint));
+            }
+            ValidatePort(endpoint.Port);
+            Pop3TlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            await Pop3TlsAnalysis.AnalyzeServer(endpoint, _logger, cancellationToken);
         }
 
         /// <summary>

--- a/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
@@ -20,6 +20,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, port, string.Join(", ", tlsHosts));
             StartTlsAnalysis.Subject = domainName;
+            StartTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { port }, _logger, cancellationToken);
             if (StartTlsAnalysis.ServerResults.Count > 0 && StartTlsAnalysis.ServerResults.Values.All(v => v)) {
                 _logger.WriteInformationCode(MxCodes.TlsSupported, "All MX hosts support STARTTLS");
@@ -42,6 +43,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, port, string.Join(", ", tlsHosts));
             SmtpTlsAnalysis.Subject = domainName;
+            SmtpTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, port, _logger, cancellationToken);
 
             // DANE alignment advisory: if we have DANE results or MX but missing TLSA, or weak TLS under TLSA
@@ -95,6 +97,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, 143, string.Join(", ", tlsHosts));
             ImapTlsAnalysis.Subject = domainName;
+            ImapTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await ImapTlsAnalysis.AnalyzeServers(tlsHosts, 143, _logger, cancellationToken);
         }
 
@@ -110,6 +113,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, 110, string.Join(", ", tlsHosts));
             Pop3TlsAnalysis.Subject = domainName;
+            Pop3TlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
             await Pop3TlsAnalysis.AnalyzeServers(tlsHosts, 110, _logger, cancellationToken);
         }
 

--- a/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
+++ b/DomainDetective/DomainHealthCheck.Verification.MxTls.cs
@@ -20,7 +20,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, port, string.Join(", ", tlsHosts));
             StartTlsAnalysis.Subject = domainName;
-            StartTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(StartTlsAnalysis);
             await StartTlsAnalysis.AnalyzeServers(tlsHosts, new[] { port }, _logger, cancellationToken);
             if (StartTlsAnalysis.ServerResults.Count > 0 && StartTlsAnalysis.ServerResults.Values.All(v => v)) {
                 _logger.WriteInformationCode(MxCodes.TlsSupported, "All MX hosts support STARTTLS");
@@ -43,7 +43,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, port, string.Join(", ", tlsHosts));
             SmtpTlsAnalysis.Subject = domainName;
-            SmtpTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(SmtpTlsAnalysis);
             await SmtpTlsAnalysis.AnalyzeServers(tlsHosts, port, _logger, cancellationToken);
 
             // DANE alignment advisory: if we have DANE results or MX but missing TLSA, or weak TLS under TLSA
@@ -97,7 +97,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, 143, string.Join(", ", tlsHosts));
             ImapTlsAnalysis.Subject = domainName;
-            ImapTlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(ImapTlsAnalysis);
             await ImapTlsAnalysis.AnalyzeServers(tlsHosts, 143, _logger, cancellationToken);
         }
 
@@ -113,7 +113,7 @@ namespace DomainDetective {
             var tlsHosts = await GetMxHostsAsync(domainName, cancellationToken);
             _logger.WriteVerbose("MX targets for {0} on port {1}: {2}", domainName, 110, string.Join(", ", tlsHosts));
             Pop3TlsAnalysis.Subject = domainName;
-            Pop3TlsAnalysis.OutboundAddressResolver = OutboundAddressResolver;
+            ApplyOutboundAddressResolver(Pop3TlsAnalysis);
             await Pop3TlsAnalysis.AnalyzeServers(tlsHosts, 110, _logger, cancellationToken);
         }
 

--- a/DomainDetective/Protocols/IMAPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/IMAPTLSAnalysis.cs
@@ -14,7 +14,15 @@ public class IMAPTLSAnalysis : MailTlsAnalysis
     public Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
         => base.AnalyzeServer(MailProtocol.Imap, host, port, logger, cancellationToken);
 
+    /// <summary>Analyzes a single explicitly targeted IMAP server.</summary>
+    public Task AnalyzeServer(MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken = default)
+        => base.AnalyzeServer(MailProtocol.Imap, endpoint, logger, cancellationToken);
+
     /// <summary>Analyzes multiple IMAP servers.</summary>
     public Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
         => base.AnalyzeServers(MailProtocol.Imap, hosts, port, logger, cancellationToken);
+
+    /// <summary>Analyzes multiple explicitly targeted IMAP servers.</summary>
+    public Task AnalyzeServers(IEnumerable<MailTransportEndpoint> endpoints, InternalLogger logger, CancellationToken cancellationToken = default)
+        => base.AnalyzeServers(MailProtocol.Imap, endpoints, logger, cancellationToken);
 }

--- a/DomainDetective/Protocols/MailTlsAnalysis.cs
+++ b/DomainDetective/Protocols/MailTlsAnalysis.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Net;
@@ -32,6 +33,8 @@ public class MailTlsAnalysis : IHasAssessments {
 
     /// <summary>Result of a TLS check.</summary>
     public class TlsResult {
+        /// <summary>Requested and observed mail transport endpoint details.</summary>
+        public MailTransportConnectionEvidence Connection { get; set; } = new();
         /// <summary>Gets or sets the start tls advertised value.</summary>
         public bool StartTlsAdvertised { get; set; }
         /// <summary>Gets or sets the certificate valid value.</summary>
@@ -112,6 +115,8 @@ public class MailTlsAnalysis : IHasAssessments {
     public Dictionary<string, TlsResult> ServerResults { get; } = new();
     /// <summary>Timeout for connections.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+    /// <summary>Address family used by hostname-based probes.</summary>
+    public MailTransportAddressFamily AddressFamily { get; set; } = MailTransportAddressFamily.Any;
     /// <summary>Optional resolver that returns addresses approved for outbound connections.</summary>
     public Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>>? OutboundAddressResolver { get; set; }
 
@@ -122,9 +127,17 @@ public class MailTlsAnalysis : IHasAssessments {
 
     /// <summary>Analyzes a single host.</summary>
     public async Task AnalyzeServer(MailProtocol protocol, string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+        await AnalyzeServer(protocol, new MailTransportEndpoint(host, port) { AddressFamily = AddressFamily }, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Analyzes a single logical host using explicit transport targeting options.</summary>
+    public async Task AnalyzeServer(MailProtocol protocol, MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken = default) {
+        if (endpoint == null) {
+            throw new ArgumentNullException(nameof(endpoint));
+        }
         ServerResults.Clear();
-        var result = await CheckTls(protocol, host, port, logger, cancellationToken);
-        ServerResults[$"{host}:{port}"] = result;
+        var result = await CheckTls(protocol, endpoint, logger, cancellationToken).ConfigureAwait(false);
+        ServerResults[endpoint.Key] = result;
     }
 
     /// <summary>Analyzes multiple hosts.</summary>
@@ -132,7 +145,32 @@ public class MailTlsAnalysis : IHasAssessments {
         ServerResults.Clear();
         foreach (var host in hosts) {
             cancellationToken.ThrowIfCancellationRequested();
-            ServerResults[$"{host}:{port}"] = await CheckTls(protocol, host, port, logger, cancellationToken);
+            var endpoint = new MailTransportEndpoint(host, port) { AddressFamily = AddressFamily };
+            ServerResults[endpoint.Key] = await CheckTls(protocol, endpoint, logger, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>Analyzes multiple explicitly targeted mail endpoints.</summary>
+    public async Task AnalyzeServers(MailProtocol protocol, IEnumerable<MailTransportEndpoint> endpoints, InternalLogger logger, CancellationToken cancellationToken = default) {
+        if (endpoints == null) {
+            throw new ArgumentNullException(nameof(endpoints));
+        }
+        var targets = endpoints.ToArray();
+        if (targets.Any(endpoint => endpoint == null)) {
+            throw new ArgumentException("Endpoint collection cannot contain null values.", nameof(endpoints));
+        }
+        var duplicateKey = targets
+            .GroupBy(endpoint => endpoint.Key, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1)?.Key;
+        if (duplicateKey != null) {
+            throw new ArgumentException(
+                $"Endpoint collection contains duplicate logical result key '{duplicateKey}'. Analyze each backend separately to retain its connection evidence.",
+                nameof(endpoints));
+        }
+        ServerResults.Clear();
+        foreach (var endpoint in targets) {
+            cancellationToken.ThrowIfCancellationRequested();
+            ServerResults[endpoint.Key] = await CheckTls(protocol, endpoint, logger, cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -151,14 +189,18 @@ public class MailTlsAnalysis : IHasAssessments {
         result.KeyExchangeAlgorithm = tlsInfo.KeyExchangeAlgorithm;
     }
 
-    private async Task<TlsResult> CheckTls(MailProtocol protocol, string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
+    private async Task<TlsResult> CheckTls(MailProtocol protocol, MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken) {
+        endpoint.Validate();
+        var host = endpoint.HostName;
+        var port = endpoint.Port;
         string category = protocol switch { MailProtocol.Smtp => "SMTPTLS", MailProtocol.Imap => "IMAPTLS", MailProtocol.Pop3 => "POP3TLS", _ => "MAILTLS" };
         using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: category, target: $"{host}:{port}");
-        var result = new TlsResult();
+        var result = new TlsResult { Connection = MailTransportConnectionEvidence.FromTarget(endpoint) };
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(Timeout);
         try {
-            using var client = await ConnectAsync(host, port, timeoutCts.Token).ConfigureAwait(false);
+            using var client = await ConnectAsync(endpoint, timeoutCts.Token).ConfigureAwait(false);
+            result.Connection.Capture(client);
             using NetworkStream network = client.GetStream();
             bool directTls = (protocol == MailProtocol.Imap && port == 993) || (protocol == MailProtocol.Pop3 && port == 995);
             if (directTls) {
@@ -263,7 +305,7 @@ public class MailTlsAnalysis : IHasAssessments {
                     result.SupportsTls13 = (int)result.Protocol == 12288;
                     result.Tls13Used = result.SupportsTls13;
                     // Probe protocol support (best-effort)
-                    await ProbeProtocolSupport(host, port, result, cancellationToken);
+                    await ProbeProtocolSupport(endpoint, result, cancellationToken).ConfigureAwait(false);
                     if (result.SupportsTls10 || result.SupportsTls11) {   
                         logger.WriteWarningCode(TlsCodes.LegacyOffered, "Server offers legacy TLS ({0}{1}) on {2}:{3}",
                             result.SupportsTls10 ? "1.0" : string.Empty,
@@ -276,7 +318,9 @@ public class MailTlsAnalysis : IHasAssessments {
                     if (result.LegacyEnabled) {
                         logger.WriteWarningCode(TlsCodes.LegacyEnabled, "Legacy TLS protocol negotiated on {0}:{1} - {2}", host, port, result.Protocol);
                     }
-                    await ProbeOcspStaplingWithOpenSsl(host, port, result, logger, cancellationToken);
+                    if (OutboundAddressResolver == null || endpoint.ConnectAddress != null) {
+                        await ProbeOcspStaplingWithOpenSsl(endpoint, result, logger, cancellationToken).ConfigureAwait(false);
+                    }
                 }
                 return result;
             }
@@ -476,7 +520,7 @@ public class MailTlsAnalysis : IHasAssessments {
                 result.SupportsTls13 = (int)result.Protocol == 12288;
                 result.Tls13Used = result.SupportsTls13;
                 // Probe protocol support (best-effort)
-                await ProbeProtocolSupport(host, port, result, cancellationToken);
+                await ProbeProtocolSupport(endpoint, result, cancellationToken).ConfigureAwait(false);
                 if (result.SupportsTls10 || result.SupportsTls11) {       
                     logger?.WriteWarningCode(TlsCodes.LegacyOffered, "Server offers legacy TLS ({0}{1}) on {2}:{3}",
                         result.SupportsTls10 ? "1.0" : string.Empty,
@@ -488,7 +532,7 @@ public class MailTlsAnalysis : IHasAssessments {
                     logger?.WriteWarningCode(TlsCodes.LegacyEnabled, "Legacy TLS protocol negotiated on {0}:{1} - {2}", host, port, result.Protocol);
                 }
                 if (OutboundAddressResolver == null) {
-                    await ProbeOcspStaplingWithOpenSsl(host, port, result, logger, cancellationToken);
+                    await ProbeOcspStaplingWithOpenSsl(endpoint, result, logger, cancellationToken).ConfigureAwait(false);
                 }
             }
         } catch (Exception ex) {
@@ -508,12 +552,12 @@ public class MailTlsAnalysis : IHasAssessments {
         result.FailureKind = CertificateFailureClassifier.Classify(exception);
     }
 
-    private async Task ProbeProtocolSupport(string host, int port, TlsResult result, CancellationToken token) {
+    private async Task ProbeProtocolSupport(MailTransportEndpoint endpoint, TlsResult result, CancellationToken token) {
         async Task<bool> TryHandshake(SslProtocols proto) {
             try {
-                using var client = await ConnectAsync(host, port, token).ConfigureAwait(false);
+                using var client = await ConnectAsync(endpoint, token).ConfigureAwait(false);
                 using var ssl = new SslStream(client.GetStream(), false, static (_, _, _, _) => true);
-                await ssl.AuthenticateAsClientAsync(host, null, proto, false).WaitWithCancellation(token);
+                await ssl.AuthenticateAsClientAsync(endpoint.HostName, null, proto, false).WaitWithCancellation(token);
                 return ssl.SslProtocol == proto;
             } catch { return false; }
         }
@@ -527,33 +571,30 @@ public class MailTlsAnalysis : IHasAssessments {
     }
 
     internal async Task<TcpClient> ConnectAsync(string host, int port, CancellationToken cancellationToken) {
-        if (OutboundAddressResolver == null) {
-            var client = new TcpClient();
-            await client.ConnectAsync(host, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
-            return client;
-        }
-
-        var addresses = await OutboundAddressResolver(host, cancellationToken).ConfigureAwait(false);
-        Exception? lastError = null;
-        foreach (var address in addresses) {
-            var client = new TcpClient(address.AddressFamily);
-            try {
-                await client.ConnectAsync(address, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
-                return client;
-            } catch (Exception ex) when (ex is not OperationCanceledException) {
-                lastError = ex;
-                client.Dispose();
-            }
-        }
-        throw new SocketException(lastError is SocketException socketError ? socketError.ErrorCode : (int)SocketError.HostUnreachable);
+        var endpoint = new MailTransportEndpoint(host, port) { AddressFamily = AddressFamily };
+        return await ConnectAsync(endpoint, cancellationToken).ConfigureAwait(false);
     }
 
-    private static async Task ProbeOcspStaplingWithOpenSsl(string host, int port, TlsResult result, InternalLogger? logger, CancellationToken token) {
+    internal Task<TcpClient> ConnectAsync(MailTransportEndpoint endpoint, CancellationToken cancellationToken) =>
+        MailTransportConnector.ConnectAsync(endpoint, OutboundAddressResolver, cancellationToken);
+
+    private static async Task ProbeOcspStaplingWithOpenSsl(MailTransportEndpoint endpoint, TlsResult result, InternalLogger? logger, CancellationToken token) {
         try {
+            var host = endpoint.HostName;
+            var port = endpoint.Port;
+            var connectHost = endpoint.ConnectAddress?.ToString() ?? host;
+            if (connectHost.IndexOf(':') >= 0 && !connectHost.StartsWith("[", StringComparison.Ordinal)) {
+                connectHost = $"[{connectHost}]";
+            }
+            var familySwitch = endpoint.AddressFamily switch {
+                MailTransportAddressFamily.IPv4 => "-4 ",
+                MailTransportAddressFamily.IPv6 => "-6 ",
+                _ => string.Empty
+            };
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
             var psi = new System.Diagnostics.ProcessStartInfo {
                 FileName = "openssl",
-                Arguments = $"s_client -connect {host}:{port} -servername {host} -starttls {(port == 25 ? "smtp" : port == 110 ? "pop3" : port == 143 ? "imap" : "smtp")} -status -brief",
+                Arguments = $"s_client {familySwitch}-connect {connectHost}:{port} -servername {host} -starttls {(port == 25 ? "smtp" : port == 110 ? "pop3" : port == 143 ? "imap" : "smtp")} -status -brief",
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,

--- a/DomainDetective/Protocols/MailTransportAddressFamily.cs
+++ b/DomainDetective/Protocols/MailTransportAddressFamily.cs
@@ -1,0 +1,15 @@
+namespace DomainDetective;
+
+/// <summary>
+/// Selects the network address family used by a mail transport probe.
+/// </summary>
+public enum MailTransportAddressFamily {
+    /// <summary>Allows the operating system to select IPv4 or IPv6.</summary>
+    Any,
+
+    /// <summary>Uses IPv4 addresses only.</summary>
+    IPv4,
+
+    /// <summary>Uses IPv6 addresses only.</summary>
+    IPv6
+}

--- a/DomainDetective/Protocols/MailTransportConnectionEvidence.cs
+++ b/DomainDetective/Protocols/MailTransportConnectionEvidence.cs
@@ -1,0 +1,43 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Records the requested and observed endpoint of a mail transport connection.
+/// </summary>
+public sealed class MailTransportConnectionEvidence {
+    /// <summary>Logical hostname used by the protocol and TLS layers.</summary>
+    public string HostName { get; set; } = string.Empty;
+
+    /// <summary>TCP port used by the probe.</summary>
+    public int Port { get; set; }
+
+    /// <summary>Concrete address requested by the caller, when the connection was pinned.</summary>
+    public string? ConnectAddress { get; set; }
+
+    /// <summary>Address-family selection requested by the caller.</summary>
+    public MailTransportAddressFamily RequestedAddressFamily { get; set; }
+
+    /// <summary>Remote address observed after the TCP connection succeeded.</summary>
+    public string? RemoteAddress { get; set; }
+
+    /// <summary>Address family observed after the TCP connection succeeded.</summary>
+    public MailTransportAddressFamily? RemoteAddressFamily { get; set; }
+
+    internal static MailTransportConnectionEvidence FromTarget(MailTransportEndpoint endpoint) => new() {
+        HostName = endpoint.HostName,
+        Port = endpoint.Port,
+        ConnectAddress = endpoint.ConnectAddress?.ToString(),
+        RequestedAddressFamily = endpoint.AddressFamily
+    };
+
+    internal void Capture(TcpClient client) {
+        if (client.Client.RemoteEndPoint is not IPEndPoint remote) {
+            return;
+        }
+
+        RemoteAddress = remote.Address.ToString();
+        RemoteAddressFamily = MailTransportConnector.ToMailAddressFamily(remote.Address);
+    }
+}

--- a/DomainDetective/Protocols/MailTransportConnector.cs
+++ b/DomainDetective/Protocols/MailTransportConnector.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using DomainDetective.Helpers;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Establishes mail transport connections while preserving logical-host and address-family constraints.
+/// </summary>
+internal static class MailTransportConnector {
+    internal static async Task<TcpClient> ConnectAsync(
+        MailTransportEndpoint endpoint,
+        Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>>? outboundAddressResolver,
+        CancellationToken cancellationToken) {
+        if (endpoint == null) {
+            throw new ArgumentNullException(nameof(endpoint));
+        }
+
+        endpoint.Validate();
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (outboundAddressResolver == null &&
+            endpoint.ConnectAddress == null &&
+            endpoint.AddressFamily == MailTransportAddressFamily.Any) {
+            var isAddressLiteral = IPAddress.TryParse(endpoint.HostName, out var literalAddress);
+            var client = isAddressLiteral
+                ? new TcpClient(literalAddress!.AddressFamily)
+                : new TcpClient();
+            if (isAddressLiteral) {
+                await AwaitConnectAsync(
+                    client,
+                    client.ConnectAsync(literalAddress!, endpoint.Port),
+                    cancellationToken).ConfigureAwait(false);
+            } else {
+                await AwaitConnectAsync(
+                    client,
+                    client.ConnectAsync(endpoint.HostName, endpoint.Port),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            return client;
+        }
+
+        IReadOnlyList<IPAddress> candidates;
+        if (outboundAddressResolver != null) {
+            var approved = await outboundAddressResolver(endpoint.HostName, cancellationToken).ConfigureAwait(false)
+                ?? Array.Empty<IPAddress>();
+            if (endpoint.ConnectAddress != null) {
+                if (!approved.Any(address => address.Equals(endpoint.ConnectAddress))) {
+                    throw new InvalidOperationException(
+                        $"Connect address '{endpoint.ConnectAddress}' was not approved for logical host '{endpoint.HostName}'.");
+                }
+                candidates = new[] { endpoint.ConnectAddress };
+            } else {
+                candidates = approved;
+            }
+        } else if (endpoint.ConnectAddress != null) {
+            candidates = new[] { endpoint.ConnectAddress };
+        } else {
+            candidates = await Dns.GetHostAddressesAsync(endpoint.HostName)
+                .WaitWithCancellation(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var filtered = candidates
+            .Where(address => address != null && Matches(address, endpoint.AddressFamily))
+            .Distinct()
+            .ToArray();
+        if (filtered.Length == 0) {
+            throw new SocketException((int)SocketError.HostNotFound);
+        }
+
+        Exception? lastError = null;
+        foreach (var address in filtered) {
+            cancellationToken.ThrowIfCancellationRequested();
+            var client = new TcpClient(address.AddressFamily);
+            try {
+                await AwaitConnectAsync(
+                    client,
+                    client.ConnectAsync(address, endpoint.Port),
+                    cancellationToken).ConfigureAwait(false);
+                return client;
+            } catch (Exception ex) when (ex is not OperationCanceledException) {
+                lastError = ex;
+            }
+        }
+
+        if (lastError != null) {
+            throw lastError;
+        }
+        throw new SocketException((int)SocketError.HostUnreachable);
+    }
+
+    internal static async Task AwaitConnectAsync(
+        TcpClient client,
+        Task connectTask,
+        CancellationToken cancellationToken) {
+        try {
+            await connectTask.WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+        } catch {
+            client.Dispose();
+            throw;
+        }
+    }
+
+    internal static bool Matches(IPAddress address, MailTransportAddressFamily family) => family switch {
+        MailTransportAddressFamily.Any => true,
+        MailTransportAddressFamily.IPv4 => address.AddressFamily == AddressFamily.InterNetwork,
+        MailTransportAddressFamily.IPv6 => address.AddressFamily == AddressFamily.InterNetworkV6,
+        _ => false
+    };
+
+    internal static MailTransportAddressFamily ToMailAddressFamily(IPAddress address) =>
+        address.AddressFamily == AddressFamily.InterNetworkV6
+            ? MailTransportAddressFamily.IPv6
+            : MailTransportAddressFamily.IPv4;
+}

--- a/DomainDetective/Protocols/MailTransportEndpoint.cs
+++ b/DomainDetective/Protocols/MailTransportEndpoint.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Describes a mail endpoint whose logical hostname can differ from the address used for the TCP connection.
+/// </summary>
+/// <remarks>
+/// <see cref="HostName"/> remains the protocol and TLS identity. Set <see cref="ConnectAddress"/> to pin the
+/// socket to a specific backend address without changing SNI or certificate hostname validation.
+/// </remarks>
+public sealed class MailTransportEndpoint {
+    /// <summary>Creates an empty endpoint for serializers and object initializers.</summary>
+    public MailTransportEndpoint() {
+    }
+
+    /// <summary>Creates an endpoint for a logical mail host and port.</summary>
+    public MailTransportEndpoint(string hostName, int port) {
+        HostName = hostName;
+        Port = port;
+    }
+
+    /// <summary>Logical mail hostname used for protocol identity, SNI, and certificate validation.</summary>
+    public string HostName { get; set; } = string.Empty;
+
+    /// <summary>TCP port used by the probe.</summary>
+    public int Port { get; set; }
+
+    /// <summary>Optional concrete address used for the TCP connection.</summary>
+    public IPAddress? ConnectAddress { get; set; }
+
+    /// <summary>Requested network address family.</summary>
+    public MailTransportAddressFamily AddressFamily { get; set; } = MailTransportAddressFamily.Any;
+
+    /// <summary>Stable result key based on the logical hostname and port.</summary>
+    public string Key => $"{HostName}:{Port}";
+
+    internal void Validate() {
+        if (string.IsNullOrWhiteSpace(HostName)) {
+            throw new ArgumentException("A logical mail hostname is required.", nameof(HostName));
+        }
+        if (Port < 1 || Port > 65535) {
+            throw new ArgumentOutOfRangeException(nameof(Port), "Port must be between 1 and 65535.");
+        }
+        if (ConnectAddress != null && !MailTransportConnector.Matches(ConnectAddress, AddressFamily)) {
+            throw new ArgumentException(
+                $"Connect address '{ConnectAddress}' does not match requested address family '{AddressFamily}'.",
+                nameof(ConnectAddress));
+        }
+    }
+}

--- a/DomainDetective/Protocols/POP3TLSAnalysis.cs
+++ b/DomainDetective/Protocols/POP3TLSAnalysis.cs
@@ -14,7 +14,15 @@ public class POP3TLSAnalysis : MailTlsAnalysis
     public Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
         => base.AnalyzeServer(MailProtocol.Pop3, host, port, logger, cancellationToken);
 
+    /// <summary>Analyzes a single explicitly targeted POP3 server.</summary>
+    public Task AnalyzeServer(MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken = default)
+        => base.AnalyzeServer(MailProtocol.Pop3, endpoint, logger, cancellationToken);
+
     /// <summary>Analyzes multiple POP3 servers.</summary>
     public Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
         => base.AnalyzeServers(MailProtocol.Pop3, hosts, port, logger, cancellationToken);
+
+    /// <summary>Analyzes multiple explicitly targeted POP3 servers.</summary>
+    public Task AnalyzeServers(IEnumerable<MailTransportEndpoint> endpoints, InternalLogger logger, CancellationToken cancellationToken = default)
+        => base.AnalyzeServers(MailProtocol.Pop3, endpoints, logger, cancellationToken);
 }

--- a/DomainDetective/Protocols/SMTPTLSAnalysis.cs
+++ b/DomainDetective/Protocols/SMTPTLSAnalysis.cs
@@ -14,7 +14,15 @@ public class SMTPTLSAnalysis : MailTlsAnalysis
     public Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default)
         => base.AnalyzeServer(MailProtocol.Smtp, host, port, logger, cancellationToken);
 
+    /// <summary>Analyzes a single explicitly targeted SMTP server.</summary>
+    public Task AnalyzeServer(MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken = default)
+        => base.AnalyzeServer(MailProtocol.Smtp, endpoint, logger, cancellationToken);
+
     /// <summary>Analyzes multiple SMTP servers.</summary>
     public Task AnalyzeServers(IEnumerable<string> hosts, int port, InternalLogger logger, CancellationToken cancellationToken = default)
         => base.AnalyzeServers(MailProtocol.Smtp, hosts, port, logger, cancellationToken);
+
+    /// <summary>Analyzes multiple explicitly targeted SMTP servers.</summary>
+    public Task AnalyzeServers(IEnumerable<MailTransportEndpoint> endpoints, InternalLogger logger, CancellationToken cancellationToken = default)
+        => base.AnalyzeServers(MailProtocol.Smtp, endpoints, logger, cancellationToken);
 }

--- a/DomainDetective/Protocols/STARTTLSAnalysis.cs
+++ b/DomainDetective/Protocols/STARTTLSAnalysis.cs
@@ -23,6 +23,10 @@ public class STARTTLSAnalysis : IHasAssessments {
         public Dictionary<string, STARTTLSResult> ServerDetails { get; private set; } = new();
         /// <summary>Gets or sets the timeout value.</summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+        /// <summary>Address family used by hostname-based probes.</summary>
+        public MailTransportAddressFamily AddressFamily { get; set; } = MailTransportAddressFamily.Any;
+        /// <summary>Optional resolver that returns addresses approved for outbound connections.</summary>
+        public Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>>? OutboundAddressResolver { get; set; }
 
         /// <summary>Structured assessments during STARTTLS probe.</summary>
         public List<Assessment> Assessments { get; } = new();
@@ -33,12 +37,22 @@ public class STARTTLSAnalysis : IHasAssessments {
         /// Tests a single server for STARTTLS support.
         /// </summary>
         public async Task AnalyzeServer(string host, int port, InternalLogger logger, CancellationToken cancellationToken = default) {
+            await AnalyzeServer(new MailTransportEndpoint(host, port) { AddressFamily = AddressFamily }, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Tests a single explicitly targeted server for STARTTLS support.
+        /// </summary>
+        public async Task AnalyzeServer(MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken = default) {
+            if (endpoint == null) {
+                throw new ArgumentNullException(nameof(endpoint));
+            }
             ServerResults.Clear();
             DowngradeDetected.Clear();
             ServerDetails.Clear();
             cancellationToken.ThrowIfCancellationRequested();
-            var detail = await CheckStartTls(host, port, logger, cancellationToken);
-            var key = $"{host}:{port}";
+            var detail = await CheckStartTls(endpoint, logger, cancellationToken).ConfigureAwait(false);
+            var key = endpoint.Key;
             ServerResults[key] = detail.StartTlsAdvertised || detail.TlsNegotiated;
             DowngradeDetected[key] = detail.DowngradeDetected;
             ServerDetails[key] = detail;
@@ -54,8 +68,9 @@ public class STARTTLSAnalysis : IHasAssessments {
             foreach (var host in hosts) {
                 foreach (var port in ports) {
                     cancellationToken.ThrowIfCancellationRequested();
-                    var detail = await CheckStartTls(host, port, logger, cancellationToken);
-                    var key = $"{host}:{port}";
+                    var endpoint = new MailTransportEndpoint(host, port) { AddressFamily = AddressFamily };
+                    var detail = await CheckStartTls(endpoint, logger, cancellationToken).ConfigureAwait(false);
+                    var key = endpoint.Key;
                     ServerResults[key] = detail.StartTlsAdvertised || detail.TlsNegotiated;
                     DowngradeDetected[key] = detail.DowngradeDetected;
                     ServerDetails[key] = detail;
@@ -64,32 +79,20 @@ public class STARTTLSAnalysis : IHasAssessments {
         }
 
         /// <summary>
-        /// Resolves the specified host and returns a <see cref="DnsEndPoint"/>
-        /// with address family information when an IP address is provided.
-        /// </summary>
-        private static DnsEndPoint GetEndPoint(string host, int port) {
-            return IPAddress.TryParse(host, out IPAddress? ip)
-                ? new DnsEndPoint(host, port, ip.AddressFamily)
-                : new DnsEndPoint(host, port);
-        }
-
-        /// <summary>
         /// Performs the low-level STARTTLS negotiation.
         /// </summary>
-        private async Task<STARTTLSResult> CheckStartTls(string host, int port, InternalLogger logger, CancellationToken cancellationToken) {
+        private async Task<STARTTLSResult> CheckStartTls(MailTransportEndpoint endpoint, InternalLogger logger, CancellationToken cancellationToken) {
+            endpoint.Validate();
+            var host = endpoint.HostName;
+            var port = endpoint.Port;
             using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "STARTTLS", target: $"{host}:{port}");
-            var endPoint = GetEndPoint(host, port);
-            var client = endPoint.AddressFamily == AddressFamily.Unspecified
-                ? new TcpClient()
-                : new TcpClient(endPoint.AddressFamily);
+            TcpClient? client = null;
+            var connection = MailTransportConnectionEvidence.FromTarget(endpoint);
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(Timeout);
             try {
-                if (endPoint.AddressFamily == AddressFamily.Unspecified) {
-                    await client.ConnectAsync(host, port).WaitWithCancellation(timeoutCts.Token);
-                } else {
-                    await client.Client.ConnectAsync(endPoint).WaitWithCancellation(timeoutCts.Token);
-                }
+                client = await MailTransportConnector.ConnectAsync(endpoint, OutboundAddressResolver, timeoutCts.Token).ConfigureAwait(false);
+                connection.Capture(client);
                 using NetworkStream network = client.GetStream();
                 using var reader = new StreamReader(network);
                 using var writer = new StreamWriter(network) { AutoFlush = true, NewLine = "\r\n" };
@@ -214,6 +217,7 @@ public class STARTTLSAnalysis : IHasAssessments {
                 return new STARTTLSResult {
                     Host = host,
                     Port = port,
+                    Connection = connection,
                     Banner = banner ?? string.Empty,
                     EhloLines = ehloLines,
                     Capabilities = new List<string>(capabilities),
@@ -240,6 +244,7 @@ public class STARTTLSAnalysis : IHasAssessments {
                 return new STARTTLSResult {
                     Host = host,
                     Port = port,
+                    Connection = connection,
                     Banner = string.Empty,
                     EhloLines = new List<string>(),
                     Capabilities = new List<string>(),
@@ -249,13 +254,15 @@ public class STARTTLSAnalysis : IHasAssessments {
                     TlsNegotiated = false,
                 };
             } finally {
-                client.Dispose();
+                client?.Dispose();
             }
         }
     }
 
     /// <summary>Detailed STARTTLS probe result per server.</summary>
     public sealed class STARTTLSResult {
+        /// <summary>Requested and observed mail transport endpoint details.</summary>
+        public MailTransportConnectionEvidence Connection { get; set; } = new();
         /// <summary>Gets or sets the host value.</summary>
         public string Host { get; set; } = string.Empty;
         /// <summary>Gets or sets the port value.</summary>

--- a/DomainDetective/Views/Converters.MailTls.cs
+++ b/DomainDetective/Views/Converters.MailTls.cs
@@ -24,6 +24,12 @@ public static partial class Converters
             servers.Add(new MailTlsServerInfo
             {
                 Key = kv.Key,
+                HostName = r.Connection.HostName,
+                Port = r.Connection.Port,
+                ConnectAddress = r.Connection.ConnectAddress,
+                RequestedAddressFamily = r.Connection.RequestedAddressFamily,
+                RemoteAddress = r.Connection.RemoteAddress,
+                RemoteAddressFamily = r.Connection.RemoteAddressFamily,
                 StartTlsAdvertised = r.StartTlsAdvertised,
                 Grade = r.GradeLevel,
                 CertificateValid = r.CertificateValid,
@@ -116,6 +122,18 @@ public class MailTlsServerInfo
 {
     /// <summary>Server key in the form host:port.</summary>
     public string Key { get; set; } = null!;
+    /// <summary>Logical hostname used for protocol identity and TLS validation.</summary>
+    public string HostName { get; set; } = string.Empty;
+    /// <summary>TCP port used by the probe.</summary>
+    public int Port { get; set; }
+    /// <summary>Concrete address requested by the caller, when pinned.</summary>
+    public string? ConnectAddress { get; set; }
+    /// <summary>Address family requested by the caller.</summary>
+    public MailTransportAddressFamily RequestedAddressFamily { get; set; }
+    /// <summary>Remote address observed after connecting.</summary>
+    public string? RemoteAddress { get; set; }
+    /// <summary>Address family observed after connecting.</summary>
+    public MailTransportAddressFamily? RemoteAddressFamily { get; set; }
     /// <summary>True when STARTTLS was advertised or implicit TLS used.</summary>
     public bool StartTlsAdvertised { get; set; }
     /// <summary>Computed letter grade for TLS posture.</summary>

--- a/DomainDetective/Views/Converters.StartTls.cs
+++ b/DomainDetective/Views/Converters.StartTls.cs
@@ -14,6 +14,12 @@ public static partial class Converters
         var entries = analysis.ServerDetails?.Select(kv => new StartTlsServerInfo
         {
             Key = kv.Key,
+            HostName = kv.Value.Connection.HostName,
+            Port = kv.Value.Connection.Port,
+            ConnectAddress = kv.Value.Connection.ConnectAddress,
+            RequestedAddressFamily = kv.Value.Connection.RequestedAddressFamily,
+            RemoteAddress = kv.Value.Connection.RemoteAddress,
+            RemoteAddressFamily = kv.Value.Connection.RemoteAddressFamily,
             StartTlsAdvertised = kv.Value.StartTlsAdvertised,
             TlsNegotiated = kv.Value.TlsNegotiated,
             DowngradeDetected = kv.Value.DowngradeDetected,
@@ -79,6 +85,18 @@ public class StartTlsServerInfo
 {
     /// <summary>Gets or sets the key value.</summary>
     public string Key { get; set; } = null!;
+    /// <summary>Logical hostname used for protocol identity and TLS validation.</summary>
+    public string HostName { get; set; } = string.Empty;
+    /// <summary>TCP port used by the probe.</summary>
+    public int Port { get; set; }
+    /// <summary>Concrete address requested by the caller, when pinned.</summary>
+    public string? ConnectAddress { get; set; }
+    /// <summary>Address family requested by the caller.</summary>
+    public MailTransportAddressFamily RequestedAddressFamily { get; set; }
+    /// <summary>Remote address observed after connecting.</summary>
+    public string? RemoteAddress { get; set; }
+    /// <summary>Address family observed after connecting.</summary>
+    public MailTransportAddressFamily? RemoteAddressFamily { get; set; }
     /// <summary>Gets or sets the start tls advertised value.</summary>
     public bool StartTlsAdvertised { get; set; }
     /// <summary>Gets or sets the tls negotiated value.</summary>

--- a/Module/Examples/Example.TestEmailSmtpTls.ps1
+++ b/Module/Examples/Example.TestEmailSmtpTls.ps1
@@ -10,3 +10,8 @@ $GmailTls | Select-Object Protocol,Tls13Used,CipherSuite,CipherAlgorithm,CipherS
 # Show full chain for a host
 $Example = Test-EmailSmtpTls -HostName 'mail.example.com' -ShowChain -Verbose -ErrorAction SilentlyContinue
 $Example | Format-List
+
+# Pin a backend address while preserving mail.example.com for SNI and certificate validation
+$Pinned = Test-DDEmailSmtpTls -HostName 'mail.example.com' -Port 587 `
+    -ConnectAddress '192.0.2.10' -AddressFamily IPv4
+$Pinned.Servers | Select-Object HostName,ConnectAddress,RemoteAddress,HostnameMatch,Grade | Format-Table

--- a/Module/Examples/Example.TestEmailStartTls.ps1
+++ b/Module/Examples/Example.TestEmailStartTls.ps1
@@ -14,3 +14,8 @@ $Evotec | Select-Object Host,CertificateSubject,CertificateIssuer,CertificateNot
 # Get the full analysis container for scripting
 $Example = Test-EmailStartTls -DomainName 'example.com' -DnsEndpoint System -Port 587 -FullResponse
 $Example.ServerDetails.Values | Select-Object Host,Port,StartTlsAdvertised,TlsNegotiated | Format-Table
+
+# Test STARTTLS advertisement on one backend and retain the logical host in the evidence
+$Pinned = Test-DDEmailStartTls -HostName 'mail.example.com' -Port 587 `
+    -ConnectAddress '192.0.2.10' -AddressFamily IPv4
+$Pinned.Servers | Select-Object HostName,ConnectAddress,RemoteAddress,StartTlsAdvertised,TlsNegotiated | Format-Table

--- a/README.MD
+++ b/README.MD
@@ -681,6 +681,16 @@ DKIM analysis exposes indicators such as:
 ### SMTP TLS
 
 SMTP TLS analysis stores the negotiated certificate and reports expiration details and chain validity for each server.
+Direct SMTP, IMAP, and POP3 TLS checks can also pin a backend address while keeping the public hostname for SNI and certificate validation:
+
+```powershell
+$tls = Test-DDEmailSmtpTls -HostName 'mail.example.com' -Port 587 `
+    -ConnectAddress '192.0.2.10' -AddressFamily IPv4
+$tls.Servers | Select-Object HostName, ConnectAddress, RemoteAddress, HostnameMatch, Grade
+```
+
+Use `-AddressFamily IPv4` or `-AddressFamily IPv6` without `-ConnectAddress` to test only one DNS address family. The result keeps both the requested target and the remote address observed after connecting.
+`Test-DDEmailStartTls` accepts the same transport targeting options for STARTTLS advertisement checks, but use the protocol TLS cmdlets when certificate identity and negotiation evidence are required.
 
 ### HTTP Security Headers
 


### PR DESCRIPTION
## Summary

- separate the logical mail hostname from an optional concrete TCP connect address across SMTP, IMAP, POP3 TLS, and STARTTLS diagnostics
- add explicit `Any`, `IPv4`, and `IPv6` targeting while preserving existing hostname-based APIs
- expose requested and observed connection evidence through analysis results, views, and PowerShell cmdlets
- preserve outbound-address resolver restrictions, cancellation cleanup, and .NET Framework IPv6-literal behavior

## Usage

```powershell
Test-DDEmailSmtpTls -HostName 'mail.example.com' -Port 587 `
    -ConnectAddress '192.0.2.10' -AddressFamily IPv4
```

SMTP, IMAP, and POP3 TLS checks keep `HostName` as the SNI and certificate identity. `Test-DDEmailStartTls` uses the same transport targeting for advertisement checks; use the protocol TLS cmdlets when certificate identity and negotiation evidence are required.

Endpoint collections reject duplicate logical `host:port` keys before connecting so backend evidence cannot be silently overwritten.