### PR TITLE
Add explainable endpoint service detection

### DIFF
--- a/Docs/CERTIFICATE_INVENTORY.MD
+++ b/Docs/CERTIFICATE_INVENTORY.MD
@@ -108,7 +108,7 @@ Invoke-DDCertificateInventory `
     -NoPersist
 ```
 
-With detection enabled, each row can also include the resolver, `DnsObservedAtUtc`, resolved addresses, full CNAME chain, redirect targets, and an `Attribution` result. `ObservedAtUtc` remains the protocol-observation time, while `DnsObservedAtUtc` and `Attribution.EvaluatedAtUtc` describe the current enrichment pass. Attribution retains every candidate and the evidence that contributed to it. The primary result includes a score, confidence, rule ID, and rule version; equally ranked eligible candidates with different provider/service identities are retained as ambiguous instead of selecting one by sort order. Multiple rules agreeing on the same identity remain supporting candidates rather than creating false ambiguity.
+With detection enabled, each row can also include the resolver, `DnsObservedAtUtc`, resolved addresses, full CNAME chain, redirect targets, and an `Attribution` result. `ObservedAtUtc` is stamped when that individual protocol probe completes; it is not copied from the later snapshot-finalization time. `DnsObservedAtUtc` and `Attribution.EvaluatedAtUtc` describe the current enrichment pass. Attribution retains every candidate and the evidence that contributed to it. The primary result includes a score, confidence, rule ID, and rule version; equally ranked eligible candidates with different provider/service identities are retained as ambiguous instead of selecting one by sort order. Multiple rules agreeing on the same identity remain supporting candidates rather than creating false ambiguity.
 
 Hostname prefixes and certificate issuers are weak signals. They can create review candidates, but the built-in rules do not let either signal establish a primary provider by itself. CNAME namespaces, current service-tag membership, configured IP ranges, redirect targets, reverse DNS, and ASN evidence are treated as stronger signals. Built-in web-delivery and redirection rules apply only to HTTPS observations, so a shared address or CNAME does not label an unrelated mail or FTP TLS service.
 
@@ -128,7 +128,7 @@ The FTP TLS probe does not submit credentials and does not open a data connectio
 
 | Control | Default | Purpose |
 | --- | --- | --- |
-| `-MaxTargets` (`-Limit`) | `0` (unlimited) | Cap total discovered probe targets (HTTPS + mail + FTP TLS) for test/safety runs |
+| `-MaxTargets` (`-Limit`) | `0` (unlimited) | Cap total discovered probe targets (HTTPS + mail + FTP TLS) for test/safety runs; explicit FTP TLS targets participate in the global allocation |
 | `-MaxProbeStartsPerSecond` | `0` (unlimited) | Anti-hammer throttle for probe start rate |
 | `-MaxProbeErrorWarnings` | `25` | Limit verbose endpoint error warning noise |
 | `-ReuseRecentResults` | Off | Reuse recent persisted endpoint results to skip redundant probes |

--- a/Docs/CERTIFICATE_INVENTORY.MD
+++ b/Docs/CERTIFICATE_INVENTORY.MD
@@ -71,7 +71,7 @@ DomainDetective combines endpoint probing and CT evidence:
 | --- | --- | --- |
 | HTTPS probing | Live leaf cert, chain, issuer/root, EKU/auth profile, validity, hostname match, protocol/service | Included by default (apex + `www`) |
 | MX discovery + STARTTLS | Mail host certs from SMTP 25/587; optional IMAPS/POP3S | Default includes STARTTLS; IMAP/POP3 optional |
-| Additional endpoints | Explicit app/service targets (`https://`, `smtp://`, etc.) | `-Endpoint` / `AdditionalEndpoints` |
+| Additional endpoints | Explicit app/service targets (`https://`, `smtp://`, `ftps://`, `ftps-explicit://`) | `-Endpoint` / `AdditionalEndpoints` |
 | Native CT log polling (RFC6962) | Direct CT ingestion from trusted log operators (no crt.sh dependency) | `EnableNativeCtLogSubdomainSource`, `NativeCt*` options |
 | Public CT API (`crt.sh`) | CT presence and source evidence for observed certs | Enabled by default template |
 | Optional CT APIs (Shodan/Censys/custom) | Wider CT discovery source coverage | `CtProfile`, source toggles, API keys/templates |
@@ -93,11 +93,42 @@ Notes:
 - Native CT polling now includes built-in retry/backoff, per-log circuit breaker, and catch-up mode for large cursor lag.
 - Capture results now include `NativeCtLogDiagnostics` so you can inspect per-log ingestion state (succeeded/failed/circuit-open, lag before/after, last processed index) without opening cursor JSON.
 
+## Endpoint observations and service attribution
+
+An inventory row identifies a logical endpoint by `host + port + service`. The same hostname and port can therefore retain separate HTTPS, STARTTLS, or FTPS observations instead of being merged into one ambiguous record.
+
+Live rows include `ObservedAtUtc` and `ProbeVantage`. Cached observations are reused only when their normalized vantage matches the requested vantage. When the protocol exposes the connected socket, `RemoteAddress` records the address actually reached. Service detection is opt-in because it adds DNS work:
+
+```powershell
+Invoke-DDCertificateInventory `
+    -Endpoint https://www.example.com `
+    -DetectServices `
+    -ProbeVantage branch-office `
+    -AzureServiceTagsJsonPath .\ServiceTags_Public.json `
+    -NoPersist
+```
+
+With detection enabled, each row can also include the resolver, `DnsObservedAtUtc`, resolved addresses, full CNAME chain, redirect targets, and an `Attribution` result. `ObservedAtUtc` remains the protocol-observation time, while `DnsObservedAtUtc` and `Attribution.EvaluatedAtUtc` describe the current enrichment pass. Attribution retains every candidate and the evidence that contributed to it. The primary result includes a score, confidence, rule ID, and rule version; equally ranked eligible candidates with different provider/service identities are retained as ambiguous instead of selecting one by sort order. Multiple rules agreeing on the same identity remain supporting candidates rather than creating false ambiguity.
+
+Hostname prefixes and certificate issuers are weak signals. They can create review candidates, but the built-in rules do not let either signal establish a primary provider by itself. CNAME namespaces, current service-tag membership, configured IP ranges, redirect targets, reverse DNS, and ASN evidence are treated as stronger signals. Built-in web-delivery and redirection rules apply only to HTTPS observations, so a shared address or CNAME does not label an unrelated mail or FTP TLS service.
+
+Azure address attribution is read from a caller-supplied current service-tag JSON file; DomainDetective does not embed a fixed Azure range list. The saved attribution includes the catalog source, cloud, change number, and retrieval time. A malformed optional catalog produces a capture warning instead of discarding already collected observations. The built-in NameShield redirection rule contains a versioned point-in-time seed and a provenance warning; an address from that seed needs a matching provider namespace or redirect target before it can become primary. A generic certificate issuer does not corroborate the address. API callers can replace that rule by adding an `EndpointAttributionRule` with the same `RuleId`, or add their own rules with a new ID.
+
+CSV exports include the complete serialized `AttributionCandidates` collection, including non-primary review candidates and their evidence. NDJSON retains the complete entry model directly.
+
+FTP TLS modes are explicit in the endpoint scheme:
+
+- `ftps://host[:port]` starts TLS immediately and defaults to port 990.
+- `ftps-explicit://host[:port]`, `ftpes://host[:port]`, and `ftp+tls://host[:port]` read the FTP greeting, send `AUTH TLS`, require a `234` response, and then negotiate TLS. They default to port 21.
+- `ftp://` remains unsupported because a clear-text FTP connection does not provide certificate evidence.
+
+The FTP TLS probe does not submit credentials and does not open a data connection.
+
 ### Capture controls quick reference
 
 | Control | Default | Purpose |
 | --- | --- | --- |
-| `-MaxTargets` (`-Limit`) | `0` (unlimited) | Cap total discovered probe targets (HTTPS + mail) for test/safety runs |
+| `-MaxTargets` (`-Limit`) | `0` (unlimited) | Cap total discovered probe targets (HTTPS + mail + FTP TLS) for test/safety runs |
 | `-MaxProbeStartsPerSecond` | `0` (unlimited) | Anti-hammer throttle for probe start rate |
 | `-MaxProbeErrorWarnings` | `25` | Limit verbose endpoint error warning noise |
 | `-ReuseRecentResults` | Off | Reuse recent persisted endpoint results to skip redundant probes |
@@ -105,6 +136,9 @@ Notes:
 | `-ReuseRecentFailureResults` | Off | Reuse recent stable failures to avoid immediately re-probing consistently dead endpoints |
 | `-RecentFailureResultTtlHours` | `1` | How long stable failure entries are eligible for reuse |
 | `-ReprobeExpiringWithinDays` | `14` | Always recheck endpoints whose certs expire soon |
+| `-DetectServices` | Off | Resolve DNS evidence and evaluate explainable provider/service rules |
+| `-ProbeVantage` | `default` | Persist a caller-defined observation location label |
+| `-AzureServiceTagsJsonPath` | Empty | Load current Azure service-tag ranges for IP-based attribution |
 | `-DisableNativeCtSharedIngestion` | Off | Disable shared native CT pass and fall back to per-domain native CT ingestion |
 | `-NativeCtRetryCount` | `3` | Retry transient native CT HTTP failures |
 | `-NativeCtCircuitBreakerFailureThreshold` | `3` | Open per-log circuit after repeated failures |
@@ -146,8 +180,8 @@ $domains = @(
     'evotec.pl'
     'microsoft.com'
     'google.com'
-    'eurofins.com'
-    'abb.com'
+    'example.com'
+    'example.org'
 )
 
 $capture = Invoke-DDCertificateInventory `
@@ -177,15 +211,15 @@ $capture | Format-List CapturedAtUtc,SnapshotPath,DomainCount,MxHostCount,EntryC
 
 Useful run telemetry now returned directly on the capture result:
 
-- `ReusedRecentEntryCount`, `ReusedRecentHttpsCount`, `ReusedRecentMailCount`
-- `ReusedRecentFailureEntryCount`, `ReusedRecentFailureHttpsCount`, `ReusedRecentFailureMailCount`
-- `ProbedHttpsCount`, `ProbedMailCount`
+- `ReusedRecentEntryCount`, `ReusedRecentHttpsCount`, `ReusedRecentMailCount`, `ReusedRecentFtpTlsCount`
+- `ReusedRecentFailureEntryCount`, `ReusedRecentFailureHttpsCount`, `ReusedRecentFailureMailCount`, `ReusedRecentFailureFtpTlsCount`
+- `ProbedHttpsCount`, `ProbedMailCount`, `ProbedFtpTlsCount`
 - `CtPromotedHttpsCount`, `CtSkippedHttpsPromotionCount`
 - `CtSkippedUnresolvedHttpsPromotionCount`, `CtSkippedLowConfidenceHttpsPromotionCount`, `CtSkippedDuplicateHttpsPromotionCount`
 - `MxPromotedHttpsCount`, `MxPromotedMailCount`
 - `MxInvalidArtifactCount`, `MxDuplicateHostCount`, `MxSkippedDuplicateHttpsPromotionCount`
-- `HttpsTargetCountBeforeLimit`, `MailTargetCountBeforeLimit`
-- `HttpsTargetCountDroppedByLimit`, `MailTargetCountDroppedByLimit`
+- `HttpsTargetCountBeforeLimit`, `MailTargetCountBeforeLimit`, `FtpTlsTargetCountBeforeLimit`
+- `HttpsTargetCountDroppedByLimit`, `MailTargetCountDroppedByLimit`, `FtpTlsTargetCountDroppedByLimit`
 - `TargetOriginCounts`, `CaptureDispositionCounts`
 - `TargetDecisionDiagnostics`
 - `TargetDecisionSummary`
@@ -233,7 +267,7 @@ For large domains where you want CT-seen hostnames added to scan scope:
 
 ```powershell
 Invoke-DDCertificateInventory `
-    -DomainName eurofins.com `
+    -DomainName example.com `
     -CacheDirectory .\cert-monitor `
     -IncludeCtSubdomains `
     -ReuseRecentResults `
@@ -251,7 +285,7 @@ Direct native CT ingestion (without `crt.sh`/Cert Spotter):
 
 ```powershell
 Invoke-DDCertificateInventory `
-    -DomainName eurofins.com,evotec.pl,evotec.xyz `
+    -DomainName example.com,example.org,microsoft.com `
     -CacheDirectory .\cert-monitor `
     -IncludeCtSubdomains `
     -EnableNativeCtLogSubdomains `
@@ -274,7 +308,7 @@ Invoke-DDCertificateInventory `
 CLI equivalent:
 
 ```bash
-DomainDetective.CLI CertificateInventoryCapture eurofins.com \
+DomainDetective.CLI CertificateInventoryCapture example.com \
   --include-ct-subdomains \
   --verify-ct-subdomains \
   --reuse-recent-results \

--- a/Docs/CERTIFICATE_INVENTORY.MD
+++ b/Docs/CERTIFICATE_INVENTORY.MD
@@ -44,6 +44,7 @@ When you run repeated captures against large portfolios, you can reuse recent en
 
 - Enable with `-ReuseRecentResults`.
 - Reuse window is controlled by `-RecentResultTtlHours` (default `24`).
+- Reuse age is measured from the endpoint's original `ObservedAtUtc`, not from the timestamp of a later snapshot that happens to carry the reused row.
 - Optional stable-failure reuse is controlled by `-ReuseRecentFailureResults` with `-RecentFailureResultTtlHours` (default `1`).
 - Near-expiry certificates are always refreshed based on `-ReprobeExpiringWithinDays` (default `14`).
 - Reuse is endpoint-based (`host + port + service`).
@@ -97,7 +98,7 @@ Notes:
 
 An inventory row identifies a logical endpoint by `host + port + service`. The same hostname and port can therefore retain separate HTTPS, STARTTLS, or FTPS observations instead of being merged into one ambiguous record.
 
-Live rows include `ObservedAtUtc` and `ProbeVantage`. Cached observations are reused only when their normalized vantage matches the requested vantage. When the protocol exposes the connected socket, `RemoteAddress` records the address actually reached. Service detection is opt-in because it adds DNS work:
+Live rows include `ObservedAtUtc` and `ProbeVantage`. Cached observations are reused only when their normalized vantage matches the requested vantage. When the protocol exposes the connected socket, `RemoteAddress` records the address actually reached and `RemoteAddressFamily` uses the stable `IPv4` or `IPv6` label across protocols. Legacy cached family labels and IPv4-mapped IPv6 addresses are normalized when they re-enter an inventory. Bracketed IPv6 URI hosts are retained as valid URI authorities but normalized to bare addresses for DNS and connection evidence. Service detection is opt-in because it adds DNS work:
 
 ```powershell
 Invoke-DDCertificateInventory `
@@ -108,7 +109,7 @@ Invoke-DDCertificateInventory `
     -NoPersist
 ```
 
-With detection enabled, each row can also include the resolver, `DnsObservedAtUtc`, resolved addresses, full CNAME chain, redirect targets, and an `Attribution` result. `ObservedAtUtc` is stamped when that individual protocol probe completes; it is not copied from the later snapshot-finalization time. `DnsObservedAtUtc` and `Attribution.EvaluatedAtUtc` describe the current enrichment pass. Attribution retains every candidate and the evidence that contributed to it. The primary result includes a score, confidence, rule ID, and rule version; equally ranked eligible candidates with different provider/service identities are retained as ambiguous instead of selecting one by sort order. Multiple rules agreeing on the same identity remain supporting candidates rather than creating false ambiguity.
+With detection enabled, each row can also include the resolver, `DnsObservedAtUtc`, resolved addresses, full CNAME chain, every followed cross-host redirect target in order (including returns and repeated hosts), and an `Attribution` result. CNAME service selection reconstructs owner-to-target traversal instead of trusting DNS answer order. IP-literal endpoint hosts become completed address evidence without pointless DNS queries. `ObservedAtUtc` is stamped when that individual protocol probe completes; it is not copied from the later snapshot-finalization time. `DnsObservedAtUtc` and `Attribution.EvaluatedAtUtc` describe the enrichment pass, and snapshot `CapturedAtUtc` is finalized after that enrichment completes and clamped to the latest contained observation. Attribution retains every candidate and the evidence that contributed to it. The primary result includes a score, confidence, rule ID, and rule version; equally ranked eligible candidates with different provider/service identities are retained as ambiguous instead of selecting one by sort order. Multiple rules agreeing on the same identity remain supporting candidates rather than creating false ambiguity.
 
 Hostname prefixes and certificate issuers are weak signals. They can create review candidates, but the built-in rules do not let either signal establish a primary provider by itself. CNAME namespaces, current service-tag membership, configured IP ranges, redirect targets, reverse DNS, and ASN evidence are treated as stronger signals. Built-in web-delivery and redirection rules apply only to HTTPS observations, so a shared address or CNAME does not label an unrelated mail or FTP TLS service.
 

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
@@ -17,6 +17,23 @@ public class TestCertificateInventoryCaptureCommand {
     }
 
     [Fact]
+    public async Task ExecuteAsync_AllowsEndpointOnlyCapture() {
+        var command = new CertificateInventoryCaptureCommand();
+        var settings = new CertificateInventoryCaptureSettings {
+            AdditionalEndpoints = new[] { "ftp://localhost" },
+            NoApexHttps = true,
+            NoWwwHttps = true,
+            DisableMxDiscovery = true,
+            NoPersist = true,
+            Json = true
+        };
+
+        int exitCode = await command.ExecuteForTestingAsync(null!, settings);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_SucceedsWithoutNetworkWhenAllDiscoveryAndProbesDisabled() {
         var command = new CertificateInventoryCaptureCommand();
         var settings = new CertificateInventoryCaptureSettings {
@@ -90,6 +107,10 @@ public class TestCertificateInventoryCaptureCommand {
             string summaryHeader = Assert.Single(File.ReadAllLines(summaryCsvPath));
             Assert.Contains("TargetOrigins", header, StringComparison.Ordinal);
             Assert.Contains("CaptureDisposition", header, StringComparison.Ordinal);
+            Assert.Contains("DnsObservedAtUtc", header, StringComparison.Ordinal);
+            Assert.Contains("AttributionCandidates", header, StringComparison.Ordinal);
+            Assert.Contains("AttributionEvaluatedAtUtc", header, StringComparison.Ordinal);
+            Assert.Contains("AzureServiceTagChangeNumber", header, StringComparison.Ordinal);
             Assert.Contains("Severity", summaryHeader, StringComparison.Ordinal);
             Assert.Contains("RecommendedAction", summaryHeader, StringComparison.Ordinal);
             Assert.Contains("TargetOrigins", summaryHeader, StringComparison.Ordinal);
@@ -99,6 +120,62 @@ public class TestCertificateInventoryCaptureCommand {
             }
             if (File.Exists(summaryCsvPath)) {
                 File.Delete(summaryCsvPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void WriteCsv_RetainsAllAttributionCandidatesAndCatalogProvenance() {
+        string csvPath = Path.Combine(Path.GetTempPath(), "dd-attribution-csv-" + Guid.NewGuid().ToString("N") + ".csv");
+        try {
+            var evidence = new DomainDetective.Providers.Endpoint.EndpointAttributionEvidence {
+                Kind = DomainDetective.Providers.Endpoint.EndpointAttributionSignalKind.CertificateIssuer,
+                ObservedValue = "Example Issuer",
+                MatchedValue = "Example",
+                Score = 0.15,
+                Source = "test-source"
+            };
+            var candidate = new DomainDetective.Providers.Endpoint.EndpointAttributionCandidate {
+                ProviderId = "review-provider",
+                ServiceId = "review-service",
+                DisplayName = "Review Candidate",
+                Score = 0.15,
+                Confidence = DomainDetective.Providers.Endpoint.EndpointAttributionConfidence.Low,
+                EligibleAsPrimary = false,
+                RuleId = "test.review-candidate",
+                RuleVersion = "1",
+                Evidence = new[] { evidence }
+            };
+            var entry = new CertificateInventoryEntry {
+                Host = "service.example.com",
+                ResolvedHost = "service.example.com",
+                Port = 443,
+                Service = "HTTPS",
+                Attribution = new DomainDetective.Providers.Endpoint.EndpointAttributionResult {
+                    Candidates = new[] { candidate },
+                    EvaluatedAtUtc = DateTimeOffset.UtcNow,
+                    AzureServiceTagSource = "service-tags.json",
+                    AzureServiceTagChangeNumber = "42",
+                    AzureServiceTagCloud = "Public",
+                    AzureServiceTagRetrievedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-5)
+                }
+            };
+            var result = new CertificateInventoryCaptureResult {
+                CapturedAtUtc = DateTimeOffset.UtcNow,
+                Snapshot = new CertificateInventorySnapshot { Entries = new List<CertificateInventoryEntry> { entry } }
+            };
+
+            CertificateInventoryCaptureCommand.WriteCsv(result, csvPath);
+
+            string csv = File.ReadAllText(csvPath);
+            Assert.Contains("review-provider", csv, StringComparison.Ordinal);
+            Assert.Contains("test.review-candidate", csv, StringComparison.Ordinal);
+            Assert.Contains("CertificateIssuer", csv, StringComparison.Ordinal);
+            Assert.Contains("service-tags.json", csv, StringComparison.Ordinal);
+            Assert.Contains("42", csv, StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(csvPath)) {
+                File.Delete(csvPath);
             }
         }
     }

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
@@ -186,6 +186,7 @@ public class TestCertificateInventoryCaptureCommand {
             Assert.Contains("TargetOrigins", header, StringComparison.Ordinal);
             Assert.Contains("CaptureDisposition", header, StringComparison.Ordinal);
             Assert.Contains("DnsObservedAtUtc", header, StringComparison.Ordinal);
+            Assert.Contains("DnsObservationErrors", header, StringComparison.Ordinal);
             Assert.Contains("AttributionCandidates", header, StringComparison.Ordinal);
             Assert.Contains("AttributionEvaluatedAtUtc", header, StringComparison.Ordinal);
             Assert.Contains("AzureServiceTagChangeNumber", header, StringComparison.Ordinal);
@@ -251,6 +252,40 @@ public class TestCertificateInventoryCaptureCommand {
             Assert.Contains("CertificateIssuer", csv, StringComparison.Ordinal);
             Assert.Contains("service-tags.json", csv, StringComparison.Ordinal);
             Assert.Contains("42", csv, StringComparison.Ordinal);
+        } finally {
+            if (File.Exists(csvPath)) {
+                File.Delete(csvPath);
+            }
+        }
+    }
+
+    [Fact]
+    public void WriteCsv_RetainsDnsObservationErrors() {
+        string csvPath = Path.Combine(Path.GetTempPath(), "dd-dns-errors-csv-" + Guid.NewGuid().ToString("N") + ".csv");
+        try {
+            var entry = new CertificateInventoryEntry {
+                Host = "service.example.com",
+                ResolvedHost = "service.example.com",
+                Port = 443,
+                Service = "HTTPS",
+                DnsObservationErrors = new[] {
+                    "A lookup failed: timeout",
+                    "AAAA lookup failed: refused"
+                }
+            };
+            var result = new CertificateInventoryCaptureResult {
+                CapturedAtUtc = DateTimeOffset.UtcNow,
+                Snapshot = new CertificateInventorySnapshot {
+                    Entries = new List<CertificateInventoryEntry> { entry }
+                }
+            };
+
+            CertificateInventoryCaptureCommand.WriteCsv(result, csvPath);
+
+            string[] lines = File.ReadAllLines(csvPath);
+            Assert.Equal(2, lines.Length);
+            Assert.Contains("DnsObservationErrors", lines[0], StringComparison.Ordinal);
+            Assert.Contains("A lookup failed: timeout|AAAA lookup failed: refused", lines[1], StringComparison.Ordinal);
         } finally {
             if (File.Exists(csvPath)) {
                 File.Delete(csvPath);

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
@@ -112,6 +112,38 @@ public class TestCertificateInventoryCaptureCommand {
     }
 
     [Fact]
+    public async Task ExecuteAsync_ShowEndpointsIncludesFtpTlsTargets() {
+        IAnsiConsole originalConsole = AnsiConsole.Console;
+        using var output = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output)
+        });
+        try {
+            var command = new CertificateInventoryCaptureCommand();
+            var settings = new CertificateInventoryCaptureSettings {
+                AdditionalEndpoints = new[] { "ftps-explicit://localhost:1" },
+                NoApexHttps = true,
+                NoWwwHttps = true,
+                DisableMxDiscovery = true,
+                NoPersist = true,
+                ShowEndpoints = true,
+                FtpTlsTimeoutSeconds = 1
+            };
+
+            int exitCode = await command.ExecuteForTestingAsync(null!, settings);
+
+            string rendered = output.ToString();
+            Assert.Equal(0, exitCode);
+            Assert.Contains("FTPTLS", rendered, StringComparison.Ordinal);
+            Assert.Contains("ftps-explicit://localhost:1", rendered, StringComparison.Ordinal);
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
+    }
+
+    [Fact]
     public async Task ExecuteAsync_SucceedsWithoutNetworkWhenAllDiscoveryAndProbesDisabled() {
         var command = new CertificateInventoryCaptureCommand();
         var settings = new CertificateInventoryCaptureSettings {

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
@@ -56,6 +56,44 @@ public class TestCertificateInventoryCaptureCommand {
         }
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(513)]
+    public async Task ExecuteAsync_ReturnsErrorForInvalidDnsEnrichmentParallelism(int parallelism) {
+        IAnsiConsole originalConsole = AnsiConsole.Console;
+        using var output = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output)
+        });
+        try {
+            var command = new CertificateInventoryCaptureCommand();
+            var settings = new CertificateInventoryCaptureSettings {
+                Domains = new[] { "example.com" },
+                NoApexHttps = true,
+                NoWwwHttps = true,
+                DisableMxDiscovery = true,
+                DisableSmtpStartTls = true,
+                DisableSubmissionStartTls = true,
+                IncludeImapTls = false,
+                IncludePop3Tls = false,
+                NoPersist = true,
+                DnsEnrichmentParallelism = parallelism
+            };
+
+            int exitCode = await command.ExecuteForTestingAsync(null!, settings);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(
+                "--dns-enrichment-parallelism must be between 1 and 512.",
+                output.ToString(),
+                StringComparison.Ordinal);
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
+    }
+
     [Fact]
     public async Task ExecuteAsync_AllowsEndpointOnlyCapture() {
         var command = new CertificateInventoryCaptureCommand();

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryCaptureCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using DomainDetective.CLI.Commands;
+using Spectre.Console;
 
 namespace DomainDetective.CLI.Tests;
 
@@ -14,6 +15,45 @@ public class TestCertificateInventoryCaptureCommand {
         var exitCode = await command.ExecuteForTestingAsync(null!, settings);
 
         Assert.Equal(1, exitCode);
+    }
+
+    [Theory]
+    [InlineData(-2)]
+    [InlineData(0)]
+    [InlineData(301)]
+    public async Task ExecuteAsync_ReturnsErrorForInvalidFtpTlsTimeout(int timeoutSeconds) {
+        IAnsiConsole originalConsole = AnsiConsole.Console;
+        using var output = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out = new AnsiConsoleOutput(output)
+        });
+        try {
+            var command = new CertificateInventoryCaptureCommand();
+            var settings = new CertificateInventoryCaptureSettings {
+                Domains = new[] { "example.com" },
+                NoApexHttps = true,
+                NoWwwHttps = true,
+                DisableMxDiscovery = true,
+                DisableSmtpStartTls = true,
+                DisableSubmissionStartTls = true,
+                IncludeImapTls = false,
+                IncludePop3Tls = false,
+                NoPersist = true,
+                FtpTlsTimeoutSeconds = timeoutSeconds
+            };
+
+            int exitCode = await command.ExecuteForTestingAsync(null!, settings);
+
+            Assert.Equal(1, exitCode);
+            Assert.Contains(
+                "--ftps-timeout-seconds must be between 1 and 300.",
+                output.ToString(),
+                StringComparison.Ordinal);
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
     }
 
     [Fact]

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryExports.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryExports.cs
@@ -163,7 +163,7 @@ public class TestCertificateInventoryExports {
             Assert.True(File.Exists(ndjsonPath));
 
             var csv = ReadGzipText(csvPath);
-            Assert.Contains("Host,Port,Status,ChangeReasons", csv);
+            Assert.Contains("Host,Port,ProbeVantage,Status,ChangeReasons", csv);
             Assert.Contains("Changed", csv);
             Assert.Contains("changed.example.com", csv);
 

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryExports.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryExports.cs
@@ -112,7 +112,7 @@ public class TestCertificateInventoryExports {
                         ResolvedHost = "changed.example.com",
                         Port = 443,
                         Service = "HTTPS",
-                        ProbeVantage = "branch-office",
+                        ProbeVantage = "[branch]",
                         CertificateIssuerNormalized = "Issuer A",
                         CertificateRootIssuerNormalized = "Root A",
                         CertificateThumbprint = "AA:AA",
@@ -133,7 +133,7 @@ public class TestCertificateInventoryExports {
                         ResolvedHost = "changed.example.com",
                         Port = 443,
                         Service = "HTTPS",
-                        ProbeVantage = "branch-office",
+                        ProbeVantage = "[branch]",
                         CertificateIssuerNormalized = "Issuer B",
                         CertificateRootIssuerNormalized = "Root B",
                         CertificateThumbprint = "BB:BB",
@@ -194,7 +194,7 @@ public class TestCertificateInventoryExports {
                 Assert.Contains("Service", rendered, StringComparison.Ordinal);
                 Assert.Contains("HTTPS", rendered, StringComparison.Ordinal);
                 Assert.Contains("Vantage", rendered, StringComparison.Ordinal);
-                Assert.Contains("branch-office", rendered, StringComparison.Ordinal);
+                Assert.Contains("[branch]", rendered, StringComparison.Ordinal);
             } finally {
                 AnsiConsole.Console = originalConsole;
             }
@@ -219,7 +219,7 @@ public class TestCertificateInventoryExports {
                         ResolvedHost = "drift.example.com",
                         Port = 443,
                         Service = "HTTPS",
-                        ProbeVantage = "branch-office",
+                        ProbeVantage = "[branch]",
                         CertificateThumbprint = thumbprint,
                         CertificateIssuerNormalized = "Issuer",
                         Valid = true,
@@ -255,14 +255,14 @@ public class TestCertificateInventoryExports {
                 Assert.Contains("Service", rendered, StringComparison.Ordinal);
                 Assert.Contains("HTTPS", rendered, StringComparison.Ordinal);
                 Assert.Contains("Vantage", rendered, StringComparison.Ordinal);
-                Assert.Contains("branch-office", rendered, StringComparison.Ordinal);
+                Assert.Contains("[branch]", rendered, StringComparison.Ordinal);
             } finally {
                 AnsiConsole.Console = originalConsole;
             }
 
             string csv = File.ReadAllText(csvPath, Encoding.UTF8);
             Assert.Contains("Host,Port,Service,ProbeVantage,ObservationCount", csv, StringComparison.Ordinal);
-            Assert.Contains("drift.example.com,443,HTTPS,branch-office", csv, StringComparison.Ordinal);
+            Assert.Contains("drift.example.com,443,HTTPS,[branch]", csv, StringComparison.Ordinal);
         } finally {
             DeleteDirectory(tempDirectory);
         }

--- a/DomainDetective.CLI.Tests/TestCertificateInventoryExports.cs
+++ b/DomainDetective.CLI.Tests/TestCertificateInventoryExports.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using DomainDetective;
 using DomainDetective.CLI.Commands;
 using DomainDetective.Helpers;
+using Spectre.Console;
 
 namespace DomainDetective.CLI.Tests;
 
@@ -111,6 +112,7 @@ public class TestCertificateInventoryExports {
                         ResolvedHost = "changed.example.com",
                         Port = 443,
                         Service = "HTTPS",
+                        ProbeVantage = "branch-office",
                         CertificateIssuerNormalized = "Issuer A",
                         CertificateRootIssuerNormalized = "Root A",
                         CertificateThumbprint = "AA:AA",
@@ -131,6 +133,7 @@ public class TestCertificateInventoryExports {
                         ResolvedHost = "changed.example.com",
                         Port = 443,
                         Service = "HTTPS",
+                        ProbeVantage = "branch-office",
                         CertificateIssuerNormalized = "Issuer B",
                         CertificateRootIssuerNormalized = "Root B",
                         CertificateThumbprint = "BB:BB",
@@ -170,6 +173,96 @@ public class TestCertificateInventoryExports {
             var ndjson = File.ReadAllText(ndjsonPath, Encoding.UTF8);
             Assert.Contains("\"Status\":\"Changed\"", ndjson);
             Assert.Contains("\"Host\":\"changed.example.com\"", ndjson);
+
+            IAnsiConsole originalConsole = AnsiConsole.Console;
+            using var output = new StringWriter();
+            var testConsole = AnsiConsole.Create(new AnsiConsoleSettings {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(output)
+            });
+            testConsole.Profile.Width = 500;
+            AnsiConsole.Console = testConsole;
+            try {
+                var tableResult = await command.ExecuteForTestingAsync(null!, new CertificateInventoryDiffSettings {
+                    CacheDirectory = cacheDirectory,
+                    MaxEndpoints = 100
+                });
+
+                string rendered = output.ToString();
+                Assert.Equal(0, tableResult);
+                Assert.Contains("Service", rendered, StringComparison.Ordinal);
+                Assert.Contains("HTTPS", rendered, StringComparison.Ordinal);
+                Assert.Contains("Vantage", rendered, StringComparison.Ordinal);
+                Assert.Contains("branch-office", rendered, StringComparison.Ordinal);
+            } finally {
+                AnsiConsole.Console = originalConsole;
+            }
+        } finally {
+            DeleteDirectory(tempDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task DriftCommand_PreservesServiceAndVantageInTableAndCsv() {
+        var tempDirectory = CreateTempDirectory();
+        try {
+            var cacheDirectory = Path.Combine(tempDirectory, "cache");
+            var inventoryDirectory = Path.Combine(cacheDirectory, "inventory");
+            Directory.CreateDirectory(inventoryDirectory);
+            var now = DateTimeOffset.UtcNow;
+            CertificateInventorySnapshot Snapshot(DateTimeOffset capturedAtUtc, string thumbprint) => new() {
+                CapturedAtUtc = capturedAtUtc,
+                Entries = new List<CertificateInventoryEntry> {
+                    new() {
+                        Host = "drift.example.com",
+                        ResolvedHost = "drift.example.com",
+                        Port = 443,
+                        Service = "HTTPS",
+                        ProbeVantage = "branch-office",
+                        CertificateThumbprint = thumbprint,
+                        CertificateIssuerNormalized = "Issuer",
+                        Valid = true,
+                        ChainComplete = true,
+                        HostnameMatch = true
+                    }
+                }
+            };
+            WriteSnapshot(inventoryDirectory, "snapshot-old.json", Snapshot(now.AddHours(-2), "AA:AA"));
+            WriteSnapshot(inventoryDirectory, "snapshot-new.json", Snapshot(now.AddHours(-1), "BB:BB"));
+
+            var csvPath = Path.Combine(tempDirectory, "out", "drift.csv");
+            IAnsiConsole originalConsole = AnsiConsole.Console;
+            using var output = new StringWriter();
+            var testConsole = AnsiConsole.Create(new AnsiConsoleSettings {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(output)
+            });
+            testConsole.Profile.Width = 500;
+            AnsiConsole.Console = testConsole;
+            try {
+                var result = await new CertificateInventoryDriftCommand().ExecuteForTestingAsync(
+                    null!,
+                    new CertificateInventoryDriftSettings {
+                        CacheDirectory = cacheDirectory,
+                        CsvPath = csvPath,
+                        MaxEndpoints = 100
+                    });
+
+                Assert.Equal(0, result);
+                string rendered = output.ToString();
+                Assert.Contains("Service", rendered, StringComparison.Ordinal);
+                Assert.Contains("HTTPS", rendered, StringComparison.Ordinal);
+                Assert.Contains("Vantage", rendered, StringComparison.Ordinal);
+                Assert.Contains("branch-office", rendered, StringComparison.Ordinal);
+            } finally {
+                AnsiConsole.Console = originalConsole;
+            }
+
+            string csv = File.ReadAllText(csvPath, Encoding.UTF8);
+            Assert.Contains("Host,Port,Service,ProbeVantage,ObservationCount", csv, StringComparison.Ordinal);
+            Assert.Contains("drift.example.com,443,HTTPS,branch-office", csv, StringComparison.Ordinal);
         } finally {
             DeleteDirectory(tempDirectory);
         }

--- a/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
@@ -422,6 +422,10 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
             AnsiConsole.MarkupLine("[red]--https-timeout-seconds must be between 1 and 300.[/]");
             return 1;
         }
+        if (settings.DnsEnrichmentParallelism < 1 || settings.DnsEnrichmentParallelism > 512) {
+            AnsiConsole.MarkupLine("[red]--dns-enrichment-parallelism must be between 1 and 512.[/]");
+            return 1;
+        }
         if (settings.MaxTargets < 0) {
             AnsiConsole.MarkupLine("[red]--max-targets must be 0 or greater.[/]");
             return 1;

--- a/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
@@ -763,6 +763,9 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
             foreach (var endpoint in result.MailEndpoints.Take(500)) {
                 endpointTable.AddRow("MAILTLS", Markup.Escape(endpoint));
             }
+            foreach (var endpoint in result.FtpTlsEndpoints.Take(500)) {
+                endpointTable.AddRow("FTPTLS", Markup.Escape(endpoint));
+            }
             AnsiConsole.Write(endpointTable);
         }
 

--- a/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
@@ -219,9 +219,27 @@ internal sealed class CertificateInventoryCaptureSettings : CommandSettings {
     [DefaultValue(1024)]
     public int NativeCtCatchUpBatchSize { get; set; } = 1024;
 
-    [Description("Additional endpoint(s) to probe. Repeat option for multiple values.")]
+    [Description("Additional endpoint(s) to probe, including HTTPS, mail TLS, ftps://, and ftps-explicit://. Repeat for multiple values.")]
     [CommandOption("--endpoint <ENDPOINT>")]
     public string[] AdditionalEndpoints { get; set; } = Array.Empty<string>();
+
+    [Description("Resolve endpoint DNS evidence and perform explainable provider/service attribution.")]
+    [CommandOption("--detect-services")]
+    public bool EnableEndpointAttribution { get; set; }
+
+    [Description("Label identifying the network vantage used for this observation.")]
+    [CommandOption("--probe-vantage <LABEL>")]
+    [DefaultValue("default")]
+    public string ProbeVantage { get; set; } = "default";
+
+    [Description("Optional current Azure service-tag JSON file used for IP-based attribution.")]
+    [CommandOption("--azure-service-tags-json <PATH>")]
+    public string? AzureServiceTagsJsonPath { get; set; }
+
+    [Description("Maximum concurrent DNS evidence lookups used by service detection.")]
+    [CommandOption("--dns-enrichment-parallelism <N>")]
+    [DefaultValue(8)]
+    public int DnsEnrichmentParallelism { get; set; } = 8;
 
     [Description("Maximum MX hosts retained per domain (0 means unlimited).")]
     [CommandOption("--mx-max-hosts <N>")]
@@ -243,12 +261,17 @@ internal sealed class CertificateInventoryCaptureSettings : CommandSettings {
     [DefaultValue(15)]
     public int MailTimeoutSeconds { get; set; } = 15;
 
+    [Description("FTP TLS timeout in seconds.")]
+    [CommandOption("--ftps-timeout-seconds <SECONDS>")]
+    [DefaultValue(15)]
+    public int FtpTlsTimeoutSeconds { get; set; } = 15;
+
     [Description("HTTPS certificate probe timeout in seconds.")]
     [CommandOption("--https-timeout-seconds <SECONDS>")]
     [DefaultValue(30)]
     public int HttpsTimeoutSeconds { get; set; } = 30;
 
-    [Description("Maximum total probe targets (HTTPS + mail) kept after discovery (0 means unlimited).")]
+    [Description("Maximum total probe targets (HTTPS + mail + FTP TLS) kept after discovery (0 means unlimited).")]
     [CommandOption("--max-targets <N>")]
     [DefaultValue(0)]
     public int MaxTargets { get; set; }
@@ -525,14 +548,19 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
                 return 1;
             }
         }
-        if (domains.Count == 0) {
-            AnsiConsole.MarkupLine("[red]Provide at least one domain (argument or --domains-file).[/]");
+        bool hasExplicitEndpoint = settings.AdditionalEndpoints != null && settings.AdditionalEndpoints.Any(endpoint => !string.IsNullOrWhiteSpace(endpoint));
+        if (domains.Count == 0 && !hasExplicitEndpoint) {
+            AnsiConsole.MarkupLine("[red]Provide at least one domain or --endpoint.[/]");
             return 1;
         }
 
         var options = new CertificateInventoryCaptureOptions {
             CacheDirectory = CertificateInventoryCommandHelpers.ResolveCacheDirectory(settings.CacheDirectory),
             DnsEndpoint = settings.DnsEndpoint,
+            EnableEndpointAttribution = settings.EnableEndpointAttribution,
+            ProbeVantage = settings.ProbeVantage,
+            AzureServiceTagsJsonPath = settings.AzureServiceTagsJsonPath,
+            DnsEnrichmentParallelism = settings.DnsEnrichmentParallelism,
             IncludeApexHttps = !settings.NoApexHttps,
             IncludeWwwHttps = !settings.NoWwwHttps,
             IncludeMxHosts = !settings.DisableMxDiscovery,
@@ -577,6 +605,7 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
             MaxParallelism = settings.MaxParallelism,
             DiscoveryParallelism = settings.DiscoveryParallelism,
             MailTimeout = TimeSpan.FromSeconds(settings.MailTimeoutSeconds),
+            FtpTlsTimeout = TimeSpan.FromSeconds(settings.FtpTlsTimeoutSeconds),
             HttpsTimeout = TimeSpan.FromSeconds(settings.HttpsTimeoutSeconds),
             MaxTargets = settings.MaxTargets,
             MaxProbeStartsPerSecond = settings.MaxProbeStartsPerSecond,
@@ -660,6 +689,7 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
         summary.AddRow("Domains", result.DomainCount.ToString());
         summary.AddRow("MX Hosts", result.MxHostCount.ToString());
         summary.AddRow("HTTPS Endpoints", result.HttpsEndpointCount.ToString());
+        summary.AddRow("FTP TLS Endpoints", result.FtpTlsEndpointCount.ToString());
         summary.AddRow("CT Subdomains", result.CtDiscoveredSubdomainCount.ToString());
         summary.AddRow("CT -> HTTPS", result.CtPromotedHttpsCount.ToString());
         summary.AddRow("CT Skipped HTTPS", result.CtSkippedHttpsPromotionCount.ToString());
@@ -675,8 +705,10 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
         summary.AddRow("Mail Endpoints", result.MailEndpointCount.ToString());
         summary.AddRow("HTTPS Before Limit", result.HttpsTargetCountBeforeLimit.ToString());
         summary.AddRow("Mail Before Limit", result.MailTargetCountBeforeLimit.ToString());
+        summary.AddRow("FTP TLS Before Limit", result.FtpTlsTargetCountBeforeLimit.ToString());
         summary.AddRow("HTTPS Dropped By Limit", result.HttpsTargetCountDroppedByLimit.ToString());
         summary.AddRow("Mail Dropped By Limit", result.MailTargetCountDroppedByLimit.ToString());
+        summary.AddRow("FTP TLS Dropped By Limit", result.FtpTlsTargetCountDroppedByLimit.ToString());
         summary.AddRow("Target Decision Diagnostics", result.TargetDecisionDiagnostics.Count.ToString());
         summary.AddRow("Target Decision Summary Buckets", result.TargetDecisionSummary.Count.ToString());
         summary.AddRow("Warning Decision Buckets", warningTargetDecisionBuckets.Count.ToString());
@@ -685,9 +717,11 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
         summary.AddRow("Reused Recent", result.ReusedRecentEntryCount.ToString());
         summary.AddRow("Reused Recent HTTPS", result.ReusedRecentHttpsCount.ToString());
         summary.AddRow("Reused Recent Mail", result.ReusedRecentMailCount.ToString());
+        summary.AddRow("Reused Recent FTP TLS", result.ReusedRecentFtpTlsCount.ToString());
         summary.AddRow("Reused Stable Failures", result.ReusedRecentFailureEntryCount.ToString());
         summary.AddRow("Probed HTTPS", result.ProbedHttpsCount.ToString());
         summary.AddRow("Probed Mail", result.ProbedMailCount.ToString());
+        summary.AddRow("Probed FTP TLS", result.ProbedFtpTlsCount.ToString());
         summary.AddRow("Unique Endpoints", result.UniqueEndpointCount.ToString());
         summary.AddRow("Valid", result.ValidCount.ToString());
         summary.AddRow("Expired", result.ExpiredCount.ToString());
@@ -733,7 +767,7 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
         return 0;
     }
 
-    private static void WriteCsv(CertificateInventoryCaptureResult result, string path) {
+    internal static void WriteCsv(CertificateInventoryCaptureResult result, string path) {
         var fullPath = Path.GetFullPath(path);
         var directory = Path.GetDirectoryName(fullPath);
         if (!string.IsNullOrWhiteSpace(directory)) {
@@ -741,7 +775,7 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine("CapturedAtUtc,Host,ResolvedHost,Service,Scheme,Port,CertificateThumbprint,CertificateSerialNumber,CertificateSubject,CertificateIssuer,CertificateRootIssuer,NotAfterUtc,DaysToExpire,Valid,Expired,IsReachable,FailureKind,FailureReason,HostnameMatch,ChainComplete,AuthenticationProfile,AllowsServerAuthentication,AllowsClientAuthentication,AllowsSecureEmail,PresentInCtLogs,CtDiscoverySources,CtTemplateFormatErrors,CertificateChainSource,TargetOrigins,CaptureDisposition");
+        sb.AppendLine("CapturedAtUtc,Host,ResolvedHost,Service,Scheme,Port,ObservedAtUtc,ProbeVantage,DnsResolver,DnsObservedAtUtc,RemoteAddress,RemoteAddressFamily,ResolvedAddresses,CnameChain,RedirectTargets,AttributionProvider,AttributionService,AttributionConfidence,AttributionScore,AttributionRuleId,AttributionRuleVersion,AttributionEvidence,AttributionCandidates,AttributionEvaluatedAtUtc,AttributionAmbiguous,AzureServiceTagSource,AzureServiceTagChangeNumber,AzureServiceTagCloud,AzureServiceTagRetrievedAtUtc,CertificateThumbprint,CertificateSerialNumber,CertificateSubject,CertificateIssuer,CertificateRootIssuer,NotAfterUtc,DaysToExpire,Valid,Expired,IsReachable,FailureKind,FailureReason,HostnameMatch,ChainComplete,AuthenticationProfile,AllowsServerAuthentication,AllowsClientAuthentication,AllowsSecureEmail,PresentInCtLogs,CtDiscoverySources,CtTemplateFormatErrors,CertificateChainSource,TargetOrigins,CaptureDisposition");
         foreach (var entry in result.Snapshot.Entries) {
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(result.CapturedAtUtc.UtcDateTime.ToString("O")));
             sb.Append(',');
@@ -754,6 +788,52 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Scheme));
             sb.Append(',');
             sb.Append(entry.Port);
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.ObservedAtUtc?.UtcDateTime.ToString("O") ?? string.Empty));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.ProbeVantage));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.DnsResolver));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.DnsObservedAtUtc?.UtcDateTime.ToString("O") ?? string.Empty));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.RemoteAddress));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.RemoteAddressFamily));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(string.Join("|", entry.ResolvedAddresses ?? Array.Empty<string>())));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(string.Join("|", entry.CnameChain ?? Array.Empty<string>())));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(string.Join("|", entry.RedirectTargets ?? Array.Empty<string>())));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.Primary?.ProviderId));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.Primary?.ServiceId));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.Primary?.Confidence.ToString()));
+            sb.Append(',');
+            sb.Append(entry.Attribution?.Primary?.Score.ToString("0.###", System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty);
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.Primary?.RuleId));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.Primary?.RuleVersion));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(string.Join("|", entry.Attribution?.Primary?.Evidence.Select(evidence => $"{evidence.Kind}:{evidence.ObservedValue}->{evidence.MatchedValue}") ?? Array.Empty<string>())));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(JsonSerializer.Serialize(entry.Attribution?.Candidates ?? Array.Empty<Providers.Endpoint.EndpointAttributionCandidate>())));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.EvaluatedAtUtc.UtcDateTime.ToString("O") ?? string.Empty));
+            sb.Append(',');
+            sb.Append(entry.Attribution?.IsAmbiguous.ToString() ?? string.Empty);
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.AzureServiceTagSource));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.AzureServiceTagChangeNumber));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.AzureServiceTagCloud));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.Attribution?.AzureServiceTagRetrievedAtUtc?.UtcDateTime.ToString("O") ?? string.Empty));
             sb.Append(',');
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.CertificateThumbprint));
             sb.Append(',');

--- a/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
@@ -414,6 +414,10 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
             AnsiConsole.MarkupLine("[red]--mail-timeout-seconds must be between 1 and 300.[/]");
             return 1;
         }
+        if (settings.FtpTlsTimeoutSeconds < 1 || settings.FtpTlsTimeoutSeconds > 300) {
+            AnsiConsole.MarkupLine("[red]--ftps-timeout-seconds must be between 1 and 300.[/]");
+            return 1;
+        }
         if (settings.HttpsTimeoutSeconds < 1 || settings.HttpsTimeoutSeconds > 300) {
             AnsiConsole.MarkupLine("[red]--https-timeout-seconds must be between 1 and 300.[/]");
             return 1;

--- a/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryCaptureCommand.cs
@@ -783,7 +783,7 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine("CapturedAtUtc,Host,ResolvedHost,Service,Scheme,Port,ObservedAtUtc,ProbeVantage,DnsResolver,DnsObservedAtUtc,RemoteAddress,RemoteAddressFamily,ResolvedAddresses,CnameChain,RedirectTargets,AttributionProvider,AttributionService,AttributionConfidence,AttributionScore,AttributionRuleId,AttributionRuleVersion,AttributionEvidence,AttributionCandidates,AttributionEvaluatedAtUtc,AttributionAmbiguous,AzureServiceTagSource,AzureServiceTagChangeNumber,AzureServiceTagCloud,AzureServiceTagRetrievedAtUtc,CertificateThumbprint,CertificateSerialNumber,CertificateSubject,CertificateIssuer,CertificateRootIssuer,NotAfterUtc,DaysToExpire,Valid,Expired,IsReachable,FailureKind,FailureReason,HostnameMatch,ChainComplete,AuthenticationProfile,AllowsServerAuthentication,AllowsClientAuthentication,AllowsSecureEmail,PresentInCtLogs,CtDiscoverySources,CtTemplateFormatErrors,CertificateChainSource,TargetOrigins,CaptureDisposition");
+        sb.AppendLine("CapturedAtUtc,Host,ResolvedHost,Service,Scheme,Port,ObservedAtUtc,ProbeVantage,DnsResolver,DnsObservedAtUtc,DnsObservationErrors,RemoteAddress,RemoteAddressFamily,ResolvedAddresses,CnameChain,RedirectTargets,AttributionProvider,AttributionService,AttributionConfidence,AttributionScore,AttributionRuleId,AttributionRuleVersion,AttributionEvidence,AttributionCandidates,AttributionEvaluatedAtUtc,AttributionAmbiguous,AzureServiceTagSource,AzureServiceTagChangeNumber,AzureServiceTagCloud,AzureServiceTagRetrievedAtUtc,CertificateThumbprint,CertificateSerialNumber,CertificateSubject,CertificateIssuer,CertificateRootIssuer,NotAfterUtc,DaysToExpire,Valid,Expired,IsReachable,FailureKind,FailureReason,HostnameMatch,ChainComplete,AuthenticationProfile,AllowsServerAuthentication,AllowsClientAuthentication,AllowsSecureEmail,PresentInCtLogs,CtDiscoverySources,CtTemplateFormatErrors,CertificateChainSource,TargetOrigins,CaptureDisposition");
         foreach (var entry in result.Snapshot.Entries) {
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(result.CapturedAtUtc.UtcDateTime.ToString("O")));
             sb.Append(',');
@@ -804,6 +804,8 @@ internal sealed class CertificateInventoryCaptureCommand : AsyncCommand<Certific
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.DnsResolver));
             sb.Append(',');
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.DnsObservedAtUtc?.UtcDateTime.ToString("O") ?? string.Empty));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(string.Join("|", entry.DnsObservationErrors ?? Array.Empty<string>())));
             sb.Append(',');
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(entry.RemoteAddress));
             sb.Append(',');

--- a/DomainDetective.CLI/Commands/CertificateInventoryDiffCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryDiffCommand.cs
@@ -232,14 +232,14 @@ internal sealed class CertificateInventoryDiffCommand : AsyncCommand<Certificate
                          endpoint.PreviousNotAfterUtc?.UtcDateTime.ToString("yyyy-MM-dd") ??
                          "-";
             rows.AddRow(
-                endpoint.Host,
+                Markup.Escape(endpoint.Host),
                 endpoint.Port.ToString(),
-                endpoint.ProbeVantage,
-                endpoint.CurrentService ?? endpoint.PreviousService ?? "-",
-                endpoint.Status,
-                reasons,
-                issuer,
-                root,
+                Markup.Escape(endpoint.ProbeVantage),
+                Markup.Escape(endpoint.CurrentService ?? endpoint.PreviousService ?? "-"),
+                Markup.Escape(endpoint.Status),
+                Markup.Escape(reasons),
+                Markup.Escape(issuer),
+                Markup.Escape(root),
                 expiry);
         }
         AnsiConsole.Write(rows);

--- a/DomainDetective.CLI/Commands/CertificateInventoryDiffCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryDiffCommand.cs
@@ -218,6 +218,7 @@ internal sealed class CertificateInventoryDiffCommand : AsyncCommand<Certificate
         rows.AddColumn("Host");
         rows.AddColumn("Port");
         rows.AddColumn("Vantage");
+        rows.AddColumn("Service");
         rows.AddColumn("Status");
         rows.AddColumn("Reasons");
         rows.AddColumn("Issuer");
@@ -234,6 +235,7 @@ internal sealed class CertificateInventoryDiffCommand : AsyncCommand<Certificate
                 endpoint.Host,
                 endpoint.Port.ToString(),
                 endpoint.ProbeVantage,
+                endpoint.CurrentService ?? endpoint.PreviousService ?? "-",
                 endpoint.Status,
                 reasons,
                 issuer,

--- a/DomainDetective.CLI/Commands/CertificateInventoryDiffCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryDiffCommand.cs
@@ -217,6 +217,7 @@ internal sealed class CertificateInventoryDiffCommand : AsyncCommand<Certificate
         rows.Title = new TableTitle("Certificate Snapshot Diff");
         rows.AddColumn("Host");
         rows.AddColumn("Port");
+        rows.AddColumn("Vantage");
         rows.AddColumn("Status");
         rows.AddColumn("Reasons");
         rows.AddColumn("Issuer");
@@ -232,6 +233,7 @@ internal sealed class CertificateInventoryDiffCommand : AsyncCommand<Certificate
             rows.AddRow(
                 endpoint.Host,
                 endpoint.Port.ToString(),
+                endpoint.ProbeVantage,
                 endpoint.Status,
                 reasons,
                 issuer,
@@ -257,11 +259,13 @@ internal sealed class CertificateInventoryDiffCommand : AsyncCommand<Certificate
         var currentSnapshot = diff.CurrentCapturedAtUtc?.UtcDateTime.ToString("O") ?? string.Empty;
 
         var sb = new StringBuilder();
-        sb.AppendLine("Host,Port,Status,ChangeReasons,PreviousService,CurrentService,PreviousIssuer,CurrentIssuer,PreviousRoot,CurrentRoot,PreviousThumbprint,CurrentThumbprint,PreviousNotAfterUtc,CurrentNotAfterUtc,PreviousValid,CurrentValid,PreviousChainComplete,CurrentChainComplete,PreviousHostnameMatch,CurrentHostnameMatch,RequestedPreviousSnapshotUtc,RequestedCurrentSnapshotUtc,PreviousSnapshotUtc,CurrentSnapshotUtc,Warnings");
+        sb.AppendLine("Host,Port,ProbeVantage,Status,ChangeReasons,PreviousService,CurrentService,PreviousIssuer,CurrentIssuer,PreviousRoot,CurrentRoot,PreviousThumbprint,CurrentThumbprint,PreviousNotAfterUtc,CurrentNotAfterUtc,PreviousValid,CurrentValid,PreviousChainComplete,CurrentChainComplete,PreviousHostnameMatch,CurrentHostnameMatch,RequestedPreviousSnapshotUtc,RequestedCurrentSnapshotUtc,PreviousSnapshotUtc,CurrentSnapshotUtc,Warnings");
         foreach (var endpoint in diff.Endpoints) {
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(endpoint.Host));
             sb.Append(',');
             sb.Append(endpoint.Port);
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(endpoint.ProbeVantage));
             sb.Append(',');
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(endpoint.Status));
             sb.Append(',');

--- a/DomainDetective.CLI/Commands/CertificateInventoryDriftCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryDriftCommand.cs
@@ -223,20 +223,20 @@ internal sealed class CertificateInventoryDriftCommand : AsyncCommand<Certificat
             var lastChange = endpoint.LastChangedAtUtc?.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss") ?? "-";
             var expiry = endpoint.CurrentNotAfterUtc?.UtcDateTime.ToString("yyyy-MM-dd") ?? "-";
             rows.AddRow(
-                endpoint.Host,
+                Markup.Escape(endpoint.Host),
                 endpoint.Port.ToString(),
-                endpoint.Service,
-                endpoint.ProbeVantage,
+                Markup.Escape(endpoint.Service),
+                Markup.Escape(endpoint.ProbeVantage),
                 endpoint.ObservationCount.ToString(),
                 endpoint.DistinctCertificateCount.ToString(),
-                endpoint.DriftSeverity,
-                BuildChangeKinds(endpoint),
-                changed,
+                Markup.Escape(endpoint.DriftSeverity),
+                Markup.Escape(BuildChangeKinds(endpoint)),
+                Markup.Escape(changed),
                 lastChange,
-                string.IsNullOrWhiteSpace(endpoint.CurrentIssuer) ? "-" : endpoint.CurrentIssuer!,
+                Markup.Escape(string.IsNullOrWhiteSpace(endpoint.CurrentIssuer) ? "-" : endpoint.CurrentIssuer!),
                 expiry,
-                string.IsNullOrWhiteSpace(endpoint.CurrentAuthenticationProfile) ? "-" : endpoint.CurrentAuthenticationProfile!,
-                NormalizeChainSource(endpoint.CurrentChainSource));
+                Markup.Escape(string.IsNullOrWhiteSpace(endpoint.CurrentAuthenticationProfile) ? "-" : endpoint.CurrentAuthenticationProfile!),
+                Markup.Escape(NormalizeChainSource(endpoint.CurrentChainSource)));
         }
         AnsiConsole.Write(rows);
         AnsiConsole.MarkupLine("[grey]Flags: C=Certificate, I=Issuer, E=Expiry, S=Service, A=AuthProfile, H=ChainSource[/]");

--- a/DomainDetective.CLI/Commands/CertificateInventoryDriftCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryDriftCommand.cs
@@ -199,6 +199,7 @@ internal sealed class CertificateInventoryDriftCommand : AsyncCommand<Certificat
         rows.Title = new TableTitle("Certificate Drift");
         rows.AddColumn("Host");
         rows.AddColumn("Port");
+        rows.AddColumn("Vantage");
         rows.AddColumn("Obs");
         rows.AddColumn("Distinct Certs");
         rows.AddColumn("Severity");
@@ -216,6 +217,7 @@ internal sealed class CertificateInventoryDriftCommand : AsyncCommand<Certificat
             rows.AddRow(
                 endpoint.Host,
                 endpoint.Port.ToString(),
+                endpoint.ProbeVantage,
                 endpoint.ObservationCount.ToString(),
                 endpoint.DistinctCertificateCount.ToString(),
                 endpoint.DriftSeverity,

--- a/DomainDetective.CLI/Commands/CertificateInventoryDriftCommand.cs
+++ b/DomainDetective.CLI/Commands/CertificateInventoryDriftCommand.cs
@@ -73,6 +73,13 @@ internal sealed class CertificateInventoryDriftSettings : CommandSettings {
 /// Displays endpoint-level certificate drift from persisted inventory snapshots.
 /// </summary>
 internal sealed class CertificateInventoryDriftCommand : AsyncCommand<CertificateInventoryDriftSettings> {
+    /// <summary>Runs the command implementation from tests without going through the Spectre command app.</summary>
+    [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
+    [RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
+    internal Task<int> ExecuteForTestingAsync(CommandContext context, CertificateInventoryDriftSettings settings, CancellationToken cancellationToken = default) {
+        return ExecuteAsync(context, settings, cancellationToken);
+    }
+
     [RequiresUnreferencedCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
     [RequiresDynamicCode("Calls System.Text.Json.JsonSerializer.Serialize<TValue>(TValue, JsonSerializerOptions)")]
     protected override Task<int> ExecuteAsync(CommandContext context, CertificateInventoryDriftSettings settings, CancellationToken cancellationToken) {
@@ -199,6 +206,7 @@ internal sealed class CertificateInventoryDriftCommand : AsyncCommand<Certificat
         rows.Title = new TableTitle("Certificate Drift");
         rows.AddColumn("Host");
         rows.AddColumn("Port");
+        rows.AddColumn("Service");
         rows.AddColumn("Vantage");
         rows.AddColumn("Obs");
         rows.AddColumn("Distinct Certs");
@@ -217,6 +225,7 @@ internal sealed class CertificateInventoryDriftCommand : AsyncCommand<Certificat
             rows.AddRow(
                 endpoint.Host,
                 endpoint.Port.ToString(),
+                endpoint.Service,
                 endpoint.ProbeVantage,
                 endpoint.ObservationCount.ToString(),
                 endpoint.DistinctCertificateCount.ToString(),
@@ -287,13 +296,15 @@ internal sealed class CertificateInventoryDriftCommand : AsyncCommand<Certificat
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine("Host,Port,Service,ObservationCount,DistinctCertificateCount,DriftSeverity,FirstSeenUtc,LastSeenUtc,LastChangedAtUtc,PreviousCertificateId,CurrentCertificateId,PreviousIssuer,CurrentIssuer,PreviousNotAfterUtc,CurrentNotAfterUtc,PreviousAuthenticationProfile,CurrentAuthenticationProfile,PreviousChainSource,CurrentChainSource,CertificateChanged,IssuerChanged,ExpiryChanged,ServiceChanged,AuthenticationProfileChanged,ChainSourceChanged,ChangeKinds");
+        sb.AppendLine("Host,Port,Service,ProbeVantage,ObservationCount,DistinctCertificateCount,DriftSeverity,FirstSeenUtc,LastSeenUtc,LastChangedAtUtc,PreviousCertificateId,CurrentCertificateId,PreviousIssuer,CurrentIssuer,PreviousNotAfterUtc,CurrentNotAfterUtc,PreviousAuthenticationProfile,CurrentAuthenticationProfile,PreviousChainSource,CurrentChainSource,CertificateChanged,IssuerChanged,ExpiryChanged,ServiceChanged,AuthenticationProfileChanged,ChainSourceChanged,ChangeKinds");
         foreach (var endpoint in drift.Endpoints) {
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(endpoint.Host));
             sb.Append(',');
             sb.Append(endpoint.Port);
             sb.Append(',');
             sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(endpoint.Service));
+            sb.Append(',');
+            sb.Append(CertificateInventoryCommandHelpers.EscapeCsv(endpoint.ProbeVantage));
             sb.Append(',');
             sb.Append(endpoint.ObservationCount);
             sb.Append(',');

--- a/DomainDetective.Example/ExampleCertificateInventoryCapture.cs
+++ b/DomainDetective.Example/ExampleCertificateInventoryCapture.cs
@@ -1,5 +1,6 @@
 using DomainDetective.Helpers;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -12,16 +13,19 @@ public static partial class Program {
     /// <summary>Captures one inventory snapshot for a reusable domain portfolio list.</summary>
     public static async Task ExampleCertificateInventoryCapture() {
         var domains = new[] {
-            "evotec.xyz",
-            "evotec.pl",
+            "example.com",
+            "example.org",
             "microsoft.com",
-            "google.com",
-            "eurofins.com",
-            "abb.com"
+            "google.com"
         };
 
+        string cacheDirectory = Path.Combine(Path.GetTempPath(), "DomainDetective", "cert-monitor");
+
         var options = new CertificateInventoryCaptureOptions {
-            CacheDirectory = @"C:\Temp\DomainDetective\cert-monitor",
+            CacheDirectory = cacheDirectory,
+            EnableEndpointAttribution = true,
+            ProbeVantage = "default",
+            AzureServiceTagsJsonPath = Environment.GetEnvironmentVariable("AZURE_SERVICE_TAGS_JSON"),
             IncludeApexHttps = true,
             IncludeWwwHttps = true,
             IncludeMxHosts = true,
@@ -32,7 +36,7 @@ public static partial class Program {
             EnableNativeCtLogSubdomainSource = true,
             NativeCtLogOnly = true,
             NativeCtInitialBackfillEntriesPerLog = 5000,
-            NativeCtCursorStatePath = @"C:\Temp\DomainDetective\cert-monitor\inventory\ct-native-cursor.json",
+            NativeCtCursorStatePath = Path.Combine(cacheDirectory, "inventory", "ct-native-cursor.json"),
             CtProfile = CertificateCtEnrichmentProfile.Public,
             PersistSnapshot = true,
             MaxParallelism = 24,
@@ -40,6 +44,8 @@ public static partial class Program {
             MailTimeout = TimeSpan.FromSeconds(15)
         };
         options.AdditionalEndpoints.Add("https://api.microsoft.com:443");
+        // Explicit FTPS performs the 220 -> AUTH TLS -> 234 exchange before TLS and never logs in.
+        // options.AdditionalEndpoints.Add("ftps-explicit://ftp.example.com:21");
 
         var capture = new CertificateInventoryCapture();
         var result = await capture.CaptureAsync(domains, options, new InternalLogger(false));
@@ -50,6 +56,7 @@ public static partial class Program {
         Console.WriteLine($"MX Hosts           : {result.MxHostCount}");
         Console.WriteLine($"HTTPS Endpoints    : {result.HttpsEndpointCount}");
         Console.WriteLine($"Mail Endpoints     : {result.MailEndpointCount}");
+        Console.WriteLine($"FTP TLS Endpoints  : {result.FtpTlsEndpointCount}");
         Console.WriteLine($"Snapshot Entries   : {result.EntryCount}");
         Console.WriteLine($"Unique Endpoints   : {result.UniqueEndpointCount}");
         Console.WriteLine($"Valid / Expired    : {result.ValidCount} / {result.ExpiredCount}");
@@ -71,6 +78,11 @@ public static partial class Program {
                 entry.Host,
                 entry.Service,
                 entry.Port,
+                entry.RemoteAddress,
+                entry.ProbeVantage,
+                Provider = entry.Attribution?.Primary?.ProviderId,
+                ProviderService = entry.Attribution?.Primary?.ServiceId,
+                AttributionScore = entry.Attribution?.Primary?.Score,
                 entry.CertificateIssuer,
                 entry.NotAfterUtc,
                 entry.DaysToExpire,

--- a/DomainDetective.PowerShell/CmdletInvokeCertificateInventory.cs
+++ b/DomainDetective.PowerShell/CmdletInvokeCertificateInventory.cs
@@ -9,7 +9,7 @@ using System.Threading;
 namespace DomainDetective.PowerShell;
 
 /// <summary>Captures and optionally persists a certificate inventory snapshot from domains and discovered endpoints.</summary>
-/// <para>Discovers HTTPS and mail TLS endpoints (for example MX-derived STARTTLS) and stores normalized certificate evidence in the inventory snapshot format used by certificate inventory analytics cmdlets.</para>
+/// <para>Discovers HTTPS, mail TLS, and explicit or implicit FTP TLS endpoints and stores normalized certificate and endpoint evidence in the inventory snapshot format used by certificate inventory analytics cmdlets.</para>
 /// <example>
 ///   <summary>Capture snapshot for explicit domains</summary>
 ///   <code>Invoke-DDCertificateInventory -DomainName evotec.xyz,evotec.pl -CacheDirectory .\cert-monitor</code>
@@ -24,27 +24,31 @@ namespace DomainDetective.PowerShell;
 /// </example>
 /// <example>
 ///   <summary>Capture snapshot including CT-discovered subdomains</summary>
-///   <code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -VerifyCtSubdomains -MaxCtSubdomainsPerDomain 5000 -Verbose</code>
+///   <code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -VerifyCtSubdomains -MaxCtSubdomainsPerDomain 5000 -Verbose</code>
 /// </example>
 /// <example>
 ///   <summary>Use native CT log polling without crt.sh fallback</summary>
-///   <code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -EnableNativeCtLogSubdomains -NativeCtLogOnly -NativeCtInitialBackfillEntriesPerLog 5000 -Verbose</code>
+///   <code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -EnableNativeCtLogSubdomains -NativeCtLogOnly -NativeCtInitialBackfillEntriesPerLog 5000 -Verbose</code>
 /// </example>
 /// <example>
 ///   <summary>Run a throttled test capture</summary>
-///   <code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -Limit 150 -MaxProbeStartsPerSecond 20 -MaxProbeErrorWarnings 10 -Verbose</code>
+///   <code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -Limit 150 -MaxProbeStartsPerSecond 20 -MaxProbeErrorWarnings 10 -Verbose</code>
 /// </example>
 /// <example>
 ///   <summary>Reuse recent captured endpoints to reduce repeated probing</summary>
-///   <code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -ReuseRecentResults -RecentResultTtlHours 24 -ReprobeExpiringWithinDays 14</code>
+///   <code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -ReuseRecentResults -RecentResultTtlHours 24 -ReprobeExpiringWithinDays 14</code>
 /// </example>
 /// <example>
 ///   <summary>Reuse recent stable failures for short-lived verification lanes</summary>
-///   <code>Invoke-DDCertificateInventory -DomainName eurofins.com -ReuseRecentFailureResults -RecentFailureResultTtlHours 1 -HttpsTimeoutSeconds 20</code>
+///   <code>Invoke-DDCertificateInventory -DomainName example.com -ReuseRecentFailureResults -RecentFailureResultTtlHours 1 -HttpsTimeoutSeconds 20</code>
 /// </example>
 /// <example>
 ///   <summary>Fail automation when warning-level target decisions are detected</summary>
 ///   <code>Invoke-DDCertificateInventory -DomainName example.com -Endpoint ftp://example.com -FailOnWarningTargetDecisions</code>
+/// </example>
+/// <example>
+///   <summary>Probe explicit FTPS and attach explainable service attribution evidence</summary>
+///   <code>Invoke-DDCertificateInventory -Endpoint ftps-explicit://ftp.example.com:21 -DetectServices -ProbeVantage branch-office -NoPersist</code>
 /// </example>
 [Cmdlet(VerbsLifecycle.Invoke, "DDCertificateInventory")]
 [OutputType(typeof(CertificateInventoryCaptureResult))]
@@ -66,6 +70,23 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
     /// <summary>DNS endpoint used for MX discovery.</summary>
     [Parameter(Mandatory = false)]
     public DnsEndpoint DnsEndpoint { get; set; } = DnsEndpoint.System;
+
+    /// <summary>Resolve endpoint DNS evidence and perform explainable provider/service attribution.</summary>
+    [Parameter(Mandatory = false)]
+    public SwitchParameter DetectServices { get; set; }
+
+    /// <summary>Label identifying the network vantage used for this observation.</summary>
+    [Parameter(Mandatory = false)]
+    public string ProbeVantage { get; set; } = "default";
+
+    /// <summary>Optional current Azure service-tag JSON file used for IP-based attribution.</summary>
+    [Parameter(Mandatory = false)]
+    public string? AzureServiceTagsJsonPath { get; set; }
+
+    /// <summary>Maximum concurrent DNS evidence lookups used by service detection.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateRange(1, 512)]
+    public int DnsEnrichmentParallelism { get; set; } = 8;
 
     /// <summary>Do not probe apex domains over HTTPS.</summary>
     [Parameter(Mandatory = false)]
@@ -222,7 +243,7 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
     [ValidateRange(1, 2048)]
     public int NativeCtCatchUpBatchSize { get; set; } = 1024;
 
-    /// <summary>Additional endpoint(s) to probe (supports https:// and mail schemes).</summary>
+    /// <summary>Additional endpoint(s) to probe (supports HTTPS, mail TLS, ftps://, and ftps-explicit:// schemes).</summary>
     [Parameter(Mandatory = false)]
     public string[] Endpoint { get; set; } = Array.Empty<string>();
 
@@ -246,6 +267,11 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
     [ValidateRange(1, 300)]
     public int MailTimeoutSeconds { get; set; } = 15;
 
+    /// <summary>FTP TLS timeout in seconds.</summary>
+    [Parameter(Mandatory = false)]
+    [ValidateRange(1, 300)]
+    public int FtpTlsTimeoutSeconds { get; set; } = 15;
+
     /// <summary>HTTPS certificate probe timeout in seconds.</summary>
     [Parameter(Mandatory = false)]
     [ValidateRange(1, 300)]
@@ -256,7 +282,7 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
     [ValidateRange(0, 10000)]
     public int MaxProbeErrorWarnings { get; set; } = 25;
 
-    /// <summary>Maximum total probe targets (HTTPS + mail) kept after discovery; useful for quick test runs (0 means unlimited).</summary>
+    /// <summary>Maximum total probe targets (HTTPS + mail + FTP TLS) kept after discovery; useful for quick test runs (0 means unlimited).</summary>
     [Parameter(Mandatory = false)]
     [Alias("Limit")]
     [ValidateRange(0, int.MaxValue)]
@@ -386,9 +412,10 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
             }
         }
 
-        if (domains.Count == 0) {
+        bool hasExplicitEndpoint = Endpoint != null && Array.Exists(Endpoint, endpoint => !string.IsNullOrWhiteSpace(endpoint));
+        if (domains.Count == 0 && !hasExplicitEndpoint) {
             ThrowTerminatingError(new ErrorRecord(
-                new ArgumentException("Provide at least one domain via -DomainName or -DomainsFile.", nameof(DomainName)),
+                new ArgumentException("Provide at least one domain or -Endpoint.", nameof(DomainName)),
                 "NoDomainsProvided",
                 ErrorCategory.InvalidArgument,
                 DomainName));
@@ -398,6 +425,10 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
         var options = new CertificateInventoryCaptureOptions {
             CacheDirectory = CertificateInventoryCmdletHelpers.ResolveCacheDirectory(CacheDirectory),
             DnsEndpoint = DnsEndpoint,
+            EnableEndpointAttribution = DetectServices.IsPresent,
+            ProbeVantage = ProbeVantage,
+            AzureServiceTagsJsonPath = AzureServiceTagsJsonPath,
+            DnsEnrichmentParallelism = DnsEnrichmentParallelism,
             IncludeApexHttps = !NoApexHttps.IsPresent,
             IncludeWwwHttps = !NoWwwHttps.IsPresent,
             IncludeMxHosts = !DisableMxDiscovery.IsPresent,
@@ -436,6 +467,7 @@ public sealed class CmdletInvokeCertificateInventory : PSCmdlet {
             MaxParallelism = MaxParallelism,
             DiscoveryParallelism = DiscoveryParallelism,
             MailTimeout = TimeSpan.FromSeconds(MailTimeoutSeconds),
+            FtpTlsTimeout = TimeSpan.FromSeconds(FtpTlsTimeoutSeconds),
             HttpsTimeout = TimeSpan.FromSeconds(HttpsTimeoutSeconds),
             MaxTargets = MaxTargets,
             MaxProbeStartsPerSecond = MaxProbeStartsPerSecond,

--- a/DomainDetective.Tests/Fixtures/TcpListenerFixture.cs
+++ b/DomainDetective.Tests/Fixtures/TcpListenerFixture.cs
@@ -16,9 +16,14 @@ public sealed class TcpListenerFixture : IAsyncLifetime
     public int Port { get; private set; }
 
     public TcpListenerFixture(Func<TcpListener, CancellationToken, Task> server)
+        : this(server, IPAddress.Loopback)
+    {
+    }
+
+    public TcpListenerFixture(Func<TcpListener, CancellationToken, Task> server, IPAddress bindAddress)
     {
         _server = server;
-        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener = new TcpListener(bindAddress, 0);
     }
 
     public Task InitializeAsync()

--- a/DomainDetective.Tests/Fixtures/TcpListenerFixture.cs
+++ b/DomainDetective.Tests/Fixtures/TcpListenerFixture.cs
@@ -16,14 +16,9 @@ public sealed class TcpListenerFixture : IAsyncLifetime
     public int Port { get; private set; }
 
     public TcpListenerFixture(Func<TcpListener, CancellationToken, Task> server)
-        : this(server, IPAddress.Loopback)
-    {
-    }
-
-    public TcpListenerFixture(Func<TcpListener, CancellationToken, Task> server, IPAddress bindAddress)
     {
         _server = server;
-        _listener = new TcpListener(bindAddress, 0);
+        _listener = new TcpListener(IPAddress.Loopback, 0);
     }
 
     public Task InitializeAsync()

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -55,6 +55,23 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task HttpsRedirectDowngradeIsRetainedAsEvidenceButNotFollowed() {
+            var analysis = new CertificateAnalysis();
+            var handler = new HttpsDowngradeRedirectHandler();
+            using var client = new HttpClient(handler);
+
+            HttpRequestException exception = await Assert.ThrowsAsync<HttpRequestException>(() =>
+                analysis.SendWithRedirectEvidenceAsync(
+                    client,
+                    new Uri("https://secure.example/start"),
+                    CancellationToken.None));
+
+            Assert.Contains("downgrade", exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(new[] { "https://secure.example/start" }, handler.RequestUris);
+            Assert.Equal(new[] { "plain.example" }, analysis.RedirectTargets);
+        }
+
+        [Fact]
         public async Task RedirectChainUsesOneTimeoutBudget() {
             var analysis = new CertificateAnalysis();
             var handler = new SlowRedirectSequenceHandler();
@@ -667,6 +684,21 @@ namespace DomainDetective.Tests {
                 if (RequestHosts.Count == 1) {
                     response.Headers.Location = new Uri("https://selected.example/destination");
                 }
+                return Task.FromResult(response);
+            }
+        }
+
+        private sealed class HttpsDowngradeRedirectHandler : HttpMessageHandler {
+            public List<string> RequestUris { get; } = new();
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken) {
+                RequestUris.Add(request.RequestUri?.AbsoluteUri ?? string.Empty);
+                var response = new HttpResponseMessage(HttpStatusCode.Found) {
+                    RequestMessage = request
+                };
+                response.Headers.Location = new Uri("http://plain.example/destination");
                 return Task.FromResult(response);
             }
         }

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -19,6 +19,26 @@ using DomainDetective.Tests.Fixtures;
 namespace DomainDetective.Tests {
     public class TestCertificateHTTP {
         [Fact]
+        public async Task RedirectEvidenceRetainsEveryFollowedHostInOrder() {
+            var analysis = new CertificateAnalysis();
+            var handler = new RedirectSequenceHandler();
+            using var client = new HttpClient(handler);
+
+            using HttpResponseMessage response = await analysis.SendWithRedirectEvidenceAsync(
+                client,
+                new Uri("https://origin.example/start"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(
+                new[] { "edge.azurefd.net", "origin.example", "edge.azurefd.net", "final.example" },
+                analysis.RedirectTargets);
+            Assert.Equal(
+                new[] { "origin.example", "edge.azurefd.net", "origin.example", "edge.azurefd.net", "final.example" },
+                handler.RequestHosts);
+        }
+
+        [Fact]
         public async Task UnreachableHostSetsIsReachableFalse() {
             var logger = new InternalLogger();
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
@@ -571,6 +591,35 @@ namespace DomainDetective.Tests {
             var req = new CertificateRequest($"CN={cn}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             var cert = req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(30));
             return CertificateLoaderCompat.LoadPkcs12(cert.Export(X509ContentType.Pfx));
+        }
+
+        private sealed class RedirectSequenceHandler : HttpMessageHandler {
+            public List<string> RequestHosts { get; } = new();
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken) {
+                string host = request.RequestUri?.Host ?? string.Empty;
+                RequestHosts.Add(host);
+                HttpResponseMessage response;
+                if (RequestHosts.Count == 1) {
+                    response = new HttpResponseMessage(HttpStatusCode.Found);
+                    response.Headers.Location = new Uri("https://edge.azurefd.net/hop");
+                } else if (RequestHosts.Count == 2) {
+                    response = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect);
+                    response.Headers.Location = new Uri("https://origin.example/return");
+                } else if (RequestHosts.Count == 3) {
+                    response = new HttpResponseMessage(HttpStatusCode.Found);
+                    response.Headers.Location = new Uri("https://edge.azurefd.net/again");
+                } else if (RequestHosts.Count == 4) {
+                    response = new HttpResponseMessage(HttpStatusCode.TemporaryRedirect);
+                    response.Headers.Location = new Uri("https://final.example/done");
+                } else {
+                    response = new HttpResponseMessage(HttpStatusCode.OK);
+                }
+                response.RequestMessage = request;
+                return Task.FromResult(response);
+            }
         }
     }
 }

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -75,7 +75,7 @@ namespace DomainDetective.Tests {
         public async Task RedirectChainUsesOneTimeoutBudget() {
             var analysis = new CertificateAnalysis();
             var handler = new SlowRedirectSequenceHandler();
-            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(1) };
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(3) };
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                 analysis.SendWithRedirectEvidenceAsync(
@@ -85,6 +85,31 @@ namespace DomainDetective.Tests {
 
             Assert.Equal(2, handler.RequestCount);
         }
+
+#if NET8_0_OR_GREATER
+        [Fact]
+        public async Task FullHttpProbeCapturesPinnedRemoteAddress() {
+            using var cert = CreateSelfSigned("service.invalid");
+            var server = new TcpListenerFixture((l, t) => Task.Run(() => RunServer(l, cert, SslProtocols.Tls12, t), t));
+            await server.InitializeAsync();
+
+            try {
+                var logger = new InternalLogger();
+                var analysis = new CertificateAnalysis {
+                    CtLogQueryOverride = _ => Task.FromResult("[]"),
+                    OutboundAddressResolver = (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Loopback })
+                };
+
+                await analysis.AnalyzeUrl("https://service.invalid", server.Port, logger);
+
+                Assert.True(analysis.IsReachable);
+                Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
+                Assert.NotNull(analysis.Certificate);
+            } finally {
+                await server.DisposeAsync();
+            }
+        }
+#endif
 
         [Fact]
         public async Task UnreachableHostSetsIsReachableFalse() {
@@ -710,7 +735,7 @@ namespace DomainDetective.Tests {
                 HttpRequestMessage request,
                 CancellationToken cancellationToken) {
                 RequestCount++;
-                await Task.Delay(600, cancellationToken);
+                await Task.Delay(1650, cancellationToken);
                 var response = new HttpResponseMessage(HttpStatusCode.Found) {
                     RequestMessage = request
                 };

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -39,6 +39,37 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public async Task MultipleChoicesLocationIsFollowedAndRetainedAsEvidence() {
+            var analysis = new CertificateAnalysis();
+            var handler = new MultipleChoicesRedirectHandler();
+            using var client = new HttpClient(handler);
+
+            using HttpResponseMessage response = await analysis.SendWithRedirectEvidenceAsync(
+                client,
+                new Uri("https://origin.example/start"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(new[] { "selected.example" }, analysis.RedirectTargets);
+            Assert.Equal(new[] { "origin.example", "selected.example" }, handler.RequestHosts);
+        }
+
+        [Fact]
+        public async Task RedirectChainUsesOneTimeoutBudget() {
+            var analysis = new CertificateAnalysis();
+            var handler = new SlowRedirectSequenceHandler();
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(1) };
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                analysis.SendWithRedirectEvidenceAsync(
+                    client,
+                    new Uri("https://origin.example/start"),
+                    CancellationToken.None));
+
+            Assert.Equal(2, handler.RequestCount);
+        }
+
+        [Fact]
         public async Task UnreachableHostSetsIsReachableFalse() {
             var logger = new InternalLogger();
             var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
@@ -619,6 +650,40 @@ namespace DomainDetective.Tests {
                 }
                 response.RequestMessage = request;
                 return Task.FromResult(response);
+            }
+        }
+
+        private sealed class MultipleChoicesRedirectHandler : HttpMessageHandler {
+            public List<string> RequestHosts { get; } = new();
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken) {
+                RequestHosts.Add(request.RequestUri?.Host ?? string.Empty);
+                var response = new HttpResponseMessage(
+                    RequestHosts.Count == 1 ? HttpStatusCode.MultipleChoices : HttpStatusCode.OK) {
+                    RequestMessage = request
+                };
+                if (RequestHosts.Count == 1) {
+                    response.Headers.Location = new Uri("https://selected.example/destination");
+                }
+                return Task.FromResult(response);
+            }
+        }
+
+        private sealed class SlowRedirectSequenceHandler : HttpMessageHandler {
+            public int RequestCount { get; private set; }
+
+            protected override async Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken) {
+                RequestCount++;
+                await Task.Delay(600, cancellationToken);
+                var response = new HttpResponseMessage(HttpStatusCode.Found) {
+                    RequestMessage = request
+                };
+                response.Headers.Location = new Uri($"https://hop{RequestCount}.example/next");
+                return response;
             }
         }
     }

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -86,6 +86,21 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, handler.RequestCount);
         }
 
+        [Fact]
+        public async Task RedirectHeadersAreFollowedWithoutBufferingResponseContent() {
+            var analysis = new CertificateAnalysis();
+            var handler = new RedirectWithUnbufferableContentHandler();
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+
+            using HttpResponseMessage response = await analysis.SendWithRedirectEvidenceAsync(
+                client,
+                new Uri("https://origin.example/start"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(2, handler.RequestCount);
+        }
+
 #if NET8_0_OR_GREATER
         [Fact]
         public async Task FullHttpProbeCapturesPinnedRemoteAddress() {
@@ -107,6 +122,43 @@ namespace DomainDetective.Tests {
                 Assert.NotNull(analysis.Certificate);
             } finally {
                 await server.DisposeAsync();
+            }
+        }
+
+        [Fact]
+        public async Task RedirectKeepsOriginPeerAddressWithOriginCertificate() {
+            IPAddress redirectedAddress = IPAddress.Parse("127.0.0.2");
+            using var originCert = CreateSelfSigned("origin.invalid");
+            using var redirectedCert = CreateSelfSigned("redirect.invalid");
+            var redirectedServer = new TcpListenerFixture(
+                (l, t) => Task.Run(() => RunServer(l, redirectedCert, SslProtocols.Tls12, t), t),
+                redirectedAddress);
+            await redirectedServer.InitializeAsync();
+            var originServer = new TcpListenerFixture((l, t) => Task.Run(() => RunServer(
+                l,
+                originCert,
+                SslProtocols.Tls12,
+                t,
+                "HTTP/1.1 302 Found",
+                new[] { $"Location: https://redirect.invalid:{redirectedServer.Port}/" }), t));
+            await originServer.InitializeAsync();
+
+            try {
+                var analysis = new CertificateAnalysis {
+                    CtLogQueryOverride = _ => Task.FromResult("[]"),
+                    OutboundAddressResolver = (host, _) => Task.FromResult<IReadOnlyList<IPAddress>>(
+                        new[] { host.Equals("redirect.invalid", StringComparison.OrdinalIgnoreCase) ? redirectedAddress : IPAddress.Loopback })
+                };
+
+                await analysis.AnalyzeUrl("https://origin.invalid", originServer.Port, new InternalLogger());
+
+                Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
+                Assert.NotNull(analysis.Certificate);
+                Assert.Contains("CN=origin.invalid", analysis.Certificate!.Subject, StringComparison.OrdinalIgnoreCase);
+                Assert.Contains("redirect.invalid", analysis.RedirectTargets, StringComparer.OrdinalIgnoreCase);
+            } finally {
+                await originServer.DisposeAsync();
+                await redirectedServer.DisposeAsync();
             }
         }
 #endif
@@ -741,6 +793,36 @@ namespace DomainDetective.Tests {
                 };
                 response.Headers.Location = new Uri($"https://hop{RequestCount}.example/next");
                 return response;
+            }
+        }
+
+        private sealed class RedirectWithUnbufferableContentHandler : HttpMessageHandler {
+            public int RequestCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken) {
+                RequestCount++;
+                var response = new HttpResponseMessage(
+                    RequestCount == 1 ? HttpStatusCode.Found : HttpStatusCode.OK) {
+                    RequestMessage = request
+                };
+                if (RequestCount == 1) {
+                    response.Headers.Location = new Uri("https://final.example/done");
+                    response.Content = new UnbufferableContent();
+                }
+                return Task.FromResult(response);
+            }
+        }
+
+        private sealed class UnbufferableContent : HttpContent {
+            protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) {
+                return Task.FromException(new InvalidOperationException("Redirect content must not be buffered."));
+            }
+
+            protected override bool TryComputeLength(out long length) {
+                length = 0;
+                return false;
             }
         }
     }

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -101,6 +101,22 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, handler.RequestCount);
         }
 
+        [Fact]
+        public async Task RedirectKeepsOriginPeerAddress() {
+            var analysis = new CertificateAnalysis();
+            var handler = new RemoteAddressRedirectHandler(analysis);
+            using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(5) };
+
+            using HttpResponseMessage response = await analysis.SendWithRedirectEvidenceAsync(
+                client,
+                new Uri("https://origin.example/start"),
+                CancellationToken.None);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
+            Assert.Equal(2, handler.RequestCount);
+        }
+
 #if NET8_0_OR_GREATER
         [Fact]
         public async Task FullHttpProbeCapturesPinnedRemoteAddress() {
@@ -125,42 +141,6 @@ namespace DomainDetective.Tests {
             }
         }
 
-        [Fact]
-        public async Task RedirectKeepsOriginPeerAddressWithOriginCertificate() {
-            IPAddress redirectedAddress = IPAddress.Parse("127.0.0.2");
-            using var originCert = CreateSelfSigned("origin.invalid");
-            using var redirectedCert = CreateSelfSigned("redirect.invalid");
-            var redirectedServer = new TcpListenerFixture(
-                (l, t) => Task.Run(() => RunServer(l, redirectedCert, SslProtocols.Tls12, t), t),
-                redirectedAddress);
-            await redirectedServer.InitializeAsync();
-            var originServer = new TcpListenerFixture((l, t) => Task.Run(() => RunServer(
-                l,
-                originCert,
-                SslProtocols.Tls12,
-                t,
-                "HTTP/1.1 302 Found",
-                new[] { $"Location: https://redirect.invalid:{redirectedServer.Port}/" }), t));
-            await originServer.InitializeAsync();
-
-            try {
-                var analysis = new CertificateAnalysis {
-                    CtLogQueryOverride = _ => Task.FromResult("[]"),
-                    OutboundAddressResolver = (host, _) => Task.FromResult<IReadOnlyList<IPAddress>>(
-                        new[] { host.Equals("redirect.invalid", StringComparison.OrdinalIgnoreCase) ? redirectedAddress : IPAddress.Loopback })
-                };
-
-                await analysis.AnalyzeUrl("https://origin.invalid", originServer.Port, new InternalLogger());
-
-                Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
-                Assert.NotNull(analysis.Certificate);
-                Assert.Contains("CN=origin.invalid", analysis.Certificate!.Subject, StringComparison.OrdinalIgnoreCase);
-                Assert.Contains("redirect.invalid", analysis.RedirectTargets, StringComparer.OrdinalIgnoreCase);
-            } finally {
-                await originServer.DisposeAsync();
-                await redirectedServer.DisposeAsync();
-            }
-        }
 #endif
 
         [Fact]
@@ -810,6 +790,37 @@ namespace DomainDetective.Tests {
                 if (RequestCount == 1) {
                     response.Headers.Location = new Uri("https://final.example/done");
                     response.Content = new UnbufferableContent();
+                }
+                return Task.FromResult(response);
+            }
+        }
+
+        private sealed class RemoteAddressRedirectHandler : HttpMessageHandler {
+            private readonly CertificateAnalysis _analysis;
+
+            public RemoteAddressRedirectHandler(CertificateAnalysis analysis) {
+                _analysis = analysis;
+            }
+
+            public int RequestCount { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken) {
+                RequestCount++;
+                var setter = typeof(CertificateAnalysis)
+                    .GetProperty(nameof(CertificateAnalysis.RemoteAddress))!
+                    .GetSetMethod(nonPublic: true)!;
+                setter.Invoke(_analysis, new object[] {
+                    RequestCount == 1 ? IPAddress.Loopback : IPAddress.IPv6Loopback
+                });
+
+                var response = new HttpResponseMessage(
+                    RequestCount == 1 ? HttpStatusCode.Found : HttpStatusCode.OK) {
+                    RequestMessage = request
+                };
+                if (RequestCount == 1) {
+                    response.Headers.Location = new Uri("https://final.example/done");
                 }
                 return Task.FromResult(response);
             }

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -76,14 +76,19 @@ namespace DomainDetective.Tests {
             var analysis = new CertificateAnalysis();
             var handler = new SlowRedirectSequenceHandler();
             using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(3) };
+            var stopwatch = Stopwatch.StartNew();
 
             await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
                 analysis.SendWithRedirectEvidenceAsync(
                     client,
                     new Uri("https://origin.example/start"),
                     CancellationToken.None));
+            stopwatch.Stop();
 
-            Assert.Equal(2, handler.RequestCount);
+            Assert.InRange(handler.RequestCount, 1, 3);
+            Assert.True(
+                stopwatch.Elapsed < TimeSpan.FromSeconds(6),
+                $"Redirect chain exceeded one timeout budget: {stopwatch.Elapsed}.");
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -136,6 +136,22 @@ namespace DomainDetective.Tests {
             }
         }
 
+        [Fact]
+        public async Task DirectConnectorDisposesClientWhenConnectFails() {
+            var client = new CountingTcpClient();
+            var analysis = new CertificateAnalysis {
+                TcpClientFactory = _ => client
+            };
+
+            await Assert.ThrowsAnyAsync<SocketException>(() =>
+                analysis.ConnectDirectAsync(
+                    IPAddress.Loopback.ToString(),
+                    PortHelper.GetFreePort(),
+                    CancellationToken.None));
+
+            Assert.Equal(1, client.DisposeCount);
+        }
+
 #if NET8_0_OR_GREATER
         [Fact]
         public async Task FullHttpProbeCapturesPinnedRemoteAddress() {
@@ -853,6 +869,17 @@ namespace DomainDetective.Tests {
             protected override bool TryComputeLength(out long length) {
                 length = 0;
                 return false;
+            }
+        }
+
+        private sealed class CountingTcpClient : TcpClient {
+            public int DisposeCount { get; private set; }
+
+            protected override void Dispose(bool disposing) {
+                if (disposing) {
+                    DisposeCount++;
+                }
+                base.Dispose(disposing);
             }
         }
     }

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -141,6 +141,38 @@ namespace DomainDetective.Tests {
             }
         }
 
+#if NET472
+        [Fact]
+        public async Task FrameworkFullHttpUsesCertificateFromHttpConnection() {
+            using var peerOnlyCertificate = CreateSelfSigned("peer-only.invalid");
+            using var httpCertificate = CreateSelfSigned("localhost");
+            var server = new TcpListenerFixture((listener, token) => Task.Run(
+                () => RunFrameworkPairedCertificateServer(
+                    listener,
+                    peerOnlyCertificate,
+                    httpCertificate,
+                    token),
+                token));
+            await server.InitializeAsync();
+
+            try {
+                var analysis = new CertificateAnalysis {
+                    CaptureExtendedMetadata = false,
+                    CaptureTlsDetails = false
+                };
+
+                await analysis.AnalyzeUrl("https://localhost", server.Port, new InternalLogger());
+
+                Assert.True(analysis.IsReachable);
+                Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
+                Assert.Equal(httpCertificate.Thumbprint, analysis.Certificate?.Thumbprint);
+                Assert.NotEqual(peerOnlyCertificate.Thumbprint, analysis.Certificate?.Thumbprint);
+            } finally {
+                await server.DisposeAsync();
+            }
+        }
+#endif
+
         [Fact]
         public async Task DirectConnectorDisposesClientWhenConnectFails() {
             var client = new CountingTcpClient();
@@ -737,6 +769,53 @@ namespace DomainDetective.Tests {
             var cert = req.CreateSelfSigned(DateTimeOffset.Now.AddDays(-1), DateTimeOffset.Now.AddDays(30));
             return CertificateLoaderCompat.LoadPkcs12(cert.Export(X509ContentType.Pfx));
         }
+
+#if NET472
+        private static async Task RunFrameworkPairedCertificateServer(
+            TcpListener listener,
+            X509Certificate2 peerOnlyCertificate,
+            X509Certificate2 httpCertificate,
+            CancellationToken token) {
+            int connectionCount = 0;
+            try {
+                while (!token.IsCancellationRequested) {
+                    var clientTask = listener.AcceptTcpClientAsync();
+                    var completed = await Task.WhenAny(clientTask, Task.Delay(Timeout.Infinite, token));
+                    if (completed != clientTask) {
+                        try { await clientTask; } catch { }
+                        break;
+                    }
+
+                    var client = await clientTask;
+                    int connectionNumber = Interlocked.Increment(ref connectionCount);
+                    _ = Task.Run(async () => {
+                        using var tcp = client;
+                        using var ssl = new SslStream(tcp.GetStream());
+                        X509Certificate2 certificate = connectionNumber == 1
+                            ? peerOnlyCertificate
+                            : httpCertificate;
+                        await ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+                        if (connectionNumber == 1) {
+                            return;
+                        }
+
+                        using var reader = new StreamReader(ssl);
+                        using var writer = new StreamWriter(ssl) { AutoFlush = true, NewLine = "\r\n" };
+                        await reader.ReadLineAsync();
+                        string? line;
+                        do {
+                            line = await reader.ReadLineAsync();
+                        } while (!string.IsNullOrEmpty(line));
+                        await writer.WriteLineAsync("HTTP/1.1 200 OK");
+                        await writer.WriteLineAsync("Content-Length: 0");
+                        await writer.WriteLineAsync();
+                    }, token);
+                }
+            } catch (Exception ex) when (token.IsCancellationRequested || ex is ObjectDisposedException) {
+                // ignore on shutdown
+            }
+        }
+#endif
 
         private sealed class RedirectSequenceHandler : HttpMessageHandler {
             public List<string> RequestHosts { get; } = new();

--- a/DomainDetective.Tests/TestCertificateHTTP.cs
+++ b/DomainDetective.Tests/TestCertificateHTTP.cs
@@ -117,6 +117,25 @@ namespace DomainDetective.Tests {
             Assert.Equal(2, handler.RequestCount);
         }
 
+        [Fact]
+        public async Task FullHttpProbeCapturesOriginRemoteAddress() {
+            using var cert = CreateSelfSigned("localhost");
+            var server = new TcpListenerFixture((l, t) => Task.Run(() => RunServer(l, cert, SslProtocols.Tls12, t), t));
+            await server.InitializeAsync();
+
+            try {
+                var analysis = new CertificateAnalysis { CtLogQueryOverride = _ => Task.FromResult("[]") };
+
+                await analysis.AnalyzeUrl("https://localhost", server.Port, new InternalLogger());
+
+                Assert.True(analysis.IsReachable);
+                Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
+                Assert.NotNull(analysis.Certificate);
+            } finally {
+                await server.DisposeAsync();
+            }
+        }
+
 #if NET8_0_OR_GREATER
         [Fact]
         public async Task FullHttpProbeCapturesPinnedRemoteAddress() {

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -315,6 +315,33 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task CaptureAsync_BracketedIpv6MailTargetRetainsCompletedProbeResult() {
+        var capture = new CertificateInventoryCapture();
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            MailTimeout = TimeSpan.FromSeconds(1)
+        };
+        options.AdditionalEndpoints.Add("[::1]:25");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(1, result.ProbedMailCount);
+        Assert.Equal("smtp://[::1]:25", Assert.Single(result.MailEndpoints));
+        CertificateInventoryEntry entry = Assert.Single(result.Snapshot.Entries);
+        Assert.Equal("::1", entry.Host);
+        Assert.True(
+            entry.FailureKind != CertificateFailureKind.None ||
+            entry.IsReachable ||
+            !string.IsNullOrWhiteSpace(entry.CertificateThumbprint));
+        if (entry.FailureKind != CertificateFailureKind.None) {
+            Assert.False(string.IsNullOrWhiteSpace(entry.FailureReason));
+        }
+    }
+
+    [Fact]
     public async Task CaptureAsync_PrioritizesStaleFtpTlsTargetBeforeReusableHealthyTarget() {
         DateTimeOffset now = DateTimeOffset.UtcNow;
         CertificateInventoryEntry Cached(int port, DateTimeOffset observedAtUtc, string thumbprint) => new() {

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -65,6 +65,73 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task CaptureAsync_DoesNotBlendReusedRemotePeerIntoFreshAttribution() {
+        var cachedEntry = new CertificateInventoryEntry {
+            Host = "service.example.com",
+            ResolvedHost = "service.example.com",
+            Url = "https://service.example.com/",
+            Scheme = "https",
+            Port = 443,
+            Service = "HTTPS",
+            ObservedAtUtc = DateTimeOffset.UtcNow.AddMinutes(-10),
+            RemoteAddress = "192.0.2.10",
+            RemoteAddressFamily = "IPv4",
+            CertificateThumbprint = "CACHED-CERT",
+            IsReachable = true,
+            Valid = true,
+            NotAfterUtc = DateTimeOffset.UtcNow.AddDays(90)
+        };
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["service.example.com|443|HTTPS"] = cachedEntry
+                },
+            HttpsProbeOverride = (targets, _, _, _) => {
+                Assert.Empty(targets);
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(Array.Empty<CertificateMonitor.Entry>());
+            },
+            EndpointDnsQueryOverride = (_, type, _) => Task.FromResult(
+                type == DnsRecordType.A
+                    ? new[] { new DnsAnswer { Type = DnsRecordType.A, DataRaw = "198.51.100.20" } }
+                    : Array.Empty<DnsAnswer>())
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            EnableEndpointAttribution = true,
+            ReuseRecentSnapshotEntries = true,
+            RecentSnapshotTtl = TimeSpan.FromHours(1)
+        };
+        foreach ((string ruleId, string prefix) in new[] {
+            ("custom.stale-peer", "192.0.2.0/24"),
+            ("custom.fresh-dns", "198.51.100.0/24")
+        }) {
+            var rule = new EndpointAttributionRule {
+                RuleId = ruleId,
+                RuleVersion = "1",
+                ProviderId = "example",
+                ServiceId = ruleId,
+                DisplayName = ruleId
+            };
+            rule.IpAddressPrefixes.Add(prefix);
+            options.EndpointAttributionRules.Add(rule);
+        }
+        options.AdditionalEndpoints.Add("https://service.example.com");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        CertificateInventoryEntry entry = Assert.Single(result.Snapshot.Entries);
+        Assert.Equal("reused-recent-success", entry.CaptureDisposition);
+        Assert.Equal("192.0.2.10", entry.RemoteAddress);
+        Assert.Contains("198.51.100.20", entry.ResolvedAddresses);
+        Assert.DoesNotContain(entry.Attribution!.Candidates, candidate => candidate.RuleId == "custom.stale-peer");
+        Assert.Contains(entry.Attribution.Candidates, candidate => candidate.RuleId == "custom.fresh-dns");
+        Assert.Equal("custom.fresh-dns", entry.Attribution.Primary?.RuleId);
+    }
+
+    [Fact]
     public async Task CaptureAsync_BoundsConcurrentDnsEnrichmentWithWorkerPool() {
         using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
         int activeQueries = 0;

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -2109,6 +2109,7 @@ public class TestCertificateInventoryCapture {
         var ctNotBefore = new DateTimeOffset(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var ctNotAfter = new DateTimeOffset(2026, 10, 1, 23, 59, 59, TimeSpan.Zero);
         var capture = new CertificateInventoryCapture {
+            EndpointDnsQueryOverride = (_, _, _) => Task.FromResult(Array.Empty<DnsAnswer>()),
             CtSubdomainEntryDiscoveryOverride = (domains, options, logger, cancellationToken) => {
                 IReadOnlyList<SubdomainDiscoveryEntry> discovered = new[] {
                     new SubdomainDiscoveryEntry {
@@ -2166,8 +2167,20 @@ public class TestCertificateInventoryCapture {
             IncludeSubmissionStartTls = false,
             IncludeImapTls = false,
             IncludePop3Tls = false,
+            EnableEndpointAttribution = true,
             PersistSnapshot = false
         };
+        var issuerRule = new EndpointAttributionRule {
+            RuleId = "custom.ct-issuer",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "ct-backed",
+            DisplayName = "CT-backed endpoint",
+            MinimumScore = 0.15,
+            AllowWeakSignalsAsPrimary = true
+        };
+        issuerRule.CertificateIssuerContains.Add("Test Issuer");
+        options.EndpointAttributionRules.Add(issuerRule);
 
         var result = await capture.CaptureAsync(new[] { "example.com" }, options, cancellationToken: CancellationToken.None);
 
@@ -2187,6 +2200,13 @@ public class TestCertificateInventoryCapture {
         Assert.Contains("ct-log", endpoint.CertificateChainSources, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("crt.sh", endpoint.CtDiscoverySources, StringComparer.OrdinalIgnoreCase);
         Assert.Contains("certspotter", endpoint.CtDiscoverySources, StringComparer.OrdinalIgnoreCase);
+        EndpointAttributionCandidate issuerCandidate = Assert.Single(
+            endpoint.Attribution!.Candidates,
+            candidate => candidate.RuleId == "custom.ct-issuer");
+        Assert.Contains(
+            issuerCandidate.Evidence,
+            evidence => evidence.Kind == EndpointAttributionSignalKind.CertificateIssuer &&
+                        evidence.ObservedValue.Contains("Test Issuer", StringComparison.Ordinal));
 
         var discovered = Assert.Single(result.CtDiscoveredSubdomainEntries);
         Assert.Equal("ct-only.example.com", discovered.Name);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -341,6 +341,39 @@ public class TestCertificateInventoryCapture {
         }
     }
 
+    [Theory]
+    [InlineData("ftps://localhost:0")]
+    [InlineData("ftps-explicit://localhost:0")]
+    [InlineData("smtp://localhost:0")]
+    [InlineData("submission://localhost:0")]
+    [InlineData("imap://localhost:0")]
+    [InlineData("imaps://localhost:0")]
+    [InlineData("pop3://localhost:0")]
+    [InlineData("pop3s://localhost:0")]
+    [InlineData("https://localhost:0")]
+    public async Task CaptureAsync_RejectsExplicitZeroPortEndpoint(string endpoint) {
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false
+        };
+        options.AdditionalEndpoints.Add(endpoint);
+
+        CertificateInventoryCaptureResult result = await new CertificateInventoryCapture().CaptureAsync(
+            Array.Empty<string>(),
+            options);
+
+        Assert.Equal(0, result.FtpTlsEndpointCount);
+        Assert.Equal(0, result.MailEndpointCount);
+        Assert.Equal(0, result.HttpsEndpointCount);
+        Assert.Empty(result.Snapshot.Entries);
+        Assert.Contains(result.Warnings, warning => warning.Contains("invalid endpoint", StringComparison.OrdinalIgnoreCase));
+        TargetDecisionDiagnosticEntry diagnostic = Assert.Single(result.TargetDecisionDiagnostics);
+        Assert.Equal("invalid-endpoint", diagnostic.Reason);
+        Assert.Equal(endpoint, diagnostic.Target);
+    }
+
     [Fact]
     public async Task CaptureAsync_PrioritizesStaleFtpTlsTargetBeforeReusableHealthyTarget() {
         DateTimeOffset now = DateTimeOffset.UtcNow;

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -13,6 +13,222 @@ namespace DomainDetective.Tests;
 
 public class TestCertificateInventoryCapture {
     [Fact]
+    public async Task CaptureAsync_EnrichesEndpointWithDnsEvidenceVantageAndAttribution() {
+        using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (targets, _, _, _) => {
+                CertificateMonitor.Entry entry = CreateHttpsEntry(Assert.Single(targets), certificate);
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(new[] { entry });
+            },
+            EndpointDnsQueryOverride = (name, type, _) => {
+                DnsAnswer[] answers = (name, type) switch {
+                    ("service.example.com", DnsRecordType.CNAME) =>
+                        new[] { new DnsAnswer { Type = DnsRecordType.CNAME, DataRaw = "tenant.azurefd.net." } },
+                    ("tenant.azurefd.net", DnsRecordType.A) =>
+                        new[] { new DnsAnswer { Type = DnsRecordType.A, DataRaw = "203.0.113.10" } },
+                    _ => Array.Empty<DnsAnswer>()
+                };
+                return Task.FromResult(answers);
+            }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            EnableEndpointAttribution = true,
+            ProbeVantage = "eu-test-vantage"
+        };
+        options.AdditionalEndpoints.Add("https://service.example.com");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(
+            Array.Empty<string>(),
+            options,
+            cancellationToken: CancellationToken.None);
+
+        CertificateInventoryEntry inventoryEntry = Assert.Single(result.Snapshot.Entries);
+        Assert.NotNull(inventoryEntry.ObservedAtUtc);
+        Assert.NotNull(inventoryEntry.DnsObservedAtUtc);
+        Assert.Equal("eu-test-vantage", inventoryEntry.ProbeVantage);
+        Assert.Contains("203.0.113.10", inventoryEntry.ResolvedAddresses);
+        Assert.Equal(new[] { "tenant.azurefd.net" }, inventoryEntry.CnameChain);
+        Providers.Endpoint.EndpointAttributionCandidate primary = Assert.IsType<Providers.Endpoint.EndpointAttributionCandidate>(inventoryEntry.Attribution?.Primary);
+        Assert.Equal("azure-front-door", primary.ServiceId);
+        Assert.True(inventoryEntry.Attribution!.EvaluatedAtUtc >= inventoryEntry.DnsObservedAtUtc!.Value);
+        Assert.Contains(
+            primary.Evidence,
+            evidence => evidence.Kind == Providers.Endpoint.EndpointAttributionSignalKind.Cname);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_DoesNotReuseObservationFromAnotherVantage() {
+        const int port = 1;
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["localhost|1|FTPS-EXPLICIT"] = new CertificateInventoryEntry {
+                        Host = "localhost",
+                        ResolvedHost = "localhost",
+                        Port = port,
+                        Service = "FTPS-EXPLICIT",
+                        Scheme = "ftps-explicit",
+                        ProbeVantage = "cloud",
+                        IsReachable = true,
+                        Valid = true,
+                        CertificateThumbprint = "CACHED",
+                        NotAfterUtc = DateTimeOffset.UtcNow.AddDays(90)
+                    }
+                }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentSnapshotEntries = true,
+            RecentSnapshotTtl = TimeSpan.FromHours(1),
+            ProbeVantage = "branch-office",
+            FtpTlsTimeout = TimeSpan.FromSeconds(1)
+        };
+        options.AdditionalEndpoints.Add($"ftps-explicit://localhost:{port}");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(0, result.ReusedRecentEntryCount);
+        Assert.Equal(1, result.ProbedFtpTlsCount);
+        Assert.Equal("branch-office", Assert.Single(result.Snapshot.Entries).ProbeVantage);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_ReusesRecentFtpTlsObservationWithinSameVantage() {
+        const int port = 2121;
+        var cachedEntry = new CertificateInventoryEntry {
+            Host = "ftp.example.com",
+            ResolvedHost = "ftp.example.com",
+            Port = port,
+            Service = "FTPS-EXPLICIT",
+            Scheme = "ftps-explicit",
+            ProbeVantage = "branch-office",
+            IsReachable = true,
+            Valid = true,
+            CertificateThumbprint = "CACHED-FTPS",
+            NotAfterUtc = DateTimeOffset.UtcNow.AddDays(90)
+        };
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["ftp.example.com|2121|FTPS-EXPLICIT"] = cachedEntry
+                }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentSnapshotEntries = true,
+            RecentSnapshotTtl = TimeSpan.FromHours(1),
+            ProbeVantage = "branch-office"
+        };
+        options.AdditionalEndpoints.Add($"ftps-explicit://ftp.example.com:{port}");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(1, result.ReusedRecentEntryCount);
+        Assert.Equal(1, result.ReusedRecentFtpTlsCount);
+        Assert.Equal(0, result.ProbedFtpTlsCount);
+        Assert.Equal("reused-recent-success", Assert.Single(result.Snapshot.Entries).CaptureDisposition);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_MixedVantageHistoryRetainsRequestedVantageEntry() {
+        string cacheDirectory = Path.Combine(Path.GetTempPath(), "dd-vantage-cache-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(cacheDirectory);
+        try {
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+            foreach ((string vantage, DateTimeOffset capturedAt, string thumbprint) in new[] {
+                ("branch-office", now.AddMinutes(-20), "BRANCH-CERT"),
+                ("cloud", now.AddMinutes(-10), "CLOUD-CERT")
+            }) {
+                var snapshot = new CertificateInventorySnapshot { CapturedAtUtc = capturedAt, Port = 443 };
+                snapshot.Entries.Add(new CertificateInventoryEntry {
+                    Host = "service.example.com",
+                    ResolvedHost = "service.example.com",
+                    Port = 443,
+                    Service = "HTTPS",
+                    Scheme = "https",
+                    ProbeVantage = vantage,
+                    ObservedAtUtc = capturedAt,
+                    IsReachable = true,
+                    Valid = true,
+                    CertificateThumbprint = thumbprint,
+                    NotAfterUtc = now.AddDays(90)
+                });
+                using var monitor = new CertificateMonitor { CacheDirectory = cacheDirectory, PersistInventorySnapshots = false };
+                monitor.SaveInventorySnapshot(snapshot);
+            }
+
+            int probedTargetCount = -1;
+            var capture = new CertificateInventoryCapture {
+                HttpsProbeOverride = (targets, _, _, _) => {
+                    probedTargetCount = targets.Count;
+                    return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(Array.Empty<CertificateMonitor.Entry>());
+                }
+            };
+            var options = new CertificateInventoryCaptureOptions {
+                CacheDirectory = cacheDirectory,
+                IncludeApexHttps = false,
+                IncludeWwwHttps = false,
+                IncludeMxHosts = false,
+                PersistSnapshot = false,
+                ReuseRecentSnapshotEntries = true,
+                RecentSnapshotTtl = TimeSpan.FromHours(1),
+                ProbeVantage = "branch-office"
+            };
+            options.AdditionalEndpoints.Add("https://service.example.com");
+
+            CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+            Assert.Equal(0, probedTargetCount);
+            Assert.Equal(1, result.ReusedRecentHttpsCount);
+            CertificateInventoryEntry entry = Assert.Single(result.Snapshot.Entries);
+            Assert.Equal("BRANCH-CERT", entry.CertificateThumbprint);
+            Assert.Equal("branch-office", entry.ProbeVantage);
+        } finally {
+            Directory.Delete(cacheDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task CaptureAsync_MalformedOptionalAzureCatalogBecomesWarning() {
+        string path = Path.Combine(Path.GetTempPath(), "dd-invalid-azure-" + Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(path, "{not-json");
+        try {
+            using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
+            var capture = new CertificateInventoryCapture {
+                HttpsProbeOverride = (targets, _, _, _) =>
+                    Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(new[] { CreateHttpsEntry(Assert.Single(targets), certificate) }),
+                EndpointDnsQueryOverride = (_, _, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+            };
+            var options = new CertificateInventoryCaptureOptions {
+                IncludeApexHttps = false,
+                IncludeWwwHttps = false,
+                IncludeMxHosts = false,
+                PersistSnapshot = false,
+                EnableEndpointAttribution = true,
+                AzureServiceTagsJsonPath = path
+            };
+            options.AdditionalEndpoints.Add("https://service.example.com");
+
+            CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+            Assert.Single(result.Snapshot.Entries);
+            Assert.Contains(result.Warnings, warning => warning.Contains("could not be loaded", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task CaptureAsync_DiscoversEndpointsAndPersistsSnapshot_WithOverrides() {
         using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
         CertificateInventorySnapshot? persistedSnapshot = null;

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -55,6 +55,9 @@ public class TestCertificateInventoryCapture {
         Providers.Endpoint.EndpointAttributionCandidate primary = Assert.IsType<Providers.Endpoint.EndpointAttributionCandidate>(inventoryEntry.Attribution?.Primary);
         Assert.Equal("azure-front-door", primary.ServiceId);
         Assert.True(inventoryEntry.Attribution!.EvaluatedAtUtc >= inventoryEntry.DnsObservedAtUtc!.Value);
+        Assert.True(result.Snapshot.CapturedAtUtc >= inventoryEntry.DnsObservedAtUtc.Value);
+        Assert.True(result.Snapshot.CapturedAtUtc >= inventoryEntry.Attribution.EvaluatedAtUtc);
+        Assert.Equal(result.Snapshot.CapturedAtUtc, result.CapturedAtUtc);
         Assert.Contains(
             primary.Evidence,
             evidence => evidence.Kind == Providers.Endpoint.EndpointAttributionSignalKind.Cname);
@@ -109,6 +112,8 @@ public class TestCertificateInventoryCapture {
             Service = "FTPS-EXPLICIT",
             Scheme = "ftps-explicit",
             ProbeVantage = "branch-office",
+            RemoteAddress = "::ffff:192.0.2.50",
+            RemoteAddressFamily = "InterNetworkV6",
             IsReachable = true,
             Valid = true,
             CertificateThumbprint = "CACHED-FTPS",
@@ -136,7 +141,180 @@ public class TestCertificateInventoryCapture {
         Assert.Equal(1, result.ReusedRecentEntryCount);
         Assert.Equal(1, result.ReusedRecentFtpTlsCount);
         Assert.Equal(0, result.ProbedFtpTlsCount);
-        Assert.Equal("reused-recent-success", Assert.Single(result.Snapshot.Entries).CaptureDisposition);
+        CertificateInventoryEntry reused = Assert.Single(result.Snapshot.Entries);
+        Assert.Equal("reused-recent-success", reused.CaptureDisposition);
+        Assert.Equal("192.0.2.50", reused.RemoteAddress);
+        Assert.Equal("IPv4", reused.RemoteAddressFamily);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_DoesNotRefreshFtpTlsReuseAgeFromNewerSnapshotTime() {
+        const int port = 1;
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["localhost|1|FTPS-EXPLICIT"] = new CertificateInventoryEntry {
+                        Host = "localhost",
+                        ResolvedHost = "localhost",
+                        Port = port,
+                        Service = "FTPS-EXPLICIT",
+                        Scheme = "ftps-explicit",
+                        ProbeVantage = "default",
+                        ObservedAtUtc = DateTimeOffset.UtcNow.AddHours(-2),
+                        IsReachable = true,
+                        Valid = true,
+                        CertificateThumbprint = "STALE-FTPS",
+                        NotAfterUtc = DateTimeOffset.UtcNow.AddDays(90)
+                    }
+                }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentSnapshotEntries = true,
+            RecentSnapshotTtl = TimeSpan.FromHours(1),
+            FtpTlsTimeout = TimeSpan.FromSeconds(1)
+        };
+        options.AdditionalEndpoints.Add($"ftps-explicit://localhost:{port}");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(0, result.ReusedRecentFtpTlsCount);
+        Assert.Equal(1, result.ProbedFtpTlsCount);
+        Assert.Equal("live-probe", Assert.Single(result.Snapshot.Entries).CaptureDisposition);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_DoesNotRefreshHttpsFailureReuseAgeFromNewerSnapshotTime() {
+        int observedProbeTargets = 0;
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["localhost|1|CUSTOM TLS"] = new CertificateInventoryEntry {
+                        Host = "localhost",
+                        ResolvedHost = "localhost",
+                        Port = 1,
+                        Service = "Custom TLS",
+                        Scheme = "https",
+                        ProbeVantage = "default",
+                        ObservedAtUtc = DateTimeOffset.UtcNow.AddHours(-2),
+                        IsReachable = false,
+                        FailureKind = CertificateFailureKind.ConnectionRefused,
+                        FailureReason = "Connection refused"
+                    }
+                },
+            HttpsProbeOverride = (targets, _, _, _) => {
+                observedProbeTargets = targets.Count;
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(Array.Empty<CertificateMonitor.Entry>());
+            }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentFailureSnapshotEntries = true,
+            RecentFailureSnapshotTtl = TimeSpan.FromHours(1)
+        };
+        options.AdditionalEndpoints.Add("https://localhost:1");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(0, result.ReusedRecentFailureHttpsCount);
+        Assert.Equal(1, result.ProbedHttpsCount);
+        Assert.Equal(1, observedProbeTargets);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_PrioritizesUncachedFtpTlsTargetBeforeHealthyCachedTarget() {
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["localhost|1|FTPS-EXPLICIT"] = new CertificateInventoryEntry {
+                        Host = "localhost",
+                        ResolvedHost = "localhost",
+                        Port = 1,
+                        Service = "FTPS-EXPLICIT",
+                        Scheme = "ftps-explicit",
+                        ProbeVantage = "default",
+                        ObservedAtUtc = DateTimeOffset.UtcNow,
+                        IsReachable = true,
+                        Valid = true,
+                        IsKnownCertificateAuthority = true,
+                        AllowsServerAuthentication = true,
+                        PresentInCtLogs = true,
+                        CertificateThumbprint = "HEALTHY-CACHED-FTPS",
+                        NotAfterUtc = DateTimeOffset.UtcNow.AddDays(180)
+                    }
+                }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentSnapshotEntries = true,
+            RecentSnapshotTtl = TimeSpan.FromHours(1),
+            MaxTargets = 1,
+            FtpTlsTimeout = TimeSpan.FromSeconds(1)
+        };
+        options.AdditionalEndpoints.Add("ftps-explicit://localhost:1");
+        options.AdditionalEndpoints.Add("ftps-explicit://localhost:2");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(0, result.ReusedRecentFtpTlsCount);
+        Assert.Equal(1, result.ProbedFtpTlsCount);
+        Assert.Equal(1, result.FtpTlsTargetCountDroppedByLimit);
+        Assert.Equal("ftps-explicit://localhost:2", Assert.Single(result.FtpTlsEndpoints));
+    }
+
+    [Fact]
+    public async Task CaptureAsync_PrioritizesStaleFtpTlsTargetBeforeReusableHealthyTarget() {
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+        CertificateInventoryEntry Cached(int port, DateTimeOffset observedAtUtc, string thumbprint) => new() {
+            Host = "localhost",
+            ResolvedHost = "localhost",
+            Port = port,
+            Service = "FTPS-EXPLICIT",
+            Scheme = "ftps-explicit",
+            ProbeVantage = "default",
+            ObservedAtUtc = observedAtUtc,
+            IsReachable = true,
+            Valid = true,
+            IsKnownCertificateAuthority = true,
+            AllowsServerAuthentication = true,
+            PresentInCtLogs = true,
+            CertificateThumbprint = thumbprint,
+            NotAfterUtc = now.AddDays(180)
+        };
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["localhost|1|FTPS-EXPLICIT"] = Cached(1, now, "REUSABLE-FTPS"),
+                    ["localhost|2|FTPS-EXPLICIT"] = Cached(2, now.AddHours(-2), "STALE-FTPS")
+                }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentSnapshotEntries = true,
+            RecentSnapshotTtl = TimeSpan.FromHours(1),
+            MaxTargets = 1,
+            FtpTlsTimeout = TimeSpan.FromSeconds(1)
+        };
+        options.AdditionalEndpoints.Add("ftps-explicit://localhost:1");
+        options.AdditionalEndpoints.Add("ftps-explicit://localhost:2");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(0, result.ReusedRecentFtpTlsCount);
+        Assert.Equal(1, result.ProbedFtpTlsCount);
+        Assert.Equal("ftps-explicit://localhost:2", Assert.Single(result.FtpTlsEndpoints));
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -473,6 +473,35 @@ public class TestCertificateInventoryCapture {
         Assert.Equal(endpoint, diagnostic.Target);
     }
 
+    [Theory]
+    [InlineData("[mail.example.com]:25")]
+    [InlineData("[www.example.com]")]
+    [InlineData("smtp://[mail.example.com]:25")]
+    public async Task CaptureAsync_RejectsBracketsAroundDnsHostname(string endpoint) {
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (targets, _, _, _) => {
+                Assert.Empty(targets);
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(
+                    Array.Empty<CertificateMonitor.Entry>());
+            }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false
+        };
+        options.AdditionalEndpoints.Add(endpoint);
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Empty(result.Snapshot.Entries);
+        Assert.Contains(result.Warnings, warning => warning.Contains("invalid endpoint", StringComparison.OrdinalIgnoreCase));
+        TargetDecisionDiagnosticEntry diagnostic = Assert.Single(result.TargetDecisionDiagnostics);
+        Assert.Equal("invalid-endpoint", diagnostic.Reason);
+        Assert.Equal(endpoint, diagnostic.Target);
+    }
+
     [Fact]
     public async Task CaptureAsync_PrioritizesStaleFtpTlsTargetBeforeReusableHealthyTarget() {
         DateTimeOffset now = DateTimeOffset.UtcNow;
@@ -581,6 +610,7 @@ public class TestCertificateInventoryCapture {
     [Theory]
     [InlineData("{not-json")]
     [InlineData("{\"values\":[null]}")]
+    [InlineData("{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{}}]}")]
     public async Task CaptureAsync_MalformedOptionalAzureCatalogBecomesWarning(string malformedCatalog) {
         string path = Path.Combine(Path.GetTempPath(), "dd-invalid-azure-" + Guid.NewGuid().ToString("N") + ".json");
         File.WriteAllText(path, malformedCatalog);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -229,6 +229,37 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task CaptureAsync_DuplicateAzureServiceTagsBecomeWarning() {
+        string path = Path.Combine(Path.GetTempPath(), "dd-duplicate-azure-" + Guid.NewGuid().ToString("N") + ".json");
+        File.WriteAllText(path, "{\"changeNumber\":\"7\",\"cloud\":\"Public\",\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"addressPrefixes\":[\"203.0.113.0/24\"]}},{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"addressPrefixes\":[\"2001:db8::/32\"]}}]}");
+        try {
+            using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
+            var capture = new CertificateInventoryCapture {
+                HttpsProbeOverride = (targets, _, _, _) =>
+                    Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(new[] { CreateHttpsEntry(Assert.Single(targets), certificate) }),
+                EndpointDnsQueryOverride = (_, _, _) => Task.FromResult(Array.Empty<DnsAnswer>())
+            };
+            var options = new CertificateInventoryCaptureOptions {
+                IncludeApexHttps = false,
+                IncludeWwwHttps = false,
+                IncludeMxHosts = false,
+                PersistSnapshot = false,
+                EnableEndpointAttribution = true,
+                AzureServiceTagsJsonPath = path
+            };
+            options.AdditionalEndpoints.Add("https://service.example.com");
+
+            CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+            Assert.Single(result.Snapshot.Entries);
+            Assert.Contains(result.Warnings, warning =>
+                warning.Contains("duplicate service-tag names", StringComparison.OrdinalIgnoreCase));
+        } finally {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
     public async Task CaptureAsync_DiscoversEndpointsAndPersistsSnapshot_WithOverrides() {
         using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
         CertificateInventorySnapshot? persistedSnapshot = null;

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -479,10 +479,12 @@ public class TestCertificateInventoryCapture {
         }
     }
 
-    [Fact]
-    public async Task CaptureAsync_MalformedOptionalAzureCatalogBecomesWarning() {
+    [Theory]
+    [InlineData("{not-json")]
+    [InlineData("{\"values\":[null]}")]
+    public async Task CaptureAsync_MalformedOptionalAzureCatalogBecomesWarning(string malformedCatalog) {
         string path = Path.Combine(Path.GetTempPath(), "dd-invalid-azure-" + Guid.NewGuid().ToString("N") + ".json");
-        File.WriteAllText(path, "{not-json");
+        File.WriteAllText(path, malformedCatalog);
         try {
             using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
             var capture = new CertificateInventoryCapture {

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -272,6 +272,49 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
+    public async Task CaptureAsync_ReusableFtpTlsFailureDoesNotConsumeLiveProbeBudget() {
+        var capture = new CertificateInventoryCapture {
+            RecentSnapshotLookupOverride = (_, _, _) =>
+                new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
+                    ["localhost|1|FTPS-EXPLICIT"] = new CertificateInventoryEntry {
+                        Host = "localhost",
+                        ResolvedHost = "localhost",
+                        Port = 1,
+                        Service = "FTPS-EXPLICIT",
+                        Scheme = "ftps-explicit",
+                        ProbeVantage = "default",
+                        ObservedAtUtc = DateTimeOffset.UtcNow,
+                        IsReachable = false,
+                        FailureKind = CertificateFailureKind.ConnectionRefused,
+                        FailureReason = "Connection refused"
+                    }
+                }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            ReuseRecentFailureSnapshotEntries = true,
+            RecentFailureSnapshotTtl = TimeSpan.FromHours(1),
+            MaxTargets = 1,
+            FtpTlsTimeout = TimeSpan.FromSeconds(1)
+        };
+        options.AdditionalEndpoints.Add("ftps-explicit://localhost:1");
+        options.AdditionalEndpoints.Add("ftps-explicit://localhost:2");
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(1, result.ReusedRecentFtpTlsCount);
+        Assert.Equal(1, result.ReusedRecentFailureFtpTlsCount);
+        Assert.Equal(1, result.ProbedFtpTlsCount);
+        Assert.Equal(0, result.FtpTlsTargetCountDroppedByLimit);
+        Assert.Equal("ftps-explicit://localhost:2", Assert.Single(result.FtpTlsEndpoints));
+        Assert.Contains(result.Snapshot.Entries, entry =>
+            entry.Port == 1 && entry.CaptureDisposition == "reused-recent-stable-failure");
+    }
+
+    [Fact]
     public async Task CaptureAsync_PrioritizesStaleFtpTlsTargetBeforeReusableHealthyTarget() {
         DateTimeOffset now = DateTimeOffset.UtcNow;
         CertificateInventoryEntry Cached(int port, DateTimeOffset observedAtUtc, string thumbprint) => new() {

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -237,7 +237,9 @@ public class TestCertificateInventoryCapture {
 
         Assert.Equal(1, result.ReusedRecentEntryCount);
         Assert.Equal(1, result.ReusedRecentFtpTlsCount);
+        Assert.Equal(0, result.FtpTlsEndpointCount);
         Assert.Equal(0, result.ProbedFtpTlsCount);
+        Assert.Empty(result.FtpTlsEndpoints);
         CertificateInventoryEntry reused = Assert.Single(result.Snapshot.Entries);
         Assert.Equal("reused-recent-success", reused.CaptureDisposition);
         Assert.Equal("192.0.2.50", reused.RemoteAddress);
@@ -611,6 +613,7 @@ public class TestCertificateInventoryCapture {
     [InlineData("{not-json")]
     [InlineData("{\"values\":[null]}")]
     [InlineData("{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{}}]}")]
+    [InlineData("{\"values\":[{\"name\":123,\"properties\":{\"addressPrefixes\":[]}}]}")]
     public async Task CaptureAsync_MalformedOptionalAzureCatalogBecomesWarning(string malformedCatalog) {
         string path = Path.Combine(Path.GetTempPath(), "dd-invalid-azure-" + Guid.NewGuid().ToString("N") + ".json");
         File.WriteAllText(path, malformedCatalog);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -3,6 +3,8 @@ using DomainDetective.Providers.Endpoint;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -13,6 +15,58 @@ using System.Threading.Tasks;
 namespace DomainDetective.Tests;
 
 public class TestCertificateInventoryCapture {
+    [Fact]
+    public async Task CaptureAsync_SharesProbeStartLimitAcrossProtocolPhases() {
+        var mailListener = new TcpListener(IPAddress.Loopback, 0);
+        var ftpListener = new TcpListener(IPAddress.Loopback, 0);
+        mailListener.Start();
+        ftpListener.Start();
+        int mailPort = ((IPEndPoint)mailListener.LocalEndpoint).Port;
+        int ftpPort = ((IPEndPoint)ftpListener.LocalEndpoint).Port;
+        Task mailServer = Task.Run(async () => {
+            using TcpClient client = await mailListener.AcceptTcpClientAsync();
+        });
+        Task ftpServer = Task.Run(async () => {
+            using TcpClient client = await ftpListener.AcceptTcpClientAsync();
+        });
+
+        try {
+            var options = new CertificateInventoryCaptureOptions {
+                IncludeApexHttps = false,
+                IncludeWwwHttps = false,
+                IncludeMxHosts = false,
+                PersistSnapshot = false,
+                MaxParallelism = 1,
+                MaxProbeStartsPerSecond = 2,
+                MailTimeout = TimeSpan.FromSeconds(1),
+                FtpTlsTimeout = TimeSpan.FromSeconds(1)
+            };
+            options.AdditionalEndpoints.Add($"smtp://127.0.0.1:{mailPort}");
+            options.AdditionalEndpoints.Add($"ftps-explicit://127.0.0.1:{ftpPort}");
+
+            CertificateInventoryCaptureResult result = await new CertificateInventoryCapture().CaptureAsync(
+                Array.Empty<string>(),
+                options);
+
+            Assert.Equal(1, result.ProbedMailCount);
+            Assert.Equal(1, result.ProbedFtpTlsCount);
+            CertificateInventoryEntry mailEntry = Assert.Single(
+                result.Snapshot.Entries,
+                entry => string.Equals(entry.Scheme, "smtp", StringComparison.OrdinalIgnoreCase));
+            CertificateInventoryEntry ftpEntry = Assert.Single(
+                result.Snapshot.Entries,
+                entry => string.Equals(entry.Scheme, "ftps-explicit", StringComparison.OrdinalIgnoreCase));
+            TimeSpan phaseBoundaryGap = ftpEntry.ObservedAtUtc!.Value - mailEntry.ObservedAtUtc!.Value;
+            Assert.True(
+                phaseBoundaryGap >= TimeSpan.FromMilliseconds(350),
+                $"Expected the global probe-start interval across protocol phases; observed {phaseBoundaryGap}.");
+        } finally {
+            mailListener.Stop();
+            ftpListener.Stop();
+            await Task.WhenAll(mailServer, ftpServer);
+        }
+    }
+
     [Fact]
     public async Task CaptureAsync_EnrichesEndpointWithDnsEvidenceVantageAndAttribution() {
         using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -564,6 +564,34 @@ public class TestCertificateInventoryCapture {
     }
 
     [Theory]
+    [InlineData("[2001:db8::10]:8443", "https://[2001:db8::10]:8443/")]
+    [InlineData("[2001:db8::10]", "https://[2001:db8::10]/")]
+    [InlineData("2001:db8::10", "https://[2001:db8::10]/")]
+    public async Task CaptureAsync_Ipv6HttpsEndpointRetainsUriAuthority(string endpoint, string expectedUrl) {
+        IReadOnlyList<string>? observedTargets = null;
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (targets, _, _, _) => {
+                observedTargets = targets;
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(
+                    Array.Empty<CertificateMonitor.Entry>());
+            }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false
+        };
+        options.AdditionalEndpoints.Add(endpoint);
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(expectedUrl, Assert.Single(observedTargets!));
+        Assert.Equal(expectedUrl, Assert.Single(result.HttpsEndpoints));
+        Assert.Empty(result.Warnings);
+    }
+
+    [Theory]
     [InlineData("ftps://localhost:0")]
     [InlineData("ftps-explicit://localhost:0")]
     [InlineData("smtp://localhost:0")]

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -1,4 +1,5 @@
 using DnsClientX;
+using DomainDetective.Providers.Endpoint;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -61,6 +62,102 @@ public class TestCertificateInventoryCapture {
         Assert.Contains(
             primary.Evidence,
             evidence => evidence.Kind == Providers.Endpoint.EndpointAttributionSignalKind.Cname);
+    }
+
+    [Fact]
+    public async Task CaptureAsync_BoundsConcurrentDnsEnrichmentWithWorkerPool() {
+        using var certificate = CreateSelfSignedWithEku(CertificateExtendedKeyUsageAnalyzer.ServerAuthenticationOid);
+        int activeQueries = 0;
+        int maximumActiveQueries = 0;
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (targets, _, _, _) => {
+                var entries = new List<CertificateMonitor.Entry>(targets.Count);
+                foreach (string target in targets) {
+                    entries.Add(CreateHttpsEntry(target, certificate));
+                }
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(entries);
+            },
+            EndpointDnsQueryOverride = async (_, _, cancellationToken) => {
+                int active = Interlocked.Increment(ref activeQueries);
+                int observedMaximum;
+                do {
+                    observedMaximum = Volatile.Read(ref maximumActiveQueries);
+                    if (active <= observedMaximum) {
+                        break;
+                    }
+                } while (Interlocked.CompareExchange(
+                    ref maximumActiveQueries,
+                    active,
+                    observedMaximum) != observedMaximum);
+
+                try {
+                    await Task.Delay(10, cancellationToken);
+                    return Array.Empty<DnsAnswer>();
+                } finally {
+                    Interlocked.Decrement(ref activeQueries);
+                }
+            }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            EnableEndpointAttribution = true,
+            DnsEnrichmentParallelism = 3
+        };
+        for (int host = 0; host < 20; host++) {
+            options.AdditionalEndpoints.Add($"https://service-{host}.example.com");
+        }
+
+        CertificateInventoryCaptureResult result = await capture.CaptureAsync(Array.Empty<string>(), options);
+
+        Assert.Equal(20, result.Snapshot.Entries.Count);
+        Assert.InRange(maximumActiveQueries, 2, options.DnsEnrichmentParallelism);
+    }
+
+    [Theory]
+    [InlineData(true, nameof(EndpointAttributionRule.ReverseDnsSuffixes))]
+    [InlineData(false, nameof(EndpointAttributionRule.AutonomousSystemNumbers))]
+    public async Task CaptureAsync_RejectsCustomAttributionSignalsItCannotCollectBeforeProbing(
+        bool useReverseDns,
+        string expectedSignal) {
+        int probeCalls = 0;
+        var capture = new CertificateInventoryCapture {
+            HttpsProbeOverride = (_, _, _, _) => {
+                probeCalls++;
+                return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(Array.Empty<CertificateMonitor.Entry>());
+            }
+        };
+        var options = new CertificateInventoryCaptureOptions {
+            IncludeApexHttps = false,
+            IncludeWwwHttps = false,
+            IncludeMxHosts = false,
+            PersistSnapshot = false,
+            EnableEndpointAttribution = true
+        };
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.unsupported-capture-signal",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        if (useReverseDns) {
+            rule.ReverseDnsSuffixes.Add("edge.example.net");
+        } else {
+            rule.AutonomousSystemNumbers.Add("64500");
+        }
+        options.EndpointAttributionRules.Add(rule);
+        options.AdditionalEndpoints.Add("https://service.example.com");
+
+        NotSupportedException exception = await Assert.ThrowsAsync<NotSupportedException>(() =>
+            capture.CaptureAsync(Array.Empty<string>(), options));
+
+        Assert.Equal(0, probeCalls);
+        Assert.Contains("custom.unsupported-capture-signal", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedSignal, exception.Message, StringComparison.Ordinal);
+        Assert.Contains(nameof(EndpointAttributionDetector), exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -228,7 +325,7 @@ public class TestCertificateInventoryCapture {
     }
 
     [Fact]
-    public async Task CaptureAsync_PrioritizesUncachedFtpTlsTargetBeforeHealthyCachedTarget() {
+    public async Task CaptureAsync_PrioritizesUncachedFtpTlsTargetBeforeReusableHighPriorityCachedTarget() {
         var capture = new CertificateInventoryCapture {
             RecentSnapshotLookupOverride = (_, _, _) =>
                 new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase) {
@@ -244,7 +341,9 @@ public class TestCertificateInventoryCapture {
                         Valid = true,
                         IsKnownCertificateAuthority = true,
                         AllowsServerAuthentication = true,
-                        PresentInCtLogs = true,
+                        // A reusable observation can legitimately carry a high evidence
+                        // score without requiring a fresh probe.
+                        PresentInCtLogs = false,
                         CertificateThumbprint = "HEALTHY-CACHED-FTPS",
                         NotAfterUtc = DateTimeOffset.UtcNow.AddDays(180)
                     }

--- a/DomainDetective.Tests/TestCertificateInventoryDiffAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDiffAnalyzer.cs
@@ -122,7 +122,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public void BuildDiffTreatsDifferentServicesOnSameHostAndPortAsDistinctEndpoints() {
+        public void BuildDiffCorrelatesUniqueServiceReplacementWithinTransportSlot() {
             var now = DateTimeOffset.UtcNow;
             var previous = new CertificateInventorySnapshot {
                 CapturedAtUtc = now.AddHours(-1),
@@ -153,20 +153,45 @@ namespace DomainDetective.Tests {
 
             Assert.Equal(1, diff.PreviousEndpointCount);
             Assert.Equal(1, diff.CurrentEndpointCount);
-            Assert.Equal(1, diff.AddedCount);
-            Assert.Equal(1, diff.RemovedCount);
-            Assert.Equal(0, diff.ChangedCount);
+            Assert.Equal(0, diff.AddedCount);
+            Assert.Equal(0, diff.RemovedCount);
+            Assert.Equal(1, diff.ChangedCount);
             Assert.Equal(0, diff.UnchangedCount);
 
-            Assert.Equal(2, diff.Endpoints.Count);
-            Assert.Contains(diff.Endpoints, row =>
-                row.Host == "service-change.example.com" &&
-                row.Status == "Removed" &&
-                row.PreviousService == "HTTPS");
-            Assert.Contains(diff.Endpoints, row =>
-                row.Host == "service-change.example.com" &&
-                row.Status == "Added" &&
-                row.CurrentService == "HTTPS-ALT");
+            CertificateInventoryEndpointDiff endpoint = Assert.Single(diff.Endpoints);
+            Assert.Equal("service-change.example.com", endpoint.Host);
+            Assert.Equal("Changed", endpoint.Status);
+            Assert.Equal("HTTPS", endpoint.PreviousService);
+            Assert.Equal("HTTPS-ALT", endpoint.CurrentService);
+            Assert.Equal(new[] { "Service" }, endpoint.ChangeReasons);
+        }
+
+        [Fact]
+        public void BuildDiffDoesNotInventAmbiguousServiceReplacement() {
+            var now = DateTimeOffset.UtcNow;
+            CertificateInventoryEntry Entry(string service) => new() {
+                Host = "ambiguous-service.example.com",
+                ResolvedHost = "ambiguous-service.example.com",
+                Port = 443,
+                Service = service,
+                CertificateThumbprint = service
+            };
+            var previous = new CertificateInventorySnapshot {
+                CapturedAtUtc = now.AddHours(-1),
+                Entries = new List<CertificateInventoryEntry> { Entry("SERVICE-A"), Entry("SERVICE-B") }
+            };
+            var current = new CertificateInventorySnapshot {
+                CapturedAtUtc = now,
+                Entries = new List<CertificateInventoryEntry> { Entry("SERVICE-C"), Entry("SERVICE-D") }
+            };
+
+            CertificateInventoryDiffSummary diff = CertificateInventoryDiffAnalyzer.BuildDiff(new[] { previous, current });
+
+            Assert.Equal(2, diff.AddedCount);
+            Assert.Equal(2, diff.RemovedCount);
+            Assert.Equal(0, diff.ChangedCount);
+            Assert.Equal(4, diff.Endpoints.Count);
+            Assert.DoesNotContain(diff.Endpoints, endpoint => endpoint.ChangeReasons.Contains("Service"));
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCertificateInventoryDiffAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDiffAnalyzer.cs
@@ -122,7 +122,7 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
-        public void BuildDiffDetectsServiceChangeForSameHostAndPort() {
+        public void BuildDiffTreatsDifferentServicesOnSameHostAndPortAsDistinctEndpoints() {
             var now = DateTimeOffset.UtcNow;
             var previous = new CertificateInventorySnapshot {
                 CapturedAtUtc = now.AddHours(-1),
@@ -153,18 +153,20 @@ namespace DomainDetective.Tests {
 
             Assert.Equal(1, diff.PreviousEndpointCount);
             Assert.Equal(1, diff.CurrentEndpointCount);
-            Assert.Equal(0, diff.AddedCount);
-            Assert.Equal(0, diff.RemovedCount);
-            Assert.Equal(1, diff.ChangedCount);
+            Assert.Equal(1, diff.AddedCount);
+            Assert.Equal(1, diff.RemovedCount);
+            Assert.Equal(0, diff.ChangedCount);
             Assert.Equal(0, diff.UnchangedCount);
 
-            var row = Assert.Single(diff.Endpoints);
-            Assert.Equal("service-change.example.com", row.Host);
-            Assert.Equal(443, row.Port);
-            Assert.Equal("Changed", row.Status);
-            Assert.Equal("HTTPS", row.PreviousService);
-            Assert.Equal("HTTPS-ALT", row.CurrentService);
-            Assert.Equal(new[] { "Service" }, row.ChangeReasons);
+            Assert.Equal(2, diff.Endpoints.Count);
+            Assert.Contains(diff.Endpoints, row =>
+                row.Host == "service-change.example.com" &&
+                row.Status == "Removed" &&
+                row.PreviousService == "HTTPS");
+            Assert.Contains(diff.Endpoints, row =>
+                row.Host == "service-change.example.com" &&
+                row.Status == "Added" &&
+                row.CurrentService == "HTTPS-ALT");
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCertificateInventoryDiffAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDiffAnalyzer.cs
@@ -170,6 +170,48 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void BuildDiffKeepsProbeVantageHistoriesSeparate() {
+            var now = DateTimeOffset.UtcNow;
+            CertificateInventoryEntry Entry(string vantage, string thumbprint) => new() {
+                Host = "shared.example.com",
+                ResolvedHost = "shared.example.com",
+                Port = 443,
+                Service = "HTTPS",
+                ProbeVantage = vantage,
+                CertificateThumbprint = thumbprint
+            };
+            var previous = new CertificateInventorySnapshot {
+                CapturedAtUtc = now.AddHours(-1),
+                Entries = new List<CertificateInventoryEntry> {
+                    Entry("branch-office", "BRANCH"),
+                    Entry("cloud", "CLOUD")
+                }
+            };
+            var current = new CertificateInventorySnapshot {
+                CapturedAtUtc = now,
+                Entries = new List<CertificateInventoryEntry> {
+                    Entry(" cloud ", "CLOUD"),
+                    Entry("BRANCH-OFFICE", "BRANCH")
+                }
+            };
+
+            var diff = CertificateInventoryDiffAnalyzer.BuildDiff(
+                new[] { previous, current },
+                includeUnchanged: true);
+
+            Assert.Equal(2, diff.PreviousEndpointCount);
+            Assert.Equal(2, diff.CurrentEndpointCount);
+            Assert.Equal(0, diff.AddedCount);
+            Assert.Equal(0, diff.RemovedCount);
+            Assert.Equal(0, diff.ChangedCount);
+            Assert.Equal(2, diff.UnchangedCount);
+            Assert.Collection(
+                diff.Endpoints.OrderBy(endpoint => endpoint.ProbeVantage, StringComparer.OrdinalIgnoreCase),
+                endpoint => Assert.Equal("branch-office", endpoint.ProbeVantage, ignoreCase: true),
+                endpoint => Assert.Equal("cloud", endpoint.ProbeVantage, ignoreCase: true));
+        }
+
+        [Fact]
         public void BuildDiffDefaultsToLatestTwoSnapshotsAndCanIncludeUnchanged() {
             var now = DateTimeOffset.UtcNow;
             var snapshots = new[] {

--- a/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
@@ -148,6 +148,50 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void BuildDriftKeepsProbeVantageHistoriesSeparate() {
+            var now = DateTimeOffset.UtcNow;
+            CertificateInventoryEntry Entry(string vantage, string thumbprint) => new() {
+                Host = "shared.example.com",
+                ResolvedHost = "shared.example.com",
+                Port = 443,
+                Service = "HTTPS",
+                ProbeVantage = vantage,
+                CertificateThumbprint = thumbprint
+            };
+            var snapshots = new[] {
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-1),
+                    Entries = new List<CertificateInventoryEntry> {
+                        Entry("branch-office", "BRANCH-CERT"),
+                        Entry("cloud", "CLOUD-CERT")
+                    }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now,
+                    Entries = new List<CertificateInventoryEntry> {
+                        Entry("branch-office", "BRANCH-CERT"),
+                        Entry("cloud", "CLOUD-CERT")
+                    }
+                }
+            };
+
+            CertificateInventoryDriftSummary drift = CertificateInventoryDriftAnalyzer.BuildDrift(
+                snapshots,
+                changedOnly: false,
+                maxEndpoints: 100);
+
+            Assert.Equal(2, drift.EndpointCount);
+            Assert.Equal(0, drift.EndpointsWithAnyChange);
+            Assert.All(drift.Endpoints, endpoint => {
+                Assert.Equal(2, endpoint.ObservationCount);
+                Assert.Equal(1, endpoint.DistinctCertificateCount);
+                Assert.Equal("None", endpoint.DriftSeverity);
+            });
+            Assert.Contains(drift.Endpoints, endpoint => endpoint.ProbeVantage == "branch-office");
+            Assert.Contains(drift.Endpoints, endpoint => endpoint.ProbeVantage == "cloud");
+        }
+
+        [Fact]
         public void BuildDriftChangedOnlyFiltersUnchangedEndpoints() {
             var now = DateTimeOffset.UtcNow;
             var snapshots = new[] {

--- a/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
@@ -44,7 +44,7 @@ namespace DomainDetective.Tests {
                             Host = "api.example.com",
                             ResolvedHost = "api.example.com",
                             Port = 443,
-                            Service = "HTTPS-Alt",
+                            Service = "HTTPS",
                             CertificateThumbprint = "BBB222",
                             CertificateIssuerNormalized = "DigiCert",
                             NotAfterUtc = now.AddDays(365),
@@ -74,7 +74,7 @@ namespace DomainDetective.Tests {
             Assert.Equal(1, drift.EndpointsWithCertificateChange);
             Assert.Equal(1, drift.EndpointsWithIssuerChange);
             Assert.Equal(1, drift.EndpointsWithExpiryChange);
-            Assert.Equal(1, drift.EndpointsWithServiceChange);
+            Assert.Equal(0, drift.EndpointsWithServiceChange);
             Assert.Equal(1, drift.EndpointsWithAuthenticationProfileChange);
             Assert.Equal(1, drift.EndpointsWithChainSourceChange);
             Assert.Equal(1, drift.EndpointsWithHighSeverityDrift);
@@ -93,11 +93,11 @@ namespace DomainDetective.Tests {
             Assert.True(api.CertificateChanged);
             Assert.True(api.IssuerChanged);
             Assert.True(api.ExpiryChanged);
-            Assert.True(api.ServiceChanged);
+            Assert.False(api.ServiceChanged);
             Assert.True(api.AuthenticationProfileChanged);
             Assert.True(api.ChainSourceChanged);
             Assert.Equal("High", api.DriftSeverity);
-            Assert.Equal(new[] { "certificate", "issuer", "expiry", "service", "auth-profile", "chain-source" }, api.ChangeKinds);
+            Assert.Equal(new[] { "certificate", "issuer", "expiry", "auth-profile", "chain-source" }, api.ChangeKinds);
             Assert.Equal("AAA111", api.PreviousCertificateId);
             Assert.Equal("BBB222", api.CurrentCertificateId);
             Assert.Equal(CertificateAuthenticationProfileClassifier.ServerAuthOnly, api.PreviousAuthenticationProfile);
@@ -118,6 +118,33 @@ namespace DomainDetective.Tests {
             Assert.Equal("None", portal.DriftSeverity);
             Assert.Empty(portal.ChangeKinds);
             Assert.Null(portal.LastChangedAtUtc);
+        }
+
+        [Fact]
+        public void BuildDriftKeepsServicesOnSameHostAndPortSeparate() {
+            var now = DateTimeOffset.UtcNow;
+            var snapshots = new[] {
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-1),
+                    Entries = new List<CertificateInventoryEntry> {
+                        new() { Host = "multi.example.com", Port = 443, Service = "HTTPS", CertificateThumbprint = "HTTPS-1" },
+                        new() { Host = "multi.example.com", Port = 443, Service = "LDAPS", CertificateThumbprint = "LDAPS-1" }
+                    }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now,
+                    Entries = new List<CertificateInventoryEntry> {
+                        new() { Host = "multi.example.com", Port = 443, Service = "HTTPS", CertificateThumbprint = "HTTPS-1" },
+                        new() { Host = "multi.example.com", Port = 443, Service = "LDAPS", CertificateThumbprint = "LDAPS-1" }
+                    }
+                }
+            };
+
+            CertificateInventoryDriftSummary drift = CertificateInventoryDriftAnalyzer.BuildDrift(snapshots, changedOnly: false, maxEndpoints: 100);
+
+            Assert.Equal(2, drift.EndpointCount);
+            Assert.Contains(drift.Endpoints, endpoint => endpoint.Service == "HTTPS" && endpoint.ObservationCount == 2);
+            Assert.Contains(drift.Endpoints, endpoint => endpoint.Service == "LDAPS" && endpoint.ObservationCount == 2);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
@@ -148,6 +148,129 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void BuildDriftDetectsUniqueServiceTransitionWithinTransportSlot() {
+            var now = DateTimeOffset.UtcNow;
+            var snapshots = new[] {
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-1),
+                    Entries = new List<CertificateInventoryEntry> {
+                        new() {
+                            Host = "service-identity.example.com",
+                            ResolvedHost = "service-identity.example.com",
+                            Port = 443,
+                            Service = "HTTPS",
+                            CertificateThumbprint = "SAME"
+                        }
+                    }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now,
+                    Entries = new List<CertificateInventoryEntry> {
+                        new() {
+                            Host = "service-identity.example.com",
+                            ResolvedHost = "service-identity.example.com",
+                            Port = 443,
+                            Service = "HTTPS-ALT",
+                            CertificateThumbprint = "SAME"
+                        }
+                    }
+                }
+            };
+
+            CertificateInventoryDriftSummary drift = CertificateInventoryDriftAnalyzer.BuildDrift(snapshots);
+
+            Assert.Equal(1, drift.EndpointCount);
+            Assert.Equal(1, drift.EndpointsWithServiceChange);
+            CertificateInventoryEndpointDrift endpoint = Assert.Single(drift.Endpoints);
+            Assert.Equal(2, endpoint.ObservationCount);
+            Assert.Equal("HTTPS", endpoint.PreviousService);
+            Assert.Equal("HTTPS-ALT", endpoint.CurrentService);
+            Assert.Equal("HTTPS-ALT", endpoint.Service);
+            Assert.True(endpoint.ServiceChanged);
+            Assert.Equal(new[] { "service" }, endpoint.ChangeKinds);
+            Assert.Equal("Medium", endpoint.DriftSeverity);
+        }
+
+        [Fact]
+        public void BuildDriftKeepsCoexistingServicesAsDistinctEndpointHistories() {
+            var now = DateTimeOffset.UtcNow;
+            CertificateInventoryEntry Entry(string service, DateTimeOffset observedAtUtc) => new() {
+                Host = "coexisting.example.com",
+                ResolvedHost = "coexisting.example.com",
+                Port = 443,
+                Service = service,
+                CertificateThumbprint = service,
+                ObservedAtUtc = observedAtUtc
+            };
+            var snapshots = new[] {
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-1),
+                    Entries = new List<CertificateInventoryEntry> {
+                        Entry("HTTPS", now.AddHours(-1)),
+                        Entry("HTTPS-ALT", now.AddHours(-1))
+                    }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now,
+                    Entries = new List<CertificateInventoryEntry> {
+                        Entry("HTTPS", now),
+                        Entry("HTTPS-ALT", now)
+                    }
+                }
+            };
+
+            CertificateInventoryDriftSummary drift = CertificateInventoryDriftAnalyzer.BuildDrift(snapshots);
+
+            Assert.Equal(2, drift.EndpointCount);
+            Assert.Equal(0, drift.EndpointsWithServiceChange);
+            Assert.All(drift.Endpoints, endpoint => {
+                Assert.Equal(2, endpoint.ObservationCount);
+                Assert.False(endpoint.ServiceChanged);
+            });
+        }
+
+        [Fact]
+        public void BuildDriftCorrelatesUniqueReplacementAlongsideStableService() {
+            var now = DateTimeOffset.UtcNow;
+            CertificateInventoryEntry Entry(string service) => new() {
+                Host = "partial-service-change.example.com",
+                ResolvedHost = "partial-service-change.example.com",
+                Port = 443,
+                Service = service,
+                CertificateThumbprint = service == "HTTPS" ? "STABLE" : "REPLACED"
+            };
+            var snapshots = new[] {
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-1),
+                    Entries = new List<CertificateInventoryEntry> { Entry("HTTPS"), Entry("HTTPS-LEGACY") }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now,
+                    Entries = new List<CertificateInventoryEntry> { Entry("HTTPS"), Entry("HTTPS-ALT") }
+                }
+            };
+
+            CertificateInventoryDriftSummary drift = CertificateInventoryDriftAnalyzer.BuildDrift(snapshots);
+
+            Assert.Equal(2, drift.EndpointCount);
+            Assert.Equal(1, drift.EndpointsWithServiceChange);
+            Assert.Contains(drift.Endpoints, endpoint =>
+                endpoint.Service == "HTTPS" &&
+                endpoint.ObservationCount == 2 &&
+                !endpoint.ServiceChanged);
+            Assert.Contains(drift.Endpoints, endpoint =>
+                endpoint.PreviousService == "HTTPS-LEGACY" &&
+                endpoint.CurrentService == "HTTPS-ALT" &&
+                endpoint.ServiceChanged);
+        }
+
+        [Fact]
+        public void TryNormalizeChangeKindAcceptsService() {
+            Assert.True(CertificateInventoryDriftAnalyzer.TryNormalizeChangeKind(" service ", out string? normalized));
+            Assert.Equal("service", normalized);
+        }
+
+        [Fact]
         public void BuildDriftCoalescesReusedProtocolObservations() {
             var now = DateTimeOffset.UtcNow;
             var firstObservedAt = now.AddHours(-6);

--- a/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryDriftAnalyzer.cs
@@ -148,6 +148,46 @@ namespace DomainDetective.Tests {
         }
 
         [Fact]
+        public void BuildDriftCoalescesReusedProtocolObservations() {
+            var now = DateTimeOffset.UtcNow;
+            var firstObservedAt = now.AddHours(-6);
+            var secondObservedAt = now.AddHours(-1);
+            CertificateInventoryEntry Entry(DateTimeOffset observedAt, string thumbprint) => new() {
+                Host = "reused.example.com",
+                ResolvedHost = "reused.example.com",
+                Port = 443,
+                Service = "HTTPS",
+                ObservedAtUtc = observedAt,
+                CertificateThumbprint = thumbprint,
+                CertificateIssuerNormalized = "Issuer"
+            };
+            var snapshots = new[] {
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-6),
+                    Entries = new List<CertificateInventoryEntry> { Entry(firstObservedAt, "CERT-A") }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now.AddHours(-3),
+                    Entries = new List<CertificateInventoryEntry> { Entry(firstObservedAt, "CERT-A") }
+                },
+                new CertificateInventorySnapshot {
+                    CapturedAtUtc = now,
+                    Entries = new List<CertificateInventoryEntry> { Entry(secondObservedAt, "CERT-B") }
+                }
+            };
+
+            CertificateInventoryEndpointDrift row = Assert.Single(
+                CertificateInventoryDriftAnalyzer.BuildDrift(snapshots, maxEndpoints: 100).Endpoints);
+
+            Assert.Equal(2, row.ObservationCount);
+            Assert.Equal(firstObservedAt, row.FirstSeenUtc);
+            Assert.Equal(secondObservedAt, row.LastSeenUtc);
+            Assert.Equal(secondObservedAt, row.LastChangedAtUtc);
+            Assert.Equal("CERT-A", row.PreviousCertificateId);
+            Assert.Equal("CERT-B", row.CurrentCertificateId);
+        }
+
+        [Fact]
         public void BuildDriftKeepsProbeVantageHistoriesSeparate() {
             var now = DateTimeOffset.UtcNow;
             CertificateInventoryEntry Entry(string vantage, string thumbprint) => new() {

--- a/DomainDetective.Tests/TestCertificateMonitorInventory.cs
+++ b/DomainDetective.Tests/TestCertificateMonitorInventory.cs
@@ -46,6 +46,8 @@ namespace DomainDetective.Tests {
                     Assert.Equal("HTTPS", entry.Service);
                     Assert.Equal(443, entry.Port);
                     Assert.Equal("https", entry.Scheme);
+                    Assert.NotNull(entry.ObservedAtUtc);
+                    Assert.True(entry.ObservedAtUtc <= snapshot.CapturedAtUtc);
                     Assert.True(!string.IsNullOrWhiteSpace(entry.CertificateIssuerNormalized));
                     Assert.True(!string.IsNullOrWhiteSpace(entry.CertificateThumbprint));
                     Assert.True(!string.IsNullOrWhiteSpace(entry.CertificateSerialNumber));

--- a/DomainDetective.Tests/TestCertificateMonitorInventory.cs
+++ b/DomainDetective.Tests/TestCertificateMonitorInventory.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.IO;
+using System.Net;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -11,6 +12,41 @@ using DomainDetective.Helpers;
 
 namespace DomainDetective.Tests {
     public class TestCertificateMonitorInventory {
+        [Fact]
+        public void SaveInventorySnapshotClampsCaptureTimeToLatestEvidence() {
+            string tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            try {
+                DateTimeOffset evidenceAtUtc = DateTimeOffset.UtcNow;
+                var snapshot = new CertificateInventorySnapshot {
+                    CapturedAtUtc = evidenceAtUtc.AddMinutes(-5),
+                    Port = 443,
+                    Entries = new List<CertificateInventoryEntry> {
+                        new() {
+                            Host = "example.test",
+                            Port = 443,
+                            Service = "HTTPS",
+                            ObservedAtUtc = evidenceAtUtc.AddSeconds(-2),
+                            DnsObservedAtUtc = evidenceAtUtc
+                        }
+                    }
+                };
+                using var monitor = new CertificateMonitor {
+                    CacheDirectory = tempDir,
+                    PersistInventorySnapshots = false
+                };
+
+                string path = monitor.SaveInventorySnapshot(snapshot);
+
+                Assert.False(string.IsNullOrWhiteSpace(path));
+                Assert.True(snapshot.CapturedAtUtc >= evidenceAtUtc);
+            } finally {
+                if (Directory.Exists(tempDir)) {
+                    Directory.Delete(tempDir, true);
+                }
+            }
+        }
+
         [Fact]
         public async Task AnalyzePersistsInventorySnapshot() {
             var tempDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
@@ -158,6 +194,7 @@ namespace DomainDetective.Tests {
                 Scheme = "https",
                 Port = 443,
                 Service = "HTTPS",
+                RemoteAddress = IPAddress.Parse("192.0.2.10"),
                 ExpiryDate = cert.NotAfter,
                 Valid = true,
                 Expired = false,
@@ -170,6 +207,7 @@ namespace DomainDetective.Tests {
             Assert.True(snapshotEntry.IsReachable);
             Assert.Null(snapshotEntry.FailureReason);
             Assert.Equal(CertificateFailureKind.None, snapshotEntry.FailureKind);
+            Assert.Equal("IPv4", snapshotEntry.RemoteAddressFamily);
         }
 
         [Fact]

--- a/DomainDetective.Tests/TestCertificateServiceClassifier.cs
+++ b/DomainDetective.Tests/TestCertificateServiceClassifier.cs
@@ -19,5 +19,14 @@ namespace DomainDetective.Tests {
             Assert.Equal("HTTPS-Alt", descriptor.Service);
             Assert.Equal("https://example.com:8443/app", descriptor.Url);
         }
+
+        [Fact]
+        public void ResolveClassifiesArbitraryHttpsPortByKnownTransport() {
+            var descriptor = CertificateServiceClassifier.Resolve("https://example.com:10443/app", 443);
+
+            Assert.Equal(10443, descriptor.Port);
+            Assert.Equal("https", descriptor.Scheme);
+            Assert.Equal("HTTPS-Alt", descriptor.Service);
+        }
     }
 }

--- a/DomainDetective.Tests/TestCnameNarrative.cs
+++ b/DomainDetective.Tests/TestCnameNarrative.cs
@@ -54,4 +54,31 @@ public class TestCnameNarrative {
         Assert.Contains("CNAME target resolves", narrative.Positives);
         Assert.Contains("No CNAME loop detected", narrative.Positives);
     }
+
+    [Fact]
+    public async Task AddressLookupFailureDoesNotClaimTargetDoesNotResolve() {
+        var analysis = new CnameAnalysis {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (name, type) => {
+                if (type == DnsRecordType.CNAME && name == "alias.example.com") {
+                    return Task.FromResult(new[] { CreateAnswer("target.example.com") });
+                }
+                if (type == DnsRecordType.CNAME) {
+                    return Task.FromResult(System.Array.Empty<DnsAnswer>());
+                }
+                if (type == DnsRecordType.A) {
+                    throw new System.InvalidOperationException("resolver unavailable");
+                }
+                return Task.FromResult(System.Array.Empty<DnsAnswer>());
+            }
+        };
+
+        await analysis.Analyze("alias.example.com", new InternalLogger());
+
+        Assert.True(analysis.CnameRecordExists);
+        Assert.False(analysis.TargetResolves);
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == CnameCodes.DnsLookupFailed);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == CnameCodes.TargetDoesNotResolve);
+        Assert.DoesNotContain(analysis.Recommendations, recommendation => recommendation.Code == CnameCodes.TargetDoesNotResolve);
+    }
 }

--- a/DomainDetective.Tests/TestCnameNarrative.cs
+++ b/DomainDetective.Tests/TestCnameNarrative.cs
@@ -105,4 +105,24 @@ public class TestCnameNarrative {
         Assert.Equal(0, addressQueryCount);
         Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == CnameCodes.DnsLookupFailed);
     }
+
+    [Fact]
+    public async Task AmbiguousCnamePreservesRecordExistenceAndHonestNarrative() {
+        var analysis = new CnameAnalysis {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (_, type) => Task.FromResult(type == DnsRecordType.CNAME
+                ? new[] { CreateAnswer("first.example.net"), CreateAnswer("second.example.net") }
+                : System.Array.Empty<DnsAnswer>())
+        };
+
+        await analysis.Analyze("alias.example.com", new InternalLogger());
+        CnameNarrative.Sections narrative = CnameNarrative.Build(analysis, analysis.Assessments);
+
+        Assert.True(analysis.CnameRecordExists);
+        Assert.Null(analysis.Target);
+        Assert.Contains(narrative.Highlights, highlight => highlight.Contains("ambiguous or unavailable", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("CNAME target resolution is indeterminate.", narrative.Highlights);
+        Assert.DoesNotContain(narrative.Highlights, highlight => highlight.Contains("has no CNAME record", System.StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(analysis.Assessments, assessment => assessment.Code == CnameCodes.DnsLookupFailed);
+    }
 }

--- a/DomainDetective.Tests/TestCnameNarrative.cs
+++ b/DomainDetective.Tests/TestCnameNarrative.cs
@@ -81,4 +81,28 @@ public class TestCnameNarrative {
         Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == CnameCodes.TargetDoesNotResolve);
         Assert.DoesNotContain(analysis.Recommendations, recommendation => recommendation.Code == CnameCodes.TargetDoesNotResolve);
     }
+
+    [Fact]
+    public async Task NoCnameDoesNotPerformUnneededAddressQueries() {
+        int cnameQueryCount = 0;
+        int addressQueryCount = 0;
+        var analysis = new CnameAnalysis {
+            DnsConfiguration = new DnsConfiguration(),
+            QueryDnsOverride = (_, type) => {
+                if (type == DnsRecordType.CNAME) {
+                    cnameQueryCount++;
+                } else {
+                    addressQueryCount++;
+                }
+                return Task.FromResult(System.Array.Empty<DnsAnswer>());
+            }
+        };
+
+        await analysis.Analyze("direct.example.com", new InternalLogger());
+
+        Assert.False(analysis.CnameRecordExists);
+        Assert.Equal(1, cnameQueryCount);
+        Assert.Equal(0, addressQueryCount);
+        Assert.DoesNotContain(analysis.Assessments, assessment => assessment.Code == CnameCodes.DnsLookupFailed);
+    }
 }

--- a/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
+++ b/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
@@ -157,6 +157,58 @@ public class TestConstrainedOutboundConnections {
     }
 
     [Fact]
+    public async Task CertificateConnectorNormalizesMappedAddressBeforeSocketCreation() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var analysis = new CertificateAnalysis {
+                OutboundAddressResolver = (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(
+                    new[] { IPAddress.Parse("::ffff:127.0.0.1") })
+            };
+
+            var connect = analysis.ConnectDirectAsync("service.invalid", port, CancellationToken.None);
+            using var accepted = await listener.AcceptTcpClientAsync();
+            using var client = await connect;
+
+            Assert.True(client.Connected);
+            Assert.Equal(IPAddress.Loopback, analysis.RemoteAddress);
+            var remote = Assert.IsType<IPEndPoint>(client.Client.RemoteEndPoint);
+            Assert.Equal(AddressFamily.InterNetwork, remote.AddressFamily);
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task AuxiliaryCertificateConnectionDoesNotOverwritePrimaryPeer() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var analysis = new CertificateAnalysis();
+            var setter = typeof(CertificateAnalysis)
+                .GetProperty(nameof(CertificateAnalysis.RemoteAddress))!
+                .GetSetMethod(nonPublic: true)!;
+            IPAddress primaryPeer = IPAddress.Parse("192.0.2.25");
+            setter.Invoke(analysis, new object[] { primaryPeer });
+
+            var connect = analysis.ConnectDirectAsync(
+                IPAddress.Loopback.ToString(),
+                port,
+                CancellationToken.None,
+                captureRemoteAddress: false);
+            using var accepted = await listener.AcceptTcpClientAsync();
+            using var client = await connect;
+
+            Assert.True(client.Connected);
+            Assert.Equal(primaryPeer, analysis.RemoteAddress);
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
     public async Task AwaitConnectDisposesSocketWhenCanceled() {
         using var client = new TcpClient();
         var socket = client.Client;

--- a/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
+++ b/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
@@ -5,6 +5,15 @@ namespace DomainDetective.Tests;
 
 public class TestConstrainedOutboundConnections {
     [Fact]
+    public void MailAddressFamilyTreatsMappedIpv4AsIpv4() {
+        IPAddress mapped = IPAddress.Parse("::ffff:192.0.2.40");
+
+        Assert.True(MailTransportConnector.Matches(mapped, MailTransportAddressFamily.IPv4));
+        Assert.False(MailTransportConnector.Matches(mapped, MailTransportAddressFamily.IPv6));
+        Assert.Equal(MailTransportAddressFamily.IPv4, MailTransportConnector.ToMailAddressFamily(mapped));
+    }
+
+    [Fact]
     public async Task HealthCheckHostProbesPreserveAnalysisResolversWhenTopLevelResolverIsUnset() {
         var healthCheck = new DomainHealthCheck();
         Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>> resolver =

--- a/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
+++ b/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
@@ -131,6 +131,32 @@ public class TestConstrainedOutboundConnections {
     }
 
     [Fact]
+    public async Task MailConnectorNormalizesMappedPinnedAddressBeforeApprovalAndConnect() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        try {
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var endpoint = new MailTransportEndpoint("mail.example.com", port) {
+                ConnectAddress = IPAddress.Parse("::ffff:127.0.0.1"),
+                AddressFamily = MailTransportAddressFamily.IPv4
+            };
+
+            var connect = MailTransportConnector.ConnectAsync(
+                endpoint,
+                (_, _) => Task.FromResult<IReadOnlyList<IPAddress>>(new[] { IPAddress.Loopback }),
+                CancellationToken.None);
+            using var accepted = await listener.AcceptTcpClientAsync();
+            using var client = await connect;
+
+            Assert.True(client.Connected);
+            var remote = Assert.IsType<IPEndPoint>(client.Client.RemoteEndPoint);
+            Assert.Equal(AddressFamily.InterNetwork, remote.AddressFamily);
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Fact]
     public async Task AwaitConnectDisposesSocketWhenCanceled() {
         using var client = new TcpClient();
         var socket = client.Client;

--- a/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
+++ b/DomainDetective.Tests/TestConstrainedOutboundConnections.cs
@@ -4,6 +4,25 @@ using System.Net.Sockets;
 namespace DomainDetective.Tests;
 
 public class TestConstrainedOutboundConnections {
+#if NET8_0_OR_GREATER
+    [Theory]
+    [InlineData("origin.example", 443, "https://origin.example/", true)]
+    [InlineData("origin.example", 8443, "https://origin.example:8443/", true)]
+    [InlineData("proxy.example", 8080, "https://origin.example/", false)]
+    [InlineData("origin.example", 8080, "https://origin.example/", false)]
+    public void HttpTransportEndpointIdentifiesOnlyTheRequestOrigin(
+        string connectionHost,
+        int connectionPort,
+        string requestUrl,
+        bool expected) {
+        var connectionEndpoint = new DnsEndPoint(connectionHost, connectionPort);
+
+        Assert.Equal(
+            expected,
+            CertificateAnalysis.IsOriginTransportEndpoint(connectionEndpoint, new Uri(requestUrl)));
+    }
+#endif
+
     [Fact]
     public void MailAddressFamilyTreatsMappedIpv4AsIpv4() {
         IPAddress mapped = IPAddress.Parse("::ffff:192.0.2.40");

--- a/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
@@ -213,6 +213,38 @@ public class TestDnsInventoryAnalysis
     }
 
     [Fact]
+    public async Task CnameInventoryUsesTerminalEqualRankedServiceInsteadOfLexicalOrder()
+    {
+        var analysis = new DnsInventoryAnalysis
+        {
+            IncludeAuthorities = false,
+            QueryOverride = (_, type, _) => Task.FromResult(new DnsResponse
+            {
+                Status = DnsResponseCode.NoError,
+                Answers = type == DnsRecordType.CNAME
+                    ? new[]
+                    {
+                        // Deliberately reverse DNS response order. Service selection
+                        // must follow owner-to-target links, not array position.
+                        new DnsAnswer { Name = "z.azurefd.net", Type = DnsRecordType.CNAME, DataRaw = "a.azureedge.net." },
+                        new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "z.azurefd.net." }
+                    }
+                    : Array.Empty<DnsAnswer>()
+            })
+        };
+
+        await analysis.AnalyzeAsync("example.com", new InternalLogger(), CancellationToken.None);
+
+        Assert.Equal(DnsCnameTargetProvider.Azure, analysis.CnameTargetProvider);
+        Assert.Equal(DnsCnameTargetService.AzureCdn, analysis.CnameTargetService);
+        Assert.Contains(analysis.DetectedDnsApplications, application => application.Id == "cname-target-azurecdn");
+        var evidence = analysis.CnameTargetEvidence.ToList();
+        Assert.True(
+            evidence.FindIndex(item => item.Contains("z.azurefd.net", StringComparison.OrdinalIgnoreCase)) <
+            evidence.FindIndex(item => item.Contains("a.azureedge.net", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
     public void CaaIssuerDetectorParsesCommonFormats()
     {
         var m = DnsCaaIssuerDetector.Detect(new[]

--- a/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
@@ -237,11 +237,50 @@ public class TestDnsInventoryAnalysis
 
         Assert.Equal(DnsCnameTargetProvider.Azure, analysis.CnameTargetProvider);
         Assert.Equal(DnsCnameTargetService.AzureCdn, analysis.CnameTargetService);
-        Assert.Contains(analysis.DetectedDnsApplications, application => application.Id == "cname-target-azurecdn");
+        DetectedDnsApplication application = Assert.Single(
+            analysis.DetectedDnsApplications,
+            application => application.Id == "cname-target-azurecdn");
+        Assert.Contains("a.azureedge.net", application.Evidence, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("z.azurefd.net", application.Evidence, StringComparison.OrdinalIgnoreCase);
         var evidence = analysis.CnameTargetEvidence.ToList();
         Assert.True(
             evidence.FindIndex(item => item.Contains("z.azurefd.net", StringComparison.OrdinalIgnoreCase)) <
             evidence.FindIndex(item => item.Contains("a.azureedge.net", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public async Task CnameApplicationRetainsSelectedTerminalEvidenceAfterDiagnosticCap()
+    {
+        var analysis = new DnsInventoryAnalysis
+        {
+            IncludeAuthorities = false,
+            QueryOverride = (_, type, _) => Task.FromResult(new DnsResponse
+            {
+                Status = DnsResponseCode.NoError,
+                Answers = type == DnsRecordType.CNAME
+                    ? new[]
+                    {
+                        new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "a.cloudflare.net." },
+                        new DnsAnswer { Name = "a.cloudflare.net", Type = DnsRecordType.CNAME, DataRaw = "b.cloudfront.net." },
+                        new DnsAnswer { Name = "b.cloudfront.net", Type = DnsRecordType.CNAME, DataRaw = "c.github.io." },
+                        new DnsAnswer { Name = "c.github.io", Type = DnsRecordType.CNAME, DataRaw = "d.netlify.app." },
+                        new DnsAnswer { Name = "d.netlify.app", Type = DnsRecordType.CNAME, DataRaw = "z.azurefd.net." },
+                        new DnsAnswer { Name = "z.azurefd.net", Type = DnsRecordType.CNAME, DataRaw = "terminal.azureedge.net." }
+                    }
+                    : Array.Empty<DnsAnswer>()
+            })
+        };
+
+        await analysis.AnalyzeAsync("example.com", new InternalLogger(), CancellationToken.None);
+
+        Assert.Equal(DnsCnameTargetService.AzureCdn, analysis.CnameTargetService);
+        DetectedDnsApplication application = Assert.Single(
+            analysis.DetectedDnsApplications,
+            item => item.Id == "cname-target-azurecdn");
+        Assert.Contains("terminal.azureedge.net", application.Evidence, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            analysis.CnameTargetEvidence,
+            item => item.Contains("terminal.azureedge.net", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
@@ -187,29 +187,41 @@ public class TestDnsInventoryAnalysis
         Assert.Equal(service, match.Service);
     }
 
-    [Fact]
-    public async Task CnameInventoryKeepsProviderAndServiceFromSameTargetMatch()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task CnameInventoryLeavesConflictingOwnerTargetsUnclassified(bool reverseOrder)
     {
+        var answers = new[]
+        {
+            new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "a.cloudflare.net." },
+            new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "z.azurefd.net." }
+        };
+        if (reverseOrder)
+        {
+            Array.Reverse(answers);
+        }
         var analysis = new DnsInventoryAnalysis
         {
             IncludeAuthorities = false,
             QueryOverride = (_, type, _) => Task.FromResult(new DnsResponse
             {
                 Status = DnsResponseCode.NoError,
-                Answers = type == DnsRecordType.CNAME
-                    ? new[]
-                    {
-                        new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "a.cloudflare.net." },
-                        new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "z.azurefd.net." }
-                    }
-                    : Array.Empty<DnsAnswer>()
+                Answers = type == DnsRecordType.CNAME ? answers : Array.Empty<DnsAnswer>()
             })
         };
 
         await analysis.AnalyzeAsync("example.com", new InternalLogger(), CancellationToken.None);
 
-        Assert.Equal(DnsCnameTargetProvider.Azure, analysis.CnameTargetProvider);
-        Assert.Equal(DnsCnameTargetService.AzureFrontDoor, analysis.CnameTargetService);
+        Assert.Equal(DnsCnameTargetProvider.Unknown, analysis.CnameTargetProvider);
+        Assert.Equal(DnsCnameTargetService.Unknown, analysis.CnameTargetService);
+        Assert.Equal(DnsCnameTargetFlags.None, analysis.CnameTargetFlags);
+        Assert.DoesNotContain(analysis.DetectedDnsApplications, application =>
+            application.Source == "DnsInventory.CnameTarget");
+        Assert.Contains(analysis.CnameTargetEvidence, item =>
+            item.Contains("Conflicting CNAME targets for owner: example.com", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(analysis.CnameTargetEvidence, item => item.Contains("a.cloudflare.net", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(analysis.CnameTargetEvidence, item => item.Contains("z.azurefd.net", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
+++ b/DomainDetective.Tests/TestDnsInventoryAnalysis.cs
@@ -171,6 +171,47 @@ public class TestDnsInventoryAnalysis
         Assert.Equal(DnsCnameTargetProvider.Cloudflare, b.Provider);
     }
 
+    [Theory]
+    [InlineData("tenant.azurefd.net", DnsCnameTargetProvider.Azure, DnsCnameTargetService.AzureFrontDoor)]
+    [InlineData("tenant.azureedge.net", DnsCnameTargetProvider.Azure, DnsCnameTargetService.AzureCdn)]
+    [InlineData("tenant.trafficmanager.net", DnsCnameTargetProvider.Azure, DnsCnameTargetService.AzureTrafficManager)]
+    [InlineData("cdn.perf1.com", DnsCnameTargetProvider.NameShield, DnsCnameTargetService.NameShieldRedirection)]
+    public void CnameTargetDetectorDistinguishesManagedServices(
+        string target,
+        DnsCnameTargetProvider provider,
+        DnsCnameTargetService service)
+    {
+        DnsCnameTargetDetector.Match match = DnsCnameTargetDetector.Detect(target);
+
+        Assert.Equal(provider, match.Provider);
+        Assert.Equal(service, match.Service);
+    }
+
+    [Fact]
+    public async Task CnameInventoryKeepsProviderAndServiceFromSameTargetMatch()
+    {
+        var analysis = new DnsInventoryAnalysis
+        {
+            IncludeAuthorities = false,
+            QueryOverride = (_, type, _) => Task.FromResult(new DnsResponse
+            {
+                Status = DnsResponseCode.NoError,
+                Answers = type == DnsRecordType.CNAME
+                    ? new[]
+                    {
+                        new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "a.cloudflare.net." },
+                        new DnsAnswer { Name = "example.com", Type = DnsRecordType.CNAME, DataRaw = "z.azurefd.net." }
+                    }
+                    : Array.Empty<DnsAnswer>()
+            })
+        };
+
+        await analysis.AnalyzeAsync("example.com", new InternalLogger(), CancellationToken.None);
+
+        Assert.Equal(DnsCnameTargetProvider.Azure, analysis.CnameTargetProvider);
+        Assert.Equal(DnsCnameTargetService.AzureFrontDoor, analysis.CnameTargetService);
+    }
+
     [Fact]
     public void CaaIssuerDetectorParsesCommonFormats()
     {

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -732,6 +732,46 @@ public class TestEndpointAttribution {
         Assert.Contains("usable evidence matcher", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(nameof(EndpointAttributionRule.CnameSuffixes))]
+    [InlineData(nameof(EndpointAttributionRule.RedirectTargetSuffixes))]
+    [InlineData(nameof(EndpointAttributionRule.ReverseDnsSuffixes))]
+    public void CustomRuleRejectsHostSuffixThatNormalizesToEmpty(string matcherProperty) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.empty-normalized-suffix",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Empty Normalized Suffix Rule"
+        };
+        ((List<string>)typeof(EndpointAttributionRule).GetProperty(matcherProperty)!.GetValue(rule)!).Add(" . ");
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => catalog.AddOrReplace(rule));
+
+        Assert.Empty((List<string>)typeof(EndpointAttributionRule).GetProperty(matcherProperty)!.GetValue(rule)!);
+        Assert.Contains("custom.empty-normalized-suffix", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("usable evidence matcher", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CustomRuleNormalizesAndDeduplicatesHostSuffixMatchers() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.normalized-suffixes",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Normalized Suffix Rule"
+        };
+        rule.CnameSuffixes.Add(" Edge.Example.NET. ");
+        rule.CnameSuffixes.Add("edge.example.net");
+
+        catalog.AddOrReplace(rule);
+
+        Assert.Equal(new[] { "edge.example.net" }, rule.CnameSuffixes);
+    }
+
     [Fact]
     public void DetectorRejectsRuleWithoutUsableEvidenceAddedThroughMutableCatalog() {
         var catalog = new EndpointAttributionCatalog();

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -760,6 +760,49 @@ public class TestEndpointAttribution {
     }
 
     [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void CustomRuleRejectsEmptyApplicableService(string? invalidService) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.invalid-service",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid Service Rule"
+        };
+        rule.HostnamePrefixes.Add("edge.");
+        rule.ApplicableServices.Add(invalidService!);
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.invalid-service", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("empty applicable service", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CustomRuleNormalizesAndDeduplicatesApplicableServices() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.normalized-service",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Normalized Service Rule"
+        };
+        rule.HostnamePrefixes.Add("edge.");
+        rule.ApplicableServices.Add(" HTTPS ");
+        rule.ApplicableServices.Add("https");
+
+        catalog.AddOrReplace(rule);
+
+        Assert.Equal(new[] { "HTTPS" }, rule.ApplicableServices);
+    }
+
+    [Theory]
     [InlineData(-0.01d)]
     [InlineData(1.01d)]
     [InlineData(double.NaN)]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -548,6 +548,32 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public void CustomRuleReplacementNormalizesStableIdentifier() {
+        var catalog = new EndpointAttributionCatalog();
+        catalog.AddOrReplace(new EndpointAttributionRule {
+            RuleId = "custom.edge",
+            RuleVersion = "1",
+            ProviderId = "first",
+            ServiceId = "edge",
+            DisplayName = "First Edge"
+        });
+        var replacement = new EndpointAttributionRule {
+            RuleId = " custom.edge ",
+            RuleVersion = "2",
+            ProviderId = "replacement",
+            ServiceId = "edge",
+            DisplayName = "Replacement Edge"
+        };
+
+        catalog.AddOrReplace(replacement);
+
+        EndpointAttributionRule stored = Assert.Single(catalog.Rules);
+        Assert.Equal("custom.edge", stored.RuleId);
+        Assert.Equal("replacement", stored.ProviderId);
+        _ = new EndpointAttributionDetector(catalog);
+    }
+
+    [Fact]
     public void CustomRuleRejectsMalformedIpPrefixWithRuleContext() {
         var catalog = new EndpointAttributionCatalog();
         var rule = new EndpointAttributionRule {
@@ -605,6 +631,26 @@ public class TestEndpointAttribution {
 
         Assert.Contains("custom.self-corroborating-ip", exception.Message, StringComparison.Ordinal);
         Assert.Contains("own corroborating signal", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void CustomRuleRejectsUndefinedCorroboratingSignalKind() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.undefined-signal",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid Signal Rule"
+        };
+        rule.IpAddressPrimaryCorroboratingSignals.Add((EndpointAttributionSignalKind)999);
+
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Equal((EndpointAttributionSignalKind)999, exception.ActualValue);
+        Assert.Contains("custom.undefined-signal", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("undefined corroborating signal", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -194,6 +194,17 @@ public class TestEndpointAttribution {
         Assert.Contains("AzureFrontDoor.Frontend", catalog.FindTags(IPAddress.Parse("2001:db8::8")));
     }
 
+    [Fact]
+    public void AzureCatalogRejectsInvalidAddressPrefixWithTagContext() {
+        const string json = "{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"addressPrefixes\":[\"not-a-cidr\"]}}]}";
+
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            AzureServiceTagCatalog.Parse(json, "test-catalog"));
+
+        Assert.Contains("AzureFrontDoor.Frontend", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not-a-cidr", exception.Message, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("edge.azurefd.net", "azure-front-door")]
     [InlineData("edge.azureedge.net", "azure-cdn")]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -165,6 +165,26 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public void EndpointIdentityCanonicalizesBracketedAndUnbracketedIpLiterals() {
+        CertificateEndpointIdentity bracketed = CertificateEndpointIdentity.Create(
+            "[2001:db8::40]",
+            443,
+            "HTTPS");
+        CertificateEndpointIdentity expanded = CertificateEndpointIdentity.Create(
+            "2001:0db8:0000:0000:0000:0000:0000:0040",
+            443,
+            "HTTPS");
+        CertificateEndpointIdentity mapped = CertificateEndpointIdentity.Create(
+            "::ffff:192.0.2.40",
+            443,
+            "HTTPS");
+
+        Assert.Equal(bracketed, expanded);
+        Assert.Equal("2001:db8::40", expanded.Host);
+        Assert.Equal("192.0.2.40", mapped.Host);
+    }
+
+    [Fact]
     public void ProtocolEndpointsRejectBracketsAroundDnsHostnames() {
         var mail = new MailTransportEndpoint("[mail.example.com]", 25);
 
@@ -364,6 +384,20 @@ public class TestEndpointAttribution {
 
         Assert.Contains("AzureFrontDoor.Frontend", exception.Message, StringComparison.Ordinal);
         Assert.Contains("addressPrefixes", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("123")]
+    [InlineData("null")]
+    [InlineData("{\"unexpected\":true}")]
+    public void AzureCatalogRejectsNonStringServiceTagName(string malformedName) {
+        string json = "{\"values\":[{\"name\":" + malformedName + ",\"properties\":{\"addressPrefixes\":[]}}]}";
+
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            AzureServiceTagCatalog.Parse(json, "test-catalog"));
+
+        Assert.Contains("values[0]", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("string name", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]
@@ -595,6 +629,49 @@ public class TestEndpointAttribution {
         Assert.Equal(invalidPort, exception.ActualValue);
         Assert.Contains("custom.invalid-port", exception.Message, StringComparison.Ordinal);
         Assert.Contains("between 1 and 65535", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(-0.01d)]
+    [InlineData(1.01d)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void CustomRuleRejectsInvalidMinimumScore(double invalidScore) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.invalid-score",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid Score Rule",
+            MinimumScore = invalidScore
+        };
+
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.invalid-score", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("between 0 and 1", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DetectorRejectsDuplicateRuleIdentifiersInMutableCatalog() {
+        var catalog = new EndpointAttributionCatalog();
+        foreach (string providerId in new[] { "provider-a", "provider-b" }) {
+            catalog.Rules.Add(new EndpointAttributionRule {
+                RuleId = "custom.duplicate",
+                RuleVersion = "1",
+                ProviderId = providerId,
+                ServiceId = "edge",
+                DisplayName = "Duplicate Rule"
+            });
+        }
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new EndpointAttributionDetector(catalog));
+
+        Assert.Contains("custom.duplicate", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("duplicate", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Theory]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -85,6 +85,20 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public void CidrRangeTranslatesIpv4MappedIpv6PrefixWithoutLosingBits() {
+        IpCidrRange mapped = IpCidrRange.Parse("::ffff:192.0.2.0/120");
+        IpCidrRange broadMapped = IpCidrRange.Parse("::ff00:0:0/80");
+
+        Assert.Equal("192.0.2.0/24", mapped.ToString());
+        Assert.True(mapped.Contains(IPAddress.Parse("192.0.2.42")));
+        Assert.True(mapped.Contains(IPAddress.Parse("::ffff:192.0.2.42")));
+        Assert.False(mapped.Contains(IPAddress.Parse("192.0.3.1")));
+        Assert.Equal(80, broadMapped.PrefixLength);
+        Assert.Equal(System.Net.Sockets.AddressFamily.InterNetworkV6, broadMapped.Network.AddressFamily);
+        Assert.True(broadMapped.Contains(IPAddress.Parse("::ffff:192.0.2.42")));
+    }
+
+    [Fact]
     public void AzureCatalogParsesOfficialServiceTagShape() {
         const string json = "{\"changeNumber\":\"7\",\"cloud\":\"Public\",\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"changeNumber\":\"3\",\"region\":\"\",\"systemService\":\"AzureFrontDoor\",\"addressPrefixes\":[\"203.0.113.0/24\",\"2001:db8::/32\"]}}]}";
 

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -550,6 +550,62 @@ public class TestEndpointAttribution {
         Assert.Contains("own corroborating signal", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(65536)]
+    [InlineData(70000)]
+    public void CustomRuleRejectsInvalidApplicablePort(int invalidPort) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.invalid-port",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid Port Rule"
+        };
+        rule.ApplicablePorts.Add(invalidPort);
+
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Equal(invalidPort, exception.ActualValue);
+        Assert.Contains("custom.invalid-port", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("between 1 and 65535", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(true, EndpointAttributionSignalKind.ReverseDns)]
+    [InlineData(false, EndpointAttributionSignalKind.AutonomousSystem)]
+    public void DetectorUsesExplicitReverseDnsAndAutonomousSystemEvidence(
+        bool useReverseDns,
+        EndpointAttributionSignalKind expectedSignal) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.explicit-network-evidence",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        if (useReverseDns) {
+            rule.ReverseDnsSuffixes.Add("edge.example.net");
+        } else {
+            rule.AutonomousSystemNumbers.Add("64500");
+        }
+        catalog.AddOrReplace(rule);
+
+        EndpointAttributionResult result = new EndpointAttributionDetector(catalog).Detect(
+            new EndpointAttributionInput {
+                HostName = "service.example.com",
+                ReverseDnsNames = new[] { "node.edge.example.net" },
+                AutonomousSystemNumbers = new[] { "64500" }
+            });
+
+        Assert.Equal("custom.explicit-network-evidence", result.Primary?.RuleId);
+        Assert.Contains(result.Primary!.Evidence, evidence => evidence.Kind == expectedSignal);
+    }
+
     [Fact]
     public void DetectorRejectsMalformedPrefixAddedThroughMutableRuleCollection() {
         var catalog = new EndpointAttributionCatalog();

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -577,6 +577,37 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public void DetectorNormalizesProviderAndServiceIdentityBeforeAmbiguityComparison() {
+        var catalog = new EndpointAttributionCatalog();
+        foreach ((string ruleId, string providerId, string serviceId) in new[] {
+            ("custom.edge-a", "example", "edge"),
+            ("custom.edge-b", " example ", " edge ")
+        }) {
+            var rule = new EndpointAttributionRule {
+                RuleId = ruleId,
+                RuleVersion = "1",
+                ProviderId = providerId,
+                ServiceId = serviceId,
+                DisplayName = "Example Edge"
+            };
+            rule.CnameSuffixes.Add("edge.example.net");
+            catalog.Rules.Add(rule);
+        }
+
+        EndpointAttributionResult result = new EndpointAttributionDetector(catalog).Detect(new EndpointAttributionInput {
+            HostName = "www.example.com",
+            CnameChain = new[] { "tenant.edge.example.net" }
+        });
+
+        Assert.False(result.IsAmbiguous);
+        Assert.NotNull(result.Primary);
+        Assert.All(result.Candidates, candidate => {
+            Assert.Equal("example", candidate.ProviderId);
+            Assert.Equal("edge", candidate.ServiceId);
+        });
+    }
+
+    [Fact]
     public void CustomRuleRejectsMalformedIpPrefixWithRuleContext() {
         var catalog = new EndpointAttributionCatalog();
         var rule = new EndpointAttributionRule {

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -36,6 +36,21 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public async Task DnsEvidenceResolverTreatsNullOverrideAnswersAsEmpty() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (_, _, _) => Task.FromResult<DnsAnswer[]>(null!)
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("empty.example.com");
+
+        Assert.Equal("empty.example.com", evidence.EffectiveHostName);
+        Assert.Empty(evidence.CnameChain);
+        Assert.Empty(evidence.Addresses);
+        Assert.Empty(evidence.Errors);
+        Assert.True(evidence.AddressResolutionComplete);
+    }
+
+    [Fact]
     public async Task DnsEvidenceResolverSelectsCnameOwnedByCurrentChainNode() {
         DnsAnswer[] shuffledChain = {
             new() { Name = "edge.example.net.", Type = DnsRecordType.CNAME, DataRaw = "tenant.azurefd.net." },

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -130,6 +130,49 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public async Task DnsEvidenceResolverTreatsResolverLocalCancellationAsLookupFailure() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (_, type, _) => type == DnsRecordType.A
+                ? Task.FromException<DnsAnswer[]>(new OperationCanceledException("resolver timeout"))
+                : Task.FromResult(Array.Empty<DnsAnswer>())
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("www.example.com", CancellationToken.None);
+
+        Assert.False(evidence.AddressResolutionComplete);
+        Assert.Contains(evidence.Errors, error =>
+            error.Contains("A lookup", StringComparison.Ordinal) &&
+            error.Contains("resolver timeout", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DnsEvidenceResolverTreatsResolverLocalCnameCancellationAsLookupFailure() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (_, type, _) => type == DnsRecordType.CNAME
+                ? Task.FromException<DnsAnswer[]>(new OperationCanceledException("resolver CNAME timeout"))
+                : Task.FromResult(Array.Empty<DnsAnswer>())
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("www.example.com", CancellationToken.None);
+
+        Assert.Equal("www.example.com", evidence.EffectiveHostName);
+        Assert.True(evidence.AddressResolutionComplete);
+        Assert.Contains(evidence.Errors, error =>
+            error.Contains("CNAME lookup", StringComparison.Ordinal) &&
+            error.Contains("resolver CNAME timeout", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DnsEvidenceResolverStillPropagatesCallerCancellation() {
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+        var resolver = new EndpointDnsEvidenceResolver();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            resolver.ResolveAsync("www.example.com", cancellation.Token));
+    }
+
+    [Fact]
     public void EndpointIdentityIncludesServiceAndNormalizesHost() {
         CertificateEndpointIdentity https = CertificateEndpointIdentity.Create(" WWW.Example.COM. ", 443, "HTTPS");
         CertificateEndpointIdentity ldaps = CertificateEndpointIdentity.Create("www.example.com", 443, "LDAPS");
@@ -337,6 +380,46 @@ public class TestEndpointAttribution {
         Assert.Equal("example", result.Primary?.ProviderId);
         Assert.Equal("custom.edge", result.Primary?.RuleId);
         Assert.Single(result.Candidates, candidate => candidate.RuleId == "custom.edge");
+    }
+
+    [Fact]
+    public void CustomRuleRejectsMalformedIpPrefixWithRuleContext() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.invalid-prefix",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        rule.IpAddressPrefixes.Add("not-a-cidr");
+
+        FormatException exception = Assert.Throws<FormatException>(() => catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.invalid-prefix", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not-a-cidr", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DetectorRejectsMalformedPrefixAddedThroughMutableRuleCollection() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.mutable-invalid-prefix",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        rule.IpAddressPrefixes.Add("203.0.113.0/99");
+        catalog.Rules.Add(rule);
+
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            new EndpointAttributionDetector(catalog).Detect(new EndpointAttributionInput {
+                HostName = "www.example.com"
+            }));
+
+        Assert.Contains("custom.mutable-invalid-prefix", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("203.0.113.0/99", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -550,13 +550,15 @@ public class TestEndpointAttribution {
     [Fact]
     public void CustomRuleReplacementNormalizesStableIdentifier() {
         var catalog = new EndpointAttributionCatalog();
-        catalog.AddOrReplace(new EndpointAttributionRule {
+        var original = new EndpointAttributionRule {
             RuleId = "custom.edge",
             RuleVersion = "1",
             ProviderId = "first",
             ServiceId = "edge",
             DisplayName = "First Edge"
-        });
+        };
+        original.CnameSuffixes.Add("old-edge.example.net");
+        catalog.AddOrReplace(original);
         var replacement = new EndpointAttributionRule {
             RuleId = " custom.edge ",
             RuleVersion = "2",
@@ -564,6 +566,7 @@ public class TestEndpointAttribution {
             ServiceId = "edge",
             DisplayName = "Replacement Edge"
         };
+        replacement.CnameSuffixes.Add("edge.example.net");
 
         catalog.AddOrReplace(replacement);
 
@@ -654,6 +657,54 @@ public class TestEndpointAttribution {
     }
 
     [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CustomRuleRequiresUsableEvidenceMatcher(bool addWhitespaceMatchers) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.no-evidence",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "No Evidence Rule"
+        };
+        if (addWhitespaceMatchers) {
+            rule.HostnamePrefixes.Add(" ");
+            rule.CnameSuffixes.Add("\t");
+            rule.IpAddressPrefixes.Add(" ");
+            rule.AzureServiceTagNames.Add("\r\n");
+            rule.CertificateIssuerContains.Add(" ");
+            rule.RedirectTargetSuffixes.Add("\t");
+            rule.ReverseDnsSuffixes.Add(" ");
+            rule.AutonomousSystemNumbers.Add("\r\n");
+        }
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.no-evidence", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("usable evidence matcher", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void DetectorRejectsRuleWithoutUsableEvidenceAddedThroughMutableCatalog() {
+        var catalog = new EndpointAttributionCatalog();
+        catalog.Rules.Add(new EndpointAttributionRule {
+            RuleId = "custom.mutable-no-evidence",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "No Evidence Rule"
+        });
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new EndpointAttributionDetector(catalog));
+
+        Assert.Contains("custom.mutable-no-evidence", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("usable evidence matcher", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
     [InlineData(-1)]
     [InlineData(0)]
     [InlineData(65536)]
@@ -704,13 +755,15 @@ public class TestEndpointAttribution {
     public void DetectorRejectsDuplicateRuleIdentifiersInMutableCatalog() {
         var catalog = new EndpointAttributionCatalog();
         foreach (string providerId in new[] { "provider-a", "provider-b" }) {
-            catalog.Rules.Add(new EndpointAttributionRule {
+            var rule = new EndpointAttributionRule {
                 RuleId = "custom.duplicate",
                 RuleVersion = "1",
                 ProviderId = providerId,
                 ServiceId = "edge",
                 DisplayName = "Duplicate Rule"
-            });
+            };
+            rule.HostnamePrefixes.Add("edge.");
+            catalog.Rules.Add(rule);
         }
 
         ArgumentException exception = Assert.Throws<ArgumentException>(() =>

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -447,6 +447,26 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public void CustomRuleRejectsIpAddressAsItsOwnCorroboratingSignal() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.self-corroborating-ip",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid IP Rule",
+            RequireCorroborationForIpAddressPrimary = true
+        };
+        rule.IpAddressPrefixes.Add("203.0.113.0/24");
+        rule.IpAddressPrimaryCorroboratingSignals.Add(EndpointAttributionSignalKind.IpAddress);
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.self-corroborating-ip", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("own corroborating signal", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void DetectorRejectsMalformedPrefixAddedThroughMutableRuleCollection() {
         var catalog = new EndpointAttributionCatalog();
         var rule = new EndpointAttributionRule {

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -938,6 +938,58 @@ public class TestEndpointAttribution {
         Assert.Contains(result.Primary!.Evidence, evidence => evidence.Kind == expectedSignal);
     }
 
+    [Theory]
+    [InlineData("64500", "AS64500")]
+    [InlineData("AS64500", "64500")]
+    [InlineData("as064500", "AS64500")]
+    public void DetectorNormalizesAutonomousSystemPrefixes(string ruleValue, string observedValue) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.normalized-asn",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        rule.AutonomousSystemNumbers.Add(ruleValue);
+        catalog.AddOrReplace(rule);
+
+        EndpointAttributionResult result = new EndpointAttributionDetector(catalog).Detect(
+            new EndpointAttributionInput {
+                HostName = "service.example.com",
+                AutonomousSystemNumbers = new[] { observedValue }
+            });
+
+        Assert.Equal(new[] { "64500" }, rule.AutonomousSystemNumbers);
+        Assert.Equal("custom.normalized-asn", result.Primary?.RuleId);
+        EndpointAttributionEvidence evidence = Assert.Single(result.Primary!.Evidence);
+        Assert.Equal("64500", evidence.ObservedValue);
+        Assert.Equal("64500", evidence.MatchedValue);
+    }
+
+    [Theory]
+    [InlineData("AS")]
+    [InlineData("AS0")]
+    [InlineData("AS4294967296")]
+    [InlineData("not-an-asn")]
+    public void CustomRuleRejectsInvalidAutonomousSystemNumber(string invalidValue) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.invalid-asn",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid ASN Rule"
+        };
+        rule.AutonomousSystemNumbers.Add(invalidValue);
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.invalid-asn", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("autonomous system number", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void DetectorRejectsMalformedPrefixAddedThroughMutableRuleCollection() {
         var catalog = new EndpointAttributionCatalog();

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -68,7 +68,61 @@ public class TestEndpointAttribution {
 
         Assert.Equal("www.example.com", evidence.EffectiveHostName);
         Assert.Empty(evidence.CnameChain);
+        Assert.True(evidence.CnameRecordExists);
         Assert.Contains(evidence.Errors, error => error.Contains("multiple distinct targets", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task DnsEvidenceResolverAcceptsTerminalChainAtExactDepthLimit() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            MaxCnameDepth = 2,
+            ResolveAddressesForOriginalHost = false,
+            QueryDnsOverride = (name, type, _) => {
+                if (type != DnsRecordType.CNAME) {
+                    return Task.FromResult(Array.Empty<DnsAnswer>());
+                }
+                string? next = name switch {
+                    "a.example.com" => "b.example.com",
+                    "b.example.com" => "c.example.com",
+                    _ => null
+                };
+                return Task.FromResult(next == null
+                    ? Array.Empty<DnsAnswer>()
+                    : new[] { new DnsAnswer { Type = DnsRecordType.CNAME, DataRaw = next } });
+            }
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("a.example.com");
+
+        Assert.True(evidence.CnameRecordExists);
+        Assert.Equal("c.example.com", evidence.EffectiveHostName);
+        Assert.Equal(new[] { "b.example.com", "c.example.com" }, evidence.CnameChain);
+        Assert.DoesNotContain(evidence.Errors, error => error.Contains("MaxCnameDepth", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task DnsEvidenceResolverReportsDepthOnlyWhenAnotherLinkExists() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            MaxCnameDepth = 2,
+            ResolveAddressesForOriginalHost = false,
+            QueryDnsOverride = (name, type, _) => {
+                if (type != DnsRecordType.CNAME) {
+                    return Task.FromResult(Array.Empty<DnsAnswer>());
+                }
+                string next = name switch {
+                    "a.example.com" => "b.example.com",
+                    "b.example.com" => "c.example.com",
+                    _ => "d.example.com"
+                };
+                return Task.FromResult(new[] { new DnsAnswer { Type = DnsRecordType.CNAME, DataRaw = next } });
+            }
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("a.example.com");
+
+        Assert.Equal("c.example.com", evidence.EffectiveHostName);
+        Assert.Equal(new[] { "b.example.com", "c.example.com" }, evidence.CnameChain);
+        Assert.Contains(evidence.Errors, error => error.Contains("MaxCnameDepth=2", StringComparison.Ordinal));
     }
 
     [Theory]
@@ -108,6 +162,23 @@ public class TestEndpointAttribution {
         Assert.Contains("[2001:db8::30]", https.Url);
         Assert.Equal("2001:db8::31", mail.HostName);
         Assert.Equal("2001:db8::32", ftp.HostName);
+    }
+
+    [Fact]
+    public void HttpsOnArbitraryPortRetainsWebAttributionEligibility() {
+        CertificateServiceDescriptor endpoint = CertificateServiceClassifier.Resolve(
+            "https://tenant.example.com:10443",
+            443);
+
+        EndpointAttributionResult result = new EndpointAttributionDetector().Detect(new EndpointAttributionInput {
+            HostName = endpoint.Host,
+            Port = endpoint.Port,
+            Service = endpoint.Service,
+            CnameChain = new[] { "tenant.azurefd.net" }
+        });
+
+        Assert.Equal("HTTPS-Alt", endpoint.Service);
+        Assert.Equal("azure-front-door", result.Primary?.ServiceId);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -273,6 +273,19 @@ public class TestEndpointAttribution {
     }
 
     [Theory]
+    [InlineData("null", "root")]
+    [InlineData("{\"values\":[null]}", "values[0]")]
+    [InlineData("{\"values\":[123]}", "values[0]")]
+    [InlineData("{\"values\":[\"not-an-object\"]}", "values[0]")]
+    [InlineData("{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":null}]}", "properties object")]
+    public void AzureCatalogRejectsNonObjectStructuralElements(string json, string expectedContext) {
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            AzureServiceTagCatalog.Parse(json, "test-catalog"));
+
+        Assert.Contains(expectedContext, exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
     [InlineData("edge.azurefd.net", "azure-front-door")]
     [InlineData("edge.azureedge.net", "azure-cdn")]
     [InlineData("edge.trafficmanager.net", "azure-traffic-manager")]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -803,6 +803,65 @@ public class TestEndpointAttribution {
     }
 
     [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void CustomRuleRejectsEmptyRuleVersion(string? invalidVersion) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.invalid-version",
+            RuleVersion = invalidVersion!,
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Invalid Version Rule"
+        };
+        rule.HostnamePrefixes.Add("edge.");
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.invalid-version", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("RuleVersion", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CustomRuleNormalizesRuleVersion() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.normalized-version",
+            RuleVersion = " 2026.09 ",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Normalized Version Rule"
+        };
+        rule.HostnamePrefixes.Add("edge.");
+
+        catalog.AddOrReplace(rule);
+
+        Assert.Equal("2026.09", rule.RuleVersion);
+    }
+
+    [Fact]
+    public void DetectorRejectsMissingRuleVersionAddedThroughMutableCatalog() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.mutable-missing-version",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Missing Version Rule"
+        };
+        rule.HostnamePrefixes.Add("edge.");
+        catalog.Rules.Add(rule);
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() =>
+            new EndpointAttributionDetector(catalog));
+
+        Assert.Contains("custom.mutable-missing-version", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("RuleVersion", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
     [InlineData(-0.01d)]
     [InlineData(1.01d)]
     [InlineData(double.NaN)]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -32,6 +32,46 @@ public class TestEndpointAttribution {
         Assert.Contains("2001:db8::10", evidence.Addresses);
         Assert.False(evidence.LoopDetected);
         Assert.Empty(evidence.Errors);
+        Assert.True(evidence.AddressResolutionComplete);
+    }
+
+    [Theory]
+    [InlineData("203.0.113.20", "203.0.113.20")]
+    [InlineData("2001:db8::20", "2001:db8::20")]
+    [InlineData("[2001:db8::21]", "2001:db8::21")]
+    [InlineData("::ffff:192.0.2.20", "192.0.2.20")]
+    public async Task DnsEvidenceResolverTreatsLiteralAddressAsCompletedEvidence(
+        string input,
+        string expectedAddress) {
+        int queryCount = 0;
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (_, _, _) => {
+                queryCount++;
+                return Task.FromResult(Array.Empty<DnsAnswer>());
+            }
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync(input);
+
+        Assert.Equal(0, queryCount);
+        Assert.True(evidence.AddressResolutionComplete);
+        Assert.Equal(expectedAddress, Assert.Single(evidence.Addresses));
+        Assert.Empty(evidence.CnameChain);
+        Assert.Empty(evidence.Errors);
+    }
+
+    [Fact]
+    public void EndpointParsersRemoveIpv6UriBracketsWithoutChangingUriFormatting() {
+        CertificateServiceDescriptor https = CertificateServiceClassifier.Resolve(
+            "https://[2001:db8::30]/",
+            443);
+        var mail = new MailTransportEndpoint("[2001:db8::31]", 25);
+        var ftp = new FtpTlsEndpoint("[2001:db8::32]", 990, FtpTlsMode.Implicit);
+
+        Assert.Equal("2001:db8::30", https.Host);
+        Assert.Contains("[2001:db8::30]", https.Url);
+        Assert.Equal("2001:db8::31", mail.HostName);
+        Assert.Equal("2001:db8::32", ftp.HostName);
     }
 
     [Fact]
@@ -71,6 +111,14 @@ public class TestEndpointAttribution {
     public void IpClassifierHandlesReusableRoutingScopes(string value, IpAddressVisibility expected) {
         Assert.True(IpAddressClassifier.TryClassify(value, out IpAddressVisibility actual));
         Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("192.0.2.1", "IPv4")]
+    [InlineData("::ffff:192.0.2.1", "IPv4")]
+    [InlineData("2001:db8::1", "IPv6")]
+    public void IpClassifierReturnsStableAddressFamilyLabels(string value, string expected) {
+        Assert.Equal(expected, IpAddressClassifier.GetAddressFamilyLabel(IPAddress.Parse(value)));
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -249,6 +249,30 @@ public class TestEndpointAttribution {
     }
 
     [Theory]
+    [InlineData("\"not-an-array\"")]
+    [InlineData("{}")]
+    public void AzureCatalogRejectsNonArrayAddressPrefixes(string malformedValue) {
+        string json = "{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"addressPrefixes\":" + malformedValue + "}}]}";
+
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            AzureServiceTagCatalog.Parse(json, "test-catalog"));
+
+        Assert.Contains("AzureFrontDoor.Frontend", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not an array", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AzureCatalogRejectsNonStringAddressPrefixElements() {
+        const string json = "{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"addressPrefixes\":[123]}}]}";
+
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            AzureServiceTagCatalog.Parse(json, "test-catalog"));
+
+        Assert.Contains("AzureFrontDoor.Frontend", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("non-string", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
     [InlineData("edge.azurefd.net", "azure-front-door")]
     [InlineData("edge.azureedge.net", "azure-cdn")]
     [InlineData("edge.trafficmanager.net", "azure-traffic-manager")]
@@ -400,6 +424,28 @@ public class TestEndpointAttribution {
         Assert.Contains("not-a-cidr", exception.Message, StringComparison.Ordinal);
     }
 
+    [Theory]
+    [InlineData("", "edge", "ProviderId")]
+    [InlineData("example", "", "ServiceId")]
+    public void CustomRuleRequiresStableProviderAndServiceIdentity(
+        string providerId,
+        string serviceId,
+        string expectedField) {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.missing-identity",
+            RuleVersion = "1",
+            ProviderId = providerId,
+            ServiceId = serviceId,
+            DisplayName = "Incomplete Rule"
+        };
+
+        ArgumentException exception = Assert.Throws<ArgumentException>(() => catalog.AddOrReplace(rule));
+
+        Assert.Contains("custom.missing-identity", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(expectedField, exception.Message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void DetectorRejectsMalformedPrefixAddedThroughMutableRuleCollection() {
         var catalog = new EndpointAttributionCatalog();
@@ -414,12 +460,35 @@ public class TestEndpointAttribution {
         catalog.Rules.Add(rule);
 
         FormatException exception = Assert.Throws<FormatException>(() =>
-            new EndpointAttributionDetector(catalog).Detect(new EndpointAttributionInput {
-                HostName = "www.example.com"
-            }));
+            new EndpointAttributionDetector(catalog));
 
         Assert.Contains("custom.mutable-invalid-prefix", exception.Message, StringComparison.Ordinal);
         Assert.Contains("203.0.113.0/99", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DetectorSnapshotsAndCompilesCustomPrefixesAtConstruction() {
+        var catalog = new EndpointAttributionCatalog();
+        var rule = new EndpointAttributionRule {
+            RuleId = "custom.compiled-prefix",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        rule.IpAddressPrefixes.Add("203.0.113.0/24");
+        catalog.AddOrReplace(rule);
+        var detector = new EndpointAttributionDetector(catalog);
+
+        rule.IpAddressPrefixes.Clear();
+        rule.IpAddressPrefixes.Add("invalid-after-construction");
+        EndpointAttributionResult result = detector.Detect(new EndpointAttributionInput {
+            HostName = "www.example.com",
+            IpAddresses = new[] { "203.0.113.10" }
+        });
+
+        Assert.Equal("example", result.Primary?.ProviderId);
+        Assert.Equal("edge", result.Primary?.ServiceId);
     }
 
     [Fact]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -35,6 +35,42 @@ public class TestEndpointAttribution {
         Assert.True(evidence.AddressResolutionComplete);
     }
 
+    [Fact]
+    public async Task DnsEvidenceResolverSelectsCnameOwnedByCurrentChainNode() {
+        DnsAnswer[] shuffledChain = {
+            new() { Name = "edge.example.net.", Type = DnsRecordType.CNAME, DataRaw = "tenant.azurefd.net." },
+            new() { Name = "www.example.com.", Type = DnsRecordType.CNAME, DataRaw = "edge.example.net." }
+        };
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (_, type, _) => Task.FromResult(
+                type == DnsRecordType.CNAME ? shuffledChain : Array.Empty<DnsAnswer>())
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("www.example.com");
+
+        Assert.Equal("tenant.azurefd.net", evidence.EffectiveHostName);
+        Assert.Equal(new[] { "edge.example.net", "tenant.azurefd.net" }, evidence.CnameChain);
+        Assert.False(evidence.LoopDetected);
+    }
+
+    [Fact]
+    public async Task DnsEvidenceResolverReportsAmbiguousCnameWithoutChoosingByResponseOrder() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (_, type, _) => Task.FromResult(type == DnsRecordType.CNAME
+                ? new[] {
+                    new DnsAnswer { Name = "www.example.com", Type = type, DataRaw = "first.example.net" },
+                    new DnsAnswer { Name = "www.example.com", Type = type, DataRaw = "second.example.net" }
+                }
+                : Array.Empty<DnsAnswer>())
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("www.example.com");
+
+        Assert.Equal("www.example.com", evidence.EffectiveHostName);
+        Assert.Empty(evidence.CnameChain);
+        Assert.Contains(evidence.Errors, error => error.Contains("multiple distinct targets", StringComparison.OrdinalIgnoreCase));
+    }
+
     [Theory]
     [InlineData("203.0.113.20", "203.0.113.20")]
     [InlineData("2001:db8::20", "2001:db8::20")]

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -1,0 +1,286 @@
+using DomainDetective.Network;
+using DomainDetective.Providers.Endpoint;
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestEndpointAttribution {
+    [Fact]
+    public async Task DnsEvidenceResolverRetainsFullCnameChainAndAddresses() {
+        var responses = new Dictionary<(string, DnsRecordType), DnsAnswer[]> {
+            [("www.example.com", DnsRecordType.CNAME)] = new[] { new DnsAnswer { Type = DnsRecordType.CNAME, DataRaw = "edge.example.net." } },
+            [("edge.example.net", DnsRecordType.CNAME)] = new[] { new DnsAnswer { Type = DnsRecordType.CNAME, DataRaw = "tenant.azurefd.net." } },
+            [("tenant.azurefd.net", DnsRecordType.CNAME)] = Array.Empty<DnsAnswer>(),
+            [("tenant.azurefd.net", DnsRecordType.A)] = new[] { new DnsAnswer { Type = DnsRecordType.A, DataRaw = "203.0.113.10" } },
+            [("tenant.azurefd.net", DnsRecordType.AAAA)] = new[] { new DnsAnswer { Type = DnsRecordType.AAAA, DataRaw = "2001:db8::10" } }
+        };
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (name, type, _) => Task.FromResult(responses.TryGetValue((name, type), out DnsAnswer[]? value) ? value : Array.Empty<DnsAnswer>())
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("WWW.Example.COM.");
+
+        Assert.Equal("tenant.azurefd.net", evidence.EffectiveHostName);
+        Assert.Equal(new[] { "edge.example.net", "tenant.azurefd.net" }, evidence.CnameChain);
+        Assert.Contains("203.0.113.10", evidence.Addresses);
+        Assert.Contains("2001:db8::10", evidence.Addresses);
+        Assert.False(evidence.LoopDetected);
+        Assert.Empty(evidence.Errors);
+    }
+
+    [Fact]
+    public async Task DnsEvidenceResolverReportsCnameLoopWithoutDiscardingEvidence() {
+        var resolver = new EndpointDnsEvidenceResolver {
+            QueryDnsOverride = (name, type, _) => {
+                if (type != DnsRecordType.CNAME) {
+                    return Task.FromResult(Array.Empty<DnsAnswer>());
+                }
+                string next = name == "a.example.com" ? "b.example.com" : "a.example.com";
+                return Task.FromResult(new[] { new DnsAnswer { Type = DnsRecordType.CNAME, DataRaw = next } });
+            }
+        };
+
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync("a.example.com", CancellationToken.None);
+
+        Assert.True(evidence.LoopDetected);
+        Assert.Equal(new[] { "b.example.com" }, evidence.CnameChain);
+        Assert.Contains(evidence.Errors, error => error.Contains("loop", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void EndpointIdentityIncludesServiceAndNormalizesHost() {
+        CertificateEndpointIdentity https = CertificateEndpointIdentity.Create(" WWW.Example.COM. ", 443, "HTTPS");
+        CertificateEndpointIdentity ldaps = CertificateEndpointIdentity.Create("www.example.com", 443, "LDAPS");
+
+        Assert.Equal("www.example.com|443|HTTPS", https.Key);
+        Assert.NotEqual(https, ldaps);
+    }
+
+    [Theory]
+    [InlineData("100.64.0.1", IpAddressVisibility.Shared)]
+    [InlineData("198.18.0.1", IpAddressVisibility.Reserved)]
+    [InlineData("192.0.2.1", IpAddressVisibility.Documentation)]
+    [InlineData("8.8.8.8", IpAddressVisibility.Public)]
+    [InlineData("2001:db8::1", IpAddressVisibility.Documentation)]
+    public void IpClassifierHandlesReusableRoutingScopes(string value, IpAddressVisibility expected) {
+        Assert.True(IpAddressClassifier.TryClassify(value, out IpAddressVisibility actual));
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void CidrRangeMatchesIpv4AndIpv6AndRejectsWrongFamily() {
+        IpCidrRange ipv4 = IpCidrRange.Parse("203.0.113.0/24");
+        IpCidrRange ipv6 = IpCidrRange.Parse("2001:db8::/32");
+
+        Assert.True(ipv4.Contains(IPAddress.Parse("203.0.113.42")));
+        Assert.False(ipv4.Contains(IPAddress.Parse("203.0.114.1")));
+        Assert.True(ipv6.Contains(IPAddress.Parse("2001:db8:1::1")));
+        Assert.False(ipv6.Contains(IPAddress.Parse("203.0.113.42")));
+    }
+
+    [Fact]
+    public void AzureCatalogParsesOfficialServiceTagShape() {
+        const string json = "{\"changeNumber\":\"7\",\"cloud\":\"Public\",\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"changeNumber\":\"3\",\"region\":\"\",\"systemService\":\"AzureFrontDoor\",\"addressPrefixes\":[\"203.0.113.0/24\",\"2001:db8::/32\"]}}]}";
+
+        AzureServiceTagCatalog catalog = AzureServiceTagCatalog.Parse(json, "test-catalog");
+
+        Assert.Equal("7", catalog.ChangeNumber);
+        Assert.Equal("Public", catalog.Cloud);
+        Assert.Contains("AzureFrontDoor.Frontend", catalog.FindTags(IPAddress.Parse("203.0.113.8")));
+        Assert.Contains("AzureFrontDoor.Frontend", catalog.FindTags(IPAddress.Parse("2001:db8::8")));
+    }
+
+    [Theory]
+    [InlineData("edge.azurefd.net", "azure-front-door")]
+    [InlineData("edge.azureedge.net", "azure-cdn")]
+    [InlineData("edge.trafficmanager.net", "azure-traffic-manager")]
+    [InlineData("cdn.perf1.com", "redirection")]
+    public void CnameSignalsProduceDistinctPrimaryServices(string cname, string expectedService) {
+        var detector = new EndpointAttributionDetector();
+
+        EndpointAttributionResult result = detector.Detect(new EndpointAttributionInput {
+            HostName = "service.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            CnameChain = new[] { cname }
+        });
+
+        Assert.NotNull(result.Primary);
+        Assert.Equal(expectedService, result.Primary!.ServiceId);
+        Assert.Contains(result.Primary.Evidence, evidence => evidence.Kind == EndpointAttributionSignalKind.Cname);
+    }
+
+    [Fact]
+    public void IssuerOnlyIsReviewCandidateNotPrimaryAttribution() {
+        var detector = new EndpointAttributionDetector();
+
+        EndpointAttributionResult result = detector.Detect(new EndpointAttributionInput {
+            HostName = "unrelated.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            CertificateIssuer = "CN=DigiCert Global G2"
+        });
+
+        Assert.Null(result.Primary);
+        Assert.NotEmpty(result.Candidates);
+        Assert.All(result.Candidates, candidate => Assert.False(candidate.EligibleAsPrimary));
+    }
+
+    [Fact]
+    public void CurrentAzureServiceTagCanEstablishFrontDoorAttribution() {
+        const string json = "{\"changeNumber\":\"12\",\"cloud\":\"Public\",\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"addressPrefixes\":[\"203.0.113.0/24\"]}}]}";
+        AzureServiceTagCatalog tags = AzureServiceTagCatalog.Parse(json, "downloaded-service-tags.json");
+        var detector = new EndpointAttributionDetector();
+
+        EndpointAttributionResult result = detector.Detect(new EndpointAttributionInput {
+            HostName = "service.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            IpAddresses = new[] { "203.0.113.20" },
+            AzureServiceTags = tags
+        });
+
+        Assert.Equal("azure-front-door", result.Primary?.ServiceId);
+        Assert.Contains(result.Primary!.Evidence, evidence =>
+            evidence.Kind == EndpointAttributionSignalKind.AzureServiceTag &&
+            evidence.Source == "downloaded-service-tags.json");
+        Assert.Equal("downloaded-service-tags.json", result.AzureServiceTagSource);
+        Assert.Equal("12", result.AzureServiceTagChangeNumber);
+        Assert.Equal("Public", result.AzureServiceTagCloud);
+        Assert.NotNull(result.AzureServiceTagRetrievedAtUtc);
+    }
+
+    [Fact]
+    public void PointInTimeIpSeedWithGenericIssuerRemainsReviewOnly() {
+        var detector = new EndpointAttributionDetector();
+
+        EndpointAttributionResult result = detector.Detect(new EndpointAttributionInput {
+            HostName = "service.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            IpAddresses = new[] { "81.92.94.54" },
+            CertificateIssuer = "CN=DigiCert TLS RSA SHA256 2020 CA1"
+        });
+
+        Assert.Null(result.Primary);
+        EndpointAttributionCandidate candidate = Assert.Single(result.Candidates, item => item.RuleId == "builtin.nameshield.redirection");
+        Assert.False(candidate.EligibleAsPrimary);
+        Assert.Contains(candidate.Evidence, evidence => evidence.Kind == EndpointAttributionSignalKind.IpAddress);
+        Assert.Contains(candidate.Evidence, evidence => evidence.Kind == EndpointAttributionSignalKind.CertificateIssuer);
+    }
+
+    [Fact]
+    public void PointInTimeIpSeedAloneRemainsReviewCandidate() {
+        EndpointAttributionResult result = new EndpointAttributionDetector().Detect(new EndpointAttributionInput {
+            HostName = "service.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            IpAddresses = new[] { "81.92.94.54" }
+        });
+
+        Assert.Null(result.Primary);
+        EndpointAttributionCandidate candidate = Assert.Single(result.Candidates, item => item.RuleId == "builtin.nameshield.redirection");
+        Assert.False(candidate.EligibleAsPrimary);
+    }
+
+    [Theory]
+    [InlineData("FTPS-EXPLICIT")]
+    [InlineData("SMTP-STARTTLS")]
+    public void HttpManagedServiceRulesDoNotClassifyOtherProtocols(string service) {
+        EndpointAttributionResult result = new EndpointAttributionDetector().Detect(new EndpointAttributionInput {
+            HostName = "service.example.com",
+            Port = service == "FTPS-EXPLICIT" ? 21 : 25,
+            Service = service,
+            CnameChain = new[] { "tenant.azurefd.net", "cdn.perf1.com" },
+            IpAddresses = new[] { "81.92.94.54" },
+            CertificateIssuer = "DigiCert"
+        });
+
+        Assert.DoesNotContain(result.Candidates, candidate =>
+            candidate.RuleId == "builtin.microsoft.azure-front-door" ||
+            candidate.RuleId == "builtin.nameshield.redirection");
+    }
+
+    [Fact]
+    public void CustomRuleReplacesBuiltInRuleByStableIdentifier() {
+        EndpointAttributionCatalog catalog = EndpointAttributionCatalog.CreateDefault();
+        var custom = new EndpointAttributionRule {
+            RuleId = "custom.edge",
+            RuleVersion = "1",
+            ProviderId = "example",
+            ServiceId = "edge",
+            DisplayName = "Example Edge"
+        };
+        custom.CnameSuffixes.Add("edge.example.net");
+        catalog.AddOrReplace(custom);
+
+        EndpointAttributionResult result = new EndpointAttributionDetector(catalog).Detect(new EndpointAttributionInput {
+            HostName = "www.example.com",
+            CnameChain = new[] { "tenant.edge.example.net" }
+        });
+
+        Assert.Equal("example", result.Primary?.ProviderId);
+        Assert.Equal("custom.edge", result.Primary?.RuleId);
+        Assert.Single(result.Candidates, candidate => candidate.RuleId == "custom.edge");
+    }
+
+    [Fact]
+    public void EqualEligibleCandidatesRemainExplicitlyAmbiguous() {
+        var catalog = new EndpointAttributionCatalog();
+        foreach (string provider in new[] { "provider-a", "provider-b" }) {
+            var rule = new EndpointAttributionRule {
+                RuleId = provider + ".edge",
+                RuleVersion = "1",
+                ProviderId = provider,
+                ServiceId = "edge",
+                DisplayName = provider
+            };
+            rule.CnameSuffixes.Add("shared.edge.example");
+            catalog.Rules.Add(rule);
+        }
+
+        EndpointAttributionResult result = new EndpointAttributionDetector(catalog).Detect(new EndpointAttributionInput {
+            HostName = "www.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            CnameChain = new[] { "tenant.shared.edge.example" }
+        });
+
+        Assert.True(result.IsAmbiguous);
+        Assert.Null(result.Primary);
+        Assert.Equal(2, result.Candidates.Count(candidate => candidate.EligibleAsPrimary));
+    }
+
+    [Fact]
+    public void EqualRulesThatAgreeOnIdentityAreNotAmbiguous() {
+        var catalog = new EndpointAttributionCatalog();
+        foreach (string ruleId in new[] { "shared.edge.a", "shared.edge.b" }) {
+            var rule = new EndpointAttributionRule {
+                RuleId = ruleId,
+                RuleVersion = "1",
+                ProviderId = "shared-provider",
+                ServiceId = "edge",
+                DisplayName = "Shared Edge"
+            };
+            rule.CnameSuffixes.Add("shared.edge.example");
+            catalog.Rules.Add(rule);
+        }
+
+        EndpointAttributionResult result = new EndpointAttributionDetector(catalog).Detect(new EndpointAttributionInput {
+            HostName = "www.example.com",
+            Port = 443,
+            Service = "HTTPS",
+            CnameChain = new[] { "tenant.shared.edge.example" }
+        });
+
+        Assert.False(result.IsAmbiguous);
+        Assert.Equal("shared-provider", result.Primary?.ProviderId);
+        Assert.Equal(2, result.Candidates.Count(candidate => candidate.EligibleAsPrimary));
+    }
+}

--- a/DomainDetective.Tests/TestEndpointAttribution.cs
+++ b/DomainDetective.Tests/TestEndpointAttribution.cs
@@ -165,6 +165,18 @@ public class TestEndpointAttribution {
     }
 
     [Fact]
+    public void ProtocolEndpointsRejectBracketsAroundDnsHostnames() {
+        var mail = new MailTransportEndpoint("[mail.example.com]", 25);
+
+        ArgumentException mailException = Assert.Throws<ArgumentException>(() => mail.Validate());
+        ArgumentException ftpException = Assert.Throws<ArgumentException>(() =>
+            new FtpTlsEndpoint("[ftp.example.com]", 21, FtpTlsMode.Explicit));
+
+        Assert.Contains("IPv6", mailException.Message, StringComparison.Ordinal);
+        Assert.Contains("IPv6", ftpException.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HttpsOnArbitraryPortRetainsWebAttributionEligibility() {
         CertificateServiceDescriptor endpoint = CertificateServiceClassifier.Resolve(
             "https://tenant.example.com:10443",
@@ -341,6 +353,17 @@ public class TestEndpointAttribution {
 
         Assert.Contains("AzureFrontDoor.Frontend", exception.Message, StringComparison.Ordinal);
         Assert.Contains("non-string", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AzureCatalogRejectsNamedTagWithoutAddressPrefixes() {
+        const string json = "{\"values\":[{\"name\":\"AzureFrontDoor.Frontend\",\"properties\":{\"systemService\":\"AzureFrontDoor\"}}]}";
+
+        FormatException exception = Assert.Throws<FormatException>(() =>
+            AzureServiceTagCatalog.Parse(json, "test-catalog"));
+
+        Assert.Contains("AzureFrontDoor.Frontend", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("addressPrefixes", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -54,6 +54,7 @@ public class TestFtpTlsAnalysis {
             Assert.Equal("FTPS-EXPLICIT", entry.Service);
             Assert.Equal("ftps-explicit", entry.Scheme);
             Assert.Equal(IPAddress.Loopback.ToString(), entry.RemoteAddress);
+            Assert.Equal("IPv4", entry.RemoteAddressFamily);
             Assert.NotNull(entry.ObservedAtUtc);
             Assert.True(entry.ObservedAtUtc <= capture.Snapshot.CapturedAtUtc);
             Assert.NotEqual(capture.Snapshot.CapturedAtUtc, entry.ObservedAtUtc);
@@ -158,6 +159,7 @@ public class TestFtpTlsAnalysis {
             Assert.False(result.ChainValid);
             Assert.NotEmpty(result.ChainErrors);
             Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.RemoteAddress);
+            Assert.Equal("IPv4", result.Connection.RemoteAddressFamily);
             Assert.InRange(result.ObservedAtUtc, startedAtUtc, completedAtUtc);
             Assert.Equal("220 Ready", result.Greeting[result.Greeting.Count - 1]);
             Assert.Equal("234 AUTH TLS accepted", result.AuthTlsResponse[result.AuthTlsResponse.Count - 1]);

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -15,6 +15,21 @@ using Xunit;
 namespace DomainDetective.Tests;
 
 public class TestFtpTlsAnalysis {
+    [Fact]
+    public void ResultDisposalReleasesOwnedCertificateEvidence() {
+        using X509Certificate2 sourceCertificate = CreateSelfSigned("localhost");
+        var result = new FtpTlsResult {
+            Certificate = CertificateLoaderCompat.Clone(sourceCertificate)
+        };
+        result.Chain.Add(CertificateLoaderCompat.Clone(sourceCertificate));
+
+        result.Dispose();
+        result.Dispose();
+
+        Assert.Null(result.Certificate);
+        Assert.Empty(result.Chain);
+    }
+
     [Theory]
     [InlineData(-1)]
     [InlineData(0)]
@@ -166,7 +181,7 @@ public class TestFtpTlsAnalysis {
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
             DateTimeOffset startedAtUtc = DateTimeOffset.UtcNow;
-            FtpTlsResult result = await analysis.AnalyzeAsync(
+            using FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
                 new InternalLogger());
             DateTimeOffset completedAtUtc = DateTimeOffset.UtcNow;
@@ -211,7 +226,7 @@ public class TestFtpTlsAnalysis {
 
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
-            FtpTlsResult result = await analysis.AnalyzeAsync(
+            using FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) {
                     ConnectAddress = IPAddress.Parse("::ffff:127.0.0.1")
                 },
@@ -241,7 +256,7 @@ public class TestFtpTlsAnalysis {
 
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
-            FtpTlsResult result = await analysis.AnalyzeAsync(
+            using FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
                 new InternalLogger());
 
@@ -272,7 +287,7 @@ public class TestFtpTlsAnalysis {
 
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
-            FtpTlsResult result = await analysis.AnalyzeAsync(
+            using FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
                 new InternalLogger());
 
@@ -301,7 +316,7 @@ public class TestFtpTlsAnalysis {
 
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
-            FtpTlsResult result = await analysis.AnalyzeAsync(
+            using FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Implicit) { ConnectAddress = IPAddress.Loopback },
                 new InternalLogger());
 
@@ -333,7 +348,7 @@ public class TestFtpTlsAnalysis {
 
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
-            FtpTlsResult result = await analysis.AnalyzeAsync(
+            using FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
                 new InternalLogger());
 

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Net;
 using System.Net.Security;
@@ -54,9 +55,67 @@ public class TestFtpTlsAnalysis {
             Assert.Equal("ftps-explicit", entry.Scheme);
             Assert.Equal(IPAddress.Loopback.ToString(), entry.RemoteAddress);
             Assert.NotNull(entry.ObservedAtUtc);
+            Assert.True(entry.ObservedAtUtc <= capture.Snapshot.CapturedAtUtc);
+            Assert.NotEqual(capture.Snapshot.CapturedAtUtc, entry.ObservedAtUtc);
             Assert.Equal("default", entry.ProbeVantage);
             Assert.NotNull(entry.CertificateThumbprint);
             Assert.False(entry.ChainComplete);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
+    public async Task ExplicitFtpsParticipatesInGlobalTargetAllocation() {
+        using X509Certificate2 certificate = CreateSelfSigned("localhost");
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220 Ready");
+            Assert.Equal("AUTH TLS", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("234 AUTH TLS accepted");
+            using var ssl = new SslStream(network, false);
+            await ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+        });
+
+        try {
+            int httpsTargetsObserved = -1;
+            var capture = new CertificateInventoryCapture {
+                HttpsProbeOverride = (targets, _, _, _) => {
+                    httpsTargetsObserved = targets.Count;
+                    return Task.FromResult<IReadOnlyList<CertificateMonitor.Entry>>(Array.Empty<CertificateMonitor.Entry>());
+                }
+            };
+            var options = new CertificateInventoryCaptureOptions {
+                IncludeApexHttps = true,
+                IncludeWwwHttps = false,
+                IncludeMxHosts = false,
+                PersistSnapshot = false,
+                MaxTargets = 1,
+                FtpTlsTimeout = TimeSpan.FromSeconds(5)
+            };
+            options.AdditionalEndpoints.Add($"ftps-explicit://localhost:{port}");
+
+            CertificateInventoryCaptureResult result = await capture.CaptureAsync(
+                new[] { "example.com" },
+                options,
+                new InternalLogger());
+
+            Assert.Equal(0, httpsTargetsObserved);
+            Assert.Equal(0, result.HttpsEndpointCount);
+            Assert.Equal(1, result.FtpTlsEndpointCount);
+            Assert.Equal(1, result.ProbedFtpTlsCount);
+            Assert.Equal(1, result.HttpsTargetCountDroppedByLimit);
+            Assert.Equal(0, result.FtpTlsTargetCountDroppedByLimit);
+            Assert.Equal("FTPS-EXPLICIT", Assert.Single(result.Snapshot.Entries).Service);
+            Assert.Contains(result.TargetDecisionDiagnostics, diagnostic =>
+                diagnostic.Service == "HTTPS" && diagnostic.Reason == "max-targets");
         } finally {
             listener.Stop();
             await server;
@@ -85,9 +144,11 @@ public class TestFtpTlsAnalysis {
 
         try {
             var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            DateTimeOffset startedAtUtc = DateTimeOffset.UtcNow;
             FtpTlsResult result = await analysis.AnalyzeAsync(
                 new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
                 new InternalLogger());
+            DateTimeOffset completedAtUtc = DateTimeOffset.UtcNow;
 
             Assert.Equal("AUTH TLS", receivedCommand);
             Assert.True(result.TlsNegotiated);
@@ -97,6 +158,7 @@ public class TestFtpTlsAnalysis {
             Assert.False(result.ChainValid);
             Assert.NotEmpty(result.ChainErrors);
             Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.RemoteAddress);
+            Assert.InRange(result.ObservedAtUtc, startedAtUtc, completedAtUtc);
             Assert.Equal("220 Ready", result.Greeting[result.Greeting.Count - 1]);
             Assert.Equal("234 AUTH TLS accepted", result.AuthTlsResponse[result.AuthTlsResponse.Count - 1]);
         } finally {

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -27,6 +27,14 @@ public class TestFtpTlsAnalysis {
             new InternalLogger()));
     }
 
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(2)]
+    public void RejectsUndefinedTlsMode(int mode) {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new FtpTlsEndpoint("localhost", 21, (FtpTlsMode)mode));
+    }
+
     [Fact]
     public async Task CertificateInventoryCaptureAcceptsExplicitFtpsEndpoint() {
         using X509Certificate2 certificate = CreateSelfSigned("localhost");
@@ -177,6 +185,40 @@ public class TestFtpTlsAnalysis {
             Assert.InRange(result.ObservedAtUtc, startedAtUtc, completedAtUtc);
             Assert.Equal("220 Ready", result.Greeting[result.Greeting.Count - 1]);
             Assert.Equal("234 AUTH TLS accepted", result.AuthTlsResponse[result.AuthTlsResponse.Count - 1]);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
+    public async Task ExplicitFtpsWaitsForServiceReadyAfterPreliminaryGreeting() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        string? receivedCommand = null;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("120 Service ready in a moment");
+            await writer.WriteLineAsync("220 Ready");
+            receivedCommand = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("534 TLS unavailable in fixture");
+        });
+
+        try {
+            var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            FtpTlsResult result = await analysis.AnalyzeAsync(
+                new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
+                new InternalLogger());
+
+            Assert.Equal("AUTH TLS", receivedCommand);
+            Assert.Equal(
+                new[] { "120 Service ready in a moment", "220 Ready" },
+                result.Greeting);
+            Assert.Contains("234", result.FailureReason, StringComparison.OrdinalIgnoreCase);
         } finally {
             listener.Stop();
             await server;

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -15,6 +15,18 @@ using Xunit;
 namespace DomainDetective.Tests;
 
 public class TestFtpTlsAnalysis {
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(601)]
+    public async Task RejectsInvalidTimeoutBeforeOpeningAConnection(int timeoutSeconds) {
+        var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(timeoutSeconds) };
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() => analysis.AnalyzeAsync(
+            new FtpTlsEndpoint("localhost", 21, FtpTlsMode.Explicit),
+            new InternalLogger()));
+    }
+
     [Fact]
     public async Task CertificateInventoryCaptureAcceptsExplicitFtpsEndpoint() {
         using X509Certificate2 certificate = CreateSelfSigned("localhost");
@@ -57,9 +69,9 @@ public class TestFtpTlsAnalysis {
             Assert.Equal("IPv4", entry.RemoteAddressFamily);
             Assert.NotNull(entry.ObservedAtUtc);
             Assert.True(entry.ObservedAtUtc <= capture.Snapshot.CapturedAtUtc);
-            Assert.NotEqual(capture.Snapshot.CapturedAtUtc, entry.ObservedAtUtc);
             Assert.Equal("default", entry.ProbeVantage);
             Assert.NotNull(entry.CertificateThumbprint);
+            Assert.Contains("localhost", entry.SubjectAlternativeNames, StringComparer.OrdinalIgnoreCase);
             Assert.False(entry.ChainComplete);
         } finally {
             listener.Stop();
@@ -155,6 +167,8 @@ public class TestFtpTlsAnalysis {
             Assert.True(result.TlsNegotiated);
             Assert.Equal(FtpTlsMode.Explicit, result.Mode);
             Assert.NotNull(result.Certificate);
+            Assert.Contains("localhost", result.CertificateDnsNames, StringComparer.OrdinalIgnoreCase);
+            Assert.Null(result.SanParsingError);
             Assert.False(result.CertificateValid);
             Assert.False(result.ChainValid);
             Assert.NotEmpty(result.ChainErrors);

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -228,6 +228,32 @@ public class TestFtpTlsAnalysis {
     }
 
     [Fact]
+    public async Task ExplicitFtpsRejectsOversizedGreetingLine() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true };
+            await writer.WriteAsync(new string('A', 5000));
+        });
+
+        try {
+            var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            FtpTlsResult result = await analysis.AnalyzeAsync(
+                new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
+                new InternalLogger());
+
+            Assert.False(result.TlsNegotiated);
+            Assert.Contains("line exceeded 4096 characters", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
     public async Task ExplicitFtpsWaitsForServiceReadyAfterPreliminaryGreeting() {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -1,0 +1,178 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using DomainDetective.Helpers;
+using Xunit;
+
+namespace DomainDetective.Tests;
+
+public class TestFtpTlsAnalysis {
+    [Fact]
+    public async Task CertificateInventoryCaptureAcceptsExplicitFtpsEndpoint() {
+        using X509Certificate2 certificate = CreateSelfSigned("localhost");
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220 Ready");
+            Assert.Equal("AUTH TLS", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("234 AUTH TLS accepted");
+            using var ssl = new SslStream(network, false);
+            await ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+        });
+
+        try {
+            var options = new CertificateInventoryCaptureOptions {
+                IncludeApexHttps = false,
+                IncludeWwwHttps = false,
+                IncludeMxHosts = false,
+                PersistSnapshot = false,
+                FtpTlsTimeout = TimeSpan.FromSeconds(5)
+            };
+            options.AdditionalEndpoints.Add($"ftps-explicit://localhost:{port}");
+
+            CertificateInventoryCaptureResult capture = await new CertificateInventoryCapture().CaptureAsync(
+                Array.Empty<string>(),
+                options,
+                new InternalLogger());
+
+            Assert.Equal(1, capture.FtpTlsEndpointCount);
+            Assert.Equal(1, capture.ProbedFtpTlsCount);
+            CertificateInventoryEntry entry = Assert.Single(capture.Snapshot.Entries);
+            Assert.Equal("FTPS-EXPLICIT", entry.Service);
+            Assert.Equal("ftps-explicit", entry.Scheme);
+            Assert.Equal(IPAddress.Loopback.ToString(), entry.RemoteAddress);
+            Assert.NotNull(entry.ObservedAtUtc);
+            Assert.Equal("default", entry.ProbeVantage);
+            Assert.NotNull(entry.CertificateThumbprint);
+            Assert.False(entry.ChainComplete);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
+    public async Task ExplicitFtpsUsesAuthTlsBeforeHandshake() {
+        using X509Certificate2 certificate = CreateSelfSigned("localhost");
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        string? receivedCommand = null;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220-local fixture");
+            await writer.WriteLineAsync("220 Ready");
+            receivedCommand = await reader.ReadLineAsync();
+            await writer.WriteLineAsync("234 AUTH TLS accepted");
+            using var ssl = new SslStream(network, false);
+            await ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+        });
+
+        try {
+            var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            FtpTlsResult result = await analysis.AnalyzeAsync(
+                new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
+                new InternalLogger());
+
+            Assert.Equal("AUTH TLS", receivedCommand);
+            Assert.True(result.TlsNegotiated);
+            Assert.Equal(FtpTlsMode.Explicit, result.Mode);
+            Assert.NotNull(result.Certificate);
+            Assert.False(result.CertificateValid);
+            Assert.False(result.ChainValid);
+            Assert.NotEmpty(result.ChainErrors);
+            Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.RemoteAddress);
+            Assert.Equal("220 Ready", result.Greeting[result.Greeting.Count - 1]);
+            Assert.Equal("234 AUTH TLS accepted", result.AuthTlsResponse[result.AuthTlsResponse.Count - 1]);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
+    public async Task ImplicitFtpsStartsTlsImmediately() {
+        using X509Certificate2 certificate = CreateSelfSigned("localhost");
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using var ssl = new SslStream(client.GetStream(), false);
+            await ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+        });
+
+        try {
+            var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            FtpTlsResult result = await analysis.AnalyzeAsync(
+                new FtpTlsEndpoint("localhost", port, FtpTlsMode.Implicit) { ConnectAddress = IPAddress.Loopback },
+                new InternalLogger());
+
+            Assert.True(result.TlsNegotiated);
+            Assert.Equal(FtpTlsMode.Implicit, result.Mode);
+            Assert.Empty(result.Greeting);
+            Assert.Empty(result.AuthTlsResponse);
+            Assert.NotNull(result.Certificate);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
+    public async Task ExplicitFtpsDoesNotHandshakeWhenAuthTlsIsRejected() {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220 Ready");
+            Assert.Equal("AUTH TLS", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("534 TLS unavailable");
+        });
+
+        try {
+            var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            FtpTlsResult result = await analysis.AnalyzeAsync(
+                new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) { ConnectAddress = IPAddress.Loopback },
+                new InternalLogger());
+
+            Assert.False(result.TlsNegotiated);
+            Assert.Null(result.Certificate);
+            Assert.Contains("234", result.FailureReason, StringComparison.OrdinalIgnoreCase);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    private static X509Certificate2 CreateSelfSigned(string commonName) {
+        using RSA rsa = RSA.Create(2048);
+        var request = new CertificateRequest($"CN={commonName}", rsa, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        var san = new SubjectAlternativeNameBuilder();
+        san.AddDnsName(commonName);
+        request.CertificateExtensions.Add(san.Build());
+        using X509Certificate2 certificate = request.CreateSelfSigned(
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(30));
+        return CertificateLoaderCompat.LoadPkcs12(certificate.Export(X509ContentType.Pfx));
+    }
+}

--- a/DomainDetective.Tests/TestFtpTlsAnalysis.cs
+++ b/DomainDetective.Tests/TestFtpTlsAnalysis.cs
@@ -192,6 +192,42 @@ public class TestFtpTlsAnalysis {
     }
 
     [Fact]
+    public async Task ExplicitFtpsMapsPinnedIpv4MappedAddressBeforeConnecting() {
+        using X509Certificate2 certificate = CreateSelfSigned("localhost");
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        Task server = Task.Run(async () => {
+            using TcpClient client = await listener.AcceptTcpClientAsync();
+            using NetworkStream network = client.GetStream();
+            using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+            using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) { AutoFlush = true, NewLine = "\r\n" };
+            await writer.WriteLineAsync("220 Ready");
+            Assert.Equal("AUTH TLS", await reader.ReadLineAsync());
+            await writer.WriteLineAsync("234 AUTH TLS accepted");
+            using var ssl = new SslStream(network, false);
+            await ssl.AuthenticateAsServerAsync(certificate, false, SslProtocols.Tls12, false);
+        });
+
+        try {
+            var analysis = new FtpTlsAnalysis { Timeout = TimeSpan.FromSeconds(5) };
+            FtpTlsResult result = await analysis.AnalyzeAsync(
+                new FtpTlsEndpoint("localhost", port, FtpTlsMode.Explicit) {
+                    ConnectAddress = IPAddress.Parse("::ffff:127.0.0.1")
+                },
+                new InternalLogger());
+
+            Assert.True(result.TlsNegotiated);
+            Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.ConnectAddress);
+            Assert.Equal(IPAddress.Loopback.ToString(), result.Connection.RemoteAddress);
+            Assert.Equal("IPv4", result.Connection.RemoteAddressFamily);
+        } finally {
+            listener.Stop();
+            await server;
+        }
+    }
+
+    [Fact]
     public async Task ExplicitFtpsWaitsForServiceReadyAfterPreliminaryGreeting() {
         var listener = new TcpListener(IPAddress.Loopback, 0);
         listener.Start();

--- a/DomainDetective/CertificateEndpointIdentity.cs
+++ b/DomainDetective/CertificateEndpointIdentity.cs
@@ -80,7 +80,7 @@ public sealed class CertificateEndpointIdentity : IEquatable<CertificateEndpoint
     public override string ToString() => Key;
 
     private static string NormalizeHost(string? host) {
-        string normalized = (host ?? string.Empty).Trim().TrimEnd('.');
+        string normalized = EndpointHostNormalizer.Normalize(host);
         return normalized.Length == 0 ? UnknownHost : normalized.ToLowerInvariant();
     }
 

--- a/DomainDetective/CertificateEndpointIdentity.cs
+++ b/DomainDetective/CertificateEndpointIdentity.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Globalization;
+
+namespace DomainDetective;
+
+/// <summary>
+/// Identifies a certificate-bearing service endpoint independently from any one observation.
+/// </summary>
+/// <remarks>
+/// A hostname alone is not an endpoint. Port and service remain part of the identity so that,
+/// for example, HTTPS and SMTP STARTTLS observations on the same host cannot be merged.
+/// </remarks>
+public sealed class CertificateEndpointIdentity : IEquatable<CertificateEndpointIdentity> {
+    private const string UnknownHost = "unknown-host";
+
+    private CertificateEndpointIdentity(string host, int port, string service) {
+        Host = host;
+        Port = port;
+        Service = service;
+    }
+
+    /// <summary>Normalized logical hostname used for protocol and certificate identity.</summary>
+    public string Host { get; }
+
+    /// <summary>TCP port used by the service.</summary>
+    public int Port { get; }
+
+    /// <summary>Normalized service name, such as HTTPS or SMTP-STARTTLS.</summary>
+    public string Service { get; }
+
+    /// <summary>Stable key in <c>host|port|service</c> form.</summary>
+    public string Key => Host + "|" + Port.ToString(CultureInfo.InvariantCulture) + "|" + Service;
+
+    /// <summary>Creates a normalized endpoint identity.</summary>
+    public static CertificateEndpointIdentity Create(
+        string? host,
+        int port,
+        string? service = null,
+        string? scheme = null) {
+        int normalizedPort = port > 0 ? port : 443;
+        string normalizedHost = NormalizeHost(host);
+        string normalizedService = NormalizeService(service, scheme, normalizedPort);
+        return new CertificateEndpointIdentity(normalizedHost, normalizedPort, normalizedService);
+    }
+
+    /// <summary>Creates an endpoint identity from an inventory entry.</summary>
+    public static CertificateEndpointIdentity FromEntry(CertificateInventoryEntry? entry) {
+        if (entry == null) {
+            return Create(null, 443);
+        }
+
+        string? host = !string.IsNullOrWhiteSpace(entry.ResolvedHost)
+            ? entry.ResolvedHost
+            : entry.Host;
+        return Create(host, entry.Port, entry.Service, entry.Scheme);
+    }
+
+    /// <inheritdoc />
+    public bool Equals(CertificateEndpointIdentity? other) {
+        return other != null &&
+               Port == other.Port &&
+               string.Equals(Host, other.Host, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(Service, other.Service, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) => Equals(obj as CertificateEndpointIdentity);
+
+    /// <inheritdoc />
+    public override int GetHashCode() {
+        unchecked {
+            int hash = StringComparer.OrdinalIgnoreCase.GetHashCode(Host);
+            hash = (hash * 397) ^ Port;
+            hash = (hash * 397) ^ StringComparer.OrdinalIgnoreCase.GetHashCode(Service);
+            return hash;
+        }
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Key;
+
+    private static string NormalizeHost(string? host) {
+        string normalized = (host ?? string.Empty).Trim().TrimEnd('.');
+        return normalized.Length == 0 ? UnknownHost : normalized.ToLowerInvariant();
+    }
+
+    private static string NormalizeService(string? service, string? scheme, int port) {
+        string? value = service;
+        if (string.IsNullOrWhiteSpace(value)) {
+            value = CertificateServiceClassifier.GuessService(
+                string.IsNullOrWhiteSpace(scheme) ? "https" : scheme!,
+                port);
+        }
+
+        string normalized = (value ?? string.Empty).Trim();
+        if (normalized.Length == 0) {
+            normalized = CertificateServiceClassifier.GuessService("https", port);
+        }
+
+        return normalized.ToUpperInvariant();
+    }
+}

--- a/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
+++ b/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
@@ -19,9 +19,7 @@ public sealed partial class CertificateInventoryCapture {
         DateTimeOffset capturedAtUtc,
         List<string> warnings,
         CancellationToken cancellationToken) {
-        string vantage = string.IsNullOrWhiteSpace(options.ProbeVantage)
-            ? "default"
-            : options.ProbeVantage.Trim();
+        string vantage = CertificateInventoryProbeVantage.Normalize(options.ProbeVantage);
 
         foreach (CertificateInventoryEntry entry in entries) {
             if (!entry.ObservedAtUtc.HasValue) {

--- a/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
+++ b/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
@@ -66,13 +66,13 @@ public sealed partial class CertificateInventoryCapture {
             .Where(host => host.Length > 0)
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        int parallelism = Math.Max(1, options.DnsEnrichmentParallelism);
-        using var gate = new SemaphoreSlim(parallelism, parallelism);
-        var tasks = new List<Task>(hosts.Length);
-        foreach (string host in hosts) {
-            tasks.Add(ResolveHostWithGateAsync(host));
+        int workerCount = Math.Min(hosts.Length, Math.Max(1, options.DnsEnrichmentParallelism));
+        int nextHostIndex = -1;
+        var workers = new Task[workerCount];
+        for (int workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+            workers[workerIndex] = ResolveHostsAsync();
         }
-        await Task.WhenAll(tasks).ConfigureAwait(false);
+        await Task.WhenAll(workers).ConfigureAwait(false);
 
         foreach (CertificateInventoryEntry entry in entries) {
             string host = GetObservationHost(entry);
@@ -105,17 +105,43 @@ public sealed partial class CertificateInventoryCapture {
                 DateTimeOffset.UtcNow);
         }
 
-        async Task ResolveHostWithGateAsync(string host) {
-            bool entered = false;
-            try {
-                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                entered = true;
+        async Task ResolveHostsAsync() {
+            while (true) {
+                cancellationToken.ThrowIfCancellationRequested();
+                int hostIndex = Interlocked.Increment(ref nextHostIndex);
+                if (hostIndex >= hosts.Length) {
+                    return;
+                }
+
+                string host = hosts[hostIndex];
                 EndpointDnsEvidence evidence = await resolver.ResolveAsync(host, cancellationToken).ConfigureAwait(false);
                 evidenceByHost[host] = evidence;
-            } finally {
-                if (entered) {
-                    gate.Release();
-                }
+            }
+        }
+    }
+
+    private static void ValidateEndpointAttributionCaptureOptions(CertificateInventoryCaptureOptions options) {
+        if (!options.EnableEndpointAttribution) {
+            return;
+        }
+
+        foreach (EndpointAttributionRule rule in options.EndpointAttributionRules) {
+            EndpointAttributionCatalog.ValidateAndCompileRule(
+                rule,
+                nameof(CertificateInventoryCaptureOptions.EndpointAttributionRules));
+
+            var unsupportedSignals = new List<string>(2);
+            if (rule.ReverseDnsSuffixes.Count > 0) {
+                unsupportedSignals.Add(nameof(EndpointAttributionRule.ReverseDnsSuffixes));
+            }
+            if (rule.AutonomousSystemNumbers.Count > 0) {
+                unsupportedSignals.Add(nameof(EndpointAttributionRule.AutonomousSystemNumbers));
+            }
+            if (unsupportedSignals.Count > 0) {
+                throw new NotSupportedException(
+                    $"Certificate inventory capture cannot collect {string.Join(" or ", unsupportedSignals)} " +
+                    $"for endpoint attribution rule '{rule.RuleId}'. Evaluate the rule with " +
+                    $"{nameof(EndpointAttributionDetector)} directly and supply those observed signals explicitly.");
             }
         }
     }

--- a/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
+++ b/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
@@ -85,7 +85,13 @@ public sealed partial class CertificateInventoryCapture {
             entry.DnsObservationErrors = evidence.Errors;
 
             var addresses = new HashSet<string>(evidence.Addresses, StringComparer.OrdinalIgnoreCase);
-            if (IPAddress.TryParse(entry.RemoteAddress, out IPAddress? remoteAddress) && remoteAddress != null) {
+            bool isLiveProbe = string.Equals(
+                entry.CaptureDisposition,
+                CaptureDispositionLiveProbe,
+                StringComparison.OrdinalIgnoreCase);
+            if (isLiveProbe &&
+                IPAddress.TryParse(entry.RemoteAddress, out IPAddress? remoteAddress) &&
+                remoteAddress != null) {
                 addresses.Add(remoteAddress.ToString());
             }
 

--- a/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
+++ b/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
@@ -46,7 +46,11 @@ public sealed partial class CertificateInventoryCapture {
             string serviceTagPath = options.AzureServiceTagsJsonPath!;
             try {
                 azureServiceTags = AzureServiceTagCatalog.LoadFile(serviceTagPath);
-            } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is FormatException || ex is JsonException) {
+            } catch (Exception ex) when (ex is IOException ||
+                                         ex is UnauthorizedAccessException ||
+                                         ex is ArgumentException ||
+                                         ex is FormatException ||
+                                         ex is JsonException) {
                 warnings.Add($"Azure service-tag catalog could not be loaded from '{serviceTagPath}': {ex.Message}");
             }
         }

--- a/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
+++ b/DomainDetective/CertificateInventoryCapture.EndpointObservations.cs
@@ -1,0 +1,125 @@
+using DnsClientX;
+using DomainDetective.Providers.Endpoint;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+public sealed partial class CertificateInventoryCapture {
+    private async Task EnrichEndpointObservationsAsync(
+        IReadOnlyList<CertificateInventoryEntry> entries,
+        CertificateInventoryCaptureOptions options,
+        DateTimeOffset capturedAtUtc,
+        List<string> warnings,
+        CancellationToken cancellationToken) {
+        string vantage = string.IsNullOrWhiteSpace(options.ProbeVantage)
+            ? "default"
+            : options.ProbeVantage.Trim();
+
+        foreach (CertificateInventoryEntry entry in entries) {
+            if (!entry.ObservedAtUtc.HasValue) {
+                entry.ObservedAtUtc = capturedAtUtc;
+            }
+            if (string.IsNullOrWhiteSpace(entry.ProbeVantage)) {
+                entry.ProbeVantage = vantage;
+            }
+        }
+
+        if (!options.EnableEndpointAttribution || entries.Count == 0) {
+            return;
+        }
+
+        var catalog = EndpointAttributionCatalog.CreateDefault();
+        foreach (EndpointAttributionRule rule in options.EndpointAttributionRules) {
+            catalog.AddOrReplace(rule);
+        }
+
+        AzureServiceTagCatalog? azureServiceTags = null;
+        if (!string.IsNullOrWhiteSpace(options.AzureServiceTagsJsonPath)) {
+            string serviceTagPath = options.AzureServiceTagsJsonPath!;
+            try {
+                azureServiceTags = AzureServiceTagCatalog.LoadFile(serviceTagPath);
+            } catch (Exception ex) when (ex is IOException || ex is UnauthorizedAccessException || ex is FormatException || ex is JsonException) {
+                warnings.Add($"Azure service-tag catalog could not be loaded from '{serviceTagPath}': {ex.Message}");
+            }
+        }
+
+        var detector = new EndpointAttributionDetector(catalog);
+        var resolver = new EndpointDnsEvidenceResolver {
+            DnsConfiguration = new DnsConfiguration { DnsEndpoint = options.DnsEndpoint },
+            QueryDnsOverride = EndpointDnsQueryOverride
+        };
+        var evidenceByHost = new ConcurrentDictionary<string, EndpointDnsEvidence>(StringComparer.OrdinalIgnoreCase);
+        string[] hosts = entries
+            .Select(GetObservationHost)
+            .Where(host => host.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        int parallelism = Math.Max(1, options.DnsEnrichmentParallelism);
+        using var gate = new SemaphoreSlim(parallelism, parallelism);
+        var tasks = new List<Task>(hosts.Length);
+        foreach (string host in hosts) {
+            tasks.Add(ResolveHostWithGateAsync(host));
+        }
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        foreach (CertificateInventoryEntry entry in entries) {
+            string host = GetObservationHost(entry);
+            if (host.Length == 0 || !evidenceByHost.TryGetValue(host, out EndpointDnsEvidence? evidence)) {
+                continue;
+            }
+
+            entry.DnsResolver = evidence.Resolver;
+            entry.DnsObservedAtUtc = evidence.ObservedAtUtc;
+            entry.CnameChain = evidence.CnameChain;
+            entry.ResolvedAddresses = evidence.Addresses;
+            entry.DnsObservationErrors = evidence.Errors;
+
+            var addresses = new HashSet<string>(evidence.Addresses, StringComparer.OrdinalIgnoreCase);
+            if (IPAddress.TryParse(entry.RemoteAddress, out IPAddress? remoteAddress) && remoteAddress != null) {
+                addresses.Add(remoteAddress.ToString());
+            }
+
+            entry.Attribution = detector.Detect(
+                new EndpointAttributionInput {
+                    HostName = host,
+                    Port = entry.Port,
+                    Service = entry.Service,
+                    CnameChain = evidence.CnameChain,
+                    IpAddresses = addresses.ToArray(),
+                    CertificateIssuer = entry.CertificateIssuer ?? string.Empty,
+                    RedirectTargets = entry.RedirectTargets,
+                    AzureServiceTags = azureServiceTags
+                },
+                DateTimeOffset.UtcNow);
+        }
+
+        async Task ResolveHostWithGateAsync(string host) {
+            bool entered = false;
+            try {
+                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                entered = true;
+                EndpointDnsEvidence evidence = await resolver.ResolveAsync(host, cancellationToken).ConfigureAwait(false);
+                evidenceByHost[host] = evidence;
+            } finally {
+                if (entered) {
+                    gate.Release();
+                }
+            }
+        }
+    }
+
+    private static string GetObservationHost(CertificateInventoryEntry entry) {
+        return (!string.IsNullOrWhiteSpace(entry.ResolvedHost) ? entry.ResolvedHost : entry.Host)
+            ?.Trim()
+            .TrimEnd('.')
+            .ToLowerInvariant() ?? string.Empty;
+    }
+}

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -280,6 +280,104 @@ public sealed partial class CertificateInventoryCapture {
         return results.ToList();
     }
 
+    private static async Task<IReadOnlyList<CertificateInventoryEntry>> ProbeFtpTlsAsync(
+        IReadOnlyList<FtpTlsEndpointTarget> targets,
+        CertificateInventoryCaptureOptions options,
+        InternalLogger logger,
+        CancellationToken cancellationToken) {
+        if (targets == null || targets.Count == 0) {
+            return Array.Empty<CertificateInventoryEntry>();
+        }
+
+        var results = new ConcurrentBag<CertificateInventoryEntry>();
+        int parallelism = Math.Max(1, options.MaxParallelism);
+        var rateLimiter = new ProbeStartRateLimiter(options.MaxProbeStartsPerSecond);
+        using var gate = new SemaphoreSlim(parallelism, parallelism);
+        var tasks = new List<Task>(targets.Count);
+        foreach (FtpTlsEndpointTarget target in targets) {
+            tasks.Add(ProbeOneWithGateAsync(target));
+        }
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        return results
+            .OrderBy(entry => entry.Host, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(entry => entry.Port)
+            .ThenBy(entry => entry.Service, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        async Task ProbeOneWithGateAsync(FtpTlsEndpointTarget target) {
+            bool entered = false;
+            try {
+                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+                entered = true;
+                await rateLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
+                var analysis = new FtpTlsAnalysis { Timeout = options.FtpTlsTimeout };
+                FtpTlsResult result = await analysis.AnalyzeAsync(
+                    new FtpTlsEndpoint(target.Host, target.Port, target.Mode),
+                    logger,
+                    cancellationToken).ConfigureAwait(false);
+                results.Add(ToInventoryEntry(target, result));
+            } finally {
+                if (entered) {
+                    gate.Release();
+                }
+            }
+        }
+    }
+
+    private static CertificateInventoryEntry ToInventoryEntry(FtpTlsEndpointTarget target, FtpTlsResult result) {
+        X509Certificate2? certificate = result.Certificate;
+        var mailResult = new MailTlsAnalysis.TlsResult {
+            Connection = new MailTransportConnectionEvidence {
+                HostName = target.Host,
+                Port = target.Port,
+                RemoteAddress = result.Connection.RemoteAddress,
+                RemoteAddressFamily = ParseMailAddressFamily(result.Connection.RemoteAddressFamily)
+            },
+            StartTlsAdvertised = result.TlsNegotiated,
+            CertificateValid = result.CertificateValid,
+            HostnameMatch = result.HostnameMatch,
+            Protocol = result.Protocol,
+            Certificate = certificate,
+            CertificateSubject = certificate?.Subject,
+            CertificateIssuer = certificate?.Issuer,
+            CertificateNotBefore = certificate?.NotBefore,
+            CertificateNotAfter = certificate?.NotAfter,
+            CertificateThumbprint = certificate?.Thumbprint,
+            CertificateSerialNumber = certificate?.SerialNumber,
+            DaysToExpire = certificate == null ? 0 : (int)(certificate.NotAfter - DateTime.Now).TotalDays,
+            DaysValid = certificate == null ? 0 : (int)(certificate.NotAfter - certificate.NotBefore).TotalDays,
+            IsExpired = certificate != null && certificate.NotAfter < DateTime.Now,
+            FailureReason = result.FailureReason,
+            FailureKind = result.FailureKind
+        };
+        foreach (X509Certificate2 chainElement in result.Chain) {
+            mailResult.Chain.Add(chainElement);
+        }
+        foreach (X509ChainStatusFlags chainError in result.ChainErrors) {
+            mailResult.ChainErrors.Add(chainError);
+        }
+        var mailTarget = new MailEndpointTarget {
+            Host = target.Host,
+            Port = target.Port,
+            Protocol = MailTlsAnalysis.MailProtocol.Smtp,
+            Service = target.Service,
+            Scheme = target.Scheme,
+            ChainSource = target.Mode == FtpTlsMode.Explicit ? "ftps-auth-tls" : "ftps-implicit",
+            TargetOrigins = target.TargetOrigins
+        };
+        return ToInventoryEntry(mailTarget, mailResult);
+    }
+
+    private static MailTransportAddressFamily? ParseMailAddressFamily(string? value) {
+        if (string.Equals(value, System.Net.Sockets.AddressFamily.InterNetwork.ToString(), StringComparison.Ordinal)) {
+            return MailTransportAddressFamily.IPv4;
+        }
+        if (string.Equals(value, System.Net.Sockets.AddressFamily.InterNetworkV6.ToString(), StringComparison.Ordinal)) {
+            return MailTransportAddressFamily.IPv6;
+        }
+        return null;
+    }
+
     private static List<CertificateInventoryEntry> DeduplicateEntries(List<CertificateInventoryEntry> entries) {
         var byEndpoint = new Dictionary<string, CertificateInventoryEntry>(StringComparer.OrdinalIgnoreCase);
         foreach (var entry in entries) {
@@ -366,6 +464,8 @@ public sealed partial class CertificateInventoryCapture {
             Scheme = target.Scheme,
             Port = target.Port,
             Service = target.Service,
+            RemoteAddress = result.Connection.RemoteAddress,
+            RemoteAddressFamily = result.Connection.RemoteAddressFamily?.ToString(),
             CertificateSubject = certificate?.Subject ?? result.CertificateSubject,
             CertificateIssuer = certificate?.Issuer ?? result.CertificateIssuer,
             CertificateThumbprint = certificate?.Thumbprint ?? result.CertificateThumbprint,

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -254,10 +254,10 @@ public sealed partial class CertificateInventoryCapture {
                     var analysis = new MailTlsAnalysis {
                         Timeout = options.MailTimeout
                     };
-                    await analysis.AnalyzeServer(target.Protocol, target.Host, target.Port, logger, cancellationToken).ConfigureAwait(false);
+                    var endpoint = new MailTransportEndpoint(target.Host, target.Port);
+                    await analysis.AnalyzeServer(target.Protocol, endpoint, logger, cancellationToken).ConfigureAwait(false);
                     DateTimeOffset observedAtUtc = DateTimeOffset.UtcNow;
-                    var key = $"{target.Host}:{target.Port}";
-                    if (analysis.ServerResults.TryGetValue(key, out var tlsResult)) {
+                    if (analysis.ServerResults.TryGetValue(endpoint.Key, out var tlsResult)) {
                         results.Add(ToInventoryEntry(target, tlsResult, observedAtUtc));
                     } else {
                         results.Add(ToInventoryEntry(target, new MailTlsAnalysis.TlsResult(), observedAtUtc));

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -351,6 +351,7 @@ public sealed partial class CertificateInventoryCapture {
             FailureReason = result.FailureReason,
             FailureKind = result.FailureKind
         };
+        mailResult.CertificateDnsNames.AddRange(result.CertificateDnsNames);
         foreach (X509Certificate2 chainElement in result.Chain) {
             mailResult.Chain.Add(chainElement);
         }

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -317,7 +317,7 @@ public sealed partial class CertificateInventoryCapture {
                 FtpTlsEndpointTarget target = targets[targetIndex];
                 await rateLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
                 var analysis = new FtpTlsAnalysis { Timeout = options.FtpTlsTimeout };
-                FtpTlsResult result = await analysis.AnalyzeAsync(
+                using FtpTlsResult result = await analysis.AnalyzeAsync(
                     new FtpTlsEndpoint(target.Host, target.Port, target.Mode),
                     logger,
                     cancellationToken).ConfigureAwait(false);

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -177,10 +177,10 @@ public sealed partial class CertificateInventoryCapture {
         if (Uri.TryCreate(target, UriKind.Absolute, out Uri? uri)) {
             return string.IsNullOrWhiteSpace(uri.Host)
                 ? null
-                : uri.Host.Trim().TrimEnd('.');
+                : EndpointHostNormalizer.Normalize(uri.Host);
         }
 
-        return target!.Trim().TrimEnd('.');
+        return EndpointHostNormalizer.Normalize(target);
     }
 
     private static void AddCtTemplateIfMissing(ICollection<string> templates, string? template) {
@@ -370,10 +370,12 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private static MailTransportAddressFamily? ParseMailAddressFamily(string? value) {
-        if (string.Equals(value, System.Net.Sockets.AddressFamily.InterNetwork.ToString(), StringComparison.Ordinal)) {
+        if (string.Equals(value, "IPv4", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, System.Net.Sockets.AddressFamily.InterNetwork.ToString(), StringComparison.OrdinalIgnoreCase)) {
             return MailTransportAddressFamily.IPv4;
         }
-        if (string.Equals(value, System.Net.Sockets.AddressFamily.InterNetworkV6.ToString(), StringComparison.Ordinal)) {
+        if (string.Equals(value, "IPv6", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(value, System.Net.Sockets.AddressFamily.InterNetworkV6.ToString(), StringComparison.OrdinalIgnoreCase)) {
             return MailTransportAddressFamily.IPv6;
         }
         return null;
@@ -385,6 +387,7 @@ public sealed partial class CertificateInventoryCapture {
             if (entry == null) {
                 continue;
             }
+            CertificateInventoryEntryHelpers.NormalizeRemoteAddressEvidence(entry);
             var host = !string.IsNullOrWhiteSpace(entry.ResolvedHost) ? entry.ResolvedHost! : entry.Host;
             var key = $"{host}|{entry.Port}|{entry.Service}";
             if (!byEndpoint.TryGetValue(key, out var existing)) {
@@ -464,7 +467,7 @@ public sealed partial class CertificateInventoryCapture {
         var entry = new CertificateInventoryEntry {
             Host = target.Host,
             ResolvedHost = target.Host,
-            Url = $"{target.Scheme}://{target.Host}:{target.Port}",
+            Url = $"{target.Scheme}://{EndpointHostNormalizer.FormatForUriAuthority(target.Host)}:{target.Port}",
             Scheme = target.Scheme,
             Port = target.Port,
             Service = target.Service,

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -293,23 +293,28 @@ public sealed partial class CertificateInventoryCapture {
         var results = new ConcurrentBag<CertificateInventoryEntry>();
         int parallelism = Math.Max(1, options.MaxParallelism);
         var rateLimiter = new ProbeStartRateLimiter(options.MaxProbeStartsPerSecond);
-        using var gate = new SemaphoreSlim(parallelism, parallelism);
-        var tasks = new List<Task>(targets.Count);
-        foreach (FtpTlsEndpointTarget target in targets) {
-            tasks.Add(ProbeOneWithGateAsync(target));
+        int workerCount = Math.Min(targets.Count, parallelism);
+        int nextTargetIndex = -1;
+        var workers = new Task[workerCount];
+        for (int workerIndex = 0; workerIndex < workerCount; workerIndex++) {
+            workers[workerIndex] = ProbeTargetsAsync();
         }
-        await Task.WhenAll(tasks).ConfigureAwait(false);
+        await Task.WhenAll(workers).ConfigureAwait(false);
         return results
             .OrderBy(entry => entry.Host, StringComparer.OrdinalIgnoreCase)
             .ThenBy(entry => entry.Port)
             .ThenBy(entry => entry.Service, StringComparer.OrdinalIgnoreCase)
             .ToList();
 
-        async Task ProbeOneWithGateAsync(FtpTlsEndpointTarget target) {
-            bool entered = false;
-            try {
-                await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
-                entered = true;
+        async Task ProbeTargetsAsync() {
+            while (true) {
+                cancellationToken.ThrowIfCancellationRequested();
+                int targetIndex = Interlocked.Increment(ref nextTargetIndex);
+                if (targetIndex >= targets.Count) {
+                    return;
+                }
+
+                FtpTlsEndpointTarget target = targets[targetIndex];
                 await rateLimiter.WaitAsync(cancellationToken).ConfigureAwait(false);
                 var analysis = new FtpTlsAnalysis { Timeout = options.FtpTlsTimeout };
                 FtpTlsResult result = await analysis.AnalyzeAsync(
@@ -317,10 +322,6 @@ public sealed partial class CertificateInventoryCapture {
                     logger,
                     cancellationToken).ConfigureAwait(false);
                 results.Add(ToInventoryEntry(target, result));
-            } finally {
-                if (entered) {
-                    gate.Release();
-                }
             }
         }
     }

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -255,14 +255,15 @@ public sealed partial class CertificateInventoryCapture {
                         Timeout = options.MailTimeout
                     };
                     await analysis.AnalyzeServer(target.Protocol, target.Host, target.Port, logger, cancellationToken).ConfigureAwait(false);
+                    DateTimeOffset observedAtUtc = DateTimeOffset.UtcNow;
                     var key = $"{target.Host}:{target.Port}";
                     if (analysis.ServerResults.TryGetValue(key, out var tlsResult)) {
-                        results.Add(ToInventoryEntry(target, tlsResult));
+                        results.Add(ToInventoryEntry(target, tlsResult, observedAtUtc));
                     } else {
-                        results.Add(ToInventoryEntry(target, new MailTlsAnalysis.TlsResult()));
+                        results.Add(ToInventoryEntry(target, new MailTlsAnalysis.TlsResult(), observedAtUtc));
                     }
                 } catch {
-                    results.Add(ToInventoryEntry(target, new MailTlsAnalysis.TlsResult()));
+                    results.Add(ToInventoryEntry(target, new MailTlsAnalysis.TlsResult(), DateTimeOffset.UtcNow));
                 } finally {
                     var completed = Interlocked.Increment(ref completedTargets);
                     logger.WriteProgress(
@@ -365,7 +366,7 @@ public sealed partial class CertificateInventoryCapture {
             ChainSource = target.Mode == FtpTlsMode.Explicit ? "ftps-auth-tls" : "ftps-implicit",
             TargetOrigins = target.TargetOrigins
         };
-        return ToInventoryEntry(mailTarget, mailResult);
+        return ToInventoryEntry(mailTarget, mailResult, result.ObservedAtUtc);
     }
 
     private static MailTransportAddressFamily? ParseMailAddressFamily(string? value) {
@@ -420,7 +421,10 @@ public sealed partial class CertificateInventoryCapture {
         return score;
     }
 
-    private static CertificateInventoryEntry ToInventoryEntry(MailEndpointTarget target, MailTlsAnalysis.TlsResult result) {
+    private static CertificateInventoryEntry ToInventoryEntry(
+        MailEndpointTarget target,
+        MailTlsAnalysis.TlsResult result,
+        DateTimeOffset observedAtUtc) {
         var certificate = result.Certificate;
         var chain = result.Chain != null && result.Chain.Count > 0
             ? result.Chain
@@ -464,6 +468,7 @@ public sealed partial class CertificateInventoryCapture {
             Scheme = target.Scheme,
             Port = target.Port,
             Service = target.Service,
+            ObservedAtUtc = observedAtUtc == default ? DateTimeOffset.UtcNow : observedAtUtc,
             RemoteAddress = result.Connection.RemoteAddress,
             RemoteAddressFamily = result.Connection.RemoteAddressFamily?.ToString(),
             CertificateSubject = certificate?.Subject ?? result.CertificateSubject,

--- a/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
+++ b/DomainDetective/CertificateInventoryCapture.ProbingAndMapping.cs
@@ -61,6 +61,7 @@ public sealed partial class CertificateInventoryCapture {
     private static async Task<IReadOnlyList<CertificateMonitor.Entry>> ProbeHttpsAsync(
         IEnumerable<string> httpsTargets,
         CertificateInventoryCaptureOptions options,
+        ProbeStartRateLimiter rateLimiter,
         InternalLogger logger,
         CancellationToken cancellationToken) {
         var list = httpsTargets.Where(target => !string.IsNullOrWhiteSpace(target)).Distinct(StringComparer.OrdinalIgnoreCase).ToList();
@@ -74,10 +75,6 @@ public sealed partial class CertificateInventoryCapture {
             MaxParallelism = Math.Max(1, options.MaxParallelism)
         };
         logger.WriteVerbose("Starting HTTPS probe for {0} endpoint(s).", list.Count);
-        if (options.MaxProbeStartsPerSecond > 0) {
-            logger.WriteVerbose("Probe start rate limit enabled: up to {0} start(s)/second.", options.MaxProbeStartsPerSecond);
-        }
-        var rateLimiter = new ProbeStartRateLimiter(options.MaxProbeStartsPerSecond);
         monitor.AnalysisOverride = async (url, port, internalLogger, token) => {
             await rateLimiter.WaitAsync(token).ConfigureAwait(false);
             var analysis = new CertificateAnalysis();
@@ -231,6 +228,7 @@ public sealed partial class CertificateInventoryCapture {
     private static async Task<IReadOnlyList<CertificateInventoryEntry>> ProbeMailAsync(
         IReadOnlyList<MailEndpointTarget> mailTargets,
         CertificateInventoryCaptureOptions options,
+        ProbeStartRateLimiter rateLimiter,
         InternalLogger logger,
         CancellationToken cancellationToken) {
         if (mailTargets == null || mailTargets.Count == 0) {
@@ -242,7 +240,6 @@ public sealed partial class CertificateInventoryCapture {
         var totalTargets = mailTargets.Count;
         var completedTargets = 0;
         logger.WriteVerbose("Starting mail TLS probe for {0} endpoint(s).", totalTargets);
-        var rateLimiter = new ProbeStartRateLimiter(options.MaxProbeStartsPerSecond);
         using var gate = new SemaphoreSlim(parallelism, parallelism);
         var tasks = new List<Task>(mailTargets.Count);
         foreach (var target in mailTargets) {
@@ -284,6 +281,7 @@ public sealed partial class CertificateInventoryCapture {
     private static async Task<IReadOnlyList<CertificateInventoryEntry>> ProbeFtpTlsAsync(
         IReadOnlyList<FtpTlsEndpointTarget> targets,
         CertificateInventoryCaptureOptions options,
+        ProbeStartRateLimiter rateLimiter,
         InternalLogger logger,
         CancellationToken cancellationToken) {
         if (targets == null || targets.Count == 0) {
@@ -292,7 +290,6 @@ public sealed partial class CertificateInventoryCapture {
 
         var results = new ConcurrentBag<CertificateInventoryEntry>();
         int parallelism = Math.Max(1, options.MaxParallelism);
-        var rateLimiter = new ProbeStartRateLimiter(options.MaxProbeStartsPerSecond);
         int workerCount = Math.Min(targets.Count, parallelism);
         int nextTargetIndex = -1;
         var workers = new Task[workerCount];

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -935,7 +935,9 @@ public sealed partial class CertificateInventoryCapture {
                     AddHttpsTarget(
                         httpsTargets,
                         httpsTargetOriginsByEndpointKey,
-                        BuildHttpsUrl($"{hostWithPort}:{parsedPort}", options.HttpsPort),
+                        BuildHttpsUrl(
+                            $"{EndpointHostNormalizer.FormatForUriAuthority(hostWithPort)}:{parsedPort}",
+                            options.HttpsPort),
                         TargetOriginAdditionalEndpoint);
                 }
             } else {

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -861,6 +861,20 @@ public sealed partial class CertificateInventoryCapture {
                     continue;
                 }
 
+                if (TryGetExplicitUriPort(uri, out int explicitPort) &&
+                    (explicitPort < 1 || explicitPort > 65535)) {
+                    warnings.Add($"Skipping invalid endpoint '{value}'.");
+                    targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
+                        Stage = "additional-endpoints",
+                        Action = "rejected",
+                        Reason = "invalid-endpoint",
+                        Target = value,
+                        Service = uri.Scheme.ToLowerInvariant(),
+                        Message = "An explicitly supplied endpoint port must be between 1 and 65535."
+                    });
+                    continue;
+                }
+
                 var scheme = uri.Scheme.ToLowerInvariant();
                 if (scheme == Uri.UriSchemeHttp || scheme == Uri.UriSchemeHttps) {
                     var builder = new UriBuilder(uri) {
@@ -881,9 +895,21 @@ public sealed partial class CertificateInventoryCapture {
                     continue;
                 }
 
-                if (TryCreateFtpTlsTargetFromScheme(uri, out FtpTlsEndpointTarget? ftpTlsTarget)) {
-                    ftpTlsTarget!.TargetOrigins.Add(TargetOriginAdditionalEndpoint);
-                    ftpTlsTargets[ftpTlsTarget.Key] = ftpTlsTarget;
+                if (IsFtpTlsScheme(scheme)) {
+                    if (TryCreateFtpTlsTargetFromScheme(uri, out FtpTlsEndpointTarget? ftpTlsTarget)) {
+                        ftpTlsTarget!.TargetOrigins.Add(TargetOriginAdditionalEndpoint);
+                        ftpTlsTargets[ftpTlsTarget.Key] = ftpTlsTarget;
+                    } else {
+                        warnings.Add($"Skipping invalid FTP TLS endpoint '{value}'.");
+                        targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
+                            Stage = "additional-endpoints",
+                            Action = "rejected",
+                            Reason = "invalid-endpoint",
+                            Target = value,
+                            Service = scheme,
+                            Message = "The FTP TLS endpoint requires a valid hostname and a port between 1 and 65535."
+                        });
+                    }
                     continue;
                 }
 
@@ -947,17 +973,59 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         string host = EndpointHostNormalizer.Normalize(uri.Host);
-        if (host.Length == 0) {
+        bool hasExplicitPort = TryGetExplicitUriPort(uri, out int explicitPort);
+        if (host.Length == 0 ||
+            (hasExplicitPort && (explicitPort < 1 || explicitPort > 65535)) ||
+            (!hasExplicitPort && !uri.IsDefaultPort && (uri.Port < 1 || uri.Port > 65535))) {
             return false;
         }
         target = new FtpTlsEndpointTarget {
             Host = host,
-            Port = uri.IsDefaultPort || uri.Port <= 0 ? defaultPort : uri.Port,
+            Port = hasExplicitPort ? explicitPort : (uri.IsDefaultPort ? defaultPort : uri.Port),
             Mode = mode,
             Scheme = normalizedScheme,
             Service = service
         };
         return true;
+    }
+
+    private static bool IsFtpTlsScheme(string scheme) {
+        return scheme == "ftps" ||
+               scheme == "ftps-explicit" ||
+               scheme == "ftpes" ||
+               scheme == "ftp+tls";
+    }
+
+    private static bool TryGetExplicitUriPort(Uri uri, out int port) {
+        port = 0;
+        string original = uri.OriginalString;
+        int schemeSeparator = original.IndexOf("://", StringComparison.Ordinal);
+        if (schemeSeparator < 0) {
+            return false;
+        }
+        int authorityStart = schemeSeparator + 3;
+        int authorityEnd = original.IndexOfAny(new[] { '/', '?', '#' }, authorityStart);
+        string authority = authorityEnd < 0
+            ? original.Substring(authorityStart)
+            : original.Substring(authorityStart, authorityEnd - authorityStart);
+        int userInfoSeparator = authority.LastIndexOf('@');
+        if (userInfoSeparator >= 0) {
+            authority = authority.Substring(userInfoSeparator + 1);
+        }
+
+        int portSeparator;
+        if (authority.StartsWith("[", StringComparison.Ordinal)) {
+            int bracket = authority.IndexOf(']');
+            portSeparator = bracket >= 0 && bracket + 1 < authority.Length && authority[bracket + 1] == ':'
+                ? bracket + 1
+                : -1;
+        } else {
+            portSeparator = authority.LastIndexOf(':');
+        }
+        if (portSeparator < 0 || portSeparator + 1 >= authority.Length) {
+            return false;
+        }
+        return int.TryParse(authority.Substring(portSeparator + 1), out port);
     }
 
     private static bool TryCreateMailTargetFromScheme(Uri uri, CertificateInventoryCaptureOptions options, out MailEndpointTarget? target) {

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -43,7 +43,7 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private static string BuildMailTargetLabel(MailEndpointTarget target) {
-        return $"{target.Scheme}://{target.Host}:{target.Port}";
+        return $"{target.Scheme}://{EndpointHostNormalizer.FormatForUriAuthority(target.Host)}:{target.Port}";
     }
 
     private static string BuildEndpointKey(string host, int port, string service) {
@@ -145,16 +145,18 @@ public sealed partial class CertificateInventoryCapture {
             return false;
         }
 
+        DateTimeOffset observedAtUtc = cachedEntry.Entry.ObservedAtUtc ?? cachedEntry.CapturedAtUtc;
+
         if (options.ReuseRecentSnapshotEntries &&
             options.RecentSnapshotTtl > TimeSpan.Zero &&
-            cachedEntry.CapturedAtUtc >= now - options.RecentSnapshotTtl &&
+            observedAtUtc >= now - options.RecentSnapshotTtl &&
             ShouldReuseCachedSuccessEntry(cachedEntry.Entry, now, options.ReprobeExpiringWithinDays)) {
             return true;
         }
 
         if (options.ReuseRecentFailureSnapshotEntries &&
             options.RecentFailureSnapshotTtl > TimeSpan.Zero &&
-            cachedEntry.CapturedAtUtc >= now - options.RecentFailureSnapshotTtl &&
+            observedAtUtc >= now - options.RecentFailureSnapshotTtl &&
             ShouldReuseCachedFailureEntry(cachedEntry.Entry)) {
             reusedStableFailure = true;
             return true;
@@ -174,9 +176,12 @@ public sealed partial class CertificateInventoryCapture {
             .Where(static pair => pair.Value != null)
             .ToDictionary(
                 static pair => pair.Key,
-                pair => new RecentInventoryEndpointEntry {
-                    Entry = pair.Value,
-                    CapturedAtUtc = capturedAtUtc
+                pair => {
+                    CertificateInventoryEntryHelpers.NormalizeRemoteAddressEvidence(pair.Value);
+                    return new RecentInventoryEndpointEntry {
+                        Entry = pair.Value,
+                        CapturedAtUtc = capturedAtUtc
+                    };
                 },
                 StringComparer.OrdinalIgnoreCase);
     }
@@ -218,6 +223,7 @@ public sealed partial class CertificateInventoryCapture {
                 if (!entry.ObservedAtUtc.HasValue) {
                     entry.ObservedAtUtc = snapshot.CapturedAtUtc;
                 }
+                CertificateInventoryEntryHelpers.NormalizeRemoteAddressEvidence(entry);
                 var key = BuildEndpointKey(host, entry.Port, entry.Service);
                 byEndpoint[key] = new RecentInventoryEndpointEntry {
                     Entry = entry,
@@ -690,38 +696,74 @@ public sealed partial class CertificateInventoryCapture {
         Dictionary<string, FtpTlsEndpointTarget> ftpTlsTargets,
         int allowedTargets,
         List<string> warnings,
+        IReadOnlyDictionary<string, RecentInventoryEndpointEntry>? recentByEndpoint,
         List<TargetDecisionDiagnosticEntry> targetDecisionDiagnostics) {
         if (ftpTlsTargets.Count <= allowedTargets) {
             return;
         }
 
         int originalCount = ftpTlsTargets.Count;
-        FtpTlsEndpointTarget[] ordered = ftpTlsTargets.Values
-            .OrderBy(target => target.Host, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(target => target.Port)
-            .ThenBy(target => target.Service, StringComparer.OrdinalIgnoreCase)
+        var ordered = ftpTlsTargets.Values
+            .Select(target => new {
+                Target = target,
+                Priority = ComputeFtpTlsTargetPriority(target, recentByEndpoint, options),
+                SortDays = ResolvePrioritySortDays(target, recentByEndpoint)
+            })
+            .OrderByDescending(item => item.Priority)
+            .ThenBy(item => item.SortDays)
+            .ThenBy(item => item.Target.Host, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(item => item.Target.Port)
+            .ThenBy(item => item.Target.Service, StringComparer.OrdinalIgnoreCase)
             .ToArray();
-        FtpTlsEndpointTarget[] kept = ordered.Take(Math.Max(0, allowedTargets)).ToArray();
-        FtpTlsEndpointTarget[] pruned = ordered.Skip(Math.Max(0, allowedTargets)).ToArray();
+        var kept = ordered.Take(Math.Max(0, allowedTargets)).ToArray();
+        var pruned = ordered.Skip(Math.Max(0, allowedTargets)).ToArray();
 
         ftpTlsTargets.Clear();
-        foreach (FtpTlsEndpointTarget target in kept) {
-            ftpTlsTargets[target.Key] = target;
+        foreach (var item in kept) {
+            ftpTlsTargets[item.Target.Key] = item.Target;
         }
-        foreach (FtpTlsEndpointTarget target in pruned) {
+        foreach (var item in pruned) {
+            FtpTlsEndpointTarget target = item.Target;
             targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
                 Stage = "target-limit",
                 Action = "pruned",
                 Reason = "max-targets",
-                Target = $"{target.Scheme}://{target.Host}:{target.Port}",
+                Target = $"{target.Scheme}://{EndpointHostNormalizer.FormatForUriAuthority(target.Host)}:{target.Port}",
                 Service = target.Service,
-                PriorityScore = 1000,
+                PriorityScore = item.Priority,
                 Message = $"Pruned by MaxTargets={options.MaxTargets}.",
                 TargetOrigins = target.TargetOrigins.ToList()
             });
         }
 
         warnings.Add($"FTP TLS target list capped from {originalCount} to {ftpTlsTargets.Count} by the global MaxTargets budget.");
+    }
+
+    private static int ComputeFtpTlsTargetPriority(
+        FtpTlsEndpointTarget target,
+        IReadOnlyDictionary<string, RecentInventoryEndpointEntry>? recentByEndpoint,
+        CertificateInventoryCaptureOptions options) {
+        if (target != null &&
+            recentByEndpoint != null &&
+            recentByEndpoint.TryGetValue(target.Key, out RecentInventoryEndpointEntry? cachedEntry)) {
+            int evidencePriority = ComputeCachedEntryPriority(cachedEntry.Entry, options.ReprobeExpiringWithinDays);
+            if (TryReuseCachedEntry(cachedEntry, DateTimeOffset.UtcNow, options, out _)) {
+                return evidencePriority;
+            }
+            return Math.Max(1000, evidencePriority);
+        }
+        return 1000;
+    }
+
+    private static int ResolvePrioritySortDays(
+        FtpTlsEndpointTarget target,
+        IReadOnlyDictionary<string, RecentInventoryEndpointEntry>? recentByEndpoint) {
+        if (target != null &&
+            recentByEndpoint != null &&
+            recentByEndpoint.TryGetValue(target.Key, out RecentInventoryEndpointEntry? cachedEntry)) {
+            return ParseSortDays(cachedEntry.Entry);
+        }
+        return int.MinValue;
     }
 
     private static void ResolveTargetBudget(
@@ -904,7 +946,7 @@ public sealed partial class CertificateInventoryCapture {
                 return false;
         }
 
-        string host = uri.Host.Trim().TrimEnd('.');
+        string host = EndpointHostNormalizer.Normalize(uri.Host);
         if (host.Length == 0) {
             return false;
         }
@@ -920,7 +962,7 @@ public sealed partial class CertificateInventoryCapture {
 
     private static bool TryCreateMailTargetFromScheme(Uri uri, CertificateInventoryCaptureOptions options, out MailEndpointTarget? target) {
         target = null;
-        var host = uri.Host.Trim().TrimEnd('.');
+        var host = EndpointHostNormalizer.Normalize(uri.Host);
         if (string.IsNullOrWhiteSpace(host)) {
             return false;
         }

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -853,7 +853,9 @@ public sealed partial class CertificateInventoryCapture {
             }
             var value = raw.Trim();
             if (value.IndexOf("://", StringComparison.Ordinal) >= 0) {
-                if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) || string.IsNullOrWhiteSpace(uri.Host)) {
+                if (!Uri.TryCreate(value, UriKind.Absolute, out var uri) ||
+                    string.IsNullOrWhiteSpace(uri.Host) ||
+                    !EndpointHostNormalizer.TryNormalize(uri.Host, out _)) {
                     warnings.Add($"Skipping invalid endpoint '{value}'.");
                     targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
                         Stage = "additional-endpoints",
@@ -941,11 +943,23 @@ public sealed partial class CertificateInventoryCapture {
                         TargetOriginAdditionalEndpoint);
                 }
             } else {
-                AddHttpsTarget(
-                    httpsTargets,
-                    httpsTargetOriginsByEndpointKey,
-                    BuildHttpsUrl(value, options.HttpsPort),
-                    TargetOriginAdditionalEndpoint);
+                if (EndpointHostNormalizer.TryNormalize(value, out string normalizedHost) &&
+                    normalizedHost.Length > 0) {
+                    AddHttpsTarget(
+                        httpsTargets,
+                        httpsTargetOriginsByEndpointKey,
+                        BuildHttpsUrl(normalizedHost, options.HttpsPort),
+                        TargetOriginAdditionalEndpoint);
+                } else {
+                    warnings.Add($"Skipping invalid endpoint '{value}'.");
+                    targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
+                        Stage = "additional-endpoints",
+                        Action = "rejected",
+                        Reason = "invalid-endpoint",
+                        Target = value,
+                        Message = "Brackets are valid only around an IPv6 literal endpoint host."
+                    });
+                }
             }
         }
     }
@@ -1155,7 +1169,11 @@ public sealed partial class CertificateInventoryCapture {
         if (string.IsNullOrWhiteSpace(maybeHost)) {
             return false;
         }
-        host = maybeHost;
+        if (!EndpointHostNormalizer.TryNormalize(maybeHost, out string normalizedHost) ||
+            normalizedHost.Length == 0) {
+            return false;
+        }
+        host = normalizedHost;
         port = parsed;
         return true;
     }

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -748,9 +748,13 @@ public sealed partial class CertificateInventoryCapture {
             recentByEndpoint.TryGetValue(target.Key, out RecentInventoryEndpointEntry? cachedEntry)) {
             int evidencePriority = ComputeCachedEntryPriority(cachedEntry.Entry, options.ReprobeExpiringWithinDays);
             if (TryReuseCachedEntry(cachedEntry, DateTimeOffset.UtcNow, options, out _)) {
-                return evidencePriority;
+                // Reusable successes do not need a live probe. Keep them below every
+                // uncached target even when their cached evidence carries a high score.
+                return Math.Min(999, evidencePriority);
             }
-            return Math.Max(1000, evidencePriority);
+            // Stale or otherwise non-reusable observations require fresh evidence and
+            // therefore outrank both uncached targets and reusable successes.
+            return Math.Max(1001, evidencePriority);
         }
         return 1000;
     }

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -231,6 +231,7 @@ public sealed partial class CertificateInventoryCapture {
 
     private static void ApplyTargetLimit(
         CertificateInventoryCaptureOptions options,
+        int maxTargets,
         HashSet<string> httpsTargets,
         Dictionary<string, HashSet<string>> httpsTargetOriginsByEndpointKey,
         Dictionary<string, MailEndpointTarget> mailTargets,
@@ -238,18 +239,18 @@ public sealed partial class CertificateInventoryCapture {
         IReadOnlyDictionary<string, RecentInventoryEndpointEntry>? recentByEndpoint,
         int reprobeExpiringWithinDays,
         List<TargetDecisionDiagnosticEntry> targetDecisionDiagnostics) {
-        if (options.MaxTargets <= 0) {
+        if (maxTargets < 0) {
             return;
         }
 
         var totalTargets = httpsTargets.Count + mailTargets.Count;
-        if (totalTargets <= options.MaxTargets) {
+        if (totalTargets <= maxTargets) {
             return;
         }
 
         var originalHttps = httpsTargets.Count;
         var originalMail = mailTargets.Count;
-        var limit = options.MaxTargets;
+        var limit = maxTargets;
         ResolveTargetBudget(
             originalHttps,
             originalMail,
@@ -338,11 +339,12 @@ public sealed partial class CertificateInventoryCapture {
             PruneTrackedHttpsOrigins(httpsTargetOriginsByEndpointKey, keptHttps);
         }
 
-        warnings.Add($"Probe target list capped from {totalTargets} to {options.MaxTargets} by MaxTargets (HTTPS: {originalHttps}->{httpsTargets.Count}, Mail: {originalMail}->{mailTargets.Count}).");
+        warnings.Add($"Probe target list capped from {totalTargets} to {httpsTargets.Count + mailTargets.Count} within global MaxTargets={options.MaxTargets} (HTTPS: {originalHttps}->{httpsTargets.Count}, Mail: {originalMail}->{mailTargets.Count}).");
     }
 
     private static void ApplyTargetLimitIncludingReusedSuccesses(
         CertificateInventoryCaptureOptions options,
+        int maxTargets,
         HashSet<string> httpsTargets,
         Dictionary<string, HashSet<string>> httpsTargetOriginsByEndpointKey,
         Dictionary<string, MailEndpointTarget> mailTargets,
@@ -357,6 +359,7 @@ public sealed partial class CertificateInventoryCapture {
         if (reusedSuccessCandidates.Count == 0) {
             ApplyTargetLimit(
                 options,
+                maxTargets,
                 httpsTargets,
                 httpsTargetOriginsByEndpointKey,
                 mailTargets,
@@ -367,7 +370,7 @@ public sealed partial class CertificateInventoryCapture {
             return;
         }
 
-        if (options.MaxTargets <= 0) {
+        if (maxTargets < 0) {
             cachedEntries.AddRange(reusedSuccessCandidates.Select(static candidate => candidate.Entry));
             reusedHttps += reusedSuccessCandidates.Count(static candidate => candidate.Kind == ReusedTargetKind.Https);
             reusedMail += reusedSuccessCandidates.Count(static candidate => candidate.Kind == ReusedTargetKind.Mail);
@@ -377,7 +380,7 @@ public sealed partial class CertificateInventoryCapture {
         var originalHttps = httpsTargets.Count + reusedSuccessCandidates.Count(static candidate => candidate.Kind == ReusedTargetKind.Https);
         var originalMail = mailTargets.Count + reusedSuccessCandidates.Count(static candidate => candidate.Kind == ReusedTargetKind.Mail);
         var totalTargets = originalHttps + originalMail;
-        if (totalTargets <= options.MaxTargets) {
+        if (totalTargets <= maxTargets) {
             cachedEntries.AddRange(reusedSuccessCandidates.Select(static candidate => candidate.Entry));
             reusedHttps += reusedSuccessCandidates.Count(static candidate => candidate.Kind == ReusedTargetKind.Https);
             reusedMail += reusedSuccessCandidates.Count(static candidate => candidate.Kind == ReusedTargetKind.Mail);
@@ -387,7 +390,7 @@ public sealed partial class CertificateInventoryCapture {
         ResolveTargetBudget(
             originalHttps,
             originalMail,
-            options.MaxTargets,
+            maxTargets,
             out var allowedHttps,
             out var allowedMail);
 
@@ -521,7 +524,9 @@ public sealed partial class CertificateInventoryCapture {
         reusedHttps += keptReused.Count(static candidate => candidate.Kind == ReusedTargetKind.Https);
         reusedMail += keptReused.Count(static candidate => candidate.Kind == ReusedTargetKind.Mail);
 
-        warnings.Add($"Probe target list capped from {totalTargets} to {options.MaxTargets} by MaxTargets (HTTPS: {originalHttps}->{httpsTargets.Count + keptReused.Count(static candidate => candidate.Kind == ReusedTargetKind.Https)}, Mail: {originalMail}->{mailTargets.Count + keptReused.Count(static candidate => candidate.Kind == ReusedTargetKind.Mail)}).");
+        int keptHttpsCount = httpsTargets.Count + keptReused.Count(static candidate => candidate.Kind == ReusedTargetKind.Https);
+        int keptMailCount = mailTargets.Count + keptReused.Count(static candidate => candidate.Kind == ReusedTargetKind.Mail);
+        warnings.Add($"Probe target list capped from {totalTargets} to {keptHttpsCount + keptMailCount} within global MaxTargets={options.MaxTargets} (HTTPS: {originalHttps}->{keptHttpsCount}, Mail: {originalMail}->{keptMailCount}).");
     }
 
     private static int ComputeHttpsTargetPriority(
@@ -651,6 +656,72 @@ public sealed partial class CertificateInventoryCapture {
         }
 
         return (int)Math.Floor((entry.NotAfterUtc.Value - DateTimeOffset.UtcNow).TotalDays);
+    }
+
+    private static int ResolveFtpTlsTargetBudget(
+        int ftpTlsCount,
+        int nonFtpCount,
+        int maxTargets) {
+        int normalizedFtpTls = Math.Max(0, ftpTlsCount);
+        int normalizedNonFtp = Math.Max(0, nonFtpCount);
+        if (maxTargets <= 0 || normalizedFtpTls == 0) {
+            return 0;
+        }
+        if (normalizedNonFtp == 0) {
+            return Math.Min(normalizedFtpTls, maxTargets);
+        }
+        if (maxTargets == 1) {
+            // FTP TLS targets are always explicit caller inputs. Honor that request
+            // ahead of automatically expanded HTTPS or mail targets when only one
+            // global slot exists.
+            return 1;
+        }
+
+        int total = normalizedFtpTls + normalizedNonFtp;
+        int desired = (int)Math.Round(
+            maxTargets * (double)normalizedFtpTls / total,
+            MidpointRounding.AwayFromZero);
+        desired = Math.Max(1, Math.Min(maxTargets - 1, desired));
+        return Math.Min(normalizedFtpTls, desired);
+    }
+
+    private static void ApplyFtpTlsTargetLimit(
+        CertificateInventoryCaptureOptions options,
+        Dictionary<string, FtpTlsEndpointTarget> ftpTlsTargets,
+        int allowedTargets,
+        List<string> warnings,
+        List<TargetDecisionDiagnosticEntry> targetDecisionDiagnostics) {
+        if (ftpTlsTargets.Count <= allowedTargets) {
+            return;
+        }
+
+        int originalCount = ftpTlsTargets.Count;
+        FtpTlsEndpointTarget[] ordered = ftpTlsTargets.Values
+            .OrderBy(target => target.Host, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(target => target.Port)
+            .ThenBy(target => target.Service, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        FtpTlsEndpointTarget[] kept = ordered.Take(Math.Max(0, allowedTargets)).ToArray();
+        FtpTlsEndpointTarget[] pruned = ordered.Skip(Math.Max(0, allowedTargets)).ToArray();
+
+        ftpTlsTargets.Clear();
+        foreach (FtpTlsEndpointTarget target in kept) {
+            ftpTlsTargets[target.Key] = target;
+        }
+        foreach (FtpTlsEndpointTarget target in pruned) {
+            targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
+                Stage = "target-limit",
+                Action = "pruned",
+                Reason = "max-targets",
+                Target = $"{target.Scheme}://{target.Host}:{target.Port}",
+                Service = target.Service,
+                PriorityScore = 1000,
+                Message = $"Pruned by MaxTargets={options.MaxTargets}.",
+                TargetOrigins = target.TargetOrigins.ToList()
+            });
+        }
+
+        warnings.Add($"FTP TLS target list capped from {originalCount} to {ftpTlsTargets.Count} by the global MaxTargets budget.");
     }
 
     private static void ResolveTargetBudget(

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -51,11 +51,7 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private static bool ProbeVantageMatches(CertificateInventoryEntry entry, string? requestedVantage) {
-        string cachedValue = entry.ProbeVantage ?? string.Empty;
-        string requestedValue = requestedVantage ?? string.Empty;
-        string cached = string.IsNullOrWhiteSpace(cachedValue) ? "default" : cachedValue.Trim();
-        string requested = string.IsNullOrWhiteSpace(requestedValue) ? "default" : requestedValue.Trim();
-        return string.Equals(cached, requested, StringComparison.OrdinalIgnoreCase);
+        return CertificateInventoryProbeVantage.Equals(entry.ProbeVantage, requestedVantage);
     }
 
     private static bool TryBuildHttpsEndpointKey(string target, out string key) {

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -50,6 +50,14 @@ public sealed partial class CertificateInventoryCapture {
         return CertificateInventoryEndpointKey.Build(host, null, port, service, null);
     }
 
+    private static bool ProbeVantageMatches(CertificateInventoryEntry entry, string? requestedVantage) {
+        string cachedValue = entry.ProbeVantage ?? string.Empty;
+        string requestedValue = requestedVantage ?? string.Empty;
+        string cached = string.IsNullOrWhiteSpace(cachedValue) ? "default" : cachedValue.Trim();
+        string requested = string.IsNullOrWhiteSpace(requestedValue) ? "default" : requestedValue.Trim();
+        return string.Equals(cached, requested, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static bool TryBuildHttpsEndpointKey(string target, out string key) {
         key = string.Empty;
         if (string.IsNullOrWhiteSpace(target)) {
@@ -200,9 +208,15 @@ public sealed partial class CertificateInventoryCapture {
                 if (entry == null) {
                     continue;
                 }
+                if (!ProbeVantageMatches(entry, options.ProbeVantage)) {
+                    continue;
+                }
                 var host = !string.IsNullOrWhiteSpace(entry.ResolvedHost) ? entry.ResolvedHost! : entry.Host;
                 if (string.IsNullOrWhiteSpace(host) || string.IsNullOrWhiteSpace(entry.Service) || entry.Port <= 0) {
                     continue;
+                }
+                if (!entry.ObservedAtUtc.HasValue) {
+                    entry.ObservedAtUtc = snapshot.CapturedAtUtc;
                 }
                 var key = BuildEndpointKey(host, entry.Port, entry.Service);
                 byEndpoint[key] = new RecentInventoryEndpointEntry {
@@ -713,6 +727,7 @@ public sealed partial class CertificateInventoryCapture {
         HashSet<string> httpsTargets,
         Dictionary<string, HashSet<string>> httpsTargetOriginsByEndpointKey,
         Dictionary<string, MailEndpointTarget> mailTargets,
+        Dictionary<string, FtpTlsEndpointTarget> ftpTlsTargets,
         List<string> warnings,
         List<TargetDecisionDiagnosticEntry> targetDecisionDiagnostics) {
         foreach (var raw in options.AdditionalEndpoints) {
@@ -753,6 +768,12 @@ public sealed partial class CertificateInventoryCapture {
                     continue;
                 }
 
+                if (TryCreateFtpTlsTargetFromScheme(uri, out FtpTlsEndpointTarget? ftpTlsTarget)) {
+                    ftpTlsTarget!.TargetOrigins.Add(TargetOriginAdditionalEndpoint);
+                    ftpTlsTargets[ftpTlsTarget.Key] = ftpTlsTarget;
+                    continue;
+                }
+
                 warnings.Add($"Skipping unsupported endpoint scheme in '{value}'.");
                 targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
                     Stage = "additional-endpoints",
@@ -784,6 +805,46 @@ public sealed partial class CertificateInventoryCapture {
                     TargetOriginAdditionalEndpoint);
             }
         }
+    }
+
+    private static bool TryCreateFtpTlsTargetFromScheme(Uri uri, out FtpTlsEndpointTarget? target) {
+        target = null;
+        string scheme = uri.Scheme.ToLowerInvariant();
+        FtpTlsMode mode;
+        int defaultPort;
+        string normalizedScheme;
+        string service;
+        switch (scheme) {
+            case "ftps":
+                mode = FtpTlsMode.Implicit;
+                defaultPort = 990;
+                normalizedScheme = "ftps";
+                service = "FTPS-IMPLICIT";
+                break;
+            case "ftps-explicit":
+            case "ftpes":
+            case "ftp+tls":
+                mode = FtpTlsMode.Explicit;
+                defaultPort = 21;
+                normalizedScheme = "ftps-explicit";
+                service = "FTPS-EXPLICIT";
+                break;
+            default:
+                return false;
+        }
+
+        string host = uri.Host.Trim().TrimEnd('.');
+        if (host.Length == 0) {
+            return false;
+        }
+        target = new FtpTlsEndpointTarget {
+            Host = host,
+            Port = uri.IsDefaultPort || uri.Port <= 0 ? defaultPort : uri.Port,
+            Mode = mode,
+            Scheme = normalizedScheme,
+            Service = service
+        };
+        return true;
     }
 
     private static bool TryCreateMailTargetFromScheme(Uri uri, CertificateInventoryCaptureOptions options, out MailEndpointTarget? target) {

--- a/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
+++ b/DomainDetective/CertificateInventoryCapture.TargetingAndMx.cs
@@ -1016,7 +1016,7 @@ public sealed partial class CertificateInventoryCapture {
 
     private static bool TryCreateMailTargetFromPort(string host, int port, out MailEndpointTarget? target) {
         target = null;
-        var normalized = host.Trim().TrimEnd('.');
+        var normalized = EndpointHostNormalizer.Normalize(host);
         if (string.IsNullOrWhiteSpace(normalized)) {
             return false;
         }

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1798,6 +1798,7 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private static void AddMailTarget(Dictionary<string, MailEndpointTarget> targets, MailEndpointTarget target) {
+        target.Host = EndpointHostNormalizer.Normalize(target.Host);
         var key = BuildMailTargetKey(target.Host, target.Port, target.Service);
         if (!targets.TryGetValue(key, out MailEndpointTarget? existing)) {
             targets[key] = target;
@@ -1808,7 +1809,7 @@ public sealed partial class CertificateInventoryCapture {
     }
 
     private static string BuildMailTargetKey(string host, int port, string service) {
-        return $"{host.Trim().ToLowerInvariant()}|{port}|{service.Trim().ToUpperInvariant()}";
+        return $"{EndpointHostNormalizer.Normalize(host).ToLowerInvariant()}|{port}|{service.Trim().ToUpperInvariant()}";
     }
 
 }

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1230,13 +1230,35 @@ public sealed partial class CertificateInventoryCapture {
                 }
                 mailTargetsToProbe = filteredMail;
 
+                // Stable failures are complete cached observations, not candidates for the live
+                // FTP/TLS budget. Remove them before target allocation so they cannot displace an
+                // uncached or stale endpoint that still requires a probe. Reusable successes stay
+                // in the candidate set and are ranked with the other FTP/TLS targets below.
+                foreach (FtpTlsEndpointTarget target in ftpTlsTargets.Values.ToList()) {
+                    if (recentByEndpoint.TryGetValue(target.Key, out var cached) &&
+                        TryReuseCachedEntry(cached, now, options, out bool reusedStableFailure) &&
+                        reusedStableFailure) {
+                        ApplyEntryProvenance(
+                            cached.Entry,
+                            target.TargetOrigins,
+                            CaptureDispositionReusedRecentStableFailure,
+                            replaceTargetOrigins: true);
+                        cachedEntries.Add(cached.Entry);
+                        reusedFtpTls++;
+                        reusedStableFailureFtpTls++;
+                        ftpTlsTargets.Remove(target.Key);
+                    }
+                }
+
                 logger.WriteVerbose(
-                    "Reused {0} cached endpoint result(s) from recent snapshots (HTTPS: {1}, Mail: {2}, StableFailureHTTPS: {3}, StableFailureMail: {4}).",
-                    reusedHttps + reusedMail,
+                    "Reused {0} cached endpoint result(s) from recent snapshots (HTTPS: {1}, Mail: {2}, FTPTLS: {3}, StableFailureHTTPS: {4}, StableFailureMail: {5}, StableFailureFTPTLS: {6}).",
+                    reusedHttps + reusedMail + reusedFtpTls,
                     reusedHttps,
                     reusedMail,
+                    reusedFtpTls,
                     reusedStableFailureHttps,
-                    reusedStableFailureMail);
+                    reusedStableFailureMail,
+                    reusedStableFailureFtpTls);
             }
         }
 

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1398,20 +1398,26 @@ public sealed partial class CertificateInventoryCapture {
         logger.WriteVerbose("Prepared {0} HTTPS target(s), {1} mail target(s), and {2} FTP TLS target(s).", httpsTargets.Count, mailTargets.Count, ftpTlsTargets.Count);
         AdvanceStage("Recent snapshot cache");
 
+        var probeStartRateLimiter = new ProbeStartRateLimiter(options.MaxProbeStartsPerSecond);
+        if (options.MaxProbeStartsPerSecond > 0) {
+            logger.WriteVerbose(
+                "Global probe start rate limit enabled: up to {0} start(s)/second across HTTPS, mail TLS, and FTP TLS.",
+                options.MaxProbeStartsPerSecond);
+        }
         IReadOnlyList<CertificateMonitor.Entry> httpsEntries;
         if (HttpsProbeOverride != null) {
             httpsEntries = await HttpsProbeOverride(httpsTargetsToProbe.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).ToList(), options, logger, cancellationToken).ConfigureAwait(false);
         } else {
-            httpsEntries = await ProbeHttpsAsync(httpsTargetsToProbe, options, logger, cancellationToken).ConfigureAwait(false);
+            httpsEntries = await ProbeHttpsAsync(httpsTargetsToProbe, options, probeStartRateLimiter, logger, cancellationToken).ConfigureAwait(false);
         }
         AdvanceStage("HTTPS probing");
         logger.WriteVerbose("HTTPS probing produced {0} observation(s).", httpsEntries.Count);
 
-        var mailEntries = await ProbeMailAsync(mailTargetsToProbe, options, logger, cancellationToken).ConfigureAwait(false);
+        var mailEntries = await ProbeMailAsync(mailTargetsToProbe, options, probeStartRateLimiter, logger, cancellationToken).ConfigureAwait(false);
         AdvanceStage("Mail TLS probing");
         logger.WriteVerbose("Mail TLS probing produced {0} observation(s).", mailEntries.Count);
 
-        var ftpTlsEntries = await ProbeFtpTlsAsync(ftpTlsTargetsToProbe, options, logger, cancellationToken).ConfigureAwait(false);
+        var ftpTlsEntries = await ProbeFtpTlsAsync(ftpTlsTargetsToProbe, options, probeStartRateLimiter, logger, cancellationToken).ConfigureAwait(false);
         AdvanceStage("FTP TLS probing");
         logger.WriteVerbose("FTP TLS probing produced {0} observation(s).", ftpTlsEntries.Count);
 

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1268,6 +1268,7 @@ public sealed partial class CertificateInventoryCapture {
                 ftpTlsTargets,
                 allowedFtpTls,
                 warnings,
+                recentByEndpoint,
                 targetDecisionDiagnostics);
             nonFtpTargetBudget = Math.Max(0, options.MaxTargets - ftpTlsTargets.Count);
         }
@@ -1399,9 +1400,10 @@ public sealed partial class CertificateInventoryCapture {
         allEntries.AddRange(ftpTlsEntries);
 
         var deduped = DeduplicateEntries(allEntries);
-        var capturedAtUtc = DateTimeOffset.UtcNow;
-        await EnrichEndpointObservationsAsync(deduped, options, capturedAtUtc, warnings, cancellationToken).ConfigureAwait(false);
-        EnrichEntriesWithCtSubdomainMetadata(deduped, ctDiscoveredSubdomainEntries, capturedAtUtc);
+        var observationFallbackAtUtc = DateTimeOffset.UtcNow;
+        await EnrichEndpointObservationsAsync(deduped, options, observationFallbackAtUtc, warnings, cancellationToken).ConfigureAwait(false);
+        EnrichEntriesWithCtSubdomainMetadata(deduped, ctDiscoveredSubdomainEntries, observationFallbackAtUtc);
+        var capturedAtUtc = CertificateInventoryEntryHelpers.ResolveCapturedAtUtc(deduped, DateTimeOffset.UtcNow);
         var distinctPorts = deduped
             .Select(e => e.Port)
             .Where(port => port > 0)
@@ -1515,7 +1517,7 @@ public sealed partial class CertificateInventoryCapture {
                 .OrderBy(x => x.Host, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.Port)
                 .ThenBy(x => x.Service, StringComparer.OrdinalIgnoreCase)
-                .Select(x => $"{x.Scheme}://{x.Host}:{x.Port}")
+                .Select(x => $"{x.Scheme}://{EndpointHostNormalizer.FormatForUriAuthority(x.Host)}:{x.Port}")
                 .ToList(),
             Warnings = warnings,
             NativeCtLogDiagnostics = nativeCtLogDiagnostics,

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1492,7 +1492,7 @@ public sealed partial class CertificateInventoryCapture {
             MxHostCount = mxHosts.Count,
             HttpsEndpointCount = httpsTargets.Count,
             MailEndpointCount = mailTargets.Count,
-            FtpTlsEndpointCount = ftpTlsTargets.Count,
+            FtpTlsEndpointCount = ftpTlsTargetsToProbe.Count,
             EntryCount = deduped.Count,
             ReusedRecentEntryCount = reusedHttps + reusedMail + reusedFtpTls,
             ReusedRecentHttpsCount = reusedHttps,
@@ -1542,7 +1542,7 @@ public sealed partial class CertificateInventoryCapture {
                 .ThenBy(x => x.Port)
                 .Select(BuildMailTargetLabel)
                 .ToList(),
-            FtpTlsEndpoints = ftpTlsTargets.Values
+            FtpTlsEndpoints = ftpTlsTargetsToProbe
                 .OrderBy(x => x.Host, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.Port)
                 .ThenBy(x => x.Service, StringComparer.OrdinalIgnoreCase)

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1254,8 +1254,26 @@ public sealed partial class CertificateInventoryCapture {
         var httpsTargetCountBeforeLimit = httpsTargets.Count;
         var mailTargetCountBeforeLimit = mailTargets.Count;
         var ftpTlsTargetCountBeforeLimit = ftpTlsTargets.Count;
+        int nonFtpTargetBudget = -1;
+        if (options.MaxTargets > 0) {
+            int nonFtpCandidateCount = httpsTargets.Count +
+                                       mailTargets.Count +
+                                       reusedSuccessCandidates.Count;
+            int allowedFtpTls = ResolveFtpTlsTargetBudget(
+                ftpTlsTargets.Count,
+                nonFtpCandidateCount,
+                options.MaxTargets);
+            ApplyFtpTlsTargetLimit(
+                options,
+                ftpTlsTargets,
+                allowedFtpTls,
+                warnings,
+                targetDecisionDiagnostics);
+            nonFtpTargetBudget = Math.Max(0, options.MaxTargets - ftpTlsTargets.Count);
+        }
         ApplyTargetLimitIncludingReusedSuccesses(
             options,
+            nonFtpTargetBudget,
             httpsTargets,
             httpsTargetOriginsByEndpointKey,
             mailTargets,
@@ -1267,34 +1285,6 @@ public sealed partial class CertificateInventoryCapture {
             targetDecisionDiagnostics,
             ref reusedHttps,
             ref reusedMail);
-        if (options.MaxTargets > 0 && ftpTlsTargets.Count > 0) {
-            int occupied = httpsTargets.Count + mailTargets.Count + cachedEntries.Count;
-            int available = Math.Max(0, options.MaxTargets - occupied);
-            if (ftpTlsTargets.Count > available) {
-                FtpTlsEndpointTarget[] kept = ftpTlsTargets.Values
-                    .OrderBy(target => target.Host, StringComparer.OrdinalIgnoreCase)
-                    .ThenBy(target => target.Port)
-                    .ThenBy(target => target.Service, StringComparer.OrdinalIgnoreCase)
-                    .Take(available)
-                    .ToArray();
-                FtpTlsEndpointTarget[] dropped = ftpTlsTargets.Values.Except(kept).ToArray();
-                ftpTlsTargets.Clear();
-                foreach (FtpTlsEndpointTarget target in kept) {
-                    ftpTlsTargets[target.Key] = target;
-                }
-                foreach (FtpTlsEndpointTarget target in dropped) {
-                    targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
-                        Stage = "target-limit",
-                        Action = "dropped",
-                        Reason = "max-targets",
-                        Target = $"{target.Scheme}://{target.Host}:{target.Port}",
-                        Service = target.Service,
-                        Message = "FTP TLS endpoint was outside the global MaxTargets budget."
-                    });
-                }
-                warnings.Add($"FTP TLS target list capped from {ftpTlsTargetCountBeforeLimit} to {ftpTlsTargets.Count} by the remaining MaxTargets budget.");
-            }
-        }
         var httpsTargetCountDroppedByLimit = Math.Max(0, httpsTargetCountBeforeLimit - httpsTargets.Count);
         var mailTargetCountDroppedByLimit = Math.Max(0, mailTargetCountBeforeLimit - mailTargets.Count);
         var ftpTlsTargetCountDroppedByLimit = Math.Max(0, ftpTlsTargetCountBeforeLimit - ftpTlsTargets.Count);

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1691,7 +1691,9 @@ public sealed partial class CertificateInventoryCapture {
             }
         }
 
-        var candidate = host;
+        var candidate = EndpointHostNormalizer.TryNormalize(host, out string normalizedHost)
+            ? EndpointHostNormalizer.FormatForUriAuthority(normalizedHost)
+            : host;
         if (!candidate.StartsWith("https://", StringComparison.OrdinalIgnoreCase)) {
             candidate = $"https://{candidate}";
         }

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -1430,8 +1430,8 @@ public sealed partial class CertificateInventoryCapture {
 
         var deduped = DeduplicateEntries(allEntries);
         var observationFallbackAtUtc = DateTimeOffset.UtcNow;
-        await EnrichEndpointObservationsAsync(deduped, options, observationFallbackAtUtc, warnings, cancellationToken).ConfigureAwait(false);
         EnrichEntriesWithCtSubdomainMetadata(deduped, ctDiscoveredSubdomainEntries, observationFallbackAtUtc);
+        await EnrichEndpointObservationsAsync(deduped, options, observationFallbackAtUtc, warnings, cancellationToken).ConfigureAwait(false);
         var capturedAtUtc = CertificateInventoryEntryHelpers.ResolveCapturedAtUtc(deduped, DateTimeOffset.UtcNow);
         var distinctPorts = deduped
             .Select(e => e.Port)

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -36,7 +36,13 @@ public sealed class CertificateInventoryCaptureOptions {
     /// <summary>Optional path to a current Azure service-tag JSON download.</summary>
     public string? AzureServiceTagsJsonPath { get; set; }
 
-    /// <summary>Custom endpoint attribution rules that add to or replace built-in rules by RuleId.</summary>
+    /// <summary>
+    /// Custom endpoint attribution rules that add to or replace built-in rules by RuleId.
+    /// Certificate inventory capture supplies hostname, CNAME, address, certificate, redirect,
+    /// service-tag, service, and port evidence. Rules that require reverse-DNS or autonomous-system
+    /// observations must be evaluated through <see cref="EndpointAttributionDetector"/> with those
+    /// signals supplied explicitly.
+    /// </summary>
     public List<EndpointAttributionRule> EndpointAttributionRules { get; } = new();
 
     /// <summary>When true, probes apex domains over HTTPS.</summary>
@@ -782,6 +788,7 @@ public sealed partial class CertificateInventoryCapture {
         if (options.DnsEnrichmentParallelism < 1 || options.DnsEnrichmentParallelism > 512) {
             throw new ArgumentOutOfRangeException(nameof(options.DnsEnrichmentParallelism), "DnsEnrichmentParallelism must be between 1 and 512.");
         }
+        ValidateEndpointAttributionCaptureOptions(options);
         if (options.RecentSnapshotTtl < TimeSpan.Zero) {
             throw new ArgumentOutOfRangeException(nameof(options.RecentSnapshotTtl), "RecentSnapshotTtl must be non-negative.");
         }

--- a/DomainDetective/CertificateInventoryCapture.cs
+++ b/DomainDetective/CertificateInventoryCapture.cs
@@ -10,6 +10,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Helpers;
+using DomainDetective.Providers.Endpoint;
 
 namespace DomainDetective;
 
@@ -22,6 +23,21 @@ public sealed class CertificateInventoryCaptureOptions {
 
     /// <summary>DNS endpoint used for MX discovery.</summary>
     public DnsEndpoint DnsEndpoint { get; set; } = DnsEndpoint.System;
+
+    /// <summary>When true, resolves endpoint DNS evidence and evaluates explainable provider/service attribution.</summary>
+    public bool EnableEndpointAttribution { get; set; }
+
+    /// <summary>Caller-defined probe location label persisted with live observations.</summary>
+    public string ProbeVantage { get; set; } = "default";
+
+    /// <summary>Maximum concurrent DNS evidence lookups used by endpoint attribution.</summary>
+    public int DnsEnrichmentParallelism { get; set; } = 8;
+
+    /// <summary>Optional path to a current Azure service-tag JSON download.</summary>
+    public string? AzureServiceTagsJsonPath { get; set; }
+
+    /// <summary>Custom endpoint attribution rules that add to or replace built-in rules by RuleId.</summary>
+    public List<EndpointAttributionRule> EndpointAttributionRules { get; } = new();
 
     /// <summary>When true, probes apex domains over HTTPS.</summary>
     public bool IncludeApexHttps { get; set; } = true;
@@ -299,6 +315,9 @@ public sealed class CertificateInventoryCaptureOptions {
     /// <summary>Timeout applied to mail TLS probes.</summary>
     public TimeSpan MailTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
+    /// <summary>Timeout applied to explicit and implicit FTP TLS probes.</summary>
+    public TimeSpan FtpTlsTimeout { get; set; } = TimeSpan.FromSeconds(15);
+
     /// <summary>Timeout applied to HTTPS certificate probes.</summary>
     public TimeSpan HttpsTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
@@ -311,7 +330,7 @@ public sealed class CertificateInventoryCaptureOptions {
     /// </summary>
     public bool PreferTlsHandshakeOnlyProbe { get; set; }
 
-    /// <summary>Maximum total probe targets (HTTPS + mail) kept after discovery; 0 means unlimited.</summary>
+    /// <summary>Maximum total probe targets (HTTPS + mail + FTP TLS) kept after discovery; 0 means unlimited.</summary>
     public int MaxTargets { get; set; }
 
     /// <summary>Maximum number of probe starts per second; 0 means unlimited.</summary>
@@ -433,6 +452,7 @@ public sealed class CertificateInventoryCaptureOptions {
     /// Supported forms:
     /// - https://host[:port], http://host[:port]
     /// - smtp://host[:port], submission://host[:port], imap://host[:port], pop3://host[:port], imaps://host[:port], pop3s://host[:port]
+    /// - ftps://host[:port] (implicit TLS by default), ftps-explicit://host[:port], ftpes://host[:port], ftp+tls://host[:port]
     /// - host or host:port (treated as HTTPS).
     /// </summary>
     public List<string> AdditionalEndpoints { get; } = new();
@@ -460,6 +480,9 @@ public sealed class CertificateInventoryCaptureResult {
     /// <summary>Mail endpoint probe count.</summary>
     public int MailEndpointCount { get; set; }
 
+    /// <summary>FTP TLS endpoint probe count.</summary>
+    public int FtpTlsEndpointCount { get; set; }
+
     /// <summary>Total snapshot entry count.</summary>
     public int EntryCount { get; set; }
 
@@ -472,6 +495,9 @@ public sealed class CertificateInventoryCaptureResult {
     /// <summary>Mail endpoints reused from recent snapshots.</summary>
     public int ReusedRecentMailCount { get; set; }
 
+    /// <summary>FTP TLS endpoints reused from recent snapshots.</summary>
+    public int ReusedRecentFtpTlsCount { get; set; }
+
     /// <summary>Total endpoints reused specifically because of stable recent failures.</summary>
     public int ReusedRecentFailureEntryCount { get; set; }
 
@@ -481,11 +507,17 @@ public sealed class CertificateInventoryCaptureResult {
     /// <summary>Mail endpoints reused specifically because of stable recent failures.</summary>
     public int ReusedRecentFailureMailCount { get; set; }
 
+    /// <summary>FTP TLS endpoints reused specifically because of stable recent failures.</summary>
+    public int ReusedRecentFailureFtpTlsCount { get; set; }
+
     /// <summary>HTTPS endpoints that required live probing in this run.</summary>
     public int ProbedHttpsCount { get; set; }
 
     /// <summary>Mail endpoints that required live probing in this run.</summary>
     public int ProbedMailCount { get; set; }
+
+    /// <summary>FTP TLS endpoints that required live probing in this run.</summary>
+    public int ProbedFtpTlsCount { get; set; }
 
     /// <summary>CT-discovered subdomain count included for HTTPS probing.</summary>
     public int CtDiscoveredSubdomainCount { get; set; }
@@ -526,11 +558,17 @@ public sealed class CertificateInventoryCaptureResult {
     /// <summary>Mail target count before applying MaxTargets capping.</summary>
     public int MailTargetCountBeforeLimit { get; set; }
 
+    /// <summary>FTP TLS target count before applying MaxTargets capping.</summary>
+    public int FtpTlsTargetCountBeforeLimit { get; set; }
+
     /// <summary>HTTPS targets dropped by MaxTargets capping.</summary>
     public int HttpsTargetCountDroppedByLimit { get; set; }
 
     /// <summary>Mail targets dropped by MaxTargets capping.</summary>
     public int MailTargetCountDroppedByLimit { get; set; }
+
+    /// <summary>FTP TLS targets dropped by MaxTargets capping.</summary>
+    public int FtpTlsTargetCountDroppedByLimit { get; set; }
 
     /// <summary>Counts of final entries by target-origin tag. Entries with multiple origins contribute to each matching tag.</summary>
     public IReadOnlyDictionary<string, int> TargetOriginCounts { get; set; } =
@@ -540,7 +578,7 @@ public sealed class CertificateInventoryCaptureResult {
     public IReadOnlyDictionary<string, int> CaptureDispositionCounts { get; set; } =
         new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
-    /// <summary>Unique endpoint count (host+port).</summary>
+    /// <summary>Unique endpoint count (logical host+port+service).</summary>
     public int UniqueEndpointCount { get; set; }
 
     /// <summary>Entries with valid certificates.</summary>
@@ -577,6 +615,9 @@ public sealed class CertificateInventoryCaptureResult {
 
     /// <summary>Mail endpoints probed in this run.</summary>
     public IReadOnlyList<string> MailEndpoints { get; set; } = Array.Empty<string>();
+
+    /// <summary>FTP TLS endpoints probed in this run.</summary>
+    public IReadOnlyList<string> FtpTlsEndpoints { get; set; } = Array.Empty<string>();
 
     /// <summary>Non-fatal warnings captured during discovery/probing.</summary>
     public IReadOnlyList<string> Warnings { get; set; } = Array.Empty<string>();
@@ -632,6 +673,16 @@ public sealed partial class CertificateInventoryCapture {
         public List<string> TargetOrigins { get; set; } = new();
     }
 
+    private sealed class FtpTlsEndpointTarget {
+        public string Host { get; set; } = string.Empty;
+        public int Port { get; set; }
+        public FtpTlsMode Mode { get; set; }
+        public string Scheme { get; set; } = string.Empty;
+        public string Service { get; set; } = string.Empty;
+        public List<string> TargetOrigins { get; set; } = new();
+        public string Key => CertificateEndpointIdentity.Create(Host, Port, Service).Key;
+    }
+
     private sealed class ProbeStartRateLimiter {
         private readonly int _intervalMilliseconds;
         private readonly object _sync = new();
@@ -670,6 +721,7 @@ public sealed partial class CertificateInventoryCapture {
 
     internal Func<string, DnsConfiguration, int, CancellationToken, Task<IReadOnlyList<string>>>? MxLookupOverride { get; set; }
     internal Func<IReadOnlyList<string>, CertificateInventoryCaptureOptions, InternalLogger?, CancellationToken, Task<IReadOnlyList<CertificateMonitor.Entry>>>? HttpsProbeOverride { get; set; }
+    internal Func<string, DnsRecordType, CancellationToken, Task<DnsAnswer[]>>? EndpointDnsQueryOverride { get; set; }
     internal Func<IReadOnlyList<string>, CertificateInventoryCaptureOptions, InternalLogger?, CancellationToken, Task<IReadOnlyList<SubdomainDiscoveryEntry>>>? CtSubdomainEntryDiscoveryOverride { get; set; }
     internal Func<IReadOnlyList<string>, CertificateInventoryCaptureOptions, InternalLogger?, CancellationToken, Task<IReadOnlyList<string>>>? CtSubdomainDiscoveryOverride { get; set; }
     internal Func<IReadOnlyList<string>, CertificateInventoryCaptureOptions, InternalLogger?, CancellationToken, Task<IReadOnlyList<SubdomainDiscoveryEntry>>>? CtPassiveMetadataBackfillOverride { get; set; }
@@ -718,11 +770,17 @@ public sealed partial class CertificateInventoryCapture {
         if (options.MailTimeout <= TimeSpan.Zero || options.MailTimeout > TimeSpan.FromMinutes(10)) {
             throw new ArgumentOutOfRangeException(nameof(options.MailTimeout), "MailTimeout must be greater than zero and at most 10 minutes.");
         }
+        if (options.FtpTlsTimeout <= TimeSpan.Zero || options.FtpTlsTimeout > TimeSpan.FromMinutes(10)) {
+            throw new ArgumentOutOfRangeException(nameof(options.FtpTlsTimeout), "FtpTlsTimeout must be greater than zero and at most 10 minutes.");
+        }
         if (options.MaxTargets < 0) {
             throw new ArgumentOutOfRangeException(nameof(options.MaxTargets), "MaxTargets must be 0 or greater.");
         }
         if (options.MaxProbeStartsPerSecond < 0) {
             throw new ArgumentOutOfRangeException(nameof(options.MaxProbeStartsPerSecond), "MaxProbeStartsPerSecond must be 0 or greater.");
+        }
+        if (options.DnsEnrichmentParallelism < 1 || options.DnsEnrichmentParallelism > 512) {
+            throw new ArgumentOutOfRangeException(nameof(options.DnsEnrichmentParallelism), "DnsEnrichmentParallelism must be between 1 and 512.");
         }
         if (options.RecentSnapshotTtl < TimeSpan.Zero) {
             throw new ArgumentOutOfRangeException(nameof(options.RecentSnapshotTtl), "RecentSnapshotTtl must be non-negative.");
@@ -821,7 +879,7 @@ public sealed partial class CertificateInventoryCapture {
         var targetDecisionDiagnostics = new List<TargetDecisionDiagnosticEntry>();
         var ctDiscoveredSubdomains = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var ctDiscoveredSubdomainEntries = new Dictionary<string, SubdomainDiscoveryEntry>(StringComparer.OrdinalIgnoreCase);
-        const int totalStages = 9;
+        const int totalStages = 10;
         var stage = 0;
         void AdvanceStage(string currentOperation) {
             stage++;
@@ -864,6 +922,7 @@ public sealed partial class CertificateInventoryCapture {
         var httpsTargets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var httpsTargetOriginsByEndpointKey = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
         var mailTargets = new Dictionary<string, MailEndpointTarget>(StringComparer.OrdinalIgnoreCase);
+        var ftpTlsTargets = new Dictionary<string, FtpTlsEndpointTarget>(StringComparer.OrdinalIgnoreCase);
         var ctPromotedHttpsCount = 0;
         var ctSkippedHttpsPromotionCount = 0;
         var ctSkippedUnresolvedHttpsPromotionCount = 0;
@@ -1074,7 +1133,7 @@ public sealed partial class CertificateInventoryCapture {
             mxPromotedMailCount += mailTargets.Count - mailCountBefore;
         }
 
-        ApplyAdditionalEndpoints(options, httpsTargets, httpsTargetOriginsByEndpointKey, mailTargets, warnings, targetDecisionDiagnostics);
+        ApplyAdditionalEndpoints(options, httpsTargets, httpsTargetOriginsByEndpointKey, mailTargets, ftpTlsTargets, warnings, targetDecisionDiagnostics);
         IReadOnlyDictionary<string, RecentInventoryEndpointEntry> recentByEndpoint =
             new Dictionary<string, RecentInventoryEndpointEntry>(StringComparer.OrdinalIgnoreCase);
         if (ShouldLoadRecentSnapshotEntries(options)) {
@@ -1084,6 +1143,9 @@ public sealed partial class CertificateInventoryCapture {
             } else {
                 recentByEndpoint = LoadRecentSnapshotEntries(options, now);
             }
+            recentByEndpoint = recentByEndpoint
+                .Where(pair => ProbeVantageMatches(pair.Value.Entry, options.ProbeVantage))
+                .ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.OrdinalIgnoreCase);
         }
 
         var cachedEntries = new List<CertificateInventoryEntry>();
@@ -1092,8 +1154,10 @@ public sealed partial class CertificateInventoryCapture {
         var mailTargetsToProbe = mailTargets.Values.ToList();
         var reusedHttps = 0;
         var reusedMail = 0;
+        var reusedFtpTls = 0;
         var reusedStableFailureHttps = 0;
         var reusedStableFailureMail = 0;
+        var reusedStableFailureFtpTls = 0;
         if (ShouldLoadRecentSnapshotEntries(options)) {
             var now = DateTimeOffset.UtcNow;
 
@@ -1189,6 +1253,7 @@ public sealed partial class CertificateInventoryCapture {
 
         var httpsTargetCountBeforeLimit = httpsTargets.Count;
         var mailTargetCountBeforeLimit = mailTargets.Count;
+        var ftpTlsTargetCountBeforeLimit = ftpTlsTargets.Count;
         ApplyTargetLimitIncludingReusedSuccesses(
             options,
             httpsTargets,
@@ -1202,10 +1267,40 @@ public sealed partial class CertificateInventoryCapture {
             targetDecisionDiagnostics,
             ref reusedHttps,
             ref reusedMail);
+        if (options.MaxTargets > 0 && ftpTlsTargets.Count > 0) {
+            int occupied = httpsTargets.Count + mailTargets.Count + cachedEntries.Count;
+            int available = Math.Max(0, options.MaxTargets - occupied);
+            if (ftpTlsTargets.Count > available) {
+                FtpTlsEndpointTarget[] kept = ftpTlsTargets.Values
+                    .OrderBy(target => target.Host, StringComparer.OrdinalIgnoreCase)
+                    .ThenBy(target => target.Port)
+                    .ThenBy(target => target.Service, StringComparer.OrdinalIgnoreCase)
+                    .Take(available)
+                    .ToArray();
+                FtpTlsEndpointTarget[] dropped = ftpTlsTargets.Values.Except(kept).ToArray();
+                ftpTlsTargets.Clear();
+                foreach (FtpTlsEndpointTarget target in kept) {
+                    ftpTlsTargets[target.Key] = target;
+                }
+                foreach (FtpTlsEndpointTarget target in dropped) {
+                    targetDecisionDiagnostics.Add(new TargetDecisionDiagnosticEntry {
+                        Stage = "target-limit",
+                        Action = "dropped",
+                        Reason = "max-targets",
+                        Target = $"{target.Scheme}://{target.Host}:{target.Port}",
+                        Service = target.Service,
+                        Message = "FTP TLS endpoint was outside the global MaxTargets budget."
+                    });
+                }
+                warnings.Add($"FTP TLS target list capped from {ftpTlsTargetCountBeforeLimit} to {ftpTlsTargets.Count} by the remaining MaxTargets budget.");
+            }
+        }
         var httpsTargetCountDroppedByLimit = Math.Max(0, httpsTargetCountBeforeLimit - httpsTargets.Count);
         var mailTargetCountDroppedByLimit = Math.Max(0, mailTargetCountBeforeLimit - mailTargets.Count);
+        var ftpTlsTargetCountDroppedByLimit = Math.Max(0, ftpTlsTargetCountBeforeLimit - ftpTlsTargets.Count);
         httpsTargetsToProbe = httpsTargets.ToList();
         mailTargetsToProbe = mailTargets.Values.ToList();
+        var ftpTlsTargetsToProbe = ftpTlsTargets.Values.ToList();
 
         if (ShouldLoadRecentSnapshotEntries(options) && recentByEndpoint.Count > 0) {
             var now = DateTimeOffset.UtcNow;
@@ -1248,17 +1343,39 @@ public sealed partial class CertificateInventoryCapture {
             }
             mailTargetsToProbe = filteredMail;
 
+            var filteredFtpTls = new List<FtpTlsEndpointTarget>(ftpTlsTargetsToProbe.Count);
+            foreach (FtpTlsEndpointTarget target in ftpTlsTargetsToProbe) {
+                if (recentByEndpoint.TryGetValue(target.Key, out var cached) &&
+                    TryReuseCachedEntry(cached, now, options, out bool reusedStableFailure)) {
+                    ApplyEntryProvenance(
+                        cached.Entry,
+                        target.TargetOrigins,
+                        reusedStableFailure ? CaptureDispositionReusedRecentStableFailure : CaptureDispositionReusedRecentSuccess,
+                        replaceTargetOrigins: true);
+                    cachedEntries.Add(cached.Entry);
+                    reusedFtpTls++;
+                    if (reusedStableFailure) {
+                        reusedStableFailureFtpTls++;
+                    }
+                } else {
+                    filteredFtpTls.Add(target);
+                }
+            }
+            ftpTlsTargetsToProbe = filteredFtpTls;
+
             logger.WriteVerbose(
-                "Reused {0} cached endpoint result(s) from recent snapshots (HTTPS: {1}, Mail: {2}, StableFailureHTTPS: {3}, StableFailureMail: {4}).",
-                reusedHttps + reusedMail,
+                "Reused {0} cached endpoint result(s) from recent snapshots (HTTPS: {1}, Mail: {2}, FTPTLS: {3}, StableFailureHTTPS: {4}, StableFailureMail: {5}, StableFailureFTPTLS: {6}).",
+                reusedHttps + reusedMail + reusedFtpTls,
                 reusedHttps,
                 reusedMail,
+                reusedFtpTls,
                 reusedStableFailureHttps,
-                reusedStableFailureMail);
+                reusedStableFailureMail,
+                reusedStableFailureFtpTls);
         }
 
         AdvanceStage("Endpoint expansion");
-        logger.WriteVerbose("Prepared {0} HTTPS target(s) and {1} mail target(s).", httpsTargets.Count, mailTargets.Count);
+        logger.WriteVerbose("Prepared {0} HTTPS target(s), {1} mail target(s), and {2} FTP TLS target(s).", httpsTargets.Count, mailTargets.Count, ftpTlsTargets.Count);
         AdvanceStage("Recent snapshot cache");
 
         IReadOnlyList<CertificateMonitor.Entry> httpsEntries;
@@ -1274,7 +1391,11 @@ public sealed partial class CertificateInventoryCapture {
         AdvanceStage("Mail TLS probing");
         logger.WriteVerbose("Mail TLS probing produced {0} observation(s).", mailEntries.Count);
 
-        var allEntries = new List<CertificateInventoryEntry>(cachedEntries.Count + httpsEntries.Count + mailEntries.Count);
+        var ftpTlsEntries = await ProbeFtpTlsAsync(ftpTlsTargetsToProbe, options, logger, cancellationToken).ConfigureAwait(false);
+        AdvanceStage("FTP TLS probing");
+        logger.WriteVerbose("FTP TLS probing produced {0} observation(s).", ftpTlsEntries.Count);
+
+        var allEntries = new List<CertificateInventoryEntry>(cachedEntries.Count + httpsEntries.Count + mailEntries.Count + ftpTlsEntries.Count);
         allEntries.AddRange(cachedEntries);
         foreach (var httpsEntry in httpsEntries) {
             var inventoryEntry = CertificateMonitor.ToInventoryEntry(httpsEntry);
@@ -1285,9 +1406,11 @@ public sealed partial class CertificateInventoryCapture {
             allEntries.Add(inventoryEntry);
         }
         allEntries.AddRange(mailEntries);
+        allEntries.AddRange(ftpTlsEntries);
 
         var deduped = DeduplicateEntries(allEntries);
         var capturedAtUtc = DateTimeOffset.UtcNow;
+        await EnrichEndpointObservationsAsync(deduped, options, capturedAtUtc, warnings, cancellationToken).ConfigureAwait(false);
         EnrichEntriesWithCtSubdomainMetadata(deduped, ctDiscoveredSubdomainEntries, capturedAtUtc);
         var distinctPorts = deduped
             .Select(e => e.Port)
@@ -1322,13 +1445,12 @@ public sealed partial class CertificateInventoryCapture {
         }
         AdvanceStage("Snapshot persistence");
 
-        var uniqueEndpoints = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var uniqueEndpoints = new HashSet<CertificateEndpointIdentity>();
         var validCount = 0;
         var expiredCount = 0;
         var failedCount = 0;
         foreach (var entry in deduped) {
-            var host = !string.IsNullOrWhiteSpace(entry.ResolvedHost) ? entry.ResolvedHost! : entry.Host;
-            uniqueEndpoints.Add($"{host}:{entry.Port}");
+            uniqueEndpoints.Add(CertificateEndpointIdentity.FromEntry(entry));
             if (entry.Valid) {
                 validCount++;
             }
@@ -1349,15 +1471,19 @@ public sealed partial class CertificateInventoryCapture {
             MxHostCount = mxHosts.Count,
             HttpsEndpointCount = httpsTargets.Count,
             MailEndpointCount = mailTargets.Count,
+            FtpTlsEndpointCount = ftpTlsTargets.Count,
             EntryCount = deduped.Count,
-            ReusedRecentEntryCount = reusedHttps + reusedMail,
+            ReusedRecentEntryCount = reusedHttps + reusedMail + reusedFtpTls,
             ReusedRecentHttpsCount = reusedHttps,
             ReusedRecentMailCount = reusedMail,
-            ReusedRecentFailureEntryCount = reusedStableFailureHttps + reusedStableFailureMail,
+            ReusedRecentFtpTlsCount = reusedFtpTls,
+            ReusedRecentFailureEntryCount = reusedStableFailureHttps + reusedStableFailureMail + reusedStableFailureFtpTls,
             ReusedRecentFailureHttpsCount = reusedStableFailureHttps,
             ReusedRecentFailureMailCount = reusedStableFailureMail,
+            ReusedRecentFailureFtpTlsCount = reusedStableFailureFtpTls,
             ProbedHttpsCount = httpsTargetsToProbe.Count,
             ProbedMailCount = mailTargetsToProbe.Count,
+            ProbedFtpTlsCount = ftpTlsTargetsToProbe.Count,
             CtDiscoveredSubdomainCount = ctDiscoveredSubdomains.Count,
             CtPromotedHttpsCount = ctPromotedHttpsCount,
             CtSkippedHttpsPromotionCount = ctSkippedHttpsPromotionCount,
@@ -1371,8 +1497,10 @@ public sealed partial class CertificateInventoryCapture {
             MxSkippedDuplicateHttpsPromotionCount = mxSkippedDuplicateHttpsPromotionCount,
             HttpsTargetCountBeforeLimit = httpsTargetCountBeforeLimit,
             MailTargetCountBeforeLimit = mailTargetCountBeforeLimit,
+            FtpTlsTargetCountBeforeLimit = ftpTlsTargetCountBeforeLimit,
             HttpsTargetCountDroppedByLimit = httpsTargetCountDroppedByLimit,
             MailTargetCountDroppedByLimit = mailTargetCountDroppedByLimit,
+            FtpTlsTargetCountDroppedByLimit = ftpTlsTargetCountDroppedByLimit,
             TargetOriginCounts = BuildTargetOriginCounts(deduped),
             CaptureDispositionCounts = BuildCaptureDispositionCounts(deduped),
             UniqueEndpointCount = uniqueEndpoints.Count,
@@ -1392,6 +1520,12 @@ public sealed partial class CertificateInventoryCapture {
                 .OrderBy(x => x.Host, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(x => x.Port)
                 .Select(BuildMailTargetLabel)
+                .ToList(),
+            FtpTlsEndpoints = ftpTlsTargets.Values
+                .OrderBy(x => x.Host, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(x => x.Port)
+                .ThenBy(x => x.Service, StringComparer.OrdinalIgnoreCase)
+                .Select(x => $"{x.Scheme}://{x.Host}:{x.Port}")
                 .ToList(),
             Warnings = warnings,
             NativeCtLogDiagnostics = nativeCtLogDiagnostics,

--- a/DomainDetective/CertificateInventoryDiffAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDiffAnalyzer.cs
@@ -258,7 +258,7 @@ namespace DomainDetective {
         }
 
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
-            return CertificateInventoryEndpointKey.Build(entry, includeServiceDimension: false);
+            return CertificateInventoryEndpointKey.Build(entry);
         }
 
         private static int NormalizePort(int port) {

--- a/DomainDetective/CertificateInventoryDiffAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDiffAnalyzer.cs
@@ -42,6 +42,8 @@ namespace DomainDetective {
         public string Host { get; set; } = string.Empty;
         /// <summary>Gets or sets the port value.</summary>
         public int Port { get; set; }
+        /// <summary>Gets or sets the normalized probe vantage value.</summary>
+        public string ProbeVantage { get; set; } = CertificateInventoryProbeVantage.Default;
         /// <summary>Gets or sets the status value.</summary>
         public string Status { get; set; } = "Unchanged";
         /// <summary>Gets or sets the previous service value.</summary>
@@ -140,9 +142,11 @@ namespace DomainDetective {
                 if (hasCurrent) {
                     row.Host = after!.ResolvedHost ?? after.Host;
                     row.Port = NormalizePort(after.Port);
+                    row.ProbeVantage = CertificateInventoryProbeVantage.Normalize(after.ProbeVantage);
                 } else if (hasPrevious) {
                     row.Host = before!.ResolvedHost ?? before.Host;
                     row.Port = NormalizePort(before.Port);
+                    row.ProbeVantage = CertificateInventoryProbeVantage.Normalize(before.ProbeVantage);
                 }
 
                 if (!hasPrevious && hasCurrent) {
@@ -183,6 +187,7 @@ namespace DomainDetective {
                 .OrderBy(row => StatusOrder(row.Status))
                 .ThenBy(row => row.Host, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(row => row.Port)
+                .ThenBy(row => row.ProbeVantage, StringComparer.OrdinalIgnoreCase)
                 .Take(Math.Max(0, maxEndpoints))
                 .ToList();
             return summary;
@@ -258,7 +263,7 @@ namespace DomainDetective {
         }
 
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
-            return CertificateInventoryEndpointKey.Build(entry);
+            return CertificateInventoryEndpointKey.Build(entry) + "|" + CertificateInventoryProbeVantage.Normalize(entry.ProbeVantage);
         }
 
         private static int NormalizePort(int port) {

--- a/DomainDetective/CertificateInventoryDiffAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDiffAnalyzer.cs
@@ -127,6 +127,8 @@ namespace DomainDetective {
 
             var previousMap = BuildEndpointMap(previous);
             var currentMap = BuildEndpointMap(current);
+            Dictionary<string, string> serviceChangePairs = BuildUniqueServiceChangePairs(previousMap, currentMap);
+            var serviceChangeTargets = new HashSet<string>(serviceChangePairs.Values, StringComparer.OrdinalIgnoreCase);
             summary.PreviousEndpointCount = previousMap.Count;
             summary.CurrentEndpointCount = currentMap.Count;
 
@@ -137,6 +139,12 @@ namespace DomainDetective {
             foreach (var key in keys) {
                 var hasPrevious = previousMap.TryGetValue(key, out var before);
                 var hasCurrent = currentMap.TryGetValue(key, out var after);
+                if (hasPrevious && !hasCurrent && serviceChangePairs.TryGetValue(key, out string? currentKey)) {
+                    after = currentMap[currentKey];
+                    hasCurrent = true;
+                } else if (!hasPrevious && hasCurrent && serviceChangeTargets.Contains(key)) {
+                    continue;
+                }
 
                 var row = new CertificateInventoryEndpointDiff();
                 if (hasCurrent) {
@@ -262,8 +270,35 @@ namespace DomainDetective {
             return map;
         }
 
+        private static Dictionary<string, string> BuildUniqueServiceChangePairs(
+            IReadOnlyDictionary<string, CertificateInventoryEntry> previousMap,
+            IReadOnlyDictionary<string, CertificateInventoryEntry> currentMap) {
+            var pairs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            var previousBySlot = previousMap
+                .Where(pair => !currentMap.ContainsKey(pair.Key))
+                .GroupBy(pair => BuildCorrelationKey(pair.Value), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+            var currentBySlot = currentMap
+                .Where(pair => !previousMap.ContainsKey(pair.Key))
+                .GroupBy(pair => BuildCorrelationKey(pair.Value), StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+            foreach (KeyValuePair<string, List<KeyValuePair<string, CertificateInventoryEntry>>> slot in previousBySlot) {
+                if (slot.Value.Count == 1 &&
+                    currentBySlot.TryGetValue(slot.Key, out List<KeyValuePair<string, CertificateInventoryEntry>>? currentEntries) &&
+                    currentEntries.Count == 1) {
+                    pairs[slot.Value[0].Key] = currentEntries[0].Key;
+                }
+            }
+            return pairs;
+        }
+
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
             return CertificateInventoryEndpointKey.Build(entry) + "|" + CertificateInventoryProbeVantage.Normalize(entry.ProbeVantage);
+        }
+
+        private static string BuildCorrelationKey(CertificateInventoryEntry entry) {
+            return CertificateInventoryEndpointKey.Build(entry, includeServiceDimension: false) +
+                   "|" + CertificateInventoryProbeVantage.Normalize(entry.ProbeVantage);
         }
 
         private static int NormalizePort(int port) {

--- a/DomainDetective/CertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDriftAnalyzer.cs
@@ -63,6 +63,10 @@ namespace DomainDetective {
         public int Port { get; set; }
         /// <summary>Gets or sets the service value.</summary>
         public string Service { get; set; } = string.Empty;
+        /// <summary>Gets or sets the previous service value.</summary>
+        public string? PreviousService { get; set; }
+        /// <summary>Gets or sets the current service value.</summary>
+        public string? CurrentService { get; set; }
         /// <summary>Gets or sets the probe vantage whose observations form this history.</summary>
         public string ProbeVantage { get; set; } = "default";
         /// <summary>Gets or sets the first seen utc value.</summary>
@@ -187,9 +191,10 @@ namespace DomainDetective {
                 }
             }
 
-            var driftRows = new List<CertificateInventoryEndpointDrift>(grouped.Count);
-            foreach (var pair in grouped) {
-                var observations = pair.Value
+            List<List<Observation>> histories = BuildObservationHistories(grouped.Values);
+            var driftRows = new List<CertificateInventoryEndpointDrift>(histories.Count);
+            foreach (List<Observation> history in histories) {
+                var observations = history
                     .GroupBy(o => o.ObservedAtUtc)
                     .Select(group => group
                         .OrderBy(o => o.SnapshotCapturedAtUtc)
@@ -221,10 +226,7 @@ namespace DomainDetective {
                     var expiry = observation.Entry.NotAfterUtc?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty;
                     expiries.Add(expiry);
 
-                    var service = string.IsNullOrWhiteSpace(observation.Entry.Service)
-                        ? CertificateServiceClassifier.GuessService(observation.Entry.Scheme ?? "https", observation.Entry.Port)
-                        : observation.Entry.Service!;
-                    services.Add(service);
+                    services.Add(PickService(observation.Entry));
 
                     var authenticationProfile = CertificateInventoryEntryHelpers.ResolveAuthenticationProfile(observation.Entry);
                     authenticationProfiles.Add(authenticationProfile);
@@ -245,9 +247,9 @@ namespace DomainDetective {
                 var row = new CertificateInventoryEndpointDrift {
                     Host = latest.Entry.ResolvedHost ?? latest.Entry.Host,
                     Port = latest.Entry.Port > 0 ? latest.Entry.Port : 443,
-                    Service = string.IsNullOrWhiteSpace(latest.Entry.Service)
-                        ? CertificateServiceClassifier.GuessService(latest.Entry.Scheme ?? "https", latest.Entry.Port)
-                        : latest.Entry.Service!,
+                    Service = PickService(latest.Entry),
+                    PreviousService = previous != null ? PickService(previous.Entry) : null,
+                    CurrentService = PickService(latest.Entry),
                     ProbeVantage = CertificateInventoryProbeVantage.Normalize(latest.Entry.ProbeVantage),
                     FirstSeenUtc = observations[0].ObservedAtUtc,
                     LastSeenUtc = latest.ObservedAtUtc,
@@ -301,7 +303,7 @@ namespace DomainDetective {
                 driftRows.Add(row);
             }
 
-            summary.EndpointCount = grouped.Count;
+            summary.EndpointCount = histories.Count;
             summary.EndpointsMatchingFilters = driftRows.Count;
             summary.EndpointsExcludedByFilters =
                 summary.EndpointsExcludedByChangedOnly +
@@ -363,13 +365,7 @@ namespace DomainDetective {
                 return true;
             }
 
-            var previousService = string.IsNullOrWhiteSpace(previous.Service)
-                ? CertificateServiceClassifier.GuessService(previous.Scheme ?? "https", previous.Port)
-                : previous.Service!;
-            var currentService = string.IsNullOrWhiteSpace(current.Service)
-                ? CertificateServiceClassifier.GuessService(current.Scheme ?? "https", current.Port)
-                : current.Service!;
-            if (!string.Equals(previousService, currentService, StringComparison.OrdinalIgnoreCase)) {
+            if (!string.Equals(PickService(previous), PickService(current), StringComparison.OrdinalIgnoreCase)) {
                 return true;
             }
 
@@ -386,6 +382,64 @@ namespace DomainDetective {
 
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
             return CertificateInventoryEndpointKey.Build(entry) + "|" + CertificateInventoryProbeVantage.Normalize(entry.ProbeVantage);
+        }
+
+        private static string BuildCorrelationKey(CertificateInventoryEntry entry) {
+            return CertificateInventoryEndpointKey.Build(entry, includeServiceDimension: false) +
+                   "|" + CertificateInventoryProbeVantage.Normalize(entry.ProbeVantage);
+        }
+
+        private static List<List<Observation>> BuildObservationHistories(IEnumerable<List<Observation>> serviceHistories) {
+            var histories = new List<List<Observation>>();
+            foreach (IGrouping<string, List<Observation>> slot in serviceHistories.GroupBy(
+                         history => BuildCorrelationKey(history[0].Entry),
+                         StringComparer.OrdinalIgnoreCase)) {
+                var activeByService = new Dictionary<string, List<Observation>>(StringComparer.OrdinalIgnoreCase);
+                foreach (IGrouping<DateTimeOffset, Observation> snapshot in slot
+                             .SelectMany(history => history)
+                             .GroupBy(observation => observation.SnapshotCapturedAtUtc)
+                             .OrderBy(group => group.Key)) {
+                    Dictionary<string, List<Observation>> currentByService = snapshot
+                        .GroupBy(observation => PickService(observation.Entry), StringComparer.OrdinalIgnoreCase)
+                        .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+                    var nextActiveByService = new Dictionary<string, List<Observation>>(StringComparer.OrdinalIgnoreCase);
+
+                    foreach (KeyValuePair<string, List<Observation>> current in currentByService) {
+                        if (!activeByService.TryGetValue(current.Key, out List<Observation>? history)) {
+                            continue;
+                        }
+                        history.AddRange(current.Value);
+                        nextActiveByService[current.Key] = history;
+                    }
+
+                    List<KeyValuePair<string, List<Observation>>> previousUnmatched = activeByService
+                        .Where(previous => !currentByService.ContainsKey(previous.Key))
+                        .ToList();
+                    List<KeyValuePair<string, List<Observation>>> currentUnmatched = currentByService
+                        .Where(current => !activeByService.ContainsKey(current.Key))
+                        .ToList();
+                    if (previousUnmatched.Count == 1 && currentUnmatched.Count == 1) {
+                        List<Observation> transitionHistory = previousUnmatched[0].Value;
+                        transitionHistory.AddRange(currentUnmatched[0].Value);
+                        nextActiveByService[currentUnmatched[0].Key] = transitionHistory;
+                    } else {
+                        foreach (KeyValuePair<string, List<Observation>> current in currentUnmatched) {
+                            var history = new List<Observation>(current.Value);
+                            histories.Add(history);
+                            nextActiveByService[current.Key] = history;
+                        }
+                    }
+
+                    activeByService = nextActiveByService;
+                }
+            }
+            return histories;
+        }
+
+        private static string PickService(CertificateInventoryEntry entry) {
+            return string.IsNullOrWhiteSpace(entry.Service)
+                ? CertificateServiceClassifier.GuessService(entry.Scheme ?? "https", entry.Port)
+                : entry.Service!;
         }
 
         private static string PickIssuer(CertificateInventoryEntry entry) {

--- a/DomainDetective/CertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDriftAnalyzer.cs
@@ -374,7 +374,7 @@ namespace DomainDetective {
         }
 
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
-            return CertificateInventoryEndpointKey.Build(entry, includeServiceDimension: false);
+            return CertificateInventoryEndpointKey.Build(entry);
         }
 
         private static string PickIssuer(CertificateInventoryEntry entry) {

--- a/DomainDetective/CertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDriftAnalyzer.cs
@@ -63,6 +63,8 @@ namespace DomainDetective {
         public int Port { get; set; }
         /// <summary>Gets or sets the service value.</summary>
         public string Service { get; set; } = string.Empty;
+        /// <summary>Gets or sets the probe vantage whose observations form this history.</summary>
+        public string ProbeVantage { get; set; } = "default";
         /// <summary>Gets or sets the first seen utc value.</summary>
         public DateTimeOffset? FirstSeenUtc { get; set; }
         /// <summary>Gets or sets the last seen utc value.</summary>
@@ -240,6 +242,7 @@ namespace DomainDetective {
                     Service = string.IsNullOrWhiteSpace(latest.Entry.Service)
                         ? CertificateServiceClassifier.GuessService(latest.Entry.Scheme ?? "https", latest.Entry.Port)
                         : latest.Entry.Service!,
+                    ProbeVantage = NormalizeProbeVantage(latest.Entry.ProbeVantage),
                     FirstSeenUtc = observations[0].CapturedAtUtc,
                     LastSeenUtc = latest.CapturedAtUtc,
                     ObservationCount = observations.Count,
@@ -315,6 +318,8 @@ namespace DomainDetective {
                 .OrderByDescending(row => row.LastChangedAtUtc ?? DateTimeOffset.MinValue)
                 .ThenBy(row => row.Host, StringComparer.OrdinalIgnoreCase)
                 .ThenBy(row => row.Port)
+                .ThenBy(row => row.Service, StringComparer.OrdinalIgnoreCase)
+                .ThenBy(row => row.ProbeVantage, StringComparer.OrdinalIgnoreCase)
                 .Take(effectiveMaxEndpoints)
                 .ToList();
 
@@ -374,8 +379,11 @@ namespace DomainDetective {
         }
 
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
-            return CertificateInventoryEndpointKey.Build(entry);
+            return CertificateInventoryEndpointKey.Build(entry) + "|" + NormalizeProbeVantage(entry.ProbeVantage);
         }
+
+        private static string NormalizeProbeVantage(string? probeVantage) =>
+            string.IsNullOrWhiteSpace(probeVantage) ? "default" : probeVantage!.Trim();
 
         private static string PickIssuer(CertificateInventoryEntry entry) {
             if (!string.IsNullOrWhiteSpace(entry.CertificateIssuerNormalized)) {

--- a/DomainDetective/CertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDriftAnalyzer.cs
@@ -242,7 +242,7 @@ namespace DomainDetective {
                     Service = string.IsNullOrWhiteSpace(latest.Entry.Service)
                         ? CertificateServiceClassifier.GuessService(latest.Entry.Scheme ?? "https", latest.Entry.Port)
                         : latest.Entry.Service!,
-                    ProbeVantage = NormalizeProbeVantage(latest.Entry.ProbeVantage),
+                    ProbeVantage = CertificateInventoryProbeVantage.Normalize(latest.Entry.ProbeVantage),
                     FirstSeenUtc = observations[0].CapturedAtUtc,
                     LastSeenUtc = latest.CapturedAtUtc,
                     ObservationCount = observations.Count,
@@ -379,11 +379,8 @@ namespace DomainDetective {
         }
 
         private static string BuildEndpointKey(CertificateInventoryEntry entry) {
-            return CertificateInventoryEndpointKey.Build(entry) + "|" + NormalizeProbeVantage(entry.ProbeVantage);
+            return CertificateInventoryEndpointKey.Build(entry) + "|" + CertificateInventoryProbeVantage.Normalize(entry.ProbeVantage);
         }
-
-        private static string NormalizeProbeVantage(string? probeVantage) =>
-            string.IsNullOrWhiteSpace(probeVantage) ? "default" : probeVantage!.Trim();
 
         private static string PickIssuer(CertificateInventoryEntry entry) {
             if (!string.IsNullOrWhiteSpace(entry.CertificateIssuerNormalized)) {

--- a/DomainDetective/CertificateInventoryDriftAnalyzer.cs
+++ b/DomainDetective/CertificateInventoryDriftAnalyzer.cs
@@ -131,7 +131,8 @@ namespace DomainDetective {
         private const string ChangeKindMatchAll = "All";
 
         private sealed class Observation {
-            public DateTimeOffset CapturedAtUtc { get; init; }
+            public DateTimeOffset ObservedAtUtc { get; init; }
+            public DateTimeOffset SnapshotCapturedAtUtc { get; init; }
             public CertificateInventoryEntry Entry { get; init; } = null!;
         }
 
@@ -179,7 +180,8 @@ namespace DomainDetective {
                     }
 
                     observations.Add(new Observation {
-                        CapturedAtUtc = snapshot.CapturedAtUtc,
+                        ObservedAtUtc = entry.ObservedAtUtc ?? snapshot.CapturedAtUtc,
+                        SnapshotCapturedAtUtc = snapshot.CapturedAtUtc,
                         Entry = entry
                     });
                 }
@@ -188,7 +190,11 @@ namespace DomainDetective {
             var driftRows = new List<CertificateInventoryEndpointDrift>(grouped.Count);
             foreach (var pair in grouped) {
                 var observations = pair.Value
-                    .OrderBy(o => o.CapturedAtUtc)
+                    .GroupBy(o => o.ObservedAtUtc)
+                    .Select(group => group
+                        .OrderBy(o => o.SnapshotCapturedAtUtc)
+                        .Last())
+                    .OrderBy(o => o.ObservedAtUtc)
                     .ToList();
                 if (observations.Count == 0) {
                     continue;
@@ -243,8 +249,8 @@ namespace DomainDetective {
                         ? CertificateServiceClassifier.GuessService(latest.Entry.Scheme ?? "https", latest.Entry.Port)
                         : latest.Entry.Service!,
                     ProbeVantage = CertificateInventoryProbeVantage.Normalize(latest.Entry.ProbeVantage),
-                    FirstSeenUtc = observations[0].CapturedAtUtc,
-                    LastSeenUtc = latest.CapturedAtUtc,
+                    FirstSeenUtc = observations[0].ObservedAtUtc,
+                    LastSeenUtc = latest.ObservedAtUtc,
                     ObservationCount = observations.Count,
                     DistinctCertificateCount = certificateIds.Count,
                     PreviousCertificateId = previous != null ? BuildCertificateId(previous.Entry) : null,
@@ -331,7 +337,7 @@ namespace DomainDetective {
                 var previous = observations[i - 1].Entry;
                 var current = observations[i].Entry;
                 if (EntryChanged(previous, current)) {
-                    return observations[i].CapturedAtUtc;
+                    return observations[i].ObservedAtUtc;
                 }
             }
 

--- a/DomainDetective/CertificateInventoryEndpointKey.cs
+++ b/DomainDetective/CertificateInventoryEndpointKey.cs
@@ -1,12 +1,8 @@
-using System.Globalization;
-
 namespace DomainDetective {
     /// <summary>
     /// Provides stable endpoint key construction for certificate inventory datasets.
     /// </summary>
     internal static class CertificateInventoryEndpointKey {
-        private const string UnknownHost = "unknown-host";
-
         internal static string Build(CertificateInventoryEntry entry, bool includeServiceDimension = true) {
             if (entry == null) {
                 return Build(null, null, 443, null, null, includeServiceDimension);
@@ -42,51 +38,12 @@ namespace DomainDetective {
             string? service,
             string? scheme,
             bool includeServiceDimension = true) {
-            var normalizedHost = NormalizeHost(resolvedHost, host);
-            var normalizedPort = NormalizePort(port);
+            var candidateHost = !string.IsNullOrWhiteSpace(resolvedHost) ? resolvedHost : host;
+            var identity = CertificateEndpointIdentity.Create(candidateHost, port, service, scheme);
             if (!includeServiceDimension) {
-                return normalizedHost + "|" +
-                       normalizedPort.ToString(CultureInfo.InvariantCulture);
+                return identity.Host + "|" + identity.Port;
             }
-            var normalizedService = NormalizeService(service, scheme, normalizedPort);
-            return normalizedHost + "|" +
-                   normalizedPort.ToString(CultureInfo.InvariantCulture) + "|" +
-                   normalizedService;
-        }
-
-        private static string NormalizeHost(string? resolvedHost, string? host) {
-            var candidate = !string.IsNullOrWhiteSpace(resolvedHost)
-                ? resolvedHost
-                : host;
-            if (string.IsNullOrWhiteSpace(candidate)) {
-                return UnknownHost;
-            }
-
-            var normalized = (candidate ?? string.Empty).Trim().TrimEnd('.');
-            return normalized.Length == 0
-                ? UnknownHost
-                : normalized.ToLowerInvariant();
-        }
-
-        private static int NormalizePort(int port) {
-            return port > 0 ? port : 443;
-        }
-
-        private static string NormalizeService(string? service, string? scheme, int port) {
-            var value = service;
-            if (string.IsNullOrWhiteSpace(value)) {
-                var effectiveScheme = string.IsNullOrWhiteSpace(scheme) ? "https" : scheme!;
-                value = CertificateServiceClassifier.GuessService(
-                    effectiveScheme,
-                    port);
-            }
-
-            var normalized = (value ?? string.Empty).Trim();
-            if (normalized.Length == 0) {
-                normalized = CertificateServiceClassifier.GuessService("https", port);
-            }
-
-            return normalized.ToUpperInvariant();
+            return identity.Key;
         }
     }
 }

--- a/DomainDetective/CertificateInventoryEntryHelpers.cs
+++ b/DomainDetective/CertificateInventoryEntryHelpers.cs
@@ -1,10 +1,59 @@
 using System;
 using System.Collections.Generic;
+using System.Net;
+using DomainDetective.Network;
 
 namespace DomainDetective;
 
 internal static class CertificateInventoryEntryHelpers
 {
+    public static void NormalizeRemoteAddressEvidence(CertificateInventoryEntry entry)
+    {
+        if (entry == null)
+        {
+            return;
+        }
+
+        if (IPAddress.TryParse((entry.RemoteAddress ?? string.Empty).Trim(), out IPAddress? address) && address != null)
+        {
+            IPAddress normalized = address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
+            entry.RemoteAddress = normalized.ToString();
+            entry.RemoteAddressFamily = IpAddressClassifier.GetAddressFamilyLabel(normalized);
+            return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(entry.RemoteAddressFamily))
+        {
+            entry.RemoteAddressFamily = IpAddressClassifier.GetAddressFamilyLabel(null, entry.RemoteAddressFamily);
+        }
+    }
+
+    public static DateTimeOffset ResolveCapturedAtUtc(
+        IEnumerable<CertificateInventoryEntry>? entries,
+        DateTimeOffset candidate)
+    {
+        DateTimeOffset resolved = candidate == default ? DateTimeOffset.UtcNow : candidate;
+        if (entries == null)
+        {
+            return resolved;
+        }
+
+        foreach (CertificateInventoryEntry entry in entries)
+        {
+            if (entry == null)
+            {
+                continue;
+            }
+            resolved = Max(resolved, entry.ObservedAtUtc);
+            resolved = Max(resolved, entry.DnsObservedAtUtc);
+            resolved = Max(resolved, entry.Attribution?.EvaluatedAtUtc);
+        }
+        return resolved;
+    }
+
+    private static DateTimeOffset Max(DateTimeOffset current, DateTimeOffset? candidate) =>
+        candidate.HasValue && candidate.Value > current ? candidate.Value : current;
+
     public static string ResolveAuthenticationProfile(CertificateInventoryEntry entry)
     {
         if (!string.IsNullOrWhiteSpace(entry.AuthenticationProfile))

--- a/DomainDetective/CertificateInventoryProbeVantage.cs
+++ b/DomainDetective/CertificateInventoryProbeVantage.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace DomainDetective;
+
+internal static class CertificateInventoryProbeVantage {
+    internal const string Default = "default";
+
+    internal static string Normalize(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? Default : value!.Trim();
+
+    internal static bool Equals(string? left, string? right) =>
+        string.Equals(Normalize(left), Normalize(right), StringComparison.OrdinalIgnoreCase);
+}

--- a/DomainDetective/CertificateInventorySnapshot.cs
+++ b/DomainDetective/CertificateInventorySnapshot.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using DomainDetective.Providers.Endpoint;
 
 namespace DomainDetective {
     /// <summary>
@@ -143,6 +144,28 @@ namespace DomainDetective {
         public int Port { get; set; } = 443;
         /// <summary>Gets or sets the service value.</summary>
         public string Service { get; set; } = "HTTPS";
+        /// <summary>Time at which this endpoint observation was made.</summary>
+        public DateTimeOffset? ObservedAtUtc { get; set; }
+        /// <summary>Caller-supplied identifier for the network location that performed the probe.</summary>
+        public string ProbeVantage { get; set; } = string.Empty;
+        /// <summary>DNS resolver configuration used to collect endpoint evidence.</summary>
+        public string DnsResolver { get; set; } = string.Empty;
+        /// <summary>Time at which DNS evidence was collected for this endpoint.</summary>
+        public DateTimeOffset? DnsObservedAtUtc { get; set; }
+        /// <summary>Actual remote address reached by the protocol probe, when observable.</summary>
+        public string? RemoteAddress { get; set; }
+        /// <summary>Address family of <see cref="RemoteAddress"/>.</summary>
+        public string? RemoteAddressFamily { get; set; }
+        /// <summary>Addresses resolved for the effective endpoint hostname.</summary>
+        public IReadOnlyList<string> ResolvedAddresses { get; set; } = Array.Empty<string>();
+        /// <summary>CNAME targets followed from the logical hostname, in traversal order.</summary>
+        public IReadOnlyList<string> CnameChain { get; set; } = Array.Empty<string>();
+        /// <summary>HTTP redirect target hosts observed while probing the endpoint.</summary>
+        public IReadOnlyList<string> RedirectTargets { get; set; } = Array.Empty<string>();
+        /// <summary>Non-fatal DNS evidence collection errors.</summary>
+        public IReadOnlyList<string> DnsObservationErrors { get; set; } = Array.Empty<string>();
+        /// <summary>Explainable provider or managed-service attribution for the observed endpoint.</summary>
+        public EndpointAttributionResult? Attribution { get; set; }
         /// <summary>Gets or sets the certificate subject value.</summary>
         public string? CertificateSubject { get; set; }
         /// <summary>Gets or sets the certificate issuer value.</summary>

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using DomainDetective.Network;
 using DomainDetective.Helpers;
 using PeriodicTimer = System.Threading.PeriodicTimer;
 
@@ -361,9 +362,13 @@ namespace DomainDetective {
             if (snapshot == null) {
                 throw new ArgumentNullException(nameof(snapshot));
             }
-            if (snapshot.CapturedAtUtc == default) {
-                snapshot.CapturedAtUtc = DateTimeOffset.UtcNow;
+            snapshot.Entries ??= new List<CertificateInventoryEntry>();
+            foreach (CertificateInventoryEntry entry in snapshot.Entries) {
+                CertificateInventoryEntryHelpers.NormalizeRemoteAddressEvidence(entry);
             }
+            snapshot.CapturedAtUtc = CertificateInventoryEntryHelpers.ResolveCapturedAtUtc(
+                snapshot.Entries,
+                snapshot.CapturedAtUtc);
 
             try {
                 Directory.CreateDirectory(InventoryDirectory);
@@ -404,7 +409,7 @@ namespace DomainDetective {
                 Port = entry.Port,
                 Service = entry.Service,
                 RemoteAddress = entry.RemoteAddress?.ToString(),
-                RemoteAddressFamily = entry.RemoteAddress?.AddressFamily.ToString(),
+                RemoteAddressFamily = IpAddressClassifier.GetAddressFamilyLabel(entry.RemoteAddress),
                 ObservedAtUtc = entry.ObservedAtUtc == default ? null : entry.ObservedAtUtc,
                 CertificateSubject = certificate?.Subject,
                 CertificateIssuer = certificate?.Issuer,

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -38,6 +38,8 @@ namespace DomainDetective {
             public string Service { get; init; } = "HTTPS";
             /// <summary>Actual remote address reached by the probe, when observable.</summary>
             public IPAddress? RemoteAddress { get; init; }
+            /// <summary>UTC time when this endpoint probe completed.</summary>
+            public DateTimeOffset ObservedAtUtc { get; init; }
             /// <summary>Certificate expiry date.</summary>
             public DateTime ExpiryDate { get; init; }
             /// <summary>Whether the certificate chain was validated successfully.</summary>
@@ -234,6 +236,7 @@ namespace DomainDetective {
                             await analysis.AnalyzeUrl(target.Url, target.Port, logger, cancellationToken).ConfigureAwait(false);
                         }
 
+                        DateTimeOffset observedAtUtc = DateTimeOffset.UtcNow;
                         entries[index] = new Entry {
                             Host = host,
                             Url = target.Url,
@@ -242,6 +245,7 @@ namespace DomainDetective {
                             Port = target.Port,
                             Service = target.Service,
                             RemoteAddress = analysis.RemoteAddress,
+                            ObservedAtUtc = observedAtUtc,
                             ExpiryDate = analysis.Certificate?.NotAfter ?? DateTime.MinValue,
                             Valid = analysis.IsValid,
                             Expired = analysis.IsExpired,
@@ -401,6 +405,7 @@ namespace DomainDetective {
                 Service = entry.Service,
                 RemoteAddress = entry.RemoteAddress?.ToString(),
                 RemoteAddressFamily = entry.RemoteAddress?.AddressFamily.ToString(),
+                ObservedAtUtc = entry.ObservedAtUtc == default ? null : entry.ObservedAtUtc,
                 CertificateSubject = certificate?.Subject,
                 CertificateIssuer = certificate?.Issuer,
                 CertificateThumbprint = certificate?.Thumbprint,

--- a/DomainDetective/CertificateMonitor.cs
+++ b/DomainDetective/CertificateMonitor.cs
@@ -6,6 +6,7 @@ using System.Security.Authentication;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using DomainDetective.Helpers;
@@ -35,6 +36,8 @@ namespace DomainDetective {
             public int Port { get; init; } = 443;
             /// <summary>Best-effort service classification derived from endpoint details.</summary>
             public string Service { get; init; } = "HTTPS";
+            /// <summary>Actual remote address reached by the probe, when observable.</summary>
+            public IPAddress? RemoteAddress { get; init; }
             /// <summary>Certificate expiry date.</summary>
             public DateTime ExpiryDate { get; init; }
             /// <summary>Whether the certificate chain was validated successfully.</summary>
@@ -238,6 +241,7 @@ namespace DomainDetective {
                             Scheme = target.Scheme,
                             Port = target.Port,
                             Service = target.Service,
+                            RemoteAddress = analysis.RemoteAddress,
                             ExpiryDate = analysis.Certificate?.NotAfter ?? DateTime.MinValue,
                             Valid = analysis.IsValid,
                             Expired = analysis.IsExpired,
@@ -395,6 +399,8 @@ namespace DomainDetective {
                 Scheme = entry.Scheme,
                 Port = entry.Port,
                 Service = entry.Service,
+                RemoteAddress = entry.RemoteAddress?.ToString(),
+                RemoteAddressFamily = entry.RemoteAddress?.AddressFamily.ToString(),
                 CertificateSubject = certificate?.Subject,
                 CertificateIssuer = certificate?.Issuer,
                 CertificateThumbprint = certificate?.Thumbprint,
@@ -443,6 +449,7 @@ namespace DomainDetective {
                 CtDiscoverySources = analysis.CtDiscoverySources.ToArray(),
                 CtTemplateFormatErrors = analysis.CtTemplateFormatErrors.ToArray()
             };
+            snapshotEntry.RedirectTargets = analysis.RedirectTargets.ToArray();
             snapshotEntry.CertificateChainSources.AddRange(analysis.ChainSourceHistory);
             snapshotEntry.ExtendedKeyUsageOids.AddRange(analysis.ExtendedKeyUsageOids);
             snapshotEntry.SubjectAlternativeNames.AddRange(analysis.SubjectAlternativeNames);

--- a/DomainDetective/CertificateServiceClassifier.cs
+++ b/DomainDetective/CertificateServiceClassifier.cs
@@ -57,12 +57,7 @@ namespace DomainDetective {
         /// <summary>Executes the guess service operation.</summary>
         public static string GuessService(string scheme, int port) {
             if (scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)) {
-                if (port == 443) {
-                    return "HTTPS";
-                }
-                if (port == 8443 || port == 9443 || port == 4443) {
-                    return "HTTPS-Alt";
-                }
+                return port == 443 ? "HTTPS" : "HTTPS-Alt";
             }
 
             return port switch {

--- a/DomainDetective/CertificateServiceClassifier.cs
+++ b/DomainDetective/CertificateServiceClassifier.cs
@@ -47,7 +47,7 @@ namespace DomainDetective {
             var service = GuessService(scheme, resolvedPort);
             return new CertificateServiceDescriptor {
                 Url = builder.Uri.ToString(),
-                Host = builder.Host,
+                Host = EndpointHostNormalizer.Normalize(builder.Host),
                 Scheme = scheme,
                 Port = resolvedPort,
                 Service = service

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -22,6 +22,9 @@ public sealed class EndpointDnsEvidence {
     /// <summary>IPv4 and IPv6 addresses resolved for the effective hostname.</summary>
     public IReadOnlyList<string> Addresses { get; init; } = Array.Empty<string>();
 
+    /// <summary>True when both A and AAAA lookups completed, including valid empty answers.</summary>
+    public bool AddressResolutionComplete { get; init; }
+
     /// <summary>DNS endpoint used by the resolver.</summary>
     public string Resolver { get; init; } = string.Empty;
 
@@ -96,10 +99,12 @@ public sealed class EndpointDnsEvidenceResolver {
         }
 
         var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        int completedAddressLookups = 0;
         foreach (DnsRecordType type in new[] { DnsRecordType.A, DnsRecordType.AAAA }) {
             cancellationToken.ThrowIfCancellationRequested();
             try {
                 DnsAnswer[] answers = await QueryAsync(current, type, cancellationToken).ConfigureAwait(false);
+                completedAddressLookups++;
                 foreach (DnsAnswer answer in answers) {
                     string value = (answer.Data ?? answer.DataRaw ?? string.Empty).Trim();
                     if (IPAddress.TryParse(value, out IPAddress? address) && address != null) {
@@ -118,6 +123,7 @@ public sealed class EndpointDnsEvidenceResolver {
             EffectiveHostName = current,
             CnameChain = chain,
             Addresses = addresses.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList(),
+            AddressResolutionComplete = completedAddressLookups == 2,
             Resolver = DnsConfiguration.DnsEndpoint.ToString(),
             ObservedAtUtc = DateTimeOffset.UtcNow,
             LoopDetected = loopDetected,

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -86,6 +86,9 @@ public sealed class EndpointDnsEvidenceResolver {
             DnsAnswer[] answers;
             try {
                 answers = await QueryAsync(current, DnsRecordType.CNAME, cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+                errors.Add($"CNAME lookup for '{current}' failed: {ex.Message}");
+                break;
             } catch (OperationCanceledException) {
                 throw;
             } catch (Exception ex) {
@@ -126,6 +129,8 @@ public sealed class EndpointDnsEvidenceResolver {
                         addresses.Add(address.ToString());
                     }
                 }
+            } catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested) {
+                errors.Add($"{type} lookup for '{current}' failed: {ex.Message}");
             } catch (OperationCanceledException) {
                 throw;
             } catch (Exception ex) {

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -1,0 +1,140 @@
+using DnsClientX;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>DNS evidence associated with one logical service endpoint.</summary>
+public sealed class EndpointDnsEvidence {
+    /// <summary>Logical hostname requested by the caller.</summary>
+    public string HostName { get; init; } = string.Empty;
+
+    /// <summary>Final CNAME target, or the original hostname when no CNAME exists.</summary>
+    public string EffectiveHostName { get; init; } = string.Empty;
+
+    /// <summary>CNAME targets in traversal order.</summary>
+    public IReadOnlyList<string> CnameChain { get; init; } = Array.Empty<string>();
+
+    /// <summary>IPv4 and IPv6 addresses resolved for the effective hostname.</summary>
+    public IReadOnlyList<string> Addresses { get; init; } = Array.Empty<string>();
+
+    /// <summary>DNS endpoint used by the resolver.</summary>
+    public string Resolver { get; init; } = string.Empty;
+
+    /// <summary>Time at which DNS evidence was observed.</summary>
+    public DateTimeOffset ObservedAtUtc { get; init; }
+
+    /// <summary>True when a CNAME loop was encountered.</summary>
+    public bool LoopDetected { get; init; }
+
+    /// <summary>Non-fatal lookup or parsing errors.</summary>
+    public IReadOnlyList<string> Errors { get; init; } = Array.Empty<string>();
+}
+
+/// <summary>Resolves CNAME chains and endpoint addresses as reusable classification evidence.</summary>
+public sealed class EndpointDnsEvidenceResolver {
+    /// <summary>DNS configuration used for all queries.</summary>
+    public DnsConfiguration DnsConfiguration { get; set; } = new();
+
+    /// <summary>Maximum number of CNAME links followed before the result is treated as incomplete.</summary>
+    public int MaxCnameDepth { get; set; } = 16;
+
+    /// <summary>Optional query override for deterministic callers and tests.</summary>
+    public Func<string, DnsRecordType, CancellationToken, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
+
+    /// <summary>Resolves endpoint DNS evidence without discarding partial results on lookup failure.</summary>
+    public async Task<EndpointDnsEvidence> ResolveAsync(
+        string hostName,
+        CancellationToken cancellationToken = default) {
+        string normalizedHost = NormalizeHost(hostName);
+        if (normalizedHost.Length == 0) {
+            throw new ArgumentException("A logical hostname is required.", nameof(hostName));
+        }
+        if (MaxCnameDepth < 1 || MaxCnameDepth > 128) {
+            throw new ArgumentOutOfRangeException(nameof(MaxCnameDepth), "MaxCnameDepth must be between 1 and 128.");
+        }
+
+        var chain = new List<string>();
+        var errors = new List<string>();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { normalizedHost };
+        string current = normalizedHost;
+        bool loopDetected = false;
+
+        for (int depth = 0; depth < MaxCnameDepth; depth++) {
+            cancellationToken.ThrowIfCancellationRequested();
+            DnsAnswer[] answers;
+            try {
+                answers = await QueryAsync(current, DnsRecordType.CNAME, cancellationToken).ConfigureAwait(false);
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                errors.Add($"CNAME lookup for '{current}' failed: {ex.Message}");
+                break;
+            }
+
+            string next = answers
+                .Select(answer => NormalizeHost(answer.Data ?? answer.DataRaw))
+                .FirstOrDefault(value => value.Length > 0) ?? string.Empty;
+            if (next.Length == 0) {
+                break;
+            }
+            if (!visited.Add(next)) {
+                loopDetected = true;
+                errors.Add($"CNAME loop detected at '{next}'.");
+                break;
+            }
+
+            chain.Add(next);
+            current = next;
+            if (depth == MaxCnameDepth - 1) {
+                errors.Add($"CNAME chain exceeded MaxCnameDepth={MaxCnameDepth}.");
+            }
+        }
+
+        var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (DnsRecordType type in new[] { DnsRecordType.A, DnsRecordType.AAAA }) {
+            cancellationToken.ThrowIfCancellationRequested();
+            try {
+                DnsAnswer[] answers = await QueryAsync(current, type, cancellationToken).ConfigureAwait(false);
+                foreach (DnsAnswer answer in answers) {
+                    string value = (answer.Data ?? answer.DataRaw ?? string.Empty).Trim();
+                    if (IPAddress.TryParse(value, out IPAddress? address) && address != null) {
+                        addresses.Add(address.ToString());
+                    }
+                }
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                errors.Add($"{type} lookup for '{current}' failed: {ex.Message}");
+            }
+        }
+
+        return new EndpointDnsEvidence {
+            HostName = normalizedHost,
+            EffectiveHostName = current,
+            CnameChain = chain,
+            Addresses = addresses.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList(),
+            Resolver = DnsConfiguration.DnsEndpoint.ToString(),
+            ObservedAtUtc = DateTimeOffset.UtcNow,
+            LoopDetected = loopDetected,
+            Errors = errors
+        };
+    }
+
+    private Task<DnsAnswer[]> QueryAsync(
+        string name,
+        DnsRecordType recordType,
+        CancellationToken cancellationToken) {
+        if (QueryDnsOverride != null) {
+            return QueryDnsOverride(name, recordType, cancellationToken);
+        }
+        return DnsConfiguration.QueryDNS(name, recordType, cancellationToken: cancellationToken);
+    }
+
+    private static string NormalizeHost(string? value) =>
+        (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+}

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -61,6 +61,20 @@ public sealed class EndpointDnsEvidenceResolver {
             throw new ArgumentOutOfRangeException(nameof(MaxCnameDepth), "MaxCnameDepth must be between 1 and 128.");
         }
 
+        if (IPAddress.TryParse(normalizedHost, out IPAddress? literalAddress) && literalAddress != null) {
+            IPAddress normalizedAddress = literalAddress.IsIPv4MappedToIPv6
+                ? literalAddress.MapToIPv4()
+                : literalAddress;
+            return new EndpointDnsEvidence {
+                HostName = normalizedHost,
+                EffectiveHostName = normalizedHost,
+                Addresses = new[] { normalizedAddress.ToString() },
+                AddressResolutionComplete = true,
+                Resolver = DnsConfiguration.DnsEndpoint.ToString(),
+                ObservedAtUtc = DateTimeOffset.UtcNow
+            };
+        }
+
         var chain = new List<string>();
         var errors = new List<string>();
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { normalizedHost };
@@ -142,5 +156,5 @@ public sealed class EndpointDnsEvidenceResolver {
     }
 
     private static string NormalizeHost(string? value) =>
-        (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+        EndpointHostNormalizer.Normalize(value, lowercase: true);
 }

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -46,6 +46,12 @@ public sealed class EndpointDnsEvidenceResolver {
     /// <summary>Maximum number of CNAME links followed before the result is treated as incomplete.</summary>
     public int MaxCnameDepth { get; set; } = 16;
 
+    /// <summary>
+    /// Whether A and AAAA queries are performed for the original hostname when no CNAME target is found.
+    /// Endpoint-enrichment callers normally keep this enabled; CNAME-only analysis can disable it.
+    /// </summary>
+    public bool ResolveAddressesForOriginalHost { get; set; } = true;
+
     /// <summary>Optional query override for deterministic callers and tests.</summary>
     public Func<string, DnsRecordType, CancellationToken, Task<DnsAnswer[]>>? QueryDnsOverride { private get; set; }
 
@@ -114,6 +120,19 @@ public sealed class EndpointDnsEvidenceResolver {
             if (depth == MaxCnameDepth - 1) {
                 errors.Add($"CNAME chain exceeded MaxCnameDepth={MaxCnameDepth}.");
             }
+        }
+
+        if (chain.Count == 0 && !ResolveAddressesForOriginalHost) {
+            return new EndpointDnsEvidence {
+                HostName = normalizedHost,
+                EffectiveHostName = current,
+                CnameChain = chain,
+                AddressResolutionComplete = false,
+                Resolver = DnsConfiguration.DnsEndpoint.ToString(),
+                ObservedAtUtc = DateTimeOffset.UtcNow,
+                LoopDetected = loopDetected,
+                Errors = errors
+            };
         }
 
         var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -93,9 +93,10 @@ public sealed class EndpointDnsEvidenceResolver {
                 break;
             }
 
-            string next = answers
-                .Select(answer => NormalizeHost(answer.Data ?? answer.DataRaw))
-                .FirstOrDefault(value => value.Length > 0) ?? string.Empty;
+            string next = SelectCnameTarget(current, answers, out bool ambiguousCname);
+            if (ambiguousCname) {
+                errors.Add($"CNAME lookup for '{current}' returned multiple distinct targets.");
+            }
             if (next.Length == 0) {
                 break;
             }
@@ -153,6 +154,39 @@ public sealed class EndpointDnsEvidenceResolver {
             return QueryDnsOverride(name, recordType, cancellationToken);
         }
         return DnsConfiguration.QueryDNS(name, recordType, cancellationToken: cancellationToken);
+    }
+
+    private static string SelectCnameTarget(
+        string current,
+        IReadOnlyList<DnsAnswer> answers,
+        out bool ambiguous) {
+        ambiguous = false;
+        string normalizedCurrent = NormalizeHost(current);
+        string[] ownerTargets = answers
+            .Where(answer => answer.Type == DnsRecordType.CNAME &&
+                             NormalizeHost(answer.Name).Equals(normalizedCurrent, StringComparison.OrdinalIgnoreCase))
+            .Select(answer => NormalizeHost(answer.Data ?? answer.DataRaw))
+            .Where(value => value.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToArray();
+        if (ownerTargets.Length > 0) {
+            ambiguous = ownerTargets.Length > 1;
+            return ambiguous ? string.Empty : ownerTargets[0];
+        }
+
+        // Custom resolvers and older deterministic callers may omit the owner name.
+        // They may also omit the record type because this is already a CNAME query.
+        // Preserve that contract only when the ownerless response is unambiguous.
+        string[] ownerlessTargets = answers
+            .Where(answer => NormalizeHost(answer.Name).Length == 0)
+            .Select(answer => NormalizeHost(answer.Data ?? answer.DataRaw))
+            .Where(value => value.Length > 0)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(2)
+            .ToArray();
+        ambiguous = ownerlessTargets.Length > 1;
+        return ownerlessTargets.Length == 1 ? ownerlessTargets[0] : string.Empty;
     }
 
     private static string NormalizeHost(string? value) =>

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -184,14 +184,18 @@ public sealed class EndpointDnsEvidenceResolver {
         };
     }
 
-    private Task<DnsAnswer[]> QueryAsync(
+    private async Task<DnsAnswer[]> QueryAsync(
         string name,
         DnsRecordType recordType,
         CancellationToken cancellationToken) {
+        DnsAnswer[]? answers;
         if (QueryDnsOverride != null) {
-            return QueryDnsOverride(name, recordType, cancellationToken);
+            answers = await QueryDnsOverride(name, recordType, cancellationToken).ConfigureAwait(false);
+        } else {
+            answers = await DnsConfiguration.QueryDNS(name, recordType, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
         }
-        return DnsConfiguration.QueryDNS(name, recordType, cancellationToken: cancellationToken);
+        return answers ?? Array.Empty<DnsAnswer>();
     }
 
     private static string SelectCnameTarget(

--- a/DomainDetective/EndpointDnsEvidenceResolver.cs
+++ b/DomainDetective/EndpointDnsEvidenceResolver.cs
@@ -19,6 +19,9 @@ public sealed class EndpointDnsEvidence {
     /// <summary>CNAME targets in traversal order.</summary>
     public IReadOnlyList<string> CnameChain { get; init; } = Array.Empty<string>();
 
+    /// <summary>True when a CNAME record was observed, even if its target was ambiguous.</summary>
+    public bool CnameRecordExists { get; init; }
+
     /// <summary>IPv4 and IPv6 addresses resolved for the effective hostname.</summary>
     public IReadOnlyList<string> Addresses { get; init; } = Array.Empty<string>();
 
@@ -86,8 +89,11 @@ public sealed class EndpointDnsEvidenceResolver {
         var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { normalizedHost };
         string current = normalizedHost;
         bool loopDetected = false;
+        bool cnameRecordExists = false;
 
-        for (int depth = 0; depth < MaxCnameDepth; depth++) {
+        // The extra query at MaxCnameDepth verifies whether the last followed target
+        // is terminal before reporting that another link exceeds the configured cap.
+        for (int depth = 0; depth <= MaxCnameDepth; depth++) {
             cancellationToken.ThrowIfCancellationRequested();
             DnsAnswer[] answers;
             try {
@@ -102,11 +108,20 @@ public sealed class EndpointDnsEvidenceResolver {
                 break;
             }
 
-            string next = SelectCnameTarget(current, answers, out bool ambiguousCname);
+            string next = SelectCnameTarget(
+                current,
+                answers,
+                out bool ambiguousCname,
+                out bool cnameObserved);
+            cnameRecordExists |= cnameObserved;
             if (ambiguousCname) {
                 errors.Add($"CNAME lookup for '{current}' returned multiple distinct targets.");
             }
             if (next.Length == 0) {
+                break;
+            }
+            if (depth == MaxCnameDepth) {
+                errors.Add($"CNAME chain exceeded MaxCnameDepth={MaxCnameDepth}.");
                 break;
             }
             if (!visited.Add(next)) {
@@ -117,9 +132,6 @@ public sealed class EndpointDnsEvidenceResolver {
 
             chain.Add(next);
             current = next;
-            if (depth == MaxCnameDepth - 1) {
-                errors.Add($"CNAME chain exceeded MaxCnameDepth={MaxCnameDepth}.");
-            }
         }
 
         if (chain.Count == 0 && !ResolveAddressesForOriginalHost) {
@@ -127,6 +139,7 @@ public sealed class EndpointDnsEvidenceResolver {
                 HostName = normalizedHost,
                 EffectiveHostName = current,
                 CnameChain = chain,
+                CnameRecordExists = cnameRecordExists,
                 AddressResolutionComplete = false,
                 Resolver = DnsConfiguration.DnsEndpoint.ToString(),
                 ObservedAtUtc = DateTimeOffset.UtcNow,
@@ -161,6 +174,7 @@ public sealed class EndpointDnsEvidenceResolver {
             HostName = normalizedHost,
             EffectiveHostName = current,
             CnameChain = chain,
+            CnameRecordExists = cnameRecordExists,
             Addresses = addresses.OrderBy(value => value, StringComparer.OrdinalIgnoreCase).ToList(),
             AddressResolutionComplete = completedAddressLookups == 2,
             Resolver = DnsConfiguration.DnsEndpoint.ToString(),
@@ -183,8 +197,10 @@ public sealed class EndpointDnsEvidenceResolver {
     private static string SelectCnameTarget(
         string current,
         IReadOnlyList<DnsAnswer> answers,
-        out bool ambiguous) {
+        out bool ambiguous,
+        out bool recordExists) {
         ambiguous = false;
+        recordExists = false;
         string normalizedCurrent = NormalizeHost(current);
         string[] ownerTargets = answers
             .Where(answer => answer.Type == DnsRecordType.CNAME &&
@@ -195,6 +211,7 @@ public sealed class EndpointDnsEvidenceResolver {
             .Take(2)
             .ToArray();
         if (ownerTargets.Length > 0) {
+            recordExists = true;
             ambiguous = ownerTargets.Length > 1;
             return ambiguous ? string.Empty : ownerTargets[0];
         }
@@ -210,6 +227,7 @@ public sealed class EndpointDnsEvidenceResolver {
             .Take(2)
             .ToArray();
         ambiguous = ownerlessTargets.Length > 1;
+        recordExists = ownerlessTargets.Length > 0;
         return ownerlessTargets.Length == 1 ? ownerlessTargets[0] : string.Empty;
     }
 

--- a/DomainDetective/EndpointHostNormalizer.cs
+++ b/DomainDetective/EndpointHostNormalizer.cs
@@ -30,6 +30,13 @@ internal static class EndpointHostNormalizer {
             }
             normalized = address.ToString();
         }
+
+        if (IPAddress.TryParse(normalized, out IPAddress? literalAddress) && literalAddress != null) {
+            if (literalAddress.IsIPv4MappedToIPv6) {
+                literalAddress = literalAddress.MapToIPv4();
+            }
+            normalized = literalAddress.ToString();
+        }
         normalized = lowercase ? normalized.ToLowerInvariant() : normalized;
         return true;
     }

--- a/DomainDetective/EndpointHostNormalizer.cs
+++ b/DomainDetective/EndpointHostNormalizer.cs
@@ -6,11 +6,32 @@ namespace DomainDetective;
 /// <summary>Normalizes logical endpoint hosts for protocol, DNS, and inventory use.</summary>
 internal static class EndpointHostNormalizer {
     public static string Normalize(string? value, bool lowercase = false) {
-        string normalized = (value ?? string.Empty).Trim().TrimEnd('.');
-        if (normalized.Length >= 2 && normalized[0] == '[' && normalized[normalized.Length - 1] == ']') {
-            normalized = normalized.Substring(1, normalized.Length - 2);
+        TryNormalize(value, out string normalized, lowercase);
+        return normalized;
+    }
+
+    public static bool TryNormalize(string? value, out string normalized, bool lowercase = false) {
+        normalized = (value ?? string.Empty).Trim().TrimEnd('.');
+        bool containsOpeningBracket = normalized.IndexOf('[') >= 0;
+        bool containsClosingBracket = normalized.IndexOf(']') >= 0;
+        if (containsOpeningBracket || containsClosingBracket) {
+            if (normalized.Length < 2 ||
+                normalized[0] != '[' ||
+                normalized[normalized.Length - 1] != ']') {
+                normalized = lowercase ? normalized.ToLowerInvariant() : normalized;
+                return false;
+            }
+
+            string candidate = normalized.Substring(1, normalized.Length - 2);
+            if (!IPAddress.TryParse(candidate, out IPAddress? address) ||
+                address.AddressFamily != System.Net.Sockets.AddressFamily.InterNetworkV6) {
+                normalized = lowercase ? normalized.ToLowerInvariant() : normalized;
+                return false;
+            }
+            normalized = address.ToString();
         }
-        return lowercase ? normalized.ToLowerInvariant() : normalized;
+        normalized = lowercase ? normalized.ToLowerInvariant() : normalized;
+        return true;
     }
 
     public static string FormatForUriAuthority(string? value) {

--- a/DomainDetective/EndpointHostNormalizer.cs
+++ b/DomainDetective/EndpointHostNormalizer.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Net;
+
+namespace DomainDetective;
+
+/// <summary>Normalizes logical endpoint hosts for protocol, DNS, and inventory use.</summary>
+internal static class EndpointHostNormalizer {
+    public static string Normalize(string? value, bool lowercase = false) {
+        string normalized = (value ?? string.Empty).Trim().TrimEnd('.');
+        if (normalized.Length >= 2 && normalized[0] == '[' && normalized[normalized.Length - 1] == ']') {
+            normalized = normalized.Substring(1, normalized.Length - 2);
+        }
+        return lowercase ? normalized.ToLowerInvariant() : normalized;
+    }
+
+    public static string FormatForUriAuthority(string? value) {
+        string normalized = Normalize(value);
+        return IPAddress.TryParse(normalized, out IPAddress? address) && address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetworkV6
+            ? $"[{normalized}]"
+            : normalized;
+    }
+}

--- a/DomainDetective/IpCidrRange.cs
+++ b/DomainDetective/IpCidrRange.cs
@@ -14,12 +14,28 @@ public readonly struct IpCidrRange {
 
     /// <summary>Initializes a new instance of the IpCidrRange class.</summary>
     public IpCidrRange(IPAddress network, int prefixLength) {
-        Network = network;
+        if (network == null) {
+            throw new ArgumentNullException(nameof(network));
+        }
+        if (network.IsIPv4MappedToIPv6) {
+            network = network.MapToIPv4();
+        }
+        int bitCount = network.GetAddressBytes().Length * 8;
+        if (prefixLength < 0 || prefixLength > bitCount) {
+            throw new ArgumentOutOfRangeException(nameof(prefixLength));
+        }
+        Network = new IPAddress(ApplyMask(network.GetAddressBytes(), prefixLength));
         PrefixLength = prefixLength;
     }
 
     /// <summary>Checks if the range contains the specified address.</summary>
     public bool Contains(IPAddress address) {
+        if (address == null) {
+            throw new ArgumentNullException(nameof(address));
+        }
+        if (address.IsIPv4MappedToIPv6) {
+            address = address.MapToIPv4();
+        }
         if (address.AddressFamily != Network.AddressFamily)
             return false;
         var addressBytes = address.GetAddressBytes();
@@ -37,18 +53,51 @@ public readonly struct IpCidrRange {
     }
 
     /// <summary>Parses a CIDR string.</summary>
-    public static bool TryParse(string text, out IpCidrRange range) {
+    public static bool TryParse(string? text, out IpCidrRange range) {
         range = default;
         if (string.IsNullOrWhiteSpace(text))
             return false;
-        var parts = text.Split('/');
-        if (parts.Length != 2)
+        var parts = text!.Trim().Split('/');
+        if (parts.Length < 1 || parts.Length > 2)
             return false;
-        if (!IPAddress.TryParse(parts[0], out var addr))
+        if (!IPAddress.TryParse(parts[0].Trim(), out var addr) || addr == null)
             return false;
-        if (!int.TryParse(parts[1], out var prefix))
+        if (addr.IsIPv4MappedToIPv6) {
+            addr = addr.MapToIPv4();
+        }
+        int bitCount = addr.GetAddressBytes().Length * 8;
+        int prefix = bitCount;
+        if (parts.Length == 2 && !int.TryParse(parts[1].Trim(), out prefix))
+            return false;
+        if (prefix < 0 || prefix > bitCount)
             return false;
         range = new IpCidrRange(addr, prefix);
         return true;
+    }
+
+    /// <summary>Parses a CIDR string or a single address.</summary>
+    public static IpCidrRange Parse(string text) {
+        if (!TryParse(text, out IpCidrRange range)) {
+            throw new FormatException($"'{text}' is not a valid IPv4 or IPv6 CIDR prefix.");
+        }
+        return range;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() => Network + "/" + PrefixLength;
+
+    private static byte[] ApplyMask(byte[] bytes, int prefixLength) {
+        byte[] result = (byte[])bytes.Clone();
+        int wholeBytes = prefixLength / 8;
+        int remainingBits = prefixLength % 8;
+        if (wholeBytes < result.Length && remainingBits > 0) {
+            int mask = 0xFF << (8 - remainingBits);
+            result[wholeBytes] = (byte)(result[wholeBytes] & mask);
+            wholeBytes++;
+        }
+        for (int index = wholeBytes; index < result.Length; index++) {
+            result[index] = 0;
+        }
+        return result;
     }
 }

--- a/DomainDetective/IpCidrRange.cs
+++ b/DomainDetective/IpCidrRange.cs
@@ -17,8 +17,9 @@ public readonly struct IpCidrRange {
         if (network == null) {
             throw new ArgumentNullException(nameof(network));
         }
-        if (network.IsIPv4MappedToIPv6) {
+        if (network.IsIPv4MappedToIPv6 && prefixLength >= 96) {
             network = network.MapToIPv4();
+            prefixLength -= 96;
         }
         int bitCount = network.GetAddressBytes().Length * 8;
         if (prefixLength < 0 || prefixLength > bitCount) {
@@ -33,7 +34,8 @@ public readonly struct IpCidrRange {
         if (address == null) {
             throw new ArgumentNullException(nameof(address));
         }
-        if (address.IsIPv4MappedToIPv6) {
+        if (Network.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork &&
+            address.IsIPv4MappedToIPv6) {
             address = address.MapToIPv4();
         }
         if (address.AddressFamily != Network.AddressFamily)
@@ -62,16 +64,17 @@ public readonly struct IpCidrRange {
             return false;
         if (!IPAddress.TryParse(parts[0].Trim(), out var addr) || addr == null)
             return false;
-        if (addr.IsIPv4MappedToIPv6) {
-            addr = addr.MapToIPv4();
-        }
         int bitCount = addr.GetAddressBytes().Length * 8;
         int prefix = bitCount;
         if (parts.Length == 2 && !int.TryParse(parts[1].Trim(), out prefix))
             return false;
         if (prefix < 0 || prefix > bitCount)
             return false;
-        range = new IpCidrRange(addr, prefix);
+        try {
+            range = new IpCidrRange(addr, prefix);
+        } catch (ArgumentOutOfRangeException) {
+            return false;
+        }
         return true;
     }
 

--- a/DomainDetective/Narratives/CnameNarrative.cs
+++ b/DomainDetective/Narratives/CnameNarrative.cs
@@ -40,15 +40,21 @@ public static class CnameNarrative
             };
         }
 
-        hi.Add(analysis.CnameRecordExists
-            ? $"{subj} CNAME → {analysis.Target}."
-            : $"{subj} has no CNAME record.");
+        hi.Add(!analysis.CnameRecordExists
+            ? $"{subj} has no CNAME record."
+            : string.IsNullOrWhiteSpace(analysis.Target)
+                ? $"{subj} has a CNAME record, but its target is ambiguous or unavailable."
+                : $"{subj} CNAME → {analysis.Target}.");
         hi.Add(analysis.LoopDetected
             ? "CNAME loop detected."
             : "No CNAME loop detected.");
-        hi.Add(analysis.TargetResolves
-            ? "CNAME target resolves."
-            : "CNAME target does not resolve.");
+        hi.Add(!analysis.CnameRecordExists
+            ? "CNAME target resolution is not applicable."
+            : string.IsNullOrWhiteSpace(analysis.Target)
+                ? "CNAME target resolution is indeterminate."
+                : analysis.TargetResolves
+                    ? "CNAME target resolves."
+                    : "CNAME target does not resolve.");
 
         var refs = DefaultRefs();
 

--- a/DomainDetective/Network/IpAddressClassifier.cs
+++ b/DomainDetective/Network/IpAddressClassifier.cs
@@ -2,20 +2,35 @@ using System.Net;
 
 namespace DomainDetective.Network;
 
-internal enum IpAddressVisibility
+/// <summary>Describes the routing scope of an IP address.</summary>
+public enum IpAddressVisibility
 {
+    /// <summary>The value could not be parsed or classified.</summary>
     Unknown = 0,
+    /// <summary>Globally routable public address space.</summary>
     Public = 1,
+    /// <summary>Private IPv4 address space.</summary>
     Private = 2,
+    /// <summary>Local loopback address space.</summary>
     Loopback = 3,
+    /// <summary>Link-local address space.</summary>
     LinkLocal = 4,
+    /// <summary>Multicast address space.</summary>
     Multicast = 5,
+    /// <summary>Address space reserved for documentation and examples.</summary>
     Documentation = 6,
-    UniqueLocalV6 = 7
+    /// <summary>IPv6 unique-local address space.</summary>
+    UniqueLocalV6 = 7,
+    /// <summary>Carrier-grade NAT shared address space.</summary>
+    Shared = 8,
+    /// <summary>Reserved or otherwise non-routable address space.</summary>
+    Reserved = 9
 }
 
-internal static class IpAddressClassifier
+/// <summary>Classifies IPv4 and IPv6 addresses without performing network lookups.</summary>
+public static class IpAddressClassifier
 {
+    /// <summary>Attempts to parse and classify an address.</summary>
     public static bool TryClassify(string? value, out IpAddressVisibility visibility)
     {
         visibility = IpAddressVisibility.Unknown;
@@ -34,8 +49,19 @@ internal static class IpAddressClassifier
         return true;
     }
 
+    /// <summary>Classifies an address by routing scope.</summary>
     public static IpAddressVisibility Classify(IPAddress ip)
     {
+        if (ip == null)
+        {
+            throw new System.ArgumentNullException(nameof(ip));
+        }
+
+        if (ip.IsIPv4MappedToIPv6)
+        {
+            ip = ip.MapToIPv4();
+        }
+
         if (IPAddress.IsLoopback(ip))
         {
             return IpAddressVisibility.Loopback;
@@ -67,6 +93,16 @@ internal static class IpAddressClassifier
                 return IpAddressVisibility.Documentation;
             }
 
+            if (b[0] == 100 && b[1] >= 64 && b[1] <= 127)
+            {
+                return IpAddressVisibility.Shared;
+            }
+
+            if (b[0] == 0 || b[0] >= 240 || (b[0] == 198 && (b[1] == 18 || b[1] == 19)))
+            {
+                return IpAddressVisibility.Reserved;
+            }
+
             return IpAddressVisibility.Public;
         }
 
@@ -94,9 +130,15 @@ internal static class IpAddressClassifier
             return IpAddressVisibility.Documentation;
         }
 
+        if (IPAddress.IPv6None.Equals(ip))
+        {
+            return IpAddressVisibility.Reserved;
+        }
+
         return IpAddressVisibility.Public;
     }
 
+    /// <summary>Returns true when the classification is not globally routable public space.</summary>
     public static bool IsNonPublic(IpAddressVisibility visibility)
     {
         return visibility == IpAddressVisibility.Private ||
@@ -104,6 +146,8 @@ internal static class IpAddressClassifier
                visibility == IpAddressVisibility.LinkLocal ||
                visibility == IpAddressVisibility.Multicast ||
                visibility == IpAddressVisibility.Documentation ||
-               visibility == IpAddressVisibility.UniqueLocalV6;
+               visibility == IpAddressVisibility.UniqueLocalV6 ||
+               visibility == IpAddressVisibility.Shared ||
+               visibility == IpAddressVisibility.Reserved;
     }
 }

--- a/DomainDetective/Network/IpAddressClassifier.cs
+++ b/DomainDetective/Network/IpAddressClassifier.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Net;
+using System.Net.Sockets;
 
 namespace DomainDetective.Network;
 
@@ -30,6 +32,47 @@ public enum IpAddressVisibility
 /// <summary>Classifies IPv4 and IPv6 addresses without performing network lookups.</summary>
 public static class IpAddressClassifier
 {
+    /// <summary>Returns the stable inventory label for an address family.</summary>
+    public static string GetAddressFamilyLabel(IPAddress? address)
+    {
+        if (address == null)
+        {
+            return string.Empty;
+        }
+
+        if (address.IsIPv4MappedToIPv6 || address.AddressFamily == AddressFamily.InterNetwork)
+        {
+            return "IPv4";
+        }
+        if (address.AddressFamily == AddressFamily.InterNetworkV6)
+        {
+            return "IPv6";
+        }
+        return "Unknown";
+    }
+
+    /// <summary>Returns a stable inventory label from an address or a legacy family label.</summary>
+    public static string GetAddressFamilyLabel(string? address, string? familyLabel = null)
+    {
+        if (IPAddress.TryParse((address ?? string.Empty).Trim(), out IPAddress? parsed) && parsed != null)
+        {
+            return GetAddressFamilyLabel(parsed);
+        }
+
+        string normalized = (familyLabel ?? string.Empty).Trim();
+        if (string.Equals(normalized, "IPv4", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, AddressFamily.InterNetwork.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return "IPv4";
+        }
+        if (string.Equals(normalized, "IPv6", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, AddressFamily.InterNetworkV6.ToString(), StringComparison.OrdinalIgnoreCase))
+        {
+            return "IPv6";
+        }
+        return normalized.Length == 0 ? string.Empty : "Unknown";
+    }
+
     /// <summary>Attempts to parse and classify an address.</summary>
     public static bool TryClassify(string? value, out IpAddressVisibility visibility)
     {

--- a/DomainDetective/Protocols/CertificateHTTP.TlsAndGrade.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.TlsAndGrade.cs
@@ -153,7 +153,12 @@ namespace DomainDetective {
                 while (!string.IsNullOrEmpty(await reader.ReadLineAsync())) { }
                 return tcp;
             }
-            return await ConnectDirectAsync(host, port, token).ConfigureAwait(false);
+            return await ConnectDirectAsync(
+                    host,
+                    port,
+                    token,
+                    captureRemoteAddress: false)
+                .ConfigureAwait(false);
         }
 #pragma warning restore CA2000
 

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -79,8 +79,12 @@ namespace DomainDetective {
         public bool? CrlRevoked { get; private set; }
         /// <summary>Gets or sets the HTTP request timeout.</summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+        /// <summary>Gets the actual remote address reached by the most recent observable TCP connection.</summary>
+        public IPAddress? RemoteAddress { get; private set; }
         /// <summary>Optional resolver that returns addresses approved for outbound connections.</summary>
         public Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>>? OutboundAddressResolver { get; set; }
+        /// <summary>Gets redirect target hosts observed during the most recent HTTP analysis.</summary>
+        public List<string> RedirectTargets { get; } = new();
         /// <summary>Gets DNS names listed in the certificate subject alternative name extension.</summary>
         public List<string> SubjectAlternativeNames { get; } = new();
         /// <summary>Gets wildcard entries with matching subdomains.</summary>
@@ -252,6 +256,8 @@ namespace DomainDetective {
             IsSelfSigned = false;
             FailureReason = null;
             FailureKind = CertificateFailureKind.None;
+            RemoteAddress = null;
+            RedirectTargets.Clear();
             ResetChainSourceTracking();
             bool capturedHandshakeCertificate = false;
             using var _collector = AssessmentCollector.ForAnalysis(logger, this, category: "CERT", target: url);
@@ -307,6 +313,7 @@ namespace DomainDetective {
                             VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
                         };
                         using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
+                        CaptureRedirectTarget(uri: response.RequestMessage?.RequestUri, originalUrl: url);
                         IsReachable = response.IsSuccessStatusCode;
                         ProtocolVersion = response.Version;
                         Http3Supported = response.Version >= HttpVersion.Version30;
@@ -314,6 +321,7 @@ namespace DomainDetective {
 #else
                         var request = new HttpRequestMessage(HttpMethod.Get, url);
                         using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
+                        CaptureRedirectTarget(uri: response.RequestMessage?.RequestUri, originalUrl: url);
                         IsReachable = response.IsSuccessStatusCode;
                         ProtocolVersion = response.Version;
                         Http2Supported = response.Version.Major >= 2;
@@ -411,6 +419,7 @@ namespace DomainDetective {
             if (OutboundAddressResolver == null) {
                 var client = new TcpClient();
                 await client.ConnectAsync(host, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+                CaptureRemoteAddress(client);
                 return client;
             }
 
@@ -420,6 +429,7 @@ namespace DomainDetective {
                 var client = new TcpClient(address.AddressFamily);
                 try {
                     await client.ConnectAsync(address, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+                    CaptureRemoteAddress(client);
                     return client;
                 } catch (Exception ex) when (ex is not OperationCanceledException) {
                     lastError = ex;
@@ -427,6 +437,24 @@ namespace DomainDetective {
                 }
             }
             throw new SocketException(lastError is SocketException socketError ? socketError.ErrorCode : (int)SocketError.HostUnreachable);
+        }
+
+        private void CaptureRemoteAddress(TcpClient client) {
+            if (client.Client.RemoteEndPoint is IPEndPoint endpoint) {
+                RemoteAddress = endpoint.Address.IsIPv4MappedToIPv6
+                    ? endpoint.Address.MapToIPv4()
+                    : endpoint.Address;
+            }
+        }
+
+        private void CaptureRedirectTarget(Uri? uri, string originalUrl) {
+            if (uri == null || !Uri.TryCreate(originalUrl, UriKind.Absolute, out Uri? original) ||
+                string.Equals(uri.Host, original.Host, StringComparison.OrdinalIgnoreCase)) {
+                return;
+            }
+            if (!RedirectTargets.Contains(uri.Host, StringComparer.OrdinalIgnoreCase)) {
+                RedirectTargets.Add(uri.Host);
+            }
         }
 
         internal static Exception NormalizeProbeException(

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -497,36 +497,52 @@ namespace DomainDetective {
             const int maxRedirects = 10;
             int followedRedirects = 0;
             Uri currentUri = initialUri;
+            IPAddress? originRemoteAddress = null;
+            bool capturedOriginRemoteAddress = false;
             using var redirectTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             if (client.Timeout != System.Threading.Timeout.InfiniteTimeSpan) {
                 redirectTimeoutSource.CancelAfter(client.Timeout);
             }
-            while (true) {
-                using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
+            try {
+                while (true) {
+                    using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
 #if NET8_0_OR_GREATER
-                request.Version = HttpVersion.Version30;
-                request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+                    request.Version = HttpVersion.Version30;
+                    request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
 #endif
-                HttpResponseMessage response = await client.SendAsync(request, redirectTimeoutSource.Token).ConfigureAwait(false);
-                if (!TryResolveRedirectTarget(response, currentUri, out Uri? redirectUri) || redirectUri == null) {
-                    return response;
-                }
-                if (followedRedirects >= maxRedirects) {
-                    response.Dispose();
-                    throw new HttpRequestException($"The HTTP redirect limit of {maxRedirects} was exceeded.");
-                }
+                    HttpResponseMessage response = await client.SendAsync(
+                            request,
+                            HttpCompletionOption.ResponseHeadersRead,
+                            redirectTimeoutSource.Token)
+                        .ConfigureAwait(false);
+                    if (!capturedOriginRemoteAddress) {
+                        originRemoteAddress = RemoteAddress;
+                        capturedOriginRemoteAddress = true;
+                    }
+                    if (!TryResolveRedirectTarget(response, currentUri, out Uri? redirectUri) || redirectUri == null) {
+                        return response;
+                    }
+                    if (followedRedirects >= maxRedirects) {
+                        response.Dispose();
+                        throw new HttpRequestException($"The HTTP redirect limit of {maxRedirects} was exceeded.");
+                    }
 
-                CaptureRedirectTarget(redirectUri, currentUri);
-                if (string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
-                    string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)) {
-                    response.Dispose();
-                    throw new HttpRequestException(
-                        $"HTTPS redirect downgrade to HTTP is not allowed: '{currentUri}' -> '{redirectUri}'.");
-                }
+                    CaptureRedirectTarget(redirectUri, currentUri);
+                    if (string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)) {
+                        response.Dispose();
+                        throw new HttpRequestException(
+                            $"HTTPS redirect downgrade to HTTP is not allowed: '{currentUri}' -> '{redirectUri}'.");
+                    }
 
-                followedRedirects++;
-                response.Dispose();
-                currentUri = redirectUri;
+                    followedRedirects++;
+                    response.Dispose();
+                    currentUri = redirectUri;
+                }
+            } finally {
+                if (capturedOriginRemoteAddress) {
+                    RemoteAddress = originRemoteAddress;
+                }
             }
         }
 

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -278,7 +278,7 @@ namespace DomainDetective {
                 return;
             }
 
-            using (var handler = new HttpClientHandler { AllowAutoRedirect = true, MaxAutomaticRedirections = 10, CheckCertificateRevocationList = !SkipRevocation }) {
+            using (var handler = new HttpClientHandler { AllowAutoRedirect = false, CheckCertificateRevocationList = !SkipRevocation }) {
                 handler.ServerCertificateCustomValidationCallback = (HttpRequestMessage requestMessage, X509Certificate2? certificate, X509Chain? chain, SslPolicyErrors policyErrors) => {
                     if (certificate == null) {
                         return false;
@@ -308,20 +308,13 @@ namespace DomainDetective {
                     client.Timeout = Timeout;
                     try {
 #if NET8_0_OR_GREATER
-                        var request = new HttpRequestMessage(HttpMethod.Get, url) {
-                            Version = HttpVersion.Version30,
-                            VersionPolicy = HttpVersionPolicy.RequestVersionOrLower
-                        };
-                        using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
-                        CaptureRedirectTarget(uri: response.RequestMessage?.RequestUri, originalUrl: url);
+                        using HttpResponseMessage response = await SendWithRedirectEvidenceAsync(client, new Uri(url), cancellationToken).ConfigureAwait(false);
                         IsReachable = response.IsSuccessStatusCode;
                         ProtocolVersion = response.Version;
                         Http3Supported = response.Version >= HttpVersion.Version30;
                         Http2Supported = response.Version >= HttpVersion.Version20;
 #else
-                        var request = new HttpRequestMessage(HttpMethod.Get, url);
-                        using HttpResponseMessage response = await client.SendAsync(request, cancellationToken);
-                        CaptureRedirectTarget(uri: response.RequestMessage?.RequestUri, originalUrl: url);
+                        using HttpResponseMessage response = await SendWithRedirectEvidenceAsync(client, new Uri(url), cancellationToken).ConfigureAwait(false);
                         IsReachable = response.IsSuccessStatusCode;
                         ProtocolVersion = response.Version;
                         Http2Supported = response.Version.Major >= 2;
@@ -447,14 +440,67 @@ namespace DomainDetective {
             }
         }
 
-        private void CaptureRedirectTarget(Uri? uri, string originalUrl) {
-            if (uri == null || !Uri.TryCreate(originalUrl, UriKind.Absolute, out Uri? original) ||
-                string.Equals(uri.Host, original.Host, StringComparison.OrdinalIgnoreCase)) {
+        internal async Task<HttpResponseMessage> SendWithRedirectEvidenceAsync(
+            HttpClient client,
+            Uri initialUri,
+            CancellationToken cancellationToken) {
+            if (client == null) {
+                throw new ArgumentNullException(nameof(client));
+            }
+            if (initialUri == null) {
+                throw new ArgumentNullException(nameof(initialUri));
+            }
+
+            const int maxRedirects = 10;
+            int followedRedirects = 0;
+            Uri currentUri = initialUri;
+            while (true) {
+                using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
+#if NET8_0_OR_GREATER
+                request.Version = HttpVersion.Version30;
+                request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
+#endif
+                HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                if (!TryResolveRedirectTarget(response, currentUri, out Uri? redirectUri) || redirectUri == null) {
+                    return response;
+                }
+                if (followedRedirects >= maxRedirects) {
+                    response.Dispose();
+                    throw new HttpRequestException($"The HTTP redirect limit of {maxRedirects} was exceeded.");
+                }
+
+                followedRedirects++;
+                CaptureRedirectTarget(redirectUri, currentUri);
+                response.Dispose();
+                currentUri = redirectUri;
+            }
+        }
+
+        private static bool TryResolveRedirectTarget(
+            HttpResponseMessage response,
+            Uri currentUri,
+            out Uri? redirectUri) {
+            redirectUri = null;
+            int statusCode = (int)response.StatusCode;
+            if (statusCode != 301 && statusCode != 302 && statusCode != 303 && statusCode != 307 && statusCode != 308) {
+                return false;
+            }
+
+            Uri? location = response.Headers.Location;
+            if (location == null) {
+                return false;
+            }
+            redirectUri = location.IsAbsoluteUri ? location : new Uri(currentUri, location);
+            return string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase) ||
+                   string.Equals(redirectUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private void CaptureRedirectTarget(Uri? uri, Uri? sourceUri) {
+            if (uri == null || sourceUri == null ||
+                string.Equals(uri.Host, sourceUri.Host, StringComparison.OrdinalIgnoreCase)) {
                 return;
             }
-            if (!RedirectTargets.Contains(uri.Host, StringComparer.OrdinalIgnoreCase)) {
-                RedirectTargets.Add(uri.Host);
-            }
+            RedirectTargets.Add(uri.Host);
         }
 
         internal static Exception NormalizeProbeException(

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -87,6 +87,8 @@ namespace DomainDetective {
         public IPAddress? RemoteAddress { get; private set; }
         /// <summary>Optional resolver that returns addresses approved for outbound connections.</summary>
         public Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>>? OutboundAddressResolver { get; set; }
+        internal Func<AddressFamily, TcpClient> TcpClientFactory { get; set; } = family =>
+            family == AddressFamily.Unspecified ? new TcpClient() : new TcpClient(family);
         /// <summary>Gets redirect target hosts observed during the most recent HTTP analysis.</summary>
         public List<string> RedirectTargets { get; } = new();
         /// <summary>Gets DNS names listed in the certificate subject alternative name extension.</summary>
@@ -488,21 +490,29 @@ namespace DomainDetective {
 
         internal async Task<TcpClient> ConnectDirectAsync(string host, int port, CancellationToken cancellationToken) {
             if (OutboundAddressResolver == null) {
-                var client = new TcpClient();
-                await client.ConnectAsync(host, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
-                CaptureRemoteAddress(client);
-                return client;
+                var client = TcpClientFactory(AddressFamily.Unspecified);
+                try {
+                    await client.ConnectAsync(host, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+                    CaptureRemoteAddress(client);
+                    return client;
+                } catch {
+                    client.Dispose();
+                    throw;
+                }
             }
 
             var addresses = await OutboundAddressResolver(host, cancellationToken).ConfigureAwait(false);
             Exception? lastError = null;
             foreach (var address in addresses) {
-                var client = new TcpClient(address.AddressFamily);
+                var client = TcpClientFactory(address.AddressFamily);
                 try {
                     await client.ConnectAsync(address, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
                     CaptureRemoteAddress(client);
                     return client;
-                } catch (Exception ex) when (ex is not OperationCanceledException) {
+                } catch (OperationCanceledException) {
+                    client.Dispose();
+                    throw;
+                } catch (Exception ex) {
                     lastError = ex;
                     client.Dispose();
                 }

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -331,8 +331,7 @@ namespace DomainDetective {
                 using var originSsl = new SslStream(
                     originTcp.GetStream(),
                     false,
-                    (_, certificate, chain, policyErrors) =>
-                        CaptureServerCertificate(certificate, chain, policyErrors));
+                    static (_, _, _, _) => true);
                 await originSsl.AuthenticateAsClientAsync(
                         originUri.Host,
                         null,
@@ -406,7 +405,12 @@ namespace DomainDetective {
                                 var uri = new Uri(url);
                                 timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                                 timeoutCts.CancelAfter(Timeout);
-                                using var tcp = await ConnectDirectAsync(uri.Host, port, timeoutCts.Token).ConfigureAwait(false);
+                                using var tcp = await ConnectDirectAsync(
+                                        uri.Host,
+                                        port,
+                                        timeoutCts.Token,
+                                        captureRemoteAddress: false)
+                                    .ConfigureAwait(false);
                                 using var ssl = new SslStream(tcp.GetStream(), false, (sender, certificate, chain, errors) => {
                                     HostnameMatch = (errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
                                     return errors == SslPolicyErrors.None;
@@ -488,12 +492,18 @@ namespace DomainDetective {
             IsSelfSigned = IsSelfSignedCertificate(Certificate);
         }
 
-        internal async Task<TcpClient> ConnectDirectAsync(string host, int port, CancellationToken cancellationToken) {
+        internal async Task<TcpClient> ConnectDirectAsync(
+            string host,
+            int port,
+            CancellationToken cancellationToken,
+            bool captureRemoteAddress = true) {
             if (OutboundAddressResolver == null) {
                 var client = TcpClientFactory(AddressFamily.Unspecified);
                 try {
                     await client.ConnectAsync(host, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
-                    CaptureRemoteAddress(client);
+                    if (captureRemoteAddress) {
+                        CaptureRemoteAddress(client);
+                    }
                     return client;
                 } catch {
                     client.Dispose();
@@ -501,13 +511,20 @@ namespace DomainDetective {
                 }
             }
 
-            var addresses = await OutboundAddressResolver(host, cancellationToken).ConfigureAwait(false);
+            var addresses = await OutboundAddressResolver(host, cancellationToken).ConfigureAwait(false)
+                ?? Array.Empty<IPAddress>();
             Exception? lastError = null;
-            foreach (var address in addresses) {
+            foreach (IPAddress? candidate in addresses) {
+                if (candidate == null) {
+                    continue;
+                }
+                IPAddress address = candidate.IsIPv4MappedToIPv6 ? candidate.MapToIPv4() : candidate;
                 var client = TcpClientFactory(address.AddressFamily);
                 try {
                     await client.ConnectAsync(address, port).WaitWithCancellation(cancellationToken).ConfigureAwait(false);
-                    CaptureRemoteAddress(client);
+                    if (captureRemoteAddress) {
+                        CaptureRemoteAddress(client);
+                    }
                     return client;
                 } catch (OperationCanceledException) {
                     client.Dispose();

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -365,10 +365,13 @@ namespace DomainDetective {
                 }
             };
             socketsHandler.ConnectCallback = async (context, token) => {
+                bool captureOriginAddress = context.InitialRequestMessage.RequestUri is Uri requestUri &&
+                    IsOriginTransportEndpoint(context.DnsEndPoint, requestUri);
                 TcpClient tcp = await ConnectDirectAsync(
                         context.DnsEndPoint.Host,
                         context.DnsEndPoint.Port,
-                        token)
+                        token,
+                        captureRemoteAddress: captureOriginAddress)
                     .ConfigureAwait(false);
                 return tcp.GetStream();
             };
@@ -536,6 +539,19 @@ namespace DomainDetective {
             }
             throw new SocketException(lastError is SocketException socketError ? socketError.ErrorCode : (int)SocketError.HostUnreachable);
         }
+
+#if NET8_0_OR_GREATER
+        internal static bool IsOriginTransportEndpoint(DnsEndPoint connectionEndpoint, Uri requestUri) {
+            if (connectionEndpoint == null || requestUri == null) {
+                return false;
+            }
+            return connectionEndpoint.Port == requestUri.Port &&
+                   string.Equals(
+                       EndpointHostNormalizer.Normalize(connectionEndpoint.Host, lowercase: true),
+                       EndpointHostNormalizer.Normalize(requestUri.DnsSafeHost, lowercase: true),
+                       StringComparison.OrdinalIgnoreCase);
+        }
+#endif
 
         private void CaptureRemoteAddress(TcpClient client) {
             if (client.Client.RemoteEndPoint is IPEndPoint endpoint) {

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -454,13 +454,17 @@ namespace DomainDetective {
             const int maxRedirects = 10;
             int followedRedirects = 0;
             Uri currentUri = initialUri;
+            using var redirectTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            if (client.Timeout != System.Threading.Timeout.InfiniteTimeSpan) {
+                redirectTimeoutSource.CancelAfter(client.Timeout);
+            }
             while (true) {
                 using var request = new HttpRequestMessage(HttpMethod.Get, currentUri);
 #if NET8_0_OR_GREATER
                 request.Version = HttpVersion.Version30;
                 request.VersionPolicy = HttpVersionPolicy.RequestVersionOrLower;
 #endif
-                HttpResponseMessage response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                HttpResponseMessage response = await client.SendAsync(request, redirectTimeoutSource.Token).ConfigureAwait(false);
                 if (!TryResolveRedirectTarget(response, currentUri, out Uri? redirectUri) || redirectUri == null) {
                     return response;
                 }
@@ -482,7 +486,7 @@ namespace DomainDetective {
             out Uri? redirectUri) {
             redirectUri = null;
             int statusCode = (int)response.StatusCode;
-            if (statusCode != 301 && statusCode != 302 && statusCode != 303 && statusCode != 307 && statusCode != 308) {
+            if (statusCode != 300 && statusCode != 301 && statusCode != 302 && statusCode != 303 && statusCode != 307 && statusCode != 308) {
                 return false;
             }
 

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -79,7 +79,11 @@ namespace DomainDetective {
         public bool? CrlRevoked { get; private set; }
         /// <summary>Gets or sets the HTTP request timeout.</summary>
         public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
-        /// <summary>Gets the actual remote address reached by the most recent observable TCP connection.</summary>
+        /// <summary>
+        /// Gets the actual remote address reached by the origin probe. On .NET Framework full-HTTP
+        /// analysis this comes from a paired direct TLS handshake because HttpClientHandler does not
+        /// expose its transport socket.
+        /// </summary>
         public IPAddress? RemoteAddress { get; private set; }
         /// <summary>Optional resolver that returns addresses approved for outbound connections.</summary>
         public Func<string, CancellationToken, Task<IReadOnlyList<IPAddress>>>? OutboundAddressResolver { get; set; }
@@ -315,6 +319,37 @@ namespace DomainDetective {
                 }
                 return true;
             }
+
+#if NET472
+            try {
+                var originUri = new Uri(url);
+                using var originTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                originTimeoutSource.CancelAfter(Timeout);
+                using var originTcp = await ConnectDirectAsync(originUri.Host, port, originTimeoutSource.Token).ConfigureAwait(false);
+                using var originSsl = new SslStream(
+                    originTcp.GetStream(),
+                    false,
+                    (_, certificate, chain, policyErrors) =>
+                        CaptureServerCertificate(certificate, chain, policyErrors));
+                await originSsl.AuthenticateAsClientAsync(
+                        originUri.Host,
+                        null,
+                        SslProtocols.None,
+                        !SkipRevocation)
+                    .WaitWithCancellation(originTimeoutSource.Token)
+                    .ConfigureAwait(false);
+            } catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+                throw;
+            } catch (Exception ex) {
+                if (!capturedHandshakeCertificate) {
+                    RemoteAddress = null;
+                }
+                logger.WriteVerbose(
+                    "Paired .NET Framework TLS peer capture failed for {0}; continuing with full HTTP analysis: {1}",
+                    url,
+                    BuildFailureLogMessage(ex));
+            }
+#endif
 
             HttpMessageHandler handler;
 #if NET8_0_OR_GREATER

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -473,8 +473,15 @@ namespace DomainDetective {
                     throw new HttpRequestException($"The HTTP redirect limit of {maxRedirects} was exceeded.");
                 }
 
-                followedRedirects++;
                 CaptureRedirectTarget(redirectUri, currentUri);
+                if (string.Equals(currentUri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(redirectUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)) {
+                    response.Dispose();
+                    throw new HttpRequestException(
+                        $"HTTPS redirect downgrade to HTTP is not allowed: '{currentUri}' -> '{redirectUri}'.");
+                }
+
+                followedRedirects++;
                 response.Dispose();
                 currentUri = redirectUri;
             }

--- a/DomainDetective/Protocols/CertificateHTTP.cs
+++ b/DomainDetective/Protocols/CertificateHTTP.cs
@@ -278,33 +278,76 @@ namespace DomainDetective {
                 return;
             }
 
-            using (var handler = new HttpClientHandler { AllowAutoRedirect = false, CheckCertificateRevocationList = !SkipRevocation }) {
-                handler.ServerCertificateCustomValidationCallback = (HttpRequestMessage requestMessage, X509Certificate2? certificate, X509Chain? chain, SslPolicyErrors policyErrors) => {
-                    if (certificate == null) {
-                        return false;
-                    }
+            bool CaptureServerCertificate(
+                System.Security.Cryptography.X509Certificates.X509Certificate? certificate,
+                X509Chain? chain,
+                SslPolicyErrors policyErrors) {
+                if (certificate == null) {
+                    return false;
+                }
 
-                    if (!capturedHandshakeCertificate) {
-                        var leaf = chain != null && chain.ChainElements.Count > 0
-                            ? chain.ChainElements[0].Certificate
-                            : certificate;
+                if (!capturedHandshakeCertificate) {
+                    X509Certificate2? loadedLeaf = null;
+                    var leaf = chain != null && chain.ChainElements.Count > 0
+                        ? chain.ChainElements[0].Certificate
+                        : certificate as X509Certificate2;
+                    if (leaf == null) {
+                        loadedLeaf = CertificateLoaderCompat.LoadCertificate(certificate.Export(X509ContentType.Cert));
+                        leaf = loadedLeaf;
+                    }
+                    try {
                         Certificate = CertificateLoaderCompat.Clone(leaf);
-
-                        Chain.Clear();
-                        if (chain != null) {
-                            foreach (var element in chain.ChainElements) {
-                                Chain.Add(CertificateLoaderCompat.Clone(element.Certificate));
-                            }
-                        }
-                        RecordChainSource(ChainSourceTlsHandshake);
-                        IsSelfSigned = IsSelfSignedCertificate(Certificate);
-                        IsValid = policyErrors == SslPolicyErrors.None;
-                        HostnameMatch = (policyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
-                        capturedHandshakeCertificate = true;
+                    } finally {
+                        loadedLeaf?.Dispose();
                     }
-                    return true;
-                };
-                using (var client = new HttpClient(handler)) {
+
+                    Chain.Clear();
+                    if (chain != null) {
+                        foreach (var element in chain.ChainElements) {
+                            Chain.Add(CertificateLoaderCompat.Clone(element.Certificate));
+                        }
+                    }
+                    RecordChainSource(ChainSourceTlsHandshake);
+                    IsSelfSigned = IsSelfSignedCertificate(Certificate);
+                    IsValid = policyErrors == SslPolicyErrors.None;
+                    HostnameMatch = (policyErrors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
+                    capturedHandshakeCertificate = true;
+                }
+                return true;
+            }
+
+            HttpMessageHandler handler;
+#if NET8_0_OR_GREATER
+            var socketsHandler = new SocketsHttpHandler {
+                AllowAutoRedirect = false,
+                SslOptions = new SslClientAuthenticationOptions {
+                    CertificateRevocationCheckMode = SkipRevocation
+                        ? X509RevocationMode.NoCheck
+                        : X509RevocationMode.Online,
+                    RemoteCertificateValidationCallback = (_, certificate, chain, policyErrors) =>
+                        CaptureServerCertificate(certificate, chain, policyErrors)
+                }
+            };
+            socketsHandler.ConnectCallback = async (context, token) => {
+                TcpClient tcp = await ConnectDirectAsync(
+                        context.DnsEndPoint.Host,
+                        context.DnsEndPoint.Port,
+                        token)
+                    .ConfigureAwait(false);
+                return tcp.GetStream();
+            };
+            handler = socketsHandler;
+#else
+            var httpClientHandler = new HttpClientHandler {
+                AllowAutoRedirect = false,
+                CheckCertificateRevocationList = !SkipRevocation
+            };
+            httpClientHandler.ServerCertificateCustomValidationCallback = (_, certificate, chain, policyErrors) =>
+                CaptureServerCertificate(certificate, chain, policyErrors);
+            handler = httpClientHandler;
+#endif
+            using (handler) {
+                using (var client = new HttpClient(handler, disposeHandler: false)) {
                     client.Timeout = Timeout;
                     try {
 #if NET8_0_OR_GREATER

--- a/DomainDetective/Protocols/CnameAnalysis.cs
+++ b/DomainDetective/Protocols/CnameAnalysis.cs
@@ -78,7 +78,7 @@ public class CnameAnalysis : IHasAssessments {
 
         if (TargetResolves) {
             logger?.WriteInformationCode(CnameCodes.TargetResolves, "CNAME target {0} resolves", Target);
-        } else {
+        } else if (evidence.AddressResolutionComplete) {
             logger?.WriteWarningCode(CnameCodes.TargetDoesNotResolve, "CNAME target {0} does not resolve", Target);
         }
     }

--- a/DomainDetective/Protocols/CnameAnalysis.cs
+++ b/DomainDetective/Protocols/CnameAnalysis.cs
@@ -57,9 +57,9 @@ public class CnameAnalysis : IHasAssessments {
         };
         EndpointDnsEvidence evidence = await resolver.ResolveAsync(domainName, ct).ConfigureAwait(false);
         Chain = evidence.CnameChain;
-        CnameRecordExists = Chain.Count > 0;
-        Target = CnameRecordExists ? Chain[Chain.Count - 1] : null;
-        TargetResolves = CnameRecordExists && evidence.Addresses.Count > 0;
+        CnameRecordExists = evidence.CnameRecordExists;
+        Target = Chain.Count > 0 ? Chain[Chain.Count - 1] : null;
+        TargetResolves = Target != null && evidence.Addresses.Count > 0;
         LoopDetected = evidence.LoopDetected;
 
         if (LoopDetected) {

--- a/DomainDetective/Protocols/CnameAnalysis.cs
+++ b/DomainDetective/Protocols/CnameAnalysis.cs
@@ -50,6 +50,7 @@ public class CnameAnalysis : IHasAssessments {
         Chain = Array.Empty<string>();
         var resolver = new EndpointDnsEvidenceResolver {
             DnsConfiguration = DnsConfiguration,
+            ResolveAddressesForOriginalHost = false,
             QueryDnsOverride = QueryDnsOverride == null
                 ? null
                 : (name, type, _) => QueryDnsOverride(name, type)

--- a/DomainDetective/Protocols/CnameAnalysis.cs
+++ b/DomainDetective/Protocols/CnameAnalysis.cs
@@ -22,6 +22,8 @@ public class CnameAnalysis : IHasAssessments {
     public bool CnameRecordExists { get; private set; }
     /// <summary>Gets the final CNAME target if one was found.</summary>
     public string? Target { get; private set; }
+    /// <summary>Gets CNAME targets in traversal order.</summary>
+    public IReadOnlyList<string> Chain { get; private set; } = Array.Empty<string>();
     /// <summary>Gets a value indicating whether the target resolves.</summary>
     public bool TargetResolves { get; private set; }
     /// <summary>Gets a value indicating whether a loop was detected.</summary>
@@ -45,29 +47,26 @@ public class CnameAnalysis : IHasAssessments {
         TargetResolves = false;
         LoopDetected = false;
 
-        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        var current = domainName;
-        while (true) {
-            ct.ThrowIfCancellationRequested();
-            DnsAnswer[] cname;
-            try {
-                cname = await QueryDns(current, DnsRecordType.CNAME);
-            } catch (Exception ex) {
-                logger?.WriteErrorCode(CnameCodes.DnsLookupFailed, "DNS lookup failed for {0}: {1}", current, ex.Message);
-                return;
-            }
-            if (cname == null || cname.Length == 0) {
-                break;
-            }
-            CnameRecordExists = true;
-            var next = cname[0].Data.TrimEnd('.');
-            if (!visited.Add(next)) {
-                LoopDetected = true;
-                logger?.WriteErrorCode(CnameCodes.LoopDetected, "CNAME loop detected at {0}", next);
-                return;
-            }
-            Target = next;
-            current = next;
+        Chain = Array.Empty<string>();
+        var resolver = new EndpointDnsEvidenceResolver {
+            DnsConfiguration = DnsConfiguration,
+            QueryDnsOverride = QueryDnsOverride == null
+                ? null
+                : (name, type, _) => QueryDnsOverride(name, type)
+        };
+        EndpointDnsEvidence evidence = await resolver.ResolveAsync(domainName, ct).ConfigureAwait(false);
+        Chain = evidence.CnameChain;
+        CnameRecordExists = Chain.Count > 0;
+        Target = CnameRecordExists ? Chain[Chain.Count - 1] : null;
+        TargetResolves = CnameRecordExists && evidence.Addresses.Count > 0;
+        LoopDetected = evidence.LoopDetected;
+
+        if (LoopDetected) {
+            logger?.WriteErrorCode(CnameCodes.LoopDetected, "CNAME loop detected for {0}", domainName);
+            return;
+        }
+        foreach (string error in evidence.Errors) {
+            logger?.WriteErrorCode(CnameCodes.DnsLookupFailed, "DNS lookup failed for {0}: {1}", domainName, error);
         }
 
         if (!CnameRecordExists) {
@@ -76,15 +75,6 @@ public class CnameAnalysis : IHasAssessments {
         }
 
         logger?.WriteInformationCode(CnameCodes.NoLoop, "CNAME chain has no loop");
-
-        try {
-            var a = await QueryDns(Target!, DnsRecordType.A);
-            var aaaa = await QueryDns(Target!, DnsRecordType.AAAA);
-            TargetResolves = (a != null && a.Any()) || (aaaa != null && aaaa.Any());
-        } catch (Exception ex) {
-            logger?.WriteErrorCode(CnameCodes.DnsLookupFailed, "DNS lookup failed for {0}: {1}", Target, ex.Message);
-            return;
-        }
 
         if (TargetResolves) {
             logger?.WriteInformationCode(CnameCodes.TargetResolves, "CNAME target {0} resolves", Target);

--- a/DomainDetective/Protocols/DetectedDnsApplicationCatalog.cs
+++ b/DomainDetective/Protocols/DetectedDnsApplicationCatalog.cs
@@ -47,7 +47,10 @@ internal static class DetectedDnsApplicationCatalog {
             apps.Add(mailProviderApp);
         }
 
-        var cnameTargetApp = FromCnameTargetProvider(dnsInventory.CnameTargetProvider, dnsInventory.CnameTargetEvidence);
+        var cnameTargetApp = FromCnameTargetProvider(
+            dnsInventory.CnameTargetProvider,
+            dnsInventory.CnameTargetEvidence,
+            dnsInventory.CnameTargetService);
         if (cnameTargetApp != null) {
             apps.Add(cnameTargetApp);
         }
@@ -100,7 +103,10 @@ internal static class DetectedDnsApplicationCatalog {
         };
     }
 
-    public static DetectedDnsApplication? FromCnameTargetProvider(DnsCnameTargetProvider provider, IReadOnlyList<string>? evidence) {
+    public static DetectedDnsApplication? FromCnameTargetProvider(
+        DnsCnameTargetProvider provider,
+        IReadOnlyList<string>? evidence,
+        DnsCnameTargetService service = DnsCnameTargetService.Unknown) {
         if (provider == DnsCnameTargetProvider.Unknown) {
             return null;
         }
@@ -113,9 +119,10 @@ internal static class DetectedDnsApplicationCatalog {
             _ => DetectedDnsAppCategory.Other
         };
 
+        string identity = service != DnsCnameTargetService.Unknown ? service.ToString() : provider.ToString();
         return new DetectedDnsApplication {
-            Id = "cname-target-" + provider.ToString().ToLowerInvariant(),
-            Name = provider.ToString(),
+            Id = "cname-target-" + identity.ToLowerInvariant(),
+            Name = identity,
             Category = category,
             EvidenceKind = DetectedDnsAppEvidenceKind.CnameRecord,
             Confidence = Microsoft365DetectionConfidence.Strong,

--- a/DomainDetective/Protocols/DetectedDnsApplicationCatalog.cs
+++ b/DomainDetective/Protocols/DetectedDnsApplicationCatalog.cs
@@ -126,9 +126,35 @@ internal static class DetectedDnsApplicationCatalog {
             Category = category,
             EvidenceKind = DetectedDnsAppEvidenceKind.CnameRecord,
             Confidence = Microsoft365DetectionConfidence.Strong,
-            Evidence = FirstEvidence(evidence, provider.ToString()),
+            Evidence = SelectCnameEvidence(evidence, provider, service),
             Source = "DnsInventory.CnameTarget"
         };
+    }
+
+    private static string SelectCnameEvidence(
+        IReadOnlyList<string>? evidence,
+        DnsCnameTargetProvider provider,
+        DnsCnameTargetService service) {
+        const string targetPrefix = "Apex CNAME:";
+        if (evidence != null) {
+            for (int index = evidence.Count - 1; index >= 0; index--) {
+                string item = evidence[index] ?? string.Empty;
+                if (!item.StartsWith(targetPrefix, StringComparison.OrdinalIgnoreCase)) {
+                    continue;
+                }
+
+                string target = item.Substring(targetPrefix.Length).Trim();
+                DnsCnameTargetDetector.Match match = DnsCnameTargetDetector.Detect(target);
+                bool matchesSelectedIdentity = service != DnsCnameTargetService.Unknown
+                    ? match.Service == service
+                    : match.Provider == provider;
+                if (matchesSelectedIdentity) {
+                    return item;
+                }
+            }
+        }
+
+        return FirstEvidence(evidence, provider.ToString());
     }
 
     private static string FirstEvidence(IReadOnlyList<string>? evidence, string fallback) {

--- a/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
+++ b/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
@@ -159,6 +159,8 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
 
             var evidence = new List<string>();
             var bestProvider = DnsCnameTargetProvider.Unknown;
+            var bestService = DnsCnameTargetService.Unknown;
+            var bestMatchRank = 0;
             var flags = DnsCnameTargetFlags.None;
 
             foreach (var target in targets.OrderBy(t => t, StringComparer.OrdinalIgnoreCase))
@@ -170,10 +172,14 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
 
                 var m = DnsCnameTargetDetector.Detect(target);
                 flags |= m.Flags;
-
-                if (bestProvider == DnsCnameTargetProvider.Unknown && m.Provider != DnsCnameTargetProvider.Unknown)
+                var matchRank = m.Service != DnsCnameTargetService.Unknown
+                    ? 2
+                    : (m.Provider != DnsCnameTargetProvider.Unknown ? 1 : 0);
+                if (matchRank > bestMatchRank)
                 {
                     bestProvider = m.Provider;
+                    bestService = m.Service;
+                    bestMatchRank = matchRank;
                 }
 
                 foreach (var e in m.Evidence)
@@ -191,6 +197,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
             }
 
             CnameTargetProvider = bestProvider;
+            CnameTargetService = bestService;
             CnameTargetFlags = flags;
             CnameTargetEvidence = evidence;
         }

--- a/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
+++ b/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
@@ -129,7 +129,10 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                 return;
             }
 
-            var targets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var responseTargets = new List<string>();
+            var seenResponseTargets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var targetByOwner = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            bool hasConflictingOwnerTargets = false;
             foreach (var q in queries)
             {
                 if (q.RecordType != DnsRecordType.CNAME)
@@ -144,18 +147,35 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                         continue;
                     }
 
-                    var t = NormalizeHost(r.Data);
-                    if (!string.IsNullOrWhiteSpace(t))
+                    var owner = NormalizeHost(r.Name);
+                    var target = NormalizeHost(r.Data);
+                    if (!string.IsNullOrWhiteSpace(target) && seenResponseTargets.Add(target))
                     {
-                        targets.Add(t);
+                        responseTargets.Add(target);
+                    }
+                    if (!string.IsNullOrWhiteSpace(owner) && !string.IsNullOrWhiteSpace(target))
+                    {
+                        if (targetByOwner.TryGetValue(owner, out string? existingTarget) &&
+                            !string.Equals(existingTarget, target, StringComparison.OrdinalIgnoreCase))
+                        {
+                            hasConflictingOwnerTargets = true;
+                        }
+                        else
+                        {
+                            targetByOwner[owner] = target;
+                        }
                     }
                 }
             }
 
-            if (targets.Count == 0)
+            if (responseTargets.Count == 0)
             {
                 return;
             }
+
+            var targets = hasConflictingOwnerTargets
+                ? responseTargets
+                : BuildCnameTraversal(targetByOwner, responseTargets);
 
             var evidence = new List<string>();
             var bestProvider = DnsCnameTargetProvider.Unknown;
@@ -163,7 +183,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
             var bestMatchRank = 0;
             var flags = DnsCnameTargetFlags.None;
 
-            foreach (var target in targets.OrderBy(t => t, StringComparer.OrdinalIgnoreCase))
+            foreach (var target in targets)
             {
                 if (evidence.Count < 10)
                 {
@@ -175,7 +195,10 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                 var matchRank = m.Service != DnsCnameTargetService.Unknown
                     ? 2
                     : (m.Provider != DnsCnameTargetProvider.Unknown ? 1 : 0);
-                if (matchRank > bestMatchRank)
+                // CNAME records are evaluated in owner-to-target traversal order. When
+                // equally strong services occur in one chain, the later (terminal)
+                // target describes the service actually reached.
+                if (matchRank > 0 && matchRank >= bestMatchRank)
                 {
                     bestProvider = m.Provider;
                     bestService = m.Service;
@@ -204,6 +227,34 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
         catch
         {
         }
+    }
+
+    private List<string> BuildCnameTraversal(
+        IReadOnlyDictionary<string, string> targetByOwner,
+        IReadOnlyList<string> responseTargets)
+    {
+        if (targetByOwner.Count == 0)
+        {
+            return responseTargets.ToList();
+        }
+
+        string current = NormalizeHost(Subject);
+        if (current.Length == 0 || !targetByOwner.ContainsKey(current))
+        {
+            var referenced = new HashSet<string>(targetByOwner.Values, StringComparer.OrdinalIgnoreCase);
+            current = targetByOwner.Keys.FirstOrDefault(owner => !referenced.Contains(owner))
+                ?? targetByOwner.Keys.First();
+        }
+
+        var traversal = new List<string>();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        while (visited.Add(current) && targetByOwner.TryGetValue(current, out string? target))
+        {
+            traversal.Add(target);
+            current = target;
+        }
+
+        return traversal.Count > 0 ? traversal : responseTargets.ToList();
     }
 
     private void TryDetectTxtSignals(List<DnsInventoryQuery> queries)

--- a/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
+++ b/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
@@ -181,6 +181,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
             var bestProvider = DnsCnameTargetProvider.Unknown;
             var bestService = DnsCnameTargetService.Unknown;
             var bestMatchRank = 0;
+            string? bestTarget = null;
             var flags = DnsCnameTargetFlags.None;
 
             foreach (var target in targets)
@@ -203,6 +204,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                     bestProvider = m.Provider;
                     bestService = m.Service;
                     bestMatchRank = matchRank;
+                    bestTarget = target;
                 }
 
                 foreach (var e in m.Evidence)
@@ -216,6 +218,20 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                     {
                         evidence.Add(e);
                     }
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(bestTarget))
+            {
+                string selectedTargetEvidence = $"Apex CNAME: {bestTarget}";
+                if (!evidence.Exists(item => string.Equals(
+                    item,
+                    selectedTargetEvidence,
+                    StringComparison.OrdinalIgnoreCase)))
+                {
+                    // Keep the selected identity explainable even when earlier hops
+                    // consume the bounded diagnostic evidence allocation.
+                    evidence.Add(selectedTargetEvidence);
                 }
             }
 

--- a/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
+++ b/DomainDetective/Protocols/DnsInventoryAnalysis.ProviderAndSignals.cs
@@ -132,7 +132,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
             var responseTargets = new List<string>();
             var seenResponseTargets = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var targetByOwner = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-            bool hasConflictingOwnerTargets = false;
+            var conflictingOwners = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             foreach (var q in queries)
             {
                 if (q.RecordType != DnsRecordType.CNAME)
@@ -158,7 +158,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                         if (targetByOwner.TryGetValue(owner, out string? existingTarget) &&
                             !string.Equals(existingTarget, target, StringComparison.OrdinalIgnoreCase))
                         {
-                            hasConflictingOwnerTargets = true;
+                            conflictingOwners.Add(owner);
                         }
                         else
                         {
@@ -173,11 +173,20 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                 return;
             }
 
+            bool hasConflictingOwnerTargets = conflictingOwners.Count > 0;
             var targets = hasConflictingOwnerTargets
                 ? responseTargets
                 : BuildCnameTraversal(targetByOwner, responseTargets);
 
             var evidence = new List<string>();
+            foreach (string conflictingOwner in conflictingOwners.OrderBy(owner => owner, StringComparer.OrdinalIgnoreCase))
+            {
+                if (evidence.Count >= 10)
+                {
+                    break;
+                }
+                evidence.Add($"Conflicting CNAME targets for owner: {conflictingOwner}");
+            }
             var bestProvider = DnsCnameTargetProvider.Unknown;
             var bestService = DnsCnameTargetService.Unknown;
             var bestMatchRank = 0;
@@ -192,14 +201,17 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
                 }
 
                 var m = DnsCnameTargetDetector.Detect(target);
-                flags |= m.Flags;
+                if (!hasConflictingOwnerTargets)
+                {
+                    flags |= m.Flags;
+                }
                 var matchRank = m.Service != DnsCnameTargetService.Unknown
                     ? 2
                     : (m.Provider != DnsCnameTargetProvider.Unknown ? 1 : 0);
                 // CNAME records are evaluated in owner-to-target traversal order. When
                 // equally strong services occur in one chain, the later (terminal)
                 // target describes the service actually reached.
-                if (matchRank > 0 && matchRank >= bestMatchRank)
+                if (!hasConflictingOwnerTargets && matchRank > 0 && matchRank >= bestMatchRank)
                 {
                     bestProvider = m.Provider;
                     bestService = m.Service;

--- a/DomainDetective/Protocols/DnsInventoryAnalysis.cs
+++ b/DomainDetective/Protocols/DnsInventoryAnalysis.cs
@@ -66,6 +66,9 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
     /// <summary>Best-effort inferred provider for apex CNAME target.</summary>
     public DnsCnameTargetProvider CnameTargetProvider { get; private set; } = DnsCnameTargetProvider.Unknown;
 
+    /// <summary>Best-effort inferred managed service for the apex CNAME target.</summary>
+    public DnsCnameTargetService CnameTargetService { get; private set; } = DnsCnameTargetService.Unknown;
+
     /// <summary>Flags describing the apex CNAME target (best-effort).</summary>
     public DnsCnameTargetFlags CnameTargetFlags { get; private set; } = DnsCnameTargetFlags.None;
 
@@ -542,6 +545,7 @@ public sealed partial class DnsInventoryAnalysis : IHasAssessments
         MailProviderScore = 0;
         MailProviderEvidence = Array.Empty<string>();
         CnameTargetProvider = DnsCnameTargetProvider.Unknown;
+        CnameTargetService = DnsCnameTargetService.Unknown;
         CnameTargetFlags = DnsCnameTargetFlags.None;
         CnameTargetEvidence = Array.Empty<string>();
         TxtSignals = DnsTxtSignals.None;

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -52,6 +52,9 @@ public sealed class FtpTlsEndpoint {
         if (Port < 1 || Port > 65535) {
             throw new ArgumentOutOfRangeException(nameof(Port), "Port must be between 1 and 65535.");
         }
+        if (Mode != FtpTlsMode.Explicit && Mode != FtpTlsMode.Implicit) {
+            throw new ArgumentOutOfRangeException(nameof(Mode), "Mode must be Explicit or Implicit.");
+        }
     }
 }
 
@@ -183,7 +186,7 @@ public sealed class FtpTlsAnalysis {
                     AutoFlush = true,
                     NewLine = "\r\n"
                 };
-                IReadOnlyList<string> greeting = await ReadResponseAsync(reader, timeoutCts.Token).ConfigureAwait(false);
+                IReadOnlyList<string> greeting = await ReadServiceReadyGreetingAsync(reader, timeoutCts.Token).ConfigureAwait(false);
                 result.Greeting = greeting;
                 if (!HasReplyCode(greeting, "220")) {
                     throw new InvalidDataException("FTP server did not return a 220 service-ready greeting.");
@@ -248,7 +251,11 @@ public sealed class FtpTlsAnalysis {
 
     private static async Task<IReadOnlyList<string>> ReadResponseAsync(
         StreamReader reader,
-        CancellationToken cancellationToken) {
+        CancellationToken cancellationToken,
+        int maxLines = MaxResponseLines) {
+        if (maxLines < 1) {
+            throw new InvalidDataException($"FTP response exceeded {MaxResponseLines} lines.");
+        }
         var lines = new List<string>();
         string? first = await reader.ReadLineAsync().WaitWithCancellation(cancellationToken).ConfigureAwait(false);
         if (first == null) {
@@ -260,7 +267,7 @@ public sealed class FtpTlsAnalysis {
         }
 
         string terminator = first.Substring(0, 3) + " ";
-        while (lines.Count < MaxResponseLines) {
+        while (lines.Count < maxLines) {
             string? line = await reader.ReadLineAsync().WaitWithCancellation(cancellationToken).ConfigureAwait(false);
             if (line == null) {
                 throw new EndOfStreamException("FTP server closed a multiline response before its terminator.");
@@ -271,6 +278,24 @@ public sealed class FtpTlsAnalysis {
             }
         }
         throw new InvalidDataException($"FTP response exceeded {MaxResponseLines} lines.");
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadServiceReadyGreetingAsync(
+        StreamReader reader,
+        CancellationToken cancellationToken) {
+        var lines = new List<string>();
+        while (lines.Count < MaxResponseLines) {
+            IReadOnlyList<string> response = await ReadResponseAsync(
+                    reader,
+                    cancellationToken,
+                    MaxResponseLines - lines.Count)
+                .ConfigureAwait(false);
+            lines.AddRange(response);
+            if (!HasReplyCode(response, "120")) {
+                return lines;
+            }
+        }
+        throw new InvalidDataException($"FTP response exceeded {MaxResponseLines} lines before service became ready.");
     }
 
     private static bool HasReplyCode(IReadOnlyList<string> response, string expected) {

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -49,6 +49,11 @@ public sealed class FtpTlsEndpoint {
         if (HostName.Length == 0) {
             throw new ArgumentException("An FTP TLS hostname is required.", nameof(HostName));
         }
+        if (!EndpointHostNormalizer.TryNormalize(HostName, out _)) {
+            throw new ArgumentException(
+                "Brackets are valid only around an IPv6 literal FTP TLS hostname.",
+                nameof(HostName));
+        }
         if (Port < 1 || Port > 65535) {
             throw new ArgumentOutOfRangeException(nameof(Port), "Port must be between 1 and 65535.");
         }

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -1,4 +1,5 @@
 using DomainDetective.Helpers;
+using DomainDetective.Network;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +26,7 @@ public enum FtpTlsMode {
 public sealed class FtpTlsEndpoint {
     /// <summary>Creates an FTP TLS endpoint.</summary>
     public FtpTlsEndpoint(string hostName, int port, FtpTlsMode mode) {
-        HostName = (hostName ?? string.Empty).Trim().TrimEnd('.');
+        HostName = EndpointHostNormalizer.Normalize(hostName);
         Port = port;
         Mode = mode;
         Validate();
@@ -275,7 +276,7 @@ public sealed class FtpTlsAnalysis {
         if (client.Client.RemoteEndPoint is IPEndPoint endpoint) {
             IPAddress address = endpoint.Address.IsIPv4MappedToIPv6 ? endpoint.Address.MapToIPv4() : endpoint.Address;
             connection.RemoteAddress = address.ToString();
-            connection.RemoteAddressFamily = address.AddressFamily.ToString();
+            connection.RemoteAddressFamily = IpAddressClassifier.GetAddressFamilyLabel(address);
         }
     }
 

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -115,6 +115,12 @@ public sealed class FtpTlsResult {
     /// <summary>Leaf certificate captured during negotiation.</summary>
     public X509Certificate2? Certificate { get; set; }
 
+    /// <summary>DNS subject alternative names parsed from the leaf certificate.</summary>
+    public List<string> CertificateDnsNames { get; } = new();
+
+    /// <summary>Best-effort SAN parsing error, when certificate DNS names could not be read.</summary>
+    public string? SanParsingError { get; set; }
+
     /// <summary>Certificate chain captured during negotiation.</summary>
     public List<X509Certificate2> Chain { get; } = new();
 
@@ -141,6 +147,9 @@ public sealed class FtpTlsAnalysis {
             throw new ArgumentNullException(nameof(endpoint));
         }
         endpoint.Validate();
+        if (Timeout <= TimeSpan.Zero || Timeout > TimeSpan.FromMinutes(10)) {
+            throw new ArgumentOutOfRangeException(nameof(Timeout), "Timeout must be greater than zero and at most 10 minutes.");
+        }
         var result = new FtpTlsResult {
             Mode = endpoint.Mode,
             Connection = new FtpTlsConnectionEvidence {
@@ -195,7 +204,12 @@ public sealed class FtpTlsAnalysis {
                 result.Chain.Clear();
                 result.ChainErrors.Clear();
                 if (certificate != null) {
-                    result.Certificate = CertificateLoaderCompat.LoadCertificate(certificate.Export(X509ContentType.Cert));
+                    X509Certificate2 loadedCertificate = CertificateLoaderCompat.LoadCertificate(certificate.Export(X509ContentType.Cert));
+                    result.Certificate = loadedCertificate;
+                    result.CertificateDnsNames.Clear();
+                    result.CertificateDnsNames.AddRange(
+                        TlsProbe.ExtractCertificateDnsNames(loadedCertificate, out string? sanParsingError));
+                    result.SanParsingError = sanParsingError;
                 }
                 if (chain != null) {
                     foreach (X509ChainElement element in chain.ChainElements) {

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -158,27 +158,30 @@ public sealed class FtpTlsAnalysis {
         if (Timeout <= TimeSpan.Zero || Timeout > TimeSpan.FromMinutes(10)) {
             throw new ArgumentOutOfRangeException(nameof(Timeout), "Timeout must be greater than zero and at most 10 minutes.");
         }
+        IPAddress? connectAddress = endpoint.ConnectAddress?.IsIPv4MappedToIPv6 == true
+            ? endpoint.ConnectAddress.MapToIPv4()
+            : endpoint.ConnectAddress;
         var result = new FtpTlsResult {
             Mode = endpoint.Mode,
             Connection = new FtpTlsConnectionEvidence {
                 HostName = endpoint.HostName,
                 Port = endpoint.Port,
-                ConnectAddress = endpoint.ConnectAddress?.ToString()
+                ConnectAddress = connectAddress?.ToString()
             }
         };
 
         using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutCts.CancelAfter(Timeout);
         try {
-            using var client = endpoint.ConnectAddress == null
+            using var client = connectAddress == null
                 ? new TcpClient()
-                : new TcpClient(endpoint.ConnectAddress.AddressFamily);
-            if (endpoint.ConnectAddress == null) {
+                : new TcpClient(connectAddress.AddressFamily);
+            if (connectAddress == null) {
                 await client.ConnectAsync(endpoint.HostName, endpoint.Port)
                     .WaitWithCancellation(timeoutCts.Token)
                     .ConfigureAwait(false);
             } else {
-                await client.ConnectAsync(endpoint.ConnectAddress, endpoint.Port)
+                await client.ConnectAsync(connectAddress, endpoint.Port)
                     .WaitWithCancellation(timeoutCts.Token)
                     .ConfigureAwait(false);
             }

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -1,0 +1,281 @@
+using DomainDetective.Helpers;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DomainDetective;
+
+/// <summary>FTP TLS negotiation mode.</summary>
+public enum FtpTlsMode {
+    /// <summary>Connect in clear text and upgrade with the FTP AUTH TLS command.</summary>
+    Explicit = 0,
+    /// <summary>Start TLS immediately after the TCP connection.</summary>
+    Implicit = 1
+}
+
+/// <summary>Logical FTP TLS endpoint and optional pinned transport address.</summary>
+public sealed class FtpTlsEndpoint {
+    /// <summary>Creates an FTP TLS endpoint.</summary>
+    public FtpTlsEndpoint(string hostName, int port, FtpTlsMode mode) {
+        HostName = (hostName ?? string.Empty).Trim().TrimEnd('.');
+        Port = port;
+        Mode = mode;
+        Validate();
+    }
+
+    /// <summary>Logical hostname used for DNS and TLS SNI.</summary>
+    public string HostName { get; }
+
+    /// <summary>TCP port.</summary>
+    public int Port { get; }
+
+    /// <summary>TLS negotiation mode.</summary>
+    public FtpTlsMode Mode { get; }
+
+    /// <summary>Optional concrete address to connect while retaining <see cref="HostName"/> for SNI.</summary>
+    public IPAddress? ConnectAddress { get; set; }
+
+    /// <summary>Validates the endpoint.</summary>
+    public void Validate() {
+        if (HostName.Length == 0) {
+            throw new ArgumentException("An FTP TLS hostname is required.", nameof(HostName));
+        }
+        if (Port < 1 || Port > 65535) {
+            throw new ArgumentOutOfRangeException(nameof(Port), "Port must be between 1 and 65535.");
+        }
+    }
+}
+
+/// <summary>Requested and observed FTP TLS connection evidence.</summary>
+public sealed class FtpTlsConnectionEvidence {
+    /// <summary>Logical hostname used by FTP and TLS.</summary>
+    public string HostName { get; set; } = string.Empty;
+
+    /// <summary>TCP port used by the probe.</summary>
+    public int Port { get; set; }
+
+    /// <summary>Concrete caller-selected address, when supplied.</summary>
+    public string? ConnectAddress { get; set; }
+
+    /// <summary>Actual remote address reached by the probe.</summary>
+    public string? RemoteAddress { get; set; }
+
+    /// <summary>Address family of <see cref="RemoteAddress"/>.</summary>
+    public string? RemoteAddressFamily { get; set; }
+}
+
+/// <summary>Protocol and certificate evidence returned by an FTP TLS probe.</summary>
+public sealed class FtpTlsResult {
+    /// <summary>Requested and observed connection evidence.</summary>
+    public FtpTlsConnectionEvidence Connection { get; set; } = new();
+
+    /// <summary>TLS negotiation mode used by the probe.</summary>
+    public FtpTlsMode Mode { get; set; }
+
+    /// <summary>FTP greeting lines observed before explicit TLS negotiation.</summary>
+    public IReadOnlyList<string> Greeting { get; set; } = Array.Empty<string>();
+
+    /// <summary>FTP response lines returned for AUTH TLS.</summary>
+    public IReadOnlyList<string> AuthTlsResponse { get; set; } = Array.Empty<string>();
+
+    /// <summary>True when a TLS session was negotiated.</summary>
+    public bool TlsNegotiated { get; set; }
+
+    /// <summary>True when platform certificate validation succeeded.</summary>
+    public bool CertificateValid { get; set; }
+
+    /// <summary>True when the certificate matched the logical hostname.</summary>
+    public bool HostnameMatch { get; set; }
+
+    /// <summary>TLS policy errors reported by the platform validation callback.</summary>
+    public SslPolicyErrors PolicyErrors { get; set; }
+
+    /// <summary>Certificate-chain status flags reported by platform chain validation.</summary>
+    public List<X509ChainStatusFlags> ChainErrors { get; } = new();
+
+    /// <summary>True when platform chain validation reported no chain errors.</summary>
+    public bool ChainValid => ChainErrors.Count == 0 &&
+                              (PolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) == 0;
+
+    /// <summary>Negotiated TLS protocol.</summary>
+    public SslProtocols Protocol { get; set; }
+
+    /// <summary>Leaf certificate captured during negotiation.</summary>
+    public X509Certificate2? Certificate { get; set; }
+
+    /// <summary>Certificate chain captured during negotiation.</summary>
+    public List<X509Certificate2> Chain { get; } = new();
+
+    /// <summary>Best-effort failure reason.</summary>
+    public string? FailureReason { get; set; }
+
+    /// <summary>Normalized failure classification.</summary>
+    public CertificateFailureKind FailureKind { get; set; }
+}
+
+/// <summary>Performs protocol-correct explicit or implicit FTP TLS certificate probing without authentication.</summary>
+public sealed class FtpTlsAnalysis {
+    private const int MaxResponseLines = 100;
+
+    /// <summary>Timeout applied to connect, FTP response, and TLS negotiation.</summary>
+    public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Analyzes one FTP TLS endpoint. The probe never submits user credentials or opens a data connection.</summary>
+    public async Task<FtpTlsResult> AnalyzeAsync(
+        FtpTlsEndpoint endpoint,
+        InternalLogger logger,
+        CancellationToken cancellationToken = default) {
+        if (endpoint == null) {
+            throw new ArgumentNullException(nameof(endpoint));
+        }
+        endpoint.Validate();
+        var result = new FtpTlsResult {
+            Mode = endpoint.Mode,
+            Connection = new FtpTlsConnectionEvidence {
+                HostName = endpoint.HostName,
+                Port = endpoint.Port,
+                ConnectAddress = endpoint.ConnectAddress?.ToString()
+            }
+        };
+
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutCts.CancelAfter(Timeout);
+        try {
+            using var client = endpoint.ConnectAddress == null
+                ? new TcpClient()
+                : new TcpClient(endpoint.ConnectAddress.AddressFamily);
+            if (endpoint.ConnectAddress == null) {
+                await client.ConnectAsync(endpoint.HostName, endpoint.Port)
+                    .WaitWithCancellation(timeoutCts.Token)
+                    .ConfigureAwait(false);
+            } else {
+                await client.ConnectAsync(endpoint.ConnectAddress, endpoint.Port)
+                    .WaitWithCancellation(timeoutCts.Token)
+                    .ConfigureAwait(false);
+            }
+            CaptureRemoteEndpoint(client, result.Connection);
+
+            using NetworkStream network = client.GetStream();
+            if (endpoint.Mode == FtpTlsMode.Explicit) {
+                using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+                using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) {
+                    AutoFlush = true,
+                    NewLine = "\r\n"
+                };
+                IReadOnlyList<string> greeting = await ReadResponseAsync(reader, timeoutCts.Token).ConfigureAwait(false);
+                result.Greeting = greeting;
+                if (!HasReplyCode(greeting, "220")) {
+                    throw new InvalidDataException("FTP server did not return a 220 service-ready greeting.");
+                }
+
+                await writer.WriteLineAsync("AUTH TLS").WaitWithCancellation(timeoutCts.Token).ConfigureAwait(false);
+                IReadOnlyList<string> authResponse = await ReadResponseAsync(reader, timeoutCts.Token).ConfigureAwait(false);
+                result.AuthTlsResponse = authResponse;
+                if (!HasReplyCode(authResponse, "234")) {
+                    throw new InvalidDataException("FTP server did not accept AUTH TLS with a 234 response.");
+                }
+            }
+
+            using var ssl = new SslStream(network, false, (sender, certificate, chain, errors) => {
+                result.PolicyErrors = errors;
+                result.CertificateValid = errors == SslPolicyErrors.None;
+                result.HostnameMatch = (errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
+                result.Chain.Clear();
+                result.ChainErrors.Clear();
+                if (certificate != null) {
+                    result.Certificate = CertificateLoaderCompat.LoadCertificate(certificate.Export(X509ContentType.Cert));
+                }
+                if (chain != null) {
+                    foreach (X509ChainElement element in chain.ChainElements) {
+                        result.Chain.Add(CertificateLoaderCompat.Clone(element.Certificate));
+                    }
+                    foreach (X509ChainStatus status in chain.ChainStatus) {
+                        if (status.Status != X509ChainStatusFlags.NoError) {
+                            result.ChainErrors.Add(status.Status);
+                        }
+                    }
+                }
+                if ((errors & SslPolicyErrors.RemoteCertificateChainErrors) != 0 && result.ChainErrors.Count == 0) {
+                    result.ChainErrors.Add(X509ChainStatusFlags.PartialChain);
+                }
+                return true;
+            });
+            await ssl.AuthenticateAsClientAsync(endpoint.HostName, null, SslProtocols.None, true)
+                .WaitWithCancellation(timeoutCts.Token)
+                .ConfigureAwait(false);
+            result.Protocol = ssl.SslProtocol;
+            result.TlsNegotiated = true;
+            return result;
+        } catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested) {
+            var exception = new TimeoutException("The FTP TLS probe timed out.");
+            SetFailure(result, exception);
+            logger.WriteVerbose("FTP TLS probe timed out for {0}:{1}.", endpoint.HostName, endpoint.Port);
+            return result;
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            SetFailure(result, ex);
+            logger.WriteVerbose("FTP TLS probe failed for {0}:{1}: {2}", endpoint.HostName, endpoint.Port, ex.Message);
+            return result;
+        }
+    }
+
+    private static async Task<IReadOnlyList<string>> ReadResponseAsync(
+        StreamReader reader,
+        CancellationToken cancellationToken) {
+        var lines = new List<string>();
+        string? first = await reader.ReadLineAsync().WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+        if (first == null) {
+            throw new EndOfStreamException("FTP server closed the connection before returning a response.");
+        }
+        lines.Add(first);
+        if (first.Length < 4 || first[3] != '-' || !IsReplyCode(first.Substring(0, 3))) {
+            return lines;
+        }
+
+        string terminator = first.Substring(0, 3) + " ";
+        while (lines.Count < MaxResponseLines) {
+            string? line = await reader.ReadLineAsync().WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+            if (line == null) {
+                throw new EndOfStreamException("FTP server closed a multiline response before its terminator.");
+            }
+            lines.Add(line);
+            if (line.StartsWith(terminator, StringComparison.Ordinal)) {
+                return lines;
+            }
+        }
+        throw new InvalidDataException($"FTP response exceeded {MaxResponseLines} lines.");
+    }
+
+    private static bool HasReplyCode(IReadOnlyList<string> response, string expected) {
+        if (response.Count == 0) {
+            return false;
+        }
+        string finalLine = response[response.Count - 1];
+        return string.Equals(finalLine, expected, StringComparison.Ordinal) ||
+               finalLine.StartsWith(expected + " ", StringComparison.Ordinal);
+    }
+
+    private static bool IsReplyCode(string value) {
+        return value.Length == 3 && char.IsDigit(value[0]) && char.IsDigit(value[1]) && char.IsDigit(value[2]);
+    }
+
+    private static void CaptureRemoteEndpoint(TcpClient client, FtpTlsConnectionEvidence connection) {
+        if (client.Client.RemoteEndPoint is IPEndPoint endpoint) {
+            IPAddress address = endpoint.Address.IsIPv4MappedToIPv6 ? endpoint.Address.MapToIPv4() : endpoint.Address;
+            connection.RemoteAddress = address.ToString();
+            connection.RemoteAddressFamily = address.AddressFamily.ToString();
+        }
+    }
+
+    private static void SetFailure(FtpTlsResult result, Exception exception) {
+        result.FailureReason = CertificateAnalysis.BuildFailureReason(exception);
+        result.FailureKind = CertificateFailureClassifier.Classify(exception);
+    }
+}

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -74,6 +74,9 @@ public sealed class FtpTlsConnectionEvidence {
 
 /// <summary>Protocol and certificate evidence returned by an FTP TLS probe.</summary>
 public sealed class FtpTlsResult {
+    /// <summary>UTC time when this protocol observation completed.</summary>
+    public DateTimeOffset ObservedAtUtc { get; set; }
+
     /// <summary>Requested and observed connection evidence.</summary>
     public FtpTlsConnectionEvidence Connection { get; set; } = new();
 
@@ -223,6 +226,8 @@ public sealed class FtpTlsAnalysis {
             SetFailure(result, ex);
             logger.WriteVerbose("FTP TLS probe failed for {0}:{1}: {2}", endpoint.HostName, endpoint.Port, ex.Message);
             return result;
+        } finally {
+            result.ObservedAtUtc = DateTimeOffset.UtcNow;
         }
     }
 

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -81,8 +81,13 @@ public sealed class FtpTlsConnectionEvidence {
     public string? RemoteAddressFamily { get; set; }
 }
 
-/// <summary>Protocol and certificate evidence returned by an FTP TLS probe.</summary>
-public sealed class FtpTlsResult {
+/// <summary>
+/// Protocol and certificate evidence returned by an FTP TLS probe.
+/// Dispose the result when its certificate evidence is no longer needed.
+/// </summary>
+public sealed class FtpTlsResult : IDisposable {
+    private bool _disposed;
+
     /// <summary>UTC time when this protocol observation completed.</summary>
     public DateTimeOffset ObservedAtUtc { get; set; }
 
@@ -137,6 +142,22 @@ public sealed class FtpTlsResult {
 
     /// <summary>Normalized failure classification.</summary>
     public CertificateFailureKind FailureKind { get; set; }
+
+    /// <summary>Releases the leaf and chain certificates owned by this result.</summary>
+    public void Dispose() {
+        if (_disposed) {
+            return;
+        }
+        _disposed = true;
+
+        Certificate?.Dispose();
+        Certificate = null;
+        foreach (X509Certificate2 certificate in Chain) {
+            certificate.Dispose();
+        }
+        Chain.Clear();
+        GC.SuppressFinalize(this);
+    }
 }
 
 /// <summary>Performs protocol-correct explicit or implicit FTP TLS certificate probing without authentication.</summary>
@@ -214,6 +235,11 @@ public sealed class FtpTlsAnalysis {
                 result.PolicyErrors = errors;
                 result.CertificateValid = errors == SslPolicyErrors.None;
                 result.HostnameMatch = (errors & SslPolicyErrors.RemoteCertificateNameMismatch) == 0;
+                result.Certificate?.Dispose();
+                result.Certificate = null;
+                foreach (X509Certificate2 chainCertificate in result.Chain) {
+                    chainCertificate.Dispose();
+                }
                 result.Chain.Clear();
                 result.ChainErrors.Clear();
                 if (certificate != null) {

--- a/DomainDetective/Protocols/FtpTlsAnalysis.cs
+++ b/DomainDetective/Protocols/FtpTlsAnalysis.cs
@@ -142,6 +142,7 @@ public sealed class FtpTlsResult {
 /// <summary>Performs protocol-correct explicit or implicit FTP TLS certificate probing without authentication.</summary>
 public sealed class FtpTlsAnalysis {
     private const int MaxResponseLines = 100;
+    private const int MaxResponseLineLength = 4096;
 
     /// <summary>Timeout applied to connect, FTP response, and TLS negotiation.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
@@ -190,18 +191,19 @@ public sealed class FtpTlsAnalysis {
             using NetworkStream network = client.GetStream();
             if (endpoint.Mode == FtpTlsMode.Explicit) {
                 using var reader = new StreamReader(network, Encoding.ASCII, false, 1024, true);
+                var replyReader = new FtpReplyReader(reader);
                 using var writer = new StreamWriter(network, Encoding.ASCII, 1024, true) {
                     AutoFlush = true,
                     NewLine = "\r\n"
                 };
-                IReadOnlyList<string> greeting = await ReadServiceReadyGreetingAsync(reader, timeoutCts.Token).ConfigureAwait(false);
+                IReadOnlyList<string> greeting = await ReadServiceReadyGreetingAsync(replyReader, timeoutCts.Token).ConfigureAwait(false);
                 result.Greeting = greeting;
                 if (!HasReplyCode(greeting, "220")) {
                     throw new InvalidDataException("FTP server did not return a 220 service-ready greeting.");
                 }
 
                 await writer.WriteLineAsync("AUTH TLS").WaitWithCancellation(timeoutCts.Token).ConfigureAwait(false);
-                IReadOnlyList<string> authResponse = await ReadResponseAsync(reader, timeoutCts.Token).ConfigureAwait(false);
+                IReadOnlyList<string> authResponse = await ReadResponseAsync(replyReader, timeoutCts.Token).ConfigureAwait(false);
                 result.AuthTlsResponse = authResponse;
                 if (!HasReplyCode(authResponse, "234")) {
                     throw new InvalidDataException("FTP server did not accept AUTH TLS with a 234 response.");
@@ -258,14 +260,14 @@ public sealed class FtpTlsAnalysis {
     }
 
     private static async Task<IReadOnlyList<string>> ReadResponseAsync(
-        StreamReader reader,
+        FtpReplyReader reader,
         CancellationToken cancellationToken,
         int maxLines = MaxResponseLines) {
         if (maxLines < 1) {
             throw new InvalidDataException($"FTP response exceeded {MaxResponseLines} lines.");
         }
         var lines = new List<string>();
-        string? first = await reader.ReadLineAsync().WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+        string? first = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
         if (first == null) {
             throw new EndOfStreamException("FTP server closed the connection before returning a response.");
         }
@@ -276,7 +278,7 @@ public sealed class FtpTlsAnalysis {
 
         string terminator = first.Substring(0, 3) + " ";
         while (lines.Count < maxLines) {
-            string? line = await reader.ReadLineAsync().WaitWithCancellation(cancellationToken).ConfigureAwait(false);
+            string? line = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
             if (line == null) {
                 throw new EndOfStreamException("FTP server closed a multiline response before its terminator.");
             }
@@ -289,7 +291,7 @@ public sealed class FtpTlsAnalysis {
     }
 
     private static async Task<IReadOnlyList<string>> ReadServiceReadyGreetingAsync(
-        StreamReader reader,
+        FtpReplyReader reader,
         CancellationToken cancellationToken) {
         var lines = new List<string>();
         while (lines.Count < MaxResponseLines) {
@@ -317,6 +319,64 @@ public sealed class FtpTlsAnalysis {
 
     private static bool IsReplyCode(string value) {
         return value.Length == 3 && char.IsDigit(value[0]) && char.IsDigit(value[1]) && char.IsDigit(value[2]);
+    }
+
+    private sealed class FtpReplyReader {
+        private readonly StreamReader _reader;
+        private readonly char[] _buffer = new char[1024];
+        private int _offset;
+        private int _count;
+
+        internal FtpReplyReader(StreamReader reader) {
+            _reader = reader ?? throw new ArgumentNullException(nameof(reader));
+        }
+
+        internal async Task<string?> ReadLineAsync(CancellationToken cancellationToken) {
+            var line = new StringBuilder();
+            while (true) {
+                if (_offset >= _count) {
+                    _count = await _reader.ReadAsync(_buffer, 0, _buffer.Length)
+                        .WaitWithCancellation(cancellationToken)
+                        .ConfigureAwait(false);
+                    _offset = 0;
+                    if (_count == 0) {
+                        if (line.Length == 0) {
+                            return null;
+                        }
+                        ValidateLineLength(line);
+                        return line.ToString();
+                    }
+                }
+
+                int newline = Array.IndexOf(_buffer, '\n', _offset, _count - _offset);
+                int segmentEnd = newline >= 0 ? newline : _count;
+                int segmentLength = segmentEnd - _offset;
+                if (line.Length + segmentLength > MaxResponseLineLength + 1) {
+                    throw new InvalidDataException($"FTP response line exceeded {MaxResponseLineLength} characters.");
+                }
+                line.Append(_buffer, _offset, segmentLength);
+                _offset = newline >= 0 ? newline + 1 : _count;
+                if (line.Length > MaxResponseLineLength &&
+                    (line.Length != MaxResponseLineLength + 1 || line[line.Length - 1] != '\r')) {
+                    throw new InvalidDataException($"FTP response line exceeded {MaxResponseLineLength} characters.");
+                }
+
+                if (newline < 0) {
+                    continue;
+                }
+                if (line.Length > 0 && line[line.Length - 1] == '\r') {
+                    line.Length--;
+                }
+                ValidateLineLength(line);
+                return line.ToString();
+            }
+        }
+
+        private static void ValidateLineLength(StringBuilder line) {
+            if (line.Length > MaxResponseLineLength) {
+                throw new InvalidDataException($"FTP response line exceeded {MaxResponseLineLength} characters.");
+            }
+        }
     }
 
     private static void CaptureRemoteEndpoint(TcpClient client, FtpTlsConnectionEvidence connection) {

--- a/DomainDetective/Protocols/MailTransportConnectionEvidence.cs
+++ b/DomainDetective/Protocols/MailTransportConnectionEvidence.cs
@@ -37,7 +37,8 @@ public sealed class MailTransportConnectionEvidence {
             return;
         }
 
-        RemoteAddress = remote.Address.ToString();
-        RemoteAddressFamily = MailTransportConnector.ToMailAddressFamily(remote.Address);
+        IPAddress address = remote.Address.IsIPv4MappedToIPv6 ? remote.Address.MapToIPv4() : remote.Address;
+        RemoteAddress = address.ToString();
+        RemoteAddressFamily = MailTransportConnector.ToMailAddressFamily(address);
     }
 }

--- a/DomainDetective/Protocols/MailTransportConnector.cs
+++ b/DomainDetective/Protocols/MailTransportConnector.cs
@@ -28,6 +28,9 @@ internal static class MailTransportConnector {
             endpoint.ConnectAddress == null &&
             endpoint.AddressFamily == MailTransportAddressFamily.Any) {
             var isAddressLiteral = IPAddress.TryParse(endpoint.HostName, out var literalAddress);
+            if (isAddressLiteral) {
+                literalAddress = NormalizeAddress(literalAddress!);
+            }
             var client = isAddressLiteral
                 ? new TcpClient(literalAddress!.AddressFamily)
                 : new TcpClient();
@@ -46,24 +49,34 @@ internal static class MailTransportConnector {
         }
 
         IReadOnlyList<IPAddress> candidates;
+        IPAddress? connectAddress = endpoint.ConnectAddress == null
+            ? null
+            : NormalizeAddress(endpoint.ConnectAddress);
         if (outboundAddressResolver != null) {
             var approved = await outboundAddressResolver(endpoint.HostName, cancellationToken).ConfigureAwait(false)
                 ?? Array.Empty<IPAddress>();
-            if (endpoint.ConnectAddress != null) {
-                if (!approved.Any(address => address.Equals(endpoint.ConnectAddress))) {
+            IPAddress[] normalizedApproved = approved
+                .Where(address => address != null)
+                .Select(NormalizeAddress)
+                .Distinct()
+                .ToArray();
+            if (connectAddress != null) {
+                if (!normalizedApproved.Any(address => address.Equals(connectAddress))) {
                     throw new InvalidOperationException(
                         $"Connect address '{endpoint.ConnectAddress}' was not approved for logical host '{endpoint.HostName}'.");
                 }
-                candidates = new[] { endpoint.ConnectAddress };
+                candidates = new[] { connectAddress };
             } else {
-                candidates = approved;
+                candidates = normalizedApproved;
             }
-        } else if (endpoint.ConnectAddress != null) {
-            candidates = new[] { endpoint.ConnectAddress };
+        } else if (connectAddress != null) {
+            candidates = new[] { connectAddress };
         } else {
-            candidates = await Dns.GetHostAddressesAsync(endpoint.HostName)
+            candidates = (await Dns.GetHostAddressesAsync(endpoint.HostName)
                 .WaitWithCancellation(cancellationToken)
-                .ConfigureAwait(false);
+                .ConfigureAwait(false))
+                .Select(NormalizeAddress)
+                .ToArray();
         }
 
         var filtered = candidates
@@ -118,4 +131,7 @@ internal static class MailTransportConnector {
         !address.IsIPv4MappedToIPv6 && address.AddressFamily == AddressFamily.InterNetworkV6
             ? MailTransportAddressFamily.IPv6
             : MailTransportAddressFamily.IPv4;
+
+    private static IPAddress NormalizeAddress(IPAddress address) =>
+        address.IsIPv4MappedToIPv6 ? address.MapToIPv4() : address;
 }

--- a/DomainDetective/Protocols/MailTransportConnector.cs
+++ b/DomainDetective/Protocols/MailTransportConnector.cs
@@ -109,13 +109,13 @@ internal static class MailTransportConnector {
 
     internal static bool Matches(IPAddress address, MailTransportAddressFamily family) => family switch {
         MailTransportAddressFamily.Any => true,
-        MailTransportAddressFamily.IPv4 => address.AddressFamily == AddressFamily.InterNetwork,
-        MailTransportAddressFamily.IPv6 => address.AddressFamily == AddressFamily.InterNetworkV6,
+        MailTransportAddressFamily.IPv4 => address.IsIPv4MappedToIPv6 || address.AddressFamily == AddressFamily.InterNetwork,
+        MailTransportAddressFamily.IPv6 => !address.IsIPv4MappedToIPv6 && address.AddressFamily == AddressFamily.InterNetworkV6,
         _ => false
     };
 
     internal static MailTransportAddressFamily ToMailAddressFamily(IPAddress address) =>
-        address.AddressFamily == AddressFamily.InterNetworkV6
+        !address.IsIPv4MappedToIPv6 && address.AddressFamily == AddressFamily.InterNetworkV6
             ? MailTransportAddressFamily.IPv6
             : MailTransportAddressFamily.IPv4;
 }

--- a/DomainDetective/Protocols/MailTransportEndpoint.cs
+++ b/DomainDetective/Protocols/MailTransportEndpoint.cs
@@ -11,6 +11,8 @@ namespace DomainDetective;
 /// socket to a specific backend address without changing SNI or certificate hostname validation.
 /// </remarks>
 public sealed class MailTransportEndpoint {
+    private string _hostName = string.Empty;
+
     /// <summary>Creates an empty endpoint for serializers and object initializers.</summary>
     public MailTransportEndpoint() {
     }
@@ -22,7 +24,10 @@ public sealed class MailTransportEndpoint {
     }
 
     /// <summary>Logical mail hostname used for protocol identity, SNI, and certificate validation.</summary>
-    public string HostName { get; set; } = string.Empty;
+    public string HostName {
+        get => _hostName;
+        set => _hostName = EndpointHostNormalizer.Normalize(value);
+    }
 
     /// <summary>TCP port used by the probe.</summary>
     public int Port { get; set; }

--- a/DomainDetective/Protocols/MailTransportEndpoint.cs
+++ b/DomainDetective/Protocols/MailTransportEndpoint.cs
@@ -45,6 +45,11 @@ public sealed class MailTransportEndpoint {
         if (string.IsNullOrWhiteSpace(HostName)) {
             throw new ArgumentException("A logical mail hostname is required.", nameof(HostName));
         }
+        if (!EndpointHostNormalizer.TryNormalize(HostName, out _)) {
+            throw new ArgumentException(
+                "Brackets are valid only around an IPv6 literal mail hostname.",
+                nameof(HostName));
+        }
         if (Port < 1 || Port > 65535) {
             throw new ArgumentOutOfRangeException(nameof(Port), "Port must be between 1 and 65535.");
         }

--- a/DomainDetective/Protocols/TlsProbe.cs
+++ b/DomainDetective/Protocols/TlsProbe.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using DomainDetective.Helpers;
+using System.Linq;
 using System.Net;
 using System.Net.Security;
 using System.Net.Sockets;
@@ -360,23 +361,35 @@ public static class TlsProbe
             return;
         }
 
+        IReadOnlyList<string> dnsNames = ExtractCertificateDnsNames(result.Certificate, out string? parsingError);
+        result.DnsNames.AddRange(dnsNames);
+        result.SanParsingError = parsingError;
+    }
+
+    internal static IReadOnlyList<string> ExtractCertificateDnsNames(
+        X509Certificate2 certificate,
+        out string? parsingError)
+    {
+        var dnsNames = new List<string>();
+        parsingError = null;
         try
         {
 #if NET8_0_OR_GREATER
-            var san = result.Certificate.Extensions[SubjectAlternativeNameOid];
+            var san = certificate.Extensions[SubjectAlternativeNameOid];
             if (san != null)
             {
                 var sanExt = new X509SubjectAlternativeNameExtension(san.RawData, san.Critical);
                 foreach (var name in sanExt.EnumerateDnsNames())
                 {
-                    if (!string.IsNullOrWhiteSpace(name))
+                    if (!string.IsNullOrWhiteSpace(name) &&
+                        !dnsNames.Contains(name, StringComparer.OrdinalIgnoreCase))
                     {
-                        result.DnsNames.Add(name);
+                        dnsNames.Add(name);
                     }
                 }
             }
 #else
-            var san = result.Certificate.Extensions[SubjectAlternativeNameOid];
+            var san = certificate.Extensions[SubjectAlternativeNameOid];
             if (san != null)
             {
                 var raw = san.Format(false);
@@ -387,9 +400,10 @@ public static class TlsProbe
                     if (idx > 0 && p.Substring(0, idx).Trim().Equals("DNS Name", StringComparison.OrdinalIgnoreCase))
                     {
                         var name = p.Substring(idx + 1).Trim();
-                        if (!string.IsNullOrWhiteSpace(name))
+                        if (!string.IsNullOrWhiteSpace(name) &&
+                            !dnsNames.Contains(name, StringComparer.OrdinalIgnoreCase))
                         {
-                            result.DnsNames.Add(name);
+                            dnsNames.Add(name);
                         }
                     }
                 }
@@ -398,7 +412,8 @@ public static class TlsProbe
         }
         catch (Exception ex) when (!ExceptionHelper.IsFatal(ex))
         {
-            result.SanParsingError = ex.Message;
+            parsingError = ex.Message;
         }
+        return dnsNames;
     }
 }

--- a/DomainDetective/Providers/Dns/DnsCnameTargetDetector.cs
+++ b/DomainDetective/Providers/Dns/DnsCnameTargetDetector.cs
@@ -15,6 +15,8 @@ public static class DnsCnameTargetDetector
     {
         /// <summary>Gets or sets the provider value.</summary>
         public DnsCnameTargetProvider Provider { get; init; }
+        /// <summary>Specific managed service represented by the target, when known.</summary>
+        public DnsCnameTargetService Service { get; init; }
         /// <summary>Gets or sets the flags value.</summary>
         public DnsCnameTargetFlags Flags { get; init; }
         /// <summary>Gets or sets the evidence value.</summary>
@@ -27,7 +29,11 @@ public static class DnsCnameTargetDetector
         var target = NormalizeHost(cnameTarget);
         if (string.IsNullOrWhiteSpace(target))
         {
-            return new Match { Provider = DnsCnameTargetProvider.Unknown, Flags = DnsCnameTargetFlags.None };
+            return new Match {
+                Provider = DnsCnameTargetProvider.Unknown,
+                Service = DnsCnameTargetService.Unknown,
+                Flags = DnsCnameTargetFlags.None
+            };
         }
 
         var evidence = new List<string>();
@@ -46,16 +52,21 @@ public static class DnsCnameTargetDetector
             evidence.Add("CNAME target matches takeover-risk provider list");
         }
 
-        var provider = DetectProvider(target, evidence);
+        var service = DetectService(target, evidence);
+        var provider = DetectProvider(target, service, evidence);
         return new Match
         {
             Provider = provider,
+            Service = service,
             Flags = flags,
             Evidence = evidence
         };
     }
 
-    private static DnsCnameTargetProvider DetectProvider(string target, List<string> evidence)
+    private static DnsCnameTargetProvider DetectProvider(
+        string target,
+        DnsCnameTargetService service,
+        List<string> evidence)
     {
         if (IsDomainOrSubdomainOf(target, "cloudflare.net") ||
             IsDomainOrSubdomainOf(target, "pages.dev") ||
@@ -72,12 +83,18 @@ public static class DnsCnameTargetDetector
             return DnsCnameTargetProvider.Amazon;
         }
 
-        if (IsDomainOrSubdomainOf(target, "azureedge.net") ||
-            IsDomainOrSubdomainOf(target, "azurefd.net") ||
-            IsDomainOrSubdomainOf(target, "trafficmanager.net"))
+        if (service == DnsCnameTargetService.AzureFrontDoor ||
+            service == DnsCnameTargetService.AzureCdn ||
+            service == DnsCnameTargetService.AzureTrafficManager)
         {
             evidence.Add("Provider: Azure");
             return DnsCnameTargetProvider.Azure;
+        }
+
+        if (service == DnsCnameTargetService.NameShieldRedirection)
+        {
+            evidence.Add("Provider: NameShield");
+            return DnsCnameTargetProvider.NameShield;
         }
 
         if (IsDomainOrSubdomainOf(target, "github.io") ||
@@ -112,6 +129,33 @@ public static class DnsCnameTargetDetector
         }
 
         return DnsCnameTargetProvider.Unknown;
+    }
+
+    private static DnsCnameTargetService DetectService(string target, List<string> evidence)
+    {
+        if (IsDomainOrSubdomainOf(target, "azurefd.net"))
+        {
+            evidence.Add("Service: Azure Front Door (azurefd.net)");
+            return DnsCnameTargetService.AzureFrontDoor;
+        }
+        if (IsDomainOrSubdomainOf(target, "azureedge.net"))
+        {
+            evidence.Add("Service: Azure CDN (azureedge.net)");
+            return DnsCnameTargetService.AzureCdn;
+        }
+        if (IsDomainOrSubdomainOf(target, "trafficmanager.net"))
+        {
+            evidence.Add("Service: Azure Traffic Manager (trafficmanager.net)");
+            return DnsCnameTargetService.AzureTrafficManager;
+        }
+        if (IsDomainOrSubdomainOf(target, "cdn.perf1.com") ||
+            IsDomainOrSubdomainOf(target, "perf1.com") ||
+            IsDomainOrSubdomainOf(target, "perf1.fr"))
+        {
+            evidence.Add("Service: NameShield Redirection");
+            return DnsCnameTargetService.NameShieldRedirection;
+        }
+        return DnsCnameTargetService.Unknown;
     }
 
     private static string NormalizeHost(string? value)
@@ -189,5 +233,22 @@ public enum DnsCnameTargetProvider
     /// <summary>Represents the heroku value.</summary>
     Heroku = 7,
     /// <summary>Represents the fastly value.</summary>
-    Fastly = 8
+    Fastly = 8,
+    /// <summary>Represents NameShield.</summary>
+    NameShield = 9
+}
+
+/// <summary>Specific managed service inferred from a CNAME target.</summary>
+public enum DnsCnameTargetService
+{
+    /// <summary>No specific service was identified.</summary>
+    Unknown = 0,
+    /// <summary>Azure Front Door namespace.</summary>
+    AzureFrontDoor = 1,
+    /// <summary>Azure CDN namespace.</summary>
+    AzureCdn = 2,
+    /// <summary>Azure Traffic Manager namespace.</summary>
+    AzureTrafficManager = 3,
+    /// <summary>NameShield redirection namespace.</summary>
+    NameShieldRedirection = 4
 }

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -114,25 +114,28 @@ public sealed class AzureServiceTagCatalog {
                     $"Azure service tag '{name}' must contain a properties object.");
             }
 
+            if (!properties.TryGetProperty("addressPrefixes", out JsonElement addressPrefixes)) {
+                throw new FormatException(
+                    $"Azure service tag '{name}' must contain an addressPrefixes array.");
+            }
+            if (addressPrefixes.ValueKind != JsonValueKind.Array) {
+                throw new FormatException(
+                    $"Azure service tag '{name}' contains an addressPrefixes field that is not an array.");
+            }
+
             var prefixes = new List<IpCidrRange>();
-            if (properties.TryGetProperty("addressPrefixes", out JsonElement addressPrefixes)) {
-                if (addressPrefixes.ValueKind != JsonValueKind.Array) {
+            foreach (JsonElement prefixElement in addressPrefixes.EnumerateArray()) {
+                if (prefixElement.ValueKind != JsonValueKind.String) {
                     throw new FormatException(
-                        $"Azure service tag '{name}' contains an addressPrefixes field that is not an array.");
+                        $"Azure service tag '{name}' contains a non-string address prefix value.");
                 }
-                foreach (JsonElement prefixElement in addressPrefixes.EnumerateArray()) {
-                    if (prefixElement.ValueKind != JsonValueKind.String) {
-                        throw new FormatException(
-                            $"Azure service tag '{name}' contains a non-string address prefix value.");
-                    }
-                    string prefixText = prefixElement.GetString() ?? string.Empty;
-                    try {
-                        prefixes.Add(IpCidrRange.Parse(prefixText));
-                    } catch (FormatException ex) {
-                        throw new FormatException(
-                            $"Azure service tag '{name}' contains invalid address prefix '{prefixText}'.",
-                            ex);
-                    }
+                string prefixText = prefixElement.GetString() ?? string.Empty;
+                try {
+                    prefixes.Add(IpCidrRange.Parse(prefixText));
+                } catch (FormatException ex) {
+                    throw new FormatException(
+                        $"Azure service tag '{name}' contains invalid address prefix '{prefixText}'.",
+                        ex);
                 }
             }
 

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -85,6 +85,9 @@ public sealed class AzureServiceTagCatalog {
 
         using JsonDocument document = JsonDocument.Parse(json);
         JsonElement root = document.RootElement;
+        if (root.ValueKind != JsonValueKind.Object) {
+            throw new FormatException("Azure service-tag JSON root must be an object.");
+        }
         string cloud = ReadScalar(root, "cloud");
         string changeNumber = ReadScalar(root, "changeNumber");
         var entries = new List<AzureServiceTagEntry>();
@@ -93,7 +96,13 @@ public sealed class AzureServiceTagCatalog {
             throw new FormatException("Azure service-tag JSON does not contain a values array.");
         }
 
+        int itemIndex = -1;
         foreach (JsonElement item in values.EnumerateArray()) {
+            itemIndex++;
+            if (item.ValueKind != JsonValueKind.Object) {
+                throw new FormatException(
+                    $"Azure service-tag JSON values[{itemIndex}] must be an object.");
+            }
             string name = ReadScalar(item, "name");
             if (string.IsNullOrWhiteSpace(name)) {
                 continue;
@@ -101,7 +110,8 @@ public sealed class AzureServiceTagCatalog {
 
             if (!item.TryGetProperty("properties", out JsonElement properties) ||
                 properties.ValueKind != JsonValueKind.Object) {
-                continue;
+                throw new FormatException(
+                    $"Azure service tag '{name}' must contain a properties object.");
             }
 
             var prefixes = new List<IpCidrRange>();

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -105,12 +105,17 @@ public sealed class AzureServiceTagCatalog {
             }
 
             var prefixes = new List<IpCidrRange>();
-            if (properties.TryGetProperty("addressPrefixes", out JsonElement addressPrefixes) &&
-                addressPrefixes.ValueKind == JsonValueKind.Array) {
+            if (properties.TryGetProperty("addressPrefixes", out JsonElement addressPrefixes)) {
+                if (addressPrefixes.ValueKind != JsonValueKind.Array) {
+                    throw new FormatException(
+                        $"Azure service tag '{name}' contains an addressPrefixes field that is not an array.");
+                }
                 foreach (JsonElement prefixElement in addressPrefixes.EnumerateArray()) {
-                    string prefixText = prefixElement.ValueKind == JsonValueKind.String
-                        ? prefixElement.GetString() ?? string.Empty
-                        : prefixElement.ToString();
+                    if (prefixElement.ValueKind != JsonValueKind.String) {
+                        throw new FormatException(
+                            $"Azure service tag '{name}' contains a non-string address prefix value.");
+                    }
+                    string prefixText = prefixElement.GetString() ?? string.Empty;
                     try {
                         prefixes.Add(IpCidrRange.Parse(prefixText));
                     } catch (FormatException ex) {

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -111,8 +111,12 @@ public sealed class AzureServiceTagCatalog {
                     string prefixText = prefixElement.ValueKind == JsonValueKind.String
                         ? prefixElement.GetString() ?? string.Empty
                         : prefixElement.ToString();
-                    if (IpCidrRange.TryParse(prefixText, out IpCidrRange prefix)) {
-                        prefixes.Add(prefix);
+                    try {
+                        prefixes.Add(IpCidrRange.Parse(prefixText));
+                    } catch (FormatException ex) {
+                        throw new FormatException(
+                            $"Azure service tag '{name}' contains invalid address prefix '{prefixText}'.",
+                            ex);
                     }
                 }
             }

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -103,9 +103,15 @@ public sealed class AzureServiceTagCatalog {
                 throw new FormatException(
                     $"Azure service-tag JSON values[{itemIndex}] must be an object.");
             }
-            string name = ReadScalar(item, "name");
+            if (!item.TryGetProperty("name", out JsonElement nameElement) ||
+                nameElement.ValueKind != JsonValueKind.String) {
+                throw new FormatException(
+                    $"Azure service-tag JSON values[{itemIndex}] must contain a string name.");
+            }
+            string name = nameElement.GetString() ?? string.Empty;
             if (string.IsNullOrWhiteSpace(name)) {
-                continue;
+                throw new FormatException(
+                    $"Azure service-tag JSON values[{itemIndex}] must contain a non-empty string name.");
             }
 
             if (!item.TryGetProperty("properties", out JsonElement properties) ||

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -41,7 +41,11 @@ public sealed class AzureServiceTagCatalog {
         ChangeNumber = changeNumber;
         Source = source;
         RetrievedAtUtc = retrievedAtUtc;
-        _entries = entries.ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+        try {
+            _entries = entries.ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+        } catch (ArgumentException ex) {
+            throw new FormatException("Azure service-tag JSON contains duplicate service-tag names.", ex);
+        }
     }
 
     /// <summary>Cloud name reported by the source catalog.</summary>

--- a/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/AzureServiceTagCatalog.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+
+namespace DomainDetective.Providers.Endpoint;
+
+/// <summary>One Azure service tag and its published address prefixes.</summary>
+public sealed class AzureServiceTagEntry {
+    /// <summary>Published service-tag name.</summary>
+    public string Name { get; init; } = string.Empty;
+
+    /// <summary>Tag-specific change number from the source catalog.</summary>
+    public string ChangeNumber { get; init; } = string.Empty;
+
+    /// <summary>Azure region associated with the tag, when present.</summary>
+    public string Region { get; init; } = string.Empty;
+
+    /// <summary>System service associated with the tag, when present.</summary>
+    public string SystemService { get; init; } = string.Empty;
+
+    /// <summary>Parsed IPv4 and IPv6 address prefixes.</summary>
+    public IReadOnlyList<IpCidrRange> AddressPrefixes { get; init; } = Array.Empty<IpCidrRange>();
+}
+
+/// <summary>
+/// Parses and queries Microsoft Azure service-tag JSON without embedding time-sensitive ranges.
+/// </summary>
+public sealed class AzureServiceTagCatalog {
+    private readonly Dictionary<string, AzureServiceTagEntry> _entries;
+
+    private AzureServiceTagCatalog(
+        string cloud,
+        string changeNumber,
+        string source,
+        DateTimeOffset retrievedAtUtc,
+        IEnumerable<AzureServiceTagEntry> entries) {
+        Cloud = cloud;
+        ChangeNumber = changeNumber;
+        Source = source;
+        RetrievedAtUtc = retrievedAtUtc;
+        _entries = entries.ToDictionary(entry => entry.Name, StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>Cloud name reported by the source catalog.</summary>
+    public string Cloud { get; }
+
+    /// <summary>Catalog-wide change number.</summary>
+    public string ChangeNumber { get; }
+
+    /// <summary>Caller-provided source identifier, such as a file path or discovery API URL.</summary>
+    public string Source { get; }
+
+    /// <summary>Time at which the caller retrieved or loaded the catalog.</summary>
+    public DateTimeOffset RetrievedAtUtc { get; }
+
+    /// <summary>All parsed service tags.</summary>
+    public IReadOnlyCollection<AzureServiceTagEntry> Entries => _entries.Values;
+
+    /// <summary>Loads a service-tag catalog from a JSON file.</summary>
+    public static AzureServiceTagCatalog LoadFile(
+        string path,
+        DateTimeOffset? retrievedAtUtc = null) {
+        if (string.IsNullOrWhiteSpace(path)) {
+            throw new ArgumentNullException(nameof(path));
+        }
+        string json = File.ReadAllText(path);
+        return Parse(json, path, retrievedAtUtc);
+    }
+
+    /// <summary>Parses downloadable or Service Tag Discovery API JSON.</summary>
+    public static AzureServiceTagCatalog Parse(
+        string json,
+        string source = "azure-service-tags-json",
+        DateTimeOffset? retrievedAtUtc = null) {
+        if (string.IsNullOrWhiteSpace(json)) {
+            throw new ArgumentNullException(nameof(json));
+        }
+
+        using JsonDocument document = JsonDocument.Parse(json);
+        JsonElement root = document.RootElement;
+        string cloud = ReadScalar(root, "cloud");
+        string changeNumber = ReadScalar(root, "changeNumber");
+        var entries = new List<AzureServiceTagEntry>();
+
+        if (!root.TryGetProperty("values", out JsonElement values) || values.ValueKind != JsonValueKind.Array) {
+            throw new FormatException("Azure service-tag JSON does not contain a values array.");
+        }
+
+        foreach (JsonElement item in values.EnumerateArray()) {
+            string name = ReadScalar(item, "name");
+            if (string.IsNullOrWhiteSpace(name)) {
+                continue;
+            }
+
+            if (!item.TryGetProperty("properties", out JsonElement properties) ||
+                properties.ValueKind != JsonValueKind.Object) {
+                continue;
+            }
+
+            var prefixes = new List<IpCidrRange>();
+            if (properties.TryGetProperty("addressPrefixes", out JsonElement addressPrefixes) &&
+                addressPrefixes.ValueKind == JsonValueKind.Array) {
+                foreach (JsonElement prefixElement in addressPrefixes.EnumerateArray()) {
+                    string prefixText = prefixElement.ValueKind == JsonValueKind.String
+                        ? prefixElement.GetString() ?? string.Empty
+                        : prefixElement.ToString();
+                    if (IpCidrRange.TryParse(prefixText, out IpCidrRange prefix)) {
+                        prefixes.Add(prefix);
+                    }
+                }
+            }
+
+            entries.Add(new AzureServiceTagEntry {
+                Name = name,
+                ChangeNumber = ReadScalar(properties, "changeNumber"),
+                Region = ReadScalar(properties, "region"),
+                SystemService = ReadScalar(properties, "systemService"),
+                AddressPrefixes = prefixes
+            });
+        }
+
+        return new AzureServiceTagCatalog(
+            cloud,
+            changeNumber,
+            source,
+            retrievedAtUtc ?? DateTimeOffset.UtcNow,
+            entries);
+    }
+
+    /// <summary>Returns true when a tag exists in this catalog.</summary>
+    public bool TryGetTag(string name, out AzureServiceTagEntry? entry) {
+        if (string.IsNullOrWhiteSpace(name)) {
+            entry = null;
+            return false;
+        }
+        return _entries.TryGetValue(name.Trim(), out entry);
+    }
+
+    /// <summary>Returns service-tag names containing the supplied address.</summary>
+    public IReadOnlyList<string> FindTags(IPAddress address, IEnumerable<string>? candidateTagNames = null) {
+        if (address == null) {
+            throw new ArgumentNullException(nameof(address));
+        }
+
+        IEnumerable<AzureServiceTagEntry> candidates = _entries.Values;
+        if (candidateTagNames != null) {
+            var requested = new HashSet<string>(
+                candidateTagNames.Where(name => !string.IsNullOrWhiteSpace(name)).Select(name => name.Trim()),
+                StringComparer.OrdinalIgnoreCase);
+            candidates = candidates.Where(entry => requested.Contains(entry.Name));
+        }
+
+        return candidates
+            .Where(entry => entry.AddressPrefixes.Any(prefix => prefix.Contains(address)))
+            .Select(entry => entry.Name)
+            .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string ReadScalar(JsonElement element, string propertyName) {
+        if (!element.TryGetProperty(propertyName, out JsonElement property)) {
+            return string.Empty;
+        }
+        return property.ValueKind == JsonValueKind.String
+            ? property.GetString() ?? string.Empty
+            : property.ToString();
+    }
+}

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -113,6 +113,9 @@ public sealed class EndpointAttributionCatalog {
         }
         rule.ApplicableServices.Clear();
         rule.ApplicableServices.AddRange(normalizedServices);
+        NormalizeHostSuffixMatchers(rule.CnameSuffixes);
+        NormalizeHostSuffixMatchers(rule.RedirectTargetSuffixes);
+        NormalizeHostSuffixMatchers(rule.ReverseDnsSuffixes);
         var normalizedAutonomousSystems = new List<string>(rule.AutonomousSystemNumbers.Count);
         var uniqueAutonomousSystems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (string autonomousSystem in rule.AutonomousSystemNumbers) {
@@ -177,6 +180,22 @@ public sealed class EndpointAttributionCatalog {
 
     private static bool HasText(IEnumerable<string> values) =>
         values.Any(value => !string.IsNullOrWhiteSpace(value));
+
+    private static void NormalizeHostSuffixMatchers(List<string> values) {
+        var normalizedValues = new List<string>(values.Count);
+        var uniqueValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string value in values) {
+            string normalized = NormalizeHostSuffixMatcher(value);
+            if (normalized.Length > 0 && uniqueValues.Add(normalized)) {
+                normalizedValues.Add(normalized);
+            }
+        }
+        values.Clear();
+        values.AddRange(normalizedValues);
+    }
+
+    internal static string NormalizeHostSuffixMatcher(string? value) =>
+        (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
 
     private static EndpointAttributionRule CreateAzureFrontDoorRule() {
         var rule = CreateRule(

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -49,6 +49,12 @@ public sealed class EndpointAttributionCatalog {
             throw new ArgumentException("An attribution rule requires a stable RuleId.", parameterName ?? nameof(rule));
         }
         rule.RuleId = rule.RuleId.Trim();
+        if (string.IsNullOrWhiteSpace(rule.RuleVersion)) {
+            throw new ArgumentException(
+                $"Endpoint attribution rule '{rule.RuleId}' requires a stable RuleVersion.",
+                parameterName ?? nameof(rule));
+        }
+        rule.RuleVersion = rule.RuleVersion.Trim();
         if (string.IsNullOrWhiteSpace(rule.ProviderId)) {
             throw new ArgumentException(
                 $"Endpoint attribution rule '{rule.RuleId}' requires a stable ProviderId.",

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -113,6 +113,23 @@ public sealed class EndpointAttributionCatalog {
         }
         rule.ApplicableServices.Clear();
         rule.ApplicableServices.AddRange(normalizedServices);
+        var normalizedAutonomousSystems = new List<string>(rule.AutonomousSystemNumbers.Count);
+        var uniqueAutonomousSystems = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string autonomousSystem in rule.AutonomousSystemNumbers) {
+            if (string.IsNullOrWhiteSpace(autonomousSystem)) {
+                continue;
+            }
+            if (!TryNormalizeAutonomousSystemNumber(autonomousSystem, out string normalizedAutonomousSystem)) {
+                throw new ArgumentException(
+                    $"Endpoint attribution rule '{rule.RuleId}' contains invalid autonomous system number '{autonomousSystem}'.",
+                    parameterName ?? nameof(rule));
+            }
+            if (uniqueAutonomousSystems.Add(normalizedAutonomousSystem)) {
+                normalizedAutonomousSystems.Add(normalizedAutonomousSystem);
+            }
+        }
+        rule.AutonomousSystemNumbers.Clear();
+        rule.AutonomousSystemNumbers.AddRange(normalizedAutonomousSystems);
         if (!HasUsableEvidenceMatcher(rule)) {
             throw new ArgumentException(
                 $"Endpoint attribution rule '{rule.RuleId}' requires at least one usable evidence matcher.",
@@ -128,6 +145,24 @@ public sealed class EndpointAttributionCatalog {
             compiledPrefixes.Add(compiledPrefix);
         }
         return compiledPrefixes;
+    }
+
+    internal static bool TryNormalizeAutonomousSystemNumber(string? value, out string normalized) {
+        normalized = string.Empty;
+        string candidate = (value ?? string.Empty).Trim();
+        if (candidate.StartsWith("AS", StringComparison.OrdinalIgnoreCase)) {
+            candidate = candidate.Substring(2).Trim();
+        }
+        if (!uint.TryParse(
+                candidate,
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out uint number) ||
+            number == 0) {
+            return false;
+        }
+        normalized = number.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        return true;
     }
 
     private static bool HasUsableEvidenceMatcher(EndpointAttributionRule rule) =>

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -57,6 +57,11 @@ public sealed class EndpointAttributionCatalog {
                 $"Endpoint attribution rule '{rule.RuleId}' requires a stable ServiceId.",
                 parameterName ?? nameof(rule));
         }
+        if (rule.IpAddressPrimaryCorroboratingSignals.Contains(EndpointAttributionSignalKind.IpAddress)) {
+            throw new ArgumentException(
+                $"Endpoint attribution rule '{rule.RuleId}' cannot use IpAddress as its own corroborating signal.",
+                parameterName ?? nameof(rule));
+        }
 
         var compiledPrefixes = new List<IpCidrRange>(rule.IpAddressPrefixes.Count);
         foreach (string prefix in rule.IpAddressPrefixes) {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -34,7 +34,8 @@ public sealed class EndpointAttributionCatalog {
         }
         ValidateAndCompileRule(rule, nameof(rule));
 
-        Rules.RemoveAll(existing => string.Equals(existing.RuleId, rule.RuleId, StringComparison.OrdinalIgnoreCase));
+        Rules.RemoveAll(existing => existing != null &&
+            string.Equals(existing.RuleId?.Trim(), rule.RuleId, StringComparison.OrdinalIgnoreCase));
         Rules.Add(rule);
     }
 
@@ -47,6 +48,7 @@ public sealed class EndpointAttributionCatalog {
         if (string.IsNullOrWhiteSpace(rule.RuleId)) {
             throw new ArgumentException("An attribution rule requires a stable RuleId.", parameterName ?? nameof(rule));
         }
+        rule.RuleId = rule.RuleId.Trim();
         if (string.IsNullOrWhiteSpace(rule.ProviderId)) {
             throw new ArgumentException(
                 $"Endpoint attribution rule '{rule.RuleId}' requires a stable ProviderId.",
@@ -56,6 +58,14 @@ public sealed class EndpointAttributionCatalog {
             throw new ArgumentException(
                 $"Endpoint attribution rule '{rule.RuleId}' requires a stable ServiceId.",
                 parameterName ?? nameof(rule));
+        }
+        foreach (EndpointAttributionSignalKind signalKind in rule.IpAddressPrimaryCorroboratingSignals) {
+            if (!Enum.IsDefined(typeof(EndpointAttributionSignalKind), signalKind)) {
+                throw new ArgumentOutOfRangeException(
+                    parameterName ?? nameof(rule),
+                    signalKind,
+                    $"Endpoint attribution rule '{rule.RuleId}' contains undefined corroborating signal kind '{(int)signalKind}'.");
+            }
         }
         if (rule.IpAddressPrimaryCorroboratingSignals.Contains(EndpointAttributionSignalKind.IpAddress)) {
             throw new ArgumentException(

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DomainDetective.Providers.Endpoint;
+
+/// <summary>Versioned collection of reusable endpoint attribution rules.</summary>
+public sealed class EndpointAttributionCatalog {
+    /// <summary>Version of the built-in catalog shape and point-in-time seed data.</summary>
+    public const string BuiltInVersion = "2026-09-01";
+
+    /// <summary>Catalog version persisted with detection results.</summary>
+    public string Version { get; set; } = BuiltInVersion;
+
+    /// <summary>Rules evaluated by the detector.</summary>
+    public List<EndpointAttributionRule> Rules { get; } = new();
+
+    /// <summary>Creates the built-in provider and managed-service catalog.</summary>
+    public static EndpointAttributionCatalog CreateDefault() {
+        var catalog = new EndpointAttributionCatalog();
+        catalog.Rules.Add(CreateAzureFrontDoorRule());
+        catalog.Rules.Add(CreateAzureCdnRule());
+        catalog.Rules.Add(CreateAzureTrafficManagerRule());
+        catalog.Rules.Add(CreateNameShieldRule());
+        catalog.Rules.Add(CreateMicrosoft365Rule());
+        catalog.Rules.Add(CreateCpanelCandidateRule());
+        return catalog;
+    }
+
+    /// <summary>Adds or replaces a rule with the same rule identifier.</summary>
+    public void AddOrReplace(EndpointAttributionRule rule) {
+        if (rule == null) {
+            throw new ArgumentNullException(nameof(rule));
+        }
+        if (string.IsNullOrWhiteSpace(rule.RuleId)) {
+            throw new ArgumentException("An attribution rule requires a stable RuleId.", nameof(rule));
+        }
+
+        Rules.RemoveAll(existing => string.Equals(existing.RuleId, rule.RuleId, StringComparison.OrdinalIgnoreCase));
+        Rules.Add(rule);
+    }
+
+    private static EndpointAttributionRule CreateAzureFrontDoorRule() {
+        var rule = CreateRule(
+            "microsoft",
+            "azure-front-door",
+            "Azure Front Door",
+            "builtin.microsoft.azure-front-door");
+        rule.CnameSuffixes.Add("azurefd.net");
+        rule.RedirectTargetSuffixes.Add("azurefd.net");
+        rule.AzureServiceTagNames.Add("AzureFrontDoor.Frontend");
+        rule.CertificateIssuerContains.Add("DigiCert");
+        rule.CertificateIssuerContains.Add("Microsoft");
+        AddHttpServices(rule);
+        return rule;
+    }
+
+    private static EndpointAttributionRule CreateAzureCdnRule() {
+        var rule = CreateRule(
+            "microsoft",
+            "azure-cdn",
+            "Azure CDN",
+            "builtin.microsoft.azure-cdn");
+        rule.CnameSuffixes.Add("azureedge.net");
+        rule.RedirectTargetSuffixes.Add("azureedge.net");
+        rule.CertificateIssuerContains.Add("DigiCert");
+        rule.CertificateIssuerContains.Add("Microsoft");
+        AddHttpServices(rule);
+        return rule;
+    }
+
+    private static EndpointAttributionRule CreateAzureTrafficManagerRule() {
+        var rule = CreateRule(
+            "microsoft",
+            "azure-traffic-manager",
+            "Azure Traffic Manager",
+            "builtin.microsoft.azure-traffic-manager");
+        rule.CnameSuffixes.Add("trafficmanager.net");
+        rule.RedirectTargetSuffixes.Add("trafficmanager.net");
+        rule.CertificateIssuerContains.Add("DigiCert");
+        rule.CertificateIssuerContains.Add("Microsoft");
+        AddHttpServices(rule);
+        return rule;
+    }
+
+    private static EndpointAttributionRule CreateNameShieldRule() {
+        var rule = CreateRule(
+            "nameshield",
+            "redirection",
+            "NameShield Redirection Service",
+            "builtin.nameshield.redirection");
+        rule.Source = "Versioned public endpoint seed; validate against current provider data before enforcement.";
+        rule.CnameSuffixes.AddRange(new[] { "cdn.perf1.com", "perf1.com", "perf1.fr" });
+        rule.RedirectTargetSuffixes.AddRange(new[] { "cdn.perf1.com", "perf1.com", "perf1.fr" });
+        rule.IpAddressPrefixes.AddRange(new[] {
+            "81.92.94.54/32",
+            "81.92.95.55/32",
+            "152.89.172.56/32",
+            "2a01:c8:101::55/128",
+            "2a01:c8:100::54/128",
+            "2a09:35c0:102::56/128"
+        });
+        rule.CertificateIssuerContains.Add("DigiCert");
+        rule.RequireCorroborationForIpAddressPrimary = true;
+        rule.IpAddressPrimaryCorroboratingSignals.Add(EndpointAttributionSignalKind.Cname);
+        rule.IpAddressPrimaryCorroboratingSignals.Add(EndpointAttributionSignalKind.RedirectTarget);
+        AddHttpServices(rule);
+        return rule;
+    }
+
+    private static EndpointAttributionRule CreateMicrosoft365Rule() {
+        var rule = CreateRule(
+            "microsoft",
+            "microsoft-365-service",
+            "Microsoft 365 Managed Service",
+            "builtin.microsoft.microsoft-365-service");
+        rule.CnameSuffixes.AddRange(new[] {
+            "outlook.com",
+            "office.com",
+            "office365.com",
+            "online.lync.com",
+            "microsoftonline.com",
+            "microsoftonline-p.net"
+        });
+        rule.CertificateIssuerContains.Add("Microsoft");
+        rule.ApplicableServices.AddRange(new[] { "HTTPS", "HTTPS-Alt", "SMTP-STARTTLS", "SMTP-SUBMISSION-STARTTLS", "IMAPS", "POP3S" });
+        return rule;
+    }
+
+    private static EndpointAttributionRule CreateCpanelCandidateRule() {
+        var rule = CreateRule(
+            "cpanel",
+            "generated-service-hostname",
+            "cPanel/WHM Generated Service Hostname Candidate",
+            "builtin.cpanel.generated-service-hostname");
+        rule.HostnamePrefixes.AddRange(new[] { "cpanel.", "cpcalendars.", "webdisk.", "whm." });
+        rule.MinimumScore = 0.65;
+        return rule;
+    }
+
+    private static EndpointAttributionRule CreateRule(
+        string providerId,
+        string serviceId,
+        string displayName,
+        string ruleId) {
+        return new EndpointAttributionRule {
+            ProviderId = providerId,
+            ServiceId = serviceId,
+            DisplayName = displayName,
+            RuleId = ruleId,
+            RuleVersion = BuiltInVersion,
+            Source = "DomainDetective built-in attribution catalog"
+        };
+    }
+
+    private static void AddHttpServices(EndpointAttributionRule rule) {
+        rule.ApplicableServices.Add("HTTPS");
+        rule.ApplicableServices.Add("HTTPS-Alt");
+    }
+}

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -62,6 +62,15 @@ public sealed class EndpointAttributionCatalog {
                 $"Endpoint attribution rule '{rule.RuleId}' cannot use IpAddress as its own corroborating signal.",
                 parameterName ?? nameof(rule));
         }
+        if (double.IsNaN(rule.MinimumScore) ||
+            double.IsInfinity(rule.MinimumScore) ||
+            rule.MinimumScore < 0d ||
+            rule.MinimumScore > 1d) {
+            throw new ArgumentOutOfRangeException(
+                parameterName ?? nameof(rule),
+                rule.MinimumScore,
+                $"Endpoint attribution rule '{rule.RuleId}' requires MinimumScore between 0 and 1.");
+        }
         foreach (int port in rule.ApplicablePorts) {
             if (port < 1 || port > 65535) {
                 throw new ArgumentOutOfRangeException(

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -54,11 +54,13 @@ public sealed class EndpointAttributionCatalog {
                 $"Endpoint attribution rule '{rule.RuleId}' requires a stable ProviderId.",
                 parameterName ?? nameof(rule));
         }
+        rule.ProviderId = rule.ProviderId.Trim();
         if (string.IsNullOrWhiteSpace(rule.ServiceId)) {
             throw new ArgumentException(
                 $"Endpoint attribution rule '{rule.RuleId}' requires a stable ServiceId.",
                 parameterName ?? nameof(rule));
         }
+        rule.ServiceId = rule.ServiceId.Trim();
         foreach (EndpointAttributionSignalKind signalKind in rule.IpAddressPrimaryCorroboratingSignals) {
             if (!Enum.IsDefined(typeof(EndpointAttributionSignalKind), signalKind)) {
                 throw new ArgumentOutOfRangeException(

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -92,6 +92,21 @@ public sealed class EndpointAttributionCatalog {
                     "Ports must be between 1 and 65535.");
             }
         }
+        var normalizedServices = new List<string>(rule.ApplicableServices.Count);
+        var uniqueServices = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string service in rule.ApplicableServices) {
+            if (string.IsNullOrWhiteSpace(service)) {
+                throw new ArgumentException(
+                    $"Endpoint attribution rule '{rule.RuleId}' contains an empty applicable service.",
+                    parameterName ?? nameof(rule));
+            }
+            string normalizedService = service.Trim();
+            if (uniqueServices.Add(normalizedService)) {
+                normalizedServices.Add(normalizedService);
+            }
+        }
+        rule.ApplicableServices.Clear();
+        rule.ApplicableServices.AddRange(normalizedServices);
         if (!HasUsableEvidenceMatcher(rule)) {
             throw new ArgumentException(
                 $"Endpoint attribution rule '{rule.RuleId}' requires at least one usable evidence matcher.",

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -90,6 +90,11 @@ public sealed class EndpointAttributionCatalog {
                     "Ports must be between 1 and 65535.");
             }
         }
+        if (!HasUsableEvidenceMatcher(rule)) {
+            throw new ArgumentException(
+                $"Endpoint attribution rule '{rule.RuleId}' requires at least one usable evidence matcher.",
+                parameterName ?? nameof(rule));
+        }
 
         var compiledPrefixes = new List<IpCidrRange>(rule.IpAddressPrefixes.Count);
         foreach (string prefix in rule.IpAddressPrefixes) {
@@ -101,6 +106,19 @@ public sealed class EndpointAttributionCatalog {
         }
         return compiledPrefixes;
     }
+
+    private static bool HasUsableEvidenceMatcher(EndpointAttributionRule rule) =>
+        HasText(rule.HostnamePrefixes) ||
+        HasText(rule.CnameSuffixes) ||
+        HasText(rule.IpAddressPrefixes) ||
+        HasText(rule.AzureServiceTagNames) ||
+        HasText(rule.CertificateIssuerContains) ||
+        HasText(rule.RedirectTargetSuffixes) ||
+        HasText(rule.ReverseDnsSuffixes) ||
+        HasText(rule.AutonomousSystemNumbers);
+
+    private static bool HasText(IEnumerable<string> values) =>
+        values.Any(value => !string.IsNullOrWhiteSpace(value));
 
     private static EndpointAttributionRule CreateAzureFrontDoorRule() {
         var rule = CreateRule(

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -32,12 +32,26 @@ public sealed class EndpointAttributionCatalog {
         if (rule == null) {
             throw new ArgumentNullException(nameof(rule));
         }
-        if (string.IsNullOrWhiteSpace(rule.RuleId)) {
-            throw new ArgumentException("An attribution rule requires a stable RuleId.", nameof(rule));
-        }
+        ValidateRule(rule, nameof(rule));
 
         Rules.RemoveAll(existing => string.Equals(existing.RuleId, rule.RuleId, StringComparison.OrdinalIgnoreCase));
         Rules.Add(rule);
+    }
+
+    internal static void ValidateRule(EndpointAttributionRule rule, string? parameterName = null) {
+        if (rule == null) {
+            throw new ArgumentNullException(parameterName ?? nameof(rule));
+        }
+        if (string.IsNullOrWhiteSpace(rule.RuleId)) {
+            throw new ArgumentException("An attribution rule requires a stable RuleId.", parameterName ?? nameof(rule));
+        }
+
+        foreach (string prefix in rule.IpAddressPrefixes) {
+            if (!IpCidrRange.TryParse(prefix, out _)) {
+                throw new FormatException(
+                    $"Endpoint attribution rule '{rule.RuleId}' contains invalid IP prefix '{prefix}'.");
+            }
+        }
     }
 
     private static EndpointAttributionRule CreateAzureFrontDoorRule() {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -32,26 +32,41 @@ public sealed class EndpointAttributionCatalog {
         if (rule == null) {
             throw new ArgumentNullException(nameof(rule));
         }
-        ValidateRule(rule, nameof(rule));
+        ValidateAndCompileRule(rule, nameof(rule));
 
         Rules.RemoveAll(existing => string.Equals(existing.RuleId, rule.RuleId, StringComparison.OrdinalIgnoreCase));
         Rules.Add(rule);
     }
 
-    internal static void ValidateRule(EndpointAttributionRule rule, string? parameterName = null) {
+    internal static IReadOnlyList<IpCidrRange> ValidateAndCompileRule(
+        EndpointAttributionRule rule,
+        string? parameterName = null) {
         if (rule == null) {
             throw new ArgumentNullException(parameterName ?? nameof(rule));
         }
         if (string.IsNullOrWhiteSpace(rule.RuleId)) {
             throw new ArgumentException("An attribution rule requires a stable RuleId.", parameterName ?? nameof(rule));
         }
+        if (string.IsNullOrWhiteSpace(rule.ProviderId)) {
+            throw new ArgumentException(
+                $"Endpoint attribution rule '{rule.RuleId}' requires a stable ProviderId.",
+                parameterName ?? nameof(rule));
+        }
+        if (string.IsNullOrWhiteSpace(rule.ServiceId)) {
+            throw new ArgumentException(
+                $"Endpoint attribution rule '{rule.RuleId}' requires a stable ServiceId.",
+                parameterName ?? nameof(rule));
+        }
 
+        var compiledPrefixes = new List<IpCidrRange>(rule.IpAddressPrefixes.Count);
         foreach (string prefix in rule.IpAddressPrefixes) {
-            if (!IpCidrRange.TryParse(prefix, out _)) {
+            if (!IpCidrRange.TryParse(prefix, out IpCidrRange compiledPrefix)) {
                 throw new FormatException(
                     $"Endpoint attribution rule '{rule.RuleId}' contains invalid IP prefix '{prefix}'.");
             }
+            compiledPrefixes.Add(compiledPrefix);
         }
+        return compiledPrefixes;
     }
 
     private static EndpointAttributionRule CreateAzureFrontDoorRule() {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionCatalog.cs
@@ -62,6 +62,15 @@ public sealed class EndpointAttributionCatalog {
                 $"Endpoint attribution rule '{rule.RuleId}' cannot use IpAddress as its own corroborating signal.",
                 parameterName ?? nameof(rule));
         }
+        foreach (int port in rule.ApplicablePorts) {
+            if (port < 1 || port > 65535) {
+                throw new ArgumentOutOfRangeException(
+                    parameterName ?? nameof(rule),
+                    port,
+                    $"Endpoint attribution rule '{rule.RuleId}' contains invalid applicable port '{port}'. " +
+                    "Ports must be between 1 and 65535.");
+            }
+        }
 
         var compiledPrefixes = new List<IpCidrRange>(rule.IpAddressPrefixes.Count);
         foreach (string prefix in rule.IpAddressPrefixes) {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
@@ -342,7 +342,7 @@ public sealed class EndpointAttributionDetector {
     }
 
     private static string NormalizeHost(string? value) =>
-        (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+        EndpointAttributionCatalog.NormalizeHostSuffixMatcher(value);
 
     private static EndpointAttributionRule CloneRule(EndpointAttributionRule source) {
         if (source == null) {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
@@ -8,16 +8,34 @@ namespace DomainDetective.Providers.Endpoint;
 
 /// <summary>Evaluates explainable, multi-signal provider and managed-service attribution rules.</summary>
 public sealed class EndpointAttributionDetector {
-    private readonly EndpointAttributionCatalog _catalog;
+    private readonly string _catalogVersion;
+    private readonly IReadOnlyList<CompiledAttributionRule> _rules;
+
+    private sealed class CompiledAttributionRule {
+        public CompiledAttributionRule(EndpointAttributionRule source) {
+            Rule = CloneRule(source);
+            IpAddressPrefixes = EndpointAttributionCatalog.ValidateAndCompileRule(Rule);
+        }
+
+        public EndpointAttributionRule Rule { get; }
+        public IReadOnlyList<IpCidrRange> IpAddressPrefixes { get; }
+    }
 
     /// <summary>Creates a detector using the built-in catalog.</summary>
     public EndpointAttributionDetector()
         : this(EndpointAttributionCatalog.CreateDefault()) {
     }
 
-    /// <summary>Creates a detector using an explicit catalog.</summary>
+    /// <summary>
+    /// Creates a detector using an explicit catalog. Rules and CIDR ranges are validated,
+    /// snapshotted, and compiled once; create a new detector after changing the catalog.
+    /// </summary>
     public EndpointAttributionDetector(EndpointAttributionCatalog catalog) {
-        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+        if (catalog == null) {
+            throw new ArgumentNullException(nameof(catalog));
+        }
+        _catalogVersion = catalog.Version;
+        _rules = catalog.Rules.Select(rule => new CompiledAttributionRule(rule)).ToList();
     }
 
     /// <summary>Evaluates all rules and returns both primary and review candidates.</summary>
@@ -29,11 +47,8 @@ public sealed class EndpointAttributionDetector {
         }
 
         var candidates = new List<EndpointAttributionCandidate>();
-        foreach (EndpointAttributionRule rule in _catalog.Rules) {
-            // Rules is intentionally mutable for declarative callers, so validate again at the
-            // execution boundary even when a rule did not enter through AddOrReplace.
-            EndpointAttributionCatalog.ValidateRule(rule);
-            EndpointAttributionCandidate? candidate = Evaluate(rule, input);
+        foreach (CompiledAttributionRule compiledRule in _rules) {
+            EndpointAttributionCandidate? candidate = Evaluate(compiledRule, input);
             if (candidate != null) {
                 candidates.Add(candidate);
             }
@@ -61,7 +76,7 @@ public sealed class EndpointAttributionDetector {
         return new EndpointAttributionResult {
             Primary = ambiguous ? null : eligible.FirstOrDefault(),
             Candidates = ordered,
-            CatalogVersion = _catalog.Version,
+            CatalogVersion = _catalogVersion,
             EvaluatedAtUtc = evaluatedAtUtc ?? DateTimeOffset.UtcNow,
             IsAmbiguous = ambiguous,
             AzureServiceTagSource = input.AzureServiceTags?.Source ?? string.Empty,
@@ -72,8 +87,9 @@ public sealed class EndpointAttributionDetector {
     }
 
     private static EndpointAttributionCandidate? Evaluate(
-        EndpointAttributionRule rule,
+        CompiledAttributionRule compiledRule,
         EndpointAttributionInput input) {
+        EndpointAttributionRule rule = compiledRule.Rule;
         if (!AppliesToEndpoint(rule, input)) {
             return null;
         }
@@ -89,7 +105,7 @@ public sealed class EndpointAttributionDetector {
             hasStrongSignal = true;
         }
 
-        if (TryMatchIpPrefix(input.IpAddresses, rule.IpAddressPrefixes, out string ipAddress, out string ipPrefix)) {
+        if (TryMatchIpPrefix(input.IpAddresses, compiledRule.IpAddressPrefixes, out string ipAddress, out string ipPrefix)) {
             AddEvidence(evidence, EndpointAttributionSignalKind.IpAddress, ipAddress, ipPrefix, 0.65, rule.Source);
             hasStrongSignal = true;
         }
@@ -212,24 +228,19 @@ public sealed class EndpointAttributionDetector {
 
     private static bool TryMatchIpPrefix(
         IEnumerable<string>? addresses,
-        IEnumerable<string> prefixes,
+        IReadOnlyList<IpCidrRange> prefixes,
         out string address,
         out string prefix) {
-        var parsedPrefixes = prefixes
-            .Select(IpCidrRange.Parse)
-            .ToList();
         foreach (string observed in addresses ?? Array.Empty<string>()) {
             if (!IPAddress.TryParse((observed ?? string.Empty).Trim(), out IPAddress? parsed) || parsed == null) {
                 continue;
             }
-            IpCidrRange? matched = parsedPrefixes
-                .Where(range => range.Contains(parsed))
-                .Select(range => (IpCidrRange?)range)
-                .FirstOrDefault();
-            if (matched.HasValue) {
-                address = parsed.ToString();
-                prefix = matched.Value.ToString();
-                return true;
+            foreach (IpCidrRange range in prefixes) {
+                if (range.Contains(parsed)) {
+                    address = parsed.ToString();
+                    prefix = range.ToString();
+                    return true;
+                }
             }
         }
         address = string.Empty;
@@ -313,4 +324,33 @@ public sealed class EndpointAttributionDetector {
 
     private static string NormalizeHost(string? value) =>
         (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+
+    private static EndpointAttributionRule CloneRule(EndpointAttributionRule source) {
+        if (source == null) {
+            throw new ArgumentNullException(nameof(source));
+        }
+        var clone = new EndpointAttributionRule {
+            ProviderId = source.ProviderId,
+            ServiceId = source.ServiceId,
+            DisplayName = source.DisplayName,
+            RuleId = source.RuleId,
+            RuleVersion = source.RuleVersion,
+            Source = source.Source,
+            MinimumScore = source.MinimumScore,
+            AllowWeakSignalsAsPrimary = source.AllowWeakSignalsAsPrimary,
+            RequireCorroborationForIpAddressPrimary = source.RequireCorroborationForIpAddressPrimary
+        };
+        clone.HostnamePrefixes.AddRange(source.HostnamePrefixes);
+        clone.CnameSuffixes.AddRange(source.CnameSuffixes);
+        clone.IpAddressPrefixes.AddRange(source.IpAddressPrefixes);
+        clone.AzureServiceTagNames.AddRange(source.AzureServiceTagNames);
+        clone.CertificateIssuerContains.AddRange(source.CertificateIssuerContains);
+        clone.RedirectTargetSuffixes.AddRange(source.RedirectTargetSuffixes);
+        clone.ReverseDnsSuffixes.AddRange(source.ReverseDnsSuffixes);
+        clone.AutonomousSystemNumbers.AddRange(source.AutonomousSystemNumbers);
+        clone.ApplicableServices.AddRange(source.ApplicableServices);
+        clone.ApplicablePorts.AddRange(source.ApplicablePorts);
+        clone.IpAddressPrimaryCorroboratingSignals.AddRange(source.IpAddressPrimaryCorroboratingSignals);
+        return clone;
+    }
 }

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
@@ -1,0 +1,315 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using DomainDetective.Helpers;
+
+namespace DomainDetective.Providers.Endpoint;
+
+/// <summary>Evaluates explainable, multi-signal provider and managed-service attribution rules.</summary>
+public sealed class EndpointAttributionDetector {
+    private readonly EndpointAttributionCatalog _catalog;
+
+    /// <summary>Creates a detector using the built-in catalog.</summary>
+    public EndpointAttributionDetector()
+        : this(EndpointAttributionCatalog.CreateDefault()) {
+    }
+
+    /// <summary>Creates a detector using an explicit catalog.</summary>
+    public EndpointAttributionDetector(EndpointAttributionCatalog catalog) {
+        _catalog = catalog ?? throw new ArgumentNullException(nameof(catalog));
+    }
+
+    /// <summary>Evaluates all rules and returns both primary and review candidates.</summary>
+    public EndpointAttributionResult Detect(
+        EndpointAttributionInput input,
+        DateTimeOffset? evaluatedAtUtc = null) {
+        if (input == null) {
+            throw new ArgumentNullException(nameof(input));
+        }
+
+        var candidates = new List<EndpointAttributionCandidate>();
+        foreach (EndpointAttributionRule rule in _catalog.Rules) {
+            EndpointAttributionCandidate? candidate = Evaluate(rule, input);
+            if (candidate != null) {
+                candidates.Add(candidate);
+            }
+        }
+
+        List<EndpointAttributionCandidate> ordered = candidates
+            .OrderByDescending(candidate => candidate.Score)
+            .ThenBy(candidate => candidate.ProviderId, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(candidate => candidate.ServiceId, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        List<EndpointAttributionCandidate> eligible = ordered
+            .Where(candidate => candidate.EligibleAsPrimary)
+            .ToList();
+        double? topEligibleScore = eligible.Count == 0 ? null : eligible[0].Score;
+        int topIdentityCount = topEligibleScore.HasValue
+            ? eligible
+                .Where(candidate => Math.Abs(candidate.Score - topEligibleScore.Value) < 0.000001d)
+                .Select(candidate => candidate.ProviderId + "\u001f" + candidate.ServiceId)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Count()
+            : 0;
+        bool ambiguous = topIdentityCount > 1;
+
+        return new EndpointAttributionResult {
+            Primary = ambiguous ? null : eligible.FirstOrDefault(),
+            Candidates = ordered,
+            CatalogVersion = _catalog.Version,
+            EvaluatedAtUtc = evaluatedAtUtc ?? DateTimeOffset.UtcNow,
+            IsAmbiguous = ambiguous,
+            AzureServiceTagSource = input.AzureServiceTags?.Source ?? string.Empty,
+            AzureServiceTagChangeNumber = input.AzureServiceTags?.ChangeNumber ?? string.Empty,
+            AzureServiceTagCloud = input.AzureServiceTags?.Cloud ?? string.Empty,
+            AzureServiceTagRetrievedAtUtc = input.AzureServiceTags?.RetrievedAtUtc
+        };
+    }
+
+    private static EndpointAttributionCandidate? Evaluate(
+        EndpointAttributionRule rule,
+        EndpointAttributionInput input) {
+        if (!AppliesToEndpoint(rule, input)) {
+            return null;
+        }
+        var evidence = new List<EndpointAttributionEvidence>();
+        bool hasStrongSignal = false;
+
+        if (TryMatchPrefix(input.HostName, rule.HostnamePrefixes, out string hostnamePattern)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.Hostname, input.HostName, hostnamePattern, 0.25, rule.Source);
+        }
+
+        if (TryMatchSuffix(input.CnameChain, rule.CnameSuffixes, out string cname, out string cnameSuffix)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.Cname, cname, cnameSuffix, 0.85, rule.Source);
+            hasStrongSignal = true;
+        }
+
+        if (TryMatchIpPrefix(input.IpAddresses, rule.IpAddressPrefixes, out string ipAddress, out string ipPrefix)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.IpAddress, ipAddress, ipPrefix, 0.65, rule.Source);
+            hasStrongSignal = true;
+        }
+
+        if (TryMatchAzureServiceTag(input, rule, out string serviceTagAddress, out string serviceTagName)) {
+            string source = input.AzureServiceTags?.Source ?? rule.Source;
+            AddEvidence(evidence, EndpointAttributionSignalKind.AzureServiceTag, serviceTagAddress, serviceTagName, 0.75, source);
+            hasStrongSignal = true;
+        }
+
+        if (TryMatchContains(input.CertificateIssuer, rule.CertificateIssuerContains, out string issuerPattern)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.CertificateIssuer, input.CertificateIssuer, issuerPattern, 0.15, rule.Source);
+        }
+
+        if (TryMatchSuffix(input.RedirectTargets, rule.RedirectTargetSuffixes, out string redirect, out string redirectSuffix)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.RedirectTarget, redirect, redirectSuffix, 0.65, rule.Source);
+            hasStrongSignal = true;
+        }
+
+        if (TryMatchSuffix(input.ReverseDnsNames, rule.ReverseDnsSuffixes, out string reverseDns, out string reverseDnsSuffix)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.ReverseDns, reverseDns, reverseDnsSuffix, 0.55, rule.Source);
+            hasStrongSignal = true;
+        }
+
+        if (TryMatchExact(input.AutonomousSystemNumbers, rule.AutonomousSystemNumbers, out string autonomousSystem)) {
+            AddEvidence(evidence, EndpointAttributionSignalKind.AutonomousSystem, autonomousSystem, autonomousSystem, 0.55, rule.Source);
+            hasStrongSignal = true;
+        }
+
+        if (evidence.Count == 0) {
+            return null;
+        }
+
+        double score = Math.Min(1d, evidence.Sum(item => item.Score));
+        bool ipNeedsCorroboration = rule.RequireCorroborationForIpAddressPrimary &&
+                                    evidence.Any(item => item.Kind == EndpointAttributionSignalKind.IpAddress) &&
+                                    !HasAllowedIpCorroboration(rule, evidence);
+        bool eligible = score >= Math.Max(0d, Math.Min(1d, rule.MinimumScore)) &&
+                        (hasStrongSignal || rule.AllowWeakSignalsAsPrimary) &&
+                        !ipNeedsCorroboration;
+        return new EndpointAttributionCandidate {
+            ProviderId = rule.ProviderId,
+            ServiceId = rule.ServiceId,
+            DisplayName = rule.DisplayName,
+            Score = score,
+            Confidence = ResolveConfidence(score),
+            EligibleAsPrimary = eligible,
+            RuleId = rule.RuleId,
+            RuleVersion = rule.RuleVersion,
+            Evidence = evidence
+        };
+    }
+
+    private static bool HasAllowedIpCorroboration(
+        EndpointAttributionRule rule,
+        IReadOnlyCollection<EndpointAttributionEvidence> evidence) {
+        if (rule.IpAddressPrimaryCorroboratingSignals.Count == 0) {
+            return evidence.Any(item => item.Kind != EndpointAttributionSignalKind.IpAddress);
+        }
+        return evidence.Any(item => rule.IpAddressPrimaryCorroboratingSignals.Contains(item.Kind));
+    }
+
+    private static bool AppliesToEndpoint(EndpointAttributionRule rule, EndpointAttributionInput input) {
+        if (rule.ApplicablePorts.Count > 0 && !rule.ApplicablePorts.Contains(input.Port)) {
+            return false;
+        }
+        if (rule.ApplicableServices.Count == 0) {
+            return true;
+        }
+        string service = (input.Service ?? string.Empty).Trim();
+        return rule.ApplicableServices.Any(candidate =>
+            string.Equals(candidate?.Trim(), service, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static EndpointAttributionConfidence ResolveConfidence(double score) {
+        if (score >= 0.75d) {
+            return EndpointAttributionConfidence.High;
+        }
+        if (score >= 0.5d) {
+            return EndpointAttributionConfidence.Medium;
+        }
+        return EndpointAttributionConfidence.Low;
+    }
+
+    private static bool TryMatchPrefix(string? value, IEnumerable<string> patterns, out string pattern) {
+        string normalized = NormalizeHost(value);
+        foreach (string candidate in patterns.Where(item => !string.IsNullOrWhiteSpace(item))) {
+            if (normalized.StartsWith(candidate.Trim(), StringComparison.OrdinalIgnoreCase)) {
+                pattern = candidate.Trim();
+                return true;
+            }
+        }
+        pattern = string.Empty;
+        return false;
+    }
+
+    private static bool TryMatchSuffix(
+        IEnumerable<string>? values,
+        IEnumerable<string> suffixes,
+        out string value,
+        out string suffix) {
+        foreach (string observed in values ?? Array.Empty<string>()) {
+            string normalized = NormalizeHost(observed);
+            if (normalized.Length == 0) {
+                continue;
+            }
+            foreach (string candidate in suffixes.Where(item => !string.IsNullOrWhiteSpace(item))) {
+                string normalizedSuffix = NormalizeHost(candidate);
+                if (DomainHelper.IsDomainOrSubdomainOf(normalized, normalizedSuffix)) {
+                    value = normalized;
+                    suffix = normalizedSuffix;
+                    return true;
+                }
+            }
+        }
+        value = string.Empty;
+        suffix = string.Empty;
+        return false;
+    }
+
+    private static bool TryMatchIpPrefix(
+        IEnumerable<string>? addresses,
+        IEnumerable<string> prefixes,
+        out string address,
+        out string prefix) {
+        var parsedPrefixes = prefixes
+            .Select(value => IpCidrRange.TryParse(value, out IpCidrRange range) ? (IpCidrRange?)range : null)
+            .Where(range => range.HasValue)
+            .Select(range => range!.Value)
+            .ToList();
+        foreach (string observed in addresses ?? Array.Empty<string>()) {
+            if (!IPAddress.TryParse((observed ?? string.Empty).Trim(), out IPAddress? parsed) || parsed == null) {
+                continue;
+            }
+            IpCidrRange? matched = parsedPrefixes
+                .Where(range => range.Contains(parsed))
+                .Select(range => (IpCidrRange?)range)
+                .FirstOrDefault();
+            if (matched.HasValue) {
+                address = parsed.ToString();
+                prefix = matched.Value.ToString();
+                return true;
+            }
+        }
+        address = string.Empty;
+        prefix = string.Empty;
+        return false;
+    }
+
+    private static bool TryMatchAzureServiceTag(
+        EndpointAttributionInput input,
+        EndpointAttributionRule rule,
+        out string address,
+        out string tagName) {
+        if (input.AzureServiceTags == null || rule.AzureServiceTagNames.Count == 0) {
+            address = string.Empty;
+            tagName = string.Empty;
+            return false;
+        }
+
+        foreach (string observed in input.IpAddresses ?? Array.Empty<string>()) {
+            if (!IPAddress.TryParse((observed ?? string.Empty).Trim(), out IPAddress? parsed) || parsed == null) {
+                continue;
+            }
+            IReadOnlyList<string> tags = input.AzureServiceTags.FindTags(parsed, rule.AzureServiceTagNames);
+            if (tags.Count > 0) {
+                address = parsed.ToString();
+                tagName = tags[0];
+                return true;
+            }
+        }
+
+        address = string.Empty;
+        tagName = string.Empty;
+        return false;
+    }
+
+    private static bool TryMatchContains(string? value, IEnumerable<string> patterns, out string pattern) {
+        string observed = (value ?? string.Empty).Trim();
+        foreach (string candidate in patterns.Where(item => !string.IsNullOrWhiteSpace(item))) {
+            if (observed.IndexOf(candidate.Trim(), StringComparison.OrdinalIgnoreCase) >= 0) {
+                pattern = candidate.Trim();
+                return true;
+            }
+        }
+        pattern = string.Empty;
+        return false;
+    }
+
+    private static bool TryMatchExact(
+        IEnumerable<string>? values,
+        IEnumerable<string> patterns,
+        out string value) {
+        var expected = new HashSet<string>(
+            patterns.Where(item => !string.IsNullOrWhiteSpace(item)).Select(item => item.Trim()),
+            StringComparer.OrdinalIgnoreCase);
+        foreach (string observed in values ?? Array.Empty<string>()) {
+            string normalized = (observed ?? string.Empty).Trim();
+            if (expected.Contains(normalized)) {
+                value = normalized;
+                return true;
+            }
+        }
+        value = string.Empty;
+        return false;
+    }
+
+    private static void AddEvidence(
+        ICollection<EndpointAttributionEvidence> evidence,
+        EndpointAttributionSignalKind kind,
+        string observedValue,
+        string matchedValue,
+        double score,
+        string source) {
+        evidence.Add(new EndpointAttributionEvidence {
+            Kind = kind,
+            ObservedValue = observedValue,
+            MatchedValue = matchedValue,
+            Score = score,
+            Source = source
+        });
+    }
+
+    private static string NormalizeHost(string? value) =>
+        (value ?? string.Empty).Trim().TrimEnd('.').ToLowerInvariant();
+}

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
@@ -30,6 +30,9 @@ public sealed class EndpointAttributionDetector {
 
         var candidates = new List<EndpointAttributionCandidate>();
         foreach (EndpointAttributionRule rule in _catalog.Rules) {
+            // Rules is intentionally mutable for declarative callers, so validate again at the
+            // execution boundary even when a rule did not enter through AddOrReplace.
+            EndpointAttributionCatalog.ValidateRule(rule);
             EndpointAttributionCandidate? candidate = Evaluate(rule, input);
             if (candidate != null) {
                 candidates.Add(candidate);
@@ -213,9 +216,7 @@ public sealed class EndpointAttributionDetector {
         out string address,
         out string prefix) {
         var parsedPrefixes = prefixes
-            .Select(value => IpCidrRange.TryParse(value, out IpCidrRange range) ? (IpCidrRange?)range : null)
-            .Where(range => range.HasValue)
-            .Select(range => range!.Value)
+            .Select(IpCidrRange.Parse)
             .ToList();
         foreach (string observed in addresses ?? Array.Empty<string>()) {
             if (!IPAddress.TryParse((observed ?? string.Empty).Trim(), out IPAddress? parsed) || parsed == null) {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
@@ -142,7 +142,10 @@ public sealed class EndpointAttributionDetector {
             hasStrongSignal = true;
         }
 
-        if (TryMatchExact(input.AutonomousSystemNumbers, rule.AutonomousSystemNumbers, out string autonomousSystem)) {
+        if (TryMatchAutonomousSystemNumber(
+                input.AutonomousSystemNumbers,
+                rule.AutonomousSystemNumbers,
+                out string autonomousSystem)) {
             AddEvidence(evidence, EndpointAttributionSignalKind.AutonomousSystem, autonomousSystem, autonomousSystem, 0.55, rule.Source);
             hasStrongSignal = true;
         }
@@ -300,16 +303,20 @@ public sealed class EndpointAttributionDetector {
         return false;
     }
 
-    private static bool TryMatchExact(
+    private static bool TryMatchAutonomousSystemNumber(
         IEnumerable<string>? values,
         IEnumerable<string> patterns,
         out string value) {
         var expected = new HashSet<string>(
-            patterns.Where(item => !string.IsNullOrWhiteSpace(item)).Select(item => item.Trim()),
-            StringComparer.OrdinalIgnoreCase);
+            patterns
+                .Select(pattern => EndpointAttributionCatalog.TryNormalizeAutonomousSystemNumber(pattern, out string normalized)
+                    ? normalized
+                    : string.Empty)
+                .Where(normalized => normalized.Length > 0),
+            StringComparer.Ordinal);
         foreach (string observed in values ?? Array.Empty<string>()) {
-            string normalized = (observed ?? string.Empty).Trim();
-            if (expected.Contains(normalized)) {
+            if (EndpointAttributionCatalog.TryNormalizeAutonomousSystemNumber(observed, out string normalized) &&
+                expected.Contains(normalized)) {
                 value = normalized;
                 return true;
             }

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionDetector.cs
@@ -35,7 +35,19 @@ public sealed class EndpointAttributionDetector {
             throw new ArgumentNullException(nameof(catalog));
         }
         _catalogVersion = catalog.Version;
-        _rules = catalog.Rules.Select(rule => new CompiledAttributionRule(rule)).ToList();
+        var ruleIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var compiledRules = new List<CompiledAttributionRule>(catalog.Rules.Count);
+        foreach (EndpointAttributionRule rule in catalog.Rules) {
+            var compiledRule = new CompiledAttributionRule(rule);
+            string ruleId = compiledRule.Rule.RuleId.Trim();
+            if (!ruleIds.Add(ruleId)) {
+                throw new ArgumentException(
+                    $"Endpoint attribution catalog contains duplicate RuleId '{ruleId}'.",
+                    nameof(catalog));
+            }
+            compiledRules.Add(compiledRule);
+        }
+        _rules = compiledRules;
     }
 
     /// <summary>Evaluates all rules and returns both primary and review candidates.</summary>
@@ -143,7 +155,7 @@ public sealed class EndpointAttributionDetector {
         bool ipNeedsCorroboration = rule.RequireCorroborationForIpAddressPrimary &&
                                     evidence.Any(item => item.Kind == EndpointAttributionSignalKind.IpAddress) &&
                                     !HasAllowedIpCorroboration(rule, evidence);
-        bool eligible = score >= Math.Max(0d, Math.Min(1d, rule.MinimumScore)) &&
+        bool eligible = score >= rule.MinimumScore &&
                         (hasStrongSignal || rule.AllowWeakSignalsAsPrimary) &&
                         !ipNeedsCorroboration;
         return new EndpointAttributionCandidate {

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionModels.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionModels.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+
+namespace DomainDetective.Providers.Endpoint;
+
+/// <summary>Confidence assigned to an endpoint attribution candidate.</summary>
+public enum EndpointAttributionConfidence {
+    /// <summary>No reusable provider or service signal was found.</summary>
+    None = 0,
+    /// <summary>A weak signal was found and should normally be reviewed.</summary>
+    Low = 1,
+    /// <summary>A meaningful signal was found but independent corroboration is desirable.</summary>
+    Medium = 2,
+    /// <summary>A strong namespace, catalog, or multi-signal match was found.</summary>
+    High = 3
+}
+
+/// <summary>Type of evidence used by endpoint attribution.</summary>
+public enum EndpointAttributionSignalKind {
+    /// <summary>Logical hostname pattern.</summary>
+    Hostname = 0,
+    /// <summary>DNS CNAME target suffix.</summary>
+    Cname = 1,
+    /// <summary>Resolved or connected address prefix.</summary>
+    IpAddress = 2,
+    /// <summary>Azure service-tag membership.</summary>
+    AzureServiceTag = 3,
+    /// <summary>TLS certificate issuer text.</summary>
+    CertificateIssuer = 4,
+    /// <summary>HTTP redirect target suffix.</summary>
+    RedirectTarget = 5,
+    /// <summary>Reverse-DNS target suffix.</summary>
+    ReverseDns = 6,
+    /// <summary>Autonomous-system number.</summary>
+    AutonomousSystem = 7
+}
+
+/// <summary>One explainable signal contributing to a provider or service classification.</summary>
+public sealed class EndpointAttributionEvidence {
+    /// <summary>Signal type.</summary>
+    public EndpointAttributionSignalKind Kind { get; init; }
+
+    /// <summary>Observed value.</summary>
+    public string ObservedValue { get; init; } = string.Empty;
+
+    /// <summary>Rule value that matched the observation.</summary>
+    public string MatchedValue { get; init; } = string.Empty;
+
+    /// <summary>Score contributed by this signal.</summary>
+    public double Score { get; init; }
+
+    /// <summary>Source catalog or observation source.</summary>
+    public string Source { get; init; } = string.Empty;
+}
+
+/// <summary>One provider or service attribution candidate.</summary>
+public sealed class EndpointAttributionCandidate {
+    /// <summary>Stable provider identifier.</summary>
+    public string ProviderId { get; init; } = string.Empty;
+
+    /// <summary>Stable provider service identifier.</summary>
+    public string ServiceId { get; init; } = string.Empty;
+
+    /// <summary>Human-readable classification.</summary>
+    public string DisplayName { get; init; } = string.Empty;
+
+    /// <summary>Normalized score between zero and one.</summary>
+    public double Score { get; init; }
+
+    /// <summary>Confidence derived from <see cref="Score"/>.</summary>
+    public EndpointAttributionConfidence Confidence { get; init; }
+
+    /// <summary>True when the candidate satisfied its rule's primary-classification threshold.</summary>
+    public bool EligibleAsPrimary { get; init; }
+
+    /// <summary>Rule identifier.</summary>
+    public string RuleId { get; init; } = string.Empty;
+
+    /// <summary>Rule version.</summary>
+    public string RuleVersion { get; init; } = string.Empty;
+
+    /// <summary>Signals supporting this candidate.</summary>
+    public IReadOnlyList<EndpointAttributionEvidence> Evidence { get; init; } = Array.Empty<EndpointAttributionEvidence>();
+}
+
+/// <summary>Explainable endpoint attribution result.</summary>
+public sealed class EndpointAttributionResult {
+    /// <summary>Highest-scoring candidate that satisfied its primary threshold.</summary>
+    public EndpointAttributionCandidate? Primary { get; init; }
+
+    /// <summary>All candidates with at least one signal, including low-confidence review candidates.</summary>
+    public IReadOnlyList<EndpointAttributionCandidate> Candidates { get; init; } = Array.Empty<EndpointAttributionCandidate>();
+
+    /// <summary>Catalog version used for built-in rules.</summary>
+    public string CatalogVersion { get; init; } = string.Empty;
+
+    /// <summary>Time at which the classification was evaluated.</summary>
+    public DateTimeOffset EvaluatedAtUtc { get; init; }
+
+    /// <summary>True when equally ranked eligible candidates prevent an honest primary selection.</summary>
+    public bool IsAmbiguous { get; init; }
+
+    /// <summary>Source identifier of the Azure service-tag catalog used during evaluation.</summary>
+    public string AzureServiceTagSource { get; init; } = string.Empty;
+
+    /// <summary>Catalog-wide Azure service-tag change number used during evaluation.</summary>
+    public string AzureServiceTagChangeNumber { get; init; } = string.Empty;
+
+    /// <summary>Azure cloud reported by the service-tag catalog.</summary>
+    public string AzureServiceTagCloud { get; init; } = string.Empty;
+
+    /// <summary>Time at which the Azure service-tag catalog was loaded or retrieved.</summary>
+    public DateTimeOffset? AzureServiceTagRetrievedAtUtc { get; init; }
+}
+
+/// <summary>Evidence supplied to endpoint attribution.</summary>
+public sealed class EndpointAttributionInput {
+    /// <summary>Logical endpoint hostname.</summary>
+    public string HostName { get; set; } = string.Empty;
+
+    /// <summary>Endpoint port.</summary>
+    public int Port { get; set; }
+
+    /// <summary>Endpoint service or protocol label.</summary>
+    public string Service { get; set; } = string.Empty;
+
+    /// <summary>DNS CNAME chain, in traversal order.</summary>
+    public IReadOnlyList<string> CnameChain { get; set; } = Array.Empty<string>();
+
+    /// <summary>Resolved and connected addresses observed for the endpoint.</summary>
+    public IReadOnlyList<string> IpAddresses { get; set; } = Array.Empty<string>();
+
+    /// <summary>TLS certificate issuer text.</summary>
+    public string CertificateIssuer { get; set; } = string.Empty;
+
+    /// <summary>Observed HTTP redirect target hosts.</summary>
+    public IReadOnlyList<string> RedirectTargets { get; set; } = Array.Empty<string>();
+
+    /// <summary>Observed reverse-DNS hostnames.</summary>
+    public IReadOnlyList<string> ReverseDnsNames { get; set; } = Array.Empty<string>();
+
+    /// <summary>Observed autonomous-system numbers, without requiring a particular prefix format.</summary>
+    public IReadOnlyList<string> AutonomousSystemNumbers { get; set; } = Array.Empty<string>();
+
+    /// <summary>Optional Azure service-tag catalog used for current range matching.</summary>
+    public AzureServiceTagCatalog? AzureServiceTags { get; set; }
+}

--- a/DomainDetective/Providers/Endpoint/EndpointAttributionRule.cs
+++ b/DomainDetective/Providers/Endpoint/EndpointAttributionRule.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+
+namespace DomainDetective.Providers.Endpoint;
+
+/// <summary>
+/// Declarative, serializable rule used to attribute an endpoint to a provider service.
+/// </summary>
+public sealed class EndpointAttributionRule {
+    /// <summary>Stable provider identifier.</summary>
+    public string ProviderId { get; set; } = string.Empty;
+
+    /// <summary>Stable service identifier within the provider.</summary>
+    public string ServiceId { get; set; } = string.Empty;
+
+    /// <summary>Human-readable classification.</summary>
+    public string DisplayName { get; set; } = string.Empty;
+
+    /// <summary>Stable rule identifier.</summary>
+    public string RuleId { get; set; } = string.Empty;
+
+    /// <summary>Rule version used in persisted evidence.</summary>
+    public string RuleVersion { get; set; } = string.Empty;
+
+    /// <summary>Source or provenance note for the rule.</summary>
+    public string Source { get; set; } = string.Empty;
+
+    /// <summary>Logical hostname prefixes. These are intentionally weak signals.</summary>
+    public List<string> HostnamePrefixes { get; } = new();
+
+    /// <summary>DNS CNAME suffixes.</summary>
+    public List<string> CnameSuffixes { get; } = new();
+
+    /// <summary>Point-in-time address prefixes in CIDR notation.</summary>
+    public List<string> IpAddressPrefixes { get; } = new();
+
+    /// <summary>Azure service-tag names whose current prefixes support this rule.</summary>
+    public List<string> AzureServiceTagNames { get; } = new();
+
+    /// <summary>Case-insensitive certificate issuer fragments.</summary>
+    public List<string> CertificateIssuerContains { get; } = new();
+
+    /// <summary>HTTP redirect target suffixes.</summary>
+    public List<string> RedirectTargetSuffixes { get; } = new();
+
+    /// <summary>Reverse-DNS suffixes.</summary>
+    public List<string> ReverseDnsSuffixes { get; } = new();
+
+    /// <summary>Autonomous-system identifiers.</summary>
+    public List<string> AutonomousSystemNumbers { get; } = new();
+
+    /// <summary>
+    /// Endpoint service labels to which this rule applies. An empty list allows every service.
+    /// </summary>
+    public List<string> ApplicableServices { get; } = new();
+
+    /// <summary>Endpoint ports to which this rule applies. An empty list allows every port.</summary>
+    public List<int> ApplicablePorts { get; } = new();
+
+    /// <summary>Minimum score required to become the primary classification.</summary>
+    public double MinimumScore { get; set; } = 0.5;
+
+    /// <summary>
+    /// Allows hostname or issuer evidence to establish a primary classification without a stronger
+    /// namespace, address, redirect, reverse-DNS, or ASN signal. Defaults to false.
+    /// </summary>
+    public bool AllowWeakSignalsAsPrimary { get; set; }
+
+    /// <summary>
+    /// Requires address-prefix evidence to be corroborated by a different signal kind before it
+    /// can establish a primary classification. Use this for point-in-time address seeds.
+    /// </summary>
+    public bool RequireCorroborationForIpAddressPrimary { get; set; }
+
+    /// <summary>
+    /// Signal kinds allowed to corroborate point-in-time address evidence. When empty, any
+    /// non-address signal can corroborate it; built-in point-in-time rules use an explicit list.
+    /// </summary>
+    public List<EndpointAttributionSignalKind> IpAddressPrimaryCorroboratingSignals { get; } = new();
+}

--- a/DomainDetective/Views/Converters.DnsInventory.cs
+++ b/DomainDetective/Views/Converters.DnsInventory.cs
@@ -24,9 +24,10 @@ public static partial class Converters
         var provider = analysis.Provider != DnsProvider.Unknown ? analysis.Provider.ToString() : "-";
         var mail = analysis.MailProvider != MailProviderKind.Unknown ? analysis.MailProvider.ToString() : "-";
         var cname = analysis.CnameTargetProvider != DnsCnameTargetProvider.Unknown ? analysis.CnameTargetProvider.ToString() : "-";
+        var cnameService = analysis.CnameTargetService != DnsCnameTargetService.Unknown ? analysis.CnameTargetService.ToString() : "-";
         var txt = analysis.TxtSignals != DnsTxtSignals.None ? analysis.TxtSignals.ToString() : "-";
         var caa = analysis.CaaIssuers != DnsCaaIssuers.None ? analysis.CaaIssuers.ToString() : "-";
-        var summary = $"{analysis.TotalRecords} record(s); types {analysis.RecordTypesQueried}; failed {analysis.RecordTypesFailed}; dns {provider}; mail {mail}; cname {cname}; txt {txt}; apps {analysis.DetectedDnsApplications?.Count ?? 0}; caa {caa}; authority {(analysis.IncludeAuthorities ? "on" : "off")}; additional {(analysis.IncludeAdditional ? "on" : "off")}";
+        var summary = $"{analysis.TotalRecords} record(s); types {analysis.RecordTypesQueried}; failed {analysis.RecordTypesFailed}; dns {provider}; mail {mail}; cname {cname}; cname-service {cnameService}; txt {txt}; apps {analysis.DetectedDnsApplications?.Count ?? 0}; caa {caa}; authority {(analysis.IncludeAuthorities ? "on" : "off")}; additional {(analysis.IncludeAdditional ? "on" : "off")}";
 
         return new DnsInventoryInfo
         {
@@ -45,6 +46,7 @@ public static partial class Converters
             MailProviderScore = analysis.MailProviderScore,
             MailProviderEvidence = analysis.MailProviderEvidence ?? Array.Empty<string>(),
             CnameTargetProvider = analysis.CnameTargetProvider,
+            CnameTargetService = analysis.CnameTargetService,
             CnameTargetFlags = analysis.CnameTargetFlags,
             CnameTargetEvidence = analysis.CnameTargetEvidence ?? Array.Empty<string>(),
             TxtSignals = analysis.TxtSignals,
@@ -103,6 +105,8 @@ public sealed class DnsInventoryInfo
     public IReadOnlyList<string> MailProviderEvidence { get; set; } = Array.Empty<string>();
     /// <summary>Gets or sets the cname target provider value.</summary>
     public DnsCnameTargetProvider CnameTargetProvider { get; set; }
+    /// <summary>Gets or sets the specific CNAME target service value.</summary>
+    public DnsCnameTargetService CnameTargetService { get; set; }
     /// <summary>Gets or sets the cname target flags value.</summary>
     public DnsCnameTargetFlags CnameTargetFlags { get; set; }
     /// <summary>Gets or sets the cname target evidence value.</summary>

--- a/README.MD
+++ b/README.MD
@@ -509,12 +509,20 @@ Invoke-DDCertificateInventory `
     -RecentResultTtlHours 24 `
     -IncludeCtSubdomains `
     -VerifyCtSubdomains
+
+# Explicit endpoints can be captured without a domain list. This performs AUTH TLS before the TLS handshake.
+Invoke-DDCertificateInventory `
+    -Endpoint ftps-explicit://ftp.example.com:21 `
+    -DetectServices `
+    -ProbeVantage branch-office `
+    -NoPersist
 ```
 
 CLI:
 
 ```bash
 dotnet run --project DomainDetective.CLI -- CertificateInventoryCapture example.com example.org --include-ct-subdomains --verify-ct-subdomains
+dotnet run --project DomainDetective.CLI -- cert-inventory-capture --endpoint ftps-explicit://ftp.example.com:21 --detect-services --probe-vantage branch-office --no-persist
 dotnet run --project DomainDetective.CLI -- CertificateInventorySummary --since-utc 2026-01-01
 dotnet run --project DomainDetective.CLI -- CertificateInventoryRisk --expiring-within-days 30 --json
 ```


### PR DESCRIPTION
## Summary

- add stable `host + port + service` endpoint identity with probe-vantage, connected-address, DNS, redirect, and observation-time evidence
- add explainable provider/service attribution that retains all candidates and evidence, supports configurable rules, and can load current Azure service-tag JSON without embedding volatile Azure ranges
- add protocol-correct explicit and implicit FTP TLS certificate probing without authentication or data-channel access
- expose detection and FTP TLS controls through the .NET API, CLI, PowerShell, CSV, NDJSON, examples, and certificate inventory documentation
- include HTTPS, mail TLS, and FTP TLS targets consistently in CLI endpoint-list output

## Detection behavior

- weak hostname and certificate-issuer signals remain review candidates instead of becoming primary classifications by themselves
- point-in-time provider IP seeds require provider-specific namespace or redirect corroboration
- built-in web delivery rules are constrained by known HTTPS transport on any valid port, and ambiguous provider/service identities remain explicit
- custom rules require normalized stable provider/service identities, normalized unique rule identifiers, normalized non-empty rule versions, at least one usable evidence matcher, defined corroboration signal kinds, normalized 0-1 score thresholds, and valid 1-65535 port filters; host-suffix matchers are normalized before usability validation so dot-only values are removed and rejected; rule state is snapshotted and CIDR prefixes are compiled once when a detector is created
- applicable-service filters are trimmed and deduplicated case-insensitively, and null, empty, or whitespace entries fail with contextual validation
- autonomous-system matchers accept numeric or `AS`-prefixed input, canonicalize values to their numeric form, deduplicate them, and reject malformed non-empty values
- IP address evidence cannot be configured to corroborate itself when a rule requires independent primary-classification evidence
- malformed Azure service-tag roots, array members, non-string names, properties, missing prefix collections, wrong prefix-collection types, and prefix values fail with contextual diagnostics instead of being silently ignored
- CNAME chains follow records owned by the current traversal node, retain unambiguous ownerless custom responses, preserve record existence for ambiguous answers, and leave conflicting owner targets unclassified instead of choosing by response order
- CNAME-only analysis skips A and AAAA lookups when no CNAME target exists, while endpoint enrichment retains complete address evidence
- selected CNAME applications retain evidence from the matching service hop, including terminal services reached after the bounded diagnostic evidence allocation
- the CNAME depth limit performs one bounded look-ahead query, so an exactly bounded terminal chain is not reported as overflow
- every followed cross-host redirect is retained in order, including returns, repeated hosts, and HTTP 300 responses, under one timeout budget for the complete chain; intermediate bodies are not buffered
- HTTPS-to-HTTP redirect downgrades are retained as evidence but rejected before any plaintext request is sent
- ordinary .NET 8+ HTTPS requests connect through the reusable outbound resolver and retain the actual origin transport peer instead of inferring it from DNS or replacing it with a redirect peer
- proxied .NET 8+ HTTPS connections do not expose the proxy transport peer as origin-address evidence
- IPv4-mapped HTTPS resolver results are canonicalized before socket-family selection
- auxiliary TLS metadata, protocol-support, and HTTP/3 fallback connections cannot overwrite primary HTTP peer evidence
- failed and cancelled direct HTTPS connection attempts dispose their transport clients before propagating the failure
- .NET Framework full-HTTP analysis pairs the request with a direct TLS handshake to retain the actual origin peer, while the real HTTP callback remains authoritative for certificate evidence; if direct peer capture is unavailable it keeps the HTTP result without inventing a peer
- explicit FTP TLS waits through valid preliminary 120 greetings for the terminal 220 service-ready reply, while undefined TLS modes fail before network access
- pinned IPv4-mapped FTP addresses are normalized before socket-family selection and retained as canonical IPv4 evidence
- pinned IPv4-mapped mail addresses are normalized before resolver approval, address-family filtering, and socket creation
- FTP greeting and AUTH TLS response lines are bounded to 4,096 characters before parsing
- FTP TLS observations retain certificate DNS subject alternative names through the reusable result and final inventory entry
- reusable FTP TLS results explicitly own their leaf and chain certificates, expose idempotent disposal, and are disposed immediately after inventory mapping
- invalid FTP TLS timeouts and modes, DNS enrichment parallelism, custom attribution CIDR prefixes, explicit zero ports, and brackets around non-IPv6 hostnames fail early with contextual public-surface validation
- IP-literal endpoints, including bracketed, expanded, mapped, URI, and mail forms, use one canonical identity through probing, deduplication, cache lookup, and result correlation without unnecessary DNS queries; raw and bracketed IPv6 HTTPS additions retain a valid bracketed URI authority
- remote address families use stable `IPv4` / `IPv6` labels across HTTPS, mail TLS, and FTP TLS, including mapped and legacy cached values
- recent-result reuse is partitioned by probe vantage, ages from the original endpoint observation, prioritizes stale or uncached targets before healthy reusable targets, excludes reusable stable FTP TLS failures from the live probe budget, and excludes reused FTP endpoints from live-probe telemetry
- reused observations retain their historical connected peer, while fresh attribution uses only newly resolved DNS addresses instead of blending evidence from different observation times
- DNS enrichment and FTP TLS probing use bounded worker pools, so configured parallelism limits both active work and queued task allocation
- one capture-scoped probe-start limiter applies across built-in HTTPS, mail TLS, and FTP TLS phases, preventing phase-boundary bursts
- resolver-local DNS cancellations remain non-fatal observation errors while caller cancellation still propagates
- null custom DNS override results are normalized to valid empty CNAME, A, and AAAA answers
- DNS observation errors are retained in typed results, NDJSON, and CSV alongside the resolver and observation time
- diff and drift histories, typed results, CLI tables, CSV, and NDJSON preserve the complete service and probe-vantage endpoint identity; unique service replacements are correlated within a host/port/vantage transport slot, while coexisting identities stay distinct and ambiguous replacements remain additions/removals; dynamic table cells are markup-escaped
- inventory drift uses endpoint observation time, coalesces later snapshots that reuse the same probe observation, and falls back to snapshot time only for legacy entries
- CT certificate metadata is hydrated before endpoint attribution, so persisted certificate issuer evidence and attribution candidates remain consistent
- protocol observation, DNS observation, attribution evaluation, and snapshot-finalization timestamps remain distinct and ordered

## Validation

- full DomainDetective .NET 8 suite: 2,119 passed, 16 skipped, 0 failed
- 142 focused attribution-rule, IPv6 HTTPS authority, service diff, and service drift contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 47 focused DNS, CNAME, attribution-catalog, rule-identity, CIDR-compilation, and IPv6 mail-correlation contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 23 focused FTP greeting/mode, CNAME ambiguity, IP corroboration, and cross-runtime endpoint-port contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 12 focused Azure catalog structure and non-fatal optional-input contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 94 focused endpoint-attribution, normalized-identity, rule-validation, FTP TLS, bounded-work, and mutable-catalog contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 20 focused Azure catalog, endpoint-bracket, IPv6-preservation, and non-fatal optional-catalog contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- focused FTP TLS reuse and CLI rendering contracts also pass on their supported targets
- 54 focused HTTPS/FTP transport contracts pass on .NET Framework 4.7.2 and 57 pass on .NET 8 and .NET 10
- 111 focused origin-peer, attribution-filter, and observation-time drift contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 151 focused attribution, constrained-connection, and HTTPS contracts pass on .NET Framework 4.7.2; 153 pass on .NET 8 and .NET 10
- cached-peer attribution separation and redirect timeout-budget contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10; the timeout contract also passes five consecutive .NET Framework runs
- 112 focused FTP TLS ownership, DNS-attribution, and CT-metadata contracts pass on .NET Framework 4.7.2, .NET 8, and .NET 10
- 12 focused constrained-transport and global probe-rate contracts pass on .NET Framework 4.7.2; 16 pass on .NET 8 and .NET 10
- full CLI suite: 36 passed on .NET 8 and 36 passed on .NET 10, including rendered diff/drift identity output
- PowerShell and example projects build successfully across their configured target frameworks with zero warnings or errors
- independent read-only owner and final closure reviews completed; every validated P2 finding was addressed and revalidated

## Current-data boundary

Azure address attribution uses a caller-supplied service-tag JSON catalog and persists its source, cloud, change number, and retrieval time. Catalog freshness remains controlled by the caller; malformed optional input produces a warning without discarding collected endpoint observations. The reusable detector accepts explicit reverse-DNS and ASN evidence, while certificate inventory capture rejects custom rules requiring either signal because that pipeline does not collect them.