### PR TITLE
Unify DomainDetective package and module releases

### DIFF
--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -44,10 +44,8 @@ jobs:
 
 
             - name: Refresh module manifest
-              env:
-                RefreshPSD1Only: 'true'
               run: |
-                .\Module\Build\Build-Module.ps1
+                .\Module\Build\Build-Module.ps1 -ConfigurationGateMode Manifest
               shell: pwsh
 
             - name: Commit refreshed PSD1
@@ -80,8 +78,7 @@ jobs:
                       git config user.name "github-actions[bot]"
                       git config user.email "github-actions[bot]@users.noreply.github.com"
 
-                      $Env:RefreshPSD1Only = 'true'
-                      .\Module\Build\Build-Module.ps1
+                      .\Module\Build\Build-Module.ps1 -ConfigurationGateMode Manifest
 
                       git add Module/DomainDetective.psd1
                       git diff --cached --quiet -- Module/DomainDetective.psd1
@@ -255,8 +252,6 @@ jobs:
                 }
 
             - name: Build packaged module for ALC tests
-              env:
-                RefreshPSD1Only: 'false'
               run: .\Module\Build\Build-Module.ps1
               shell: pwsh
 

--- a/Build/project.build.json
+++ b/Build/project.build.json
@@ -37,7 +37,6 @@
   "PlanOutputPath": "Artifacts/ProjectBuild/build.plan.json",
   "UpdateVersions": true,
   "Build": true,
-  "PackStrategy": "MSBuild",
   "PublishNuget": false,
   "PublishGitHub": false,
   "CreateReleaseZip": true,

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -61,7 +61,8 @@ public class TestCertificateInventoryCapture {
                 entry => string.Equals(entry.Scheme, "ftps-explicit", StringComparison.OrdinalIgnoreCase));
             long mailProbeAcceptedAt = await mailServer;
             long ftpProbeAcceptedAt = await ftpServer;
-            TimeSpan phaseBoundaryGap = Stopwatch.GetElapsedTime(mailProbeAcceptedAt, ftpProbeAcceptedAt);
+            TimeSpan phaseBoundaryGap = TimeSpan.FromSeconds(
+                (ftpProbeAcceptedAt - mailProbeAcceptedAt) / (double)Stopwatch.Frequency);
             Assert.True(
                 phaseBoundaryGap >= TimeSpan.FromMilliseconds(350),
                 $"Expected the global probe-start interval across protocol phases; observed {phaseBoundaryGap}.");

--- a/DomainDetective.Tests/TestCertificateInventoryCapture.cs
+++ b/DomainDetective.Tests/TestCertificateInventoryCapture.cs
@@ -2,6 +2,7 @@ using DnsClientX;
 using DomainDetective.Providers.Endpoint;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Sockets;
@@ -23,11 +24,13 @@ public class TestCertificateInventoryCapture {
         ftpListener.Start();
         int mailPort = ((IPEndPoint)mailListener.LocalEndpoint).Port;
         int ftpPort = ((IPEndPoint)ftpListener.LocalEndpoint).Port;
-        Task mailServer = Task.Run(async () => {
+        Task<long> mailServer = Task.Run(async () => {
             using TcpClient client = await mailListener.AcceptTcpClientAsync();
+            return Stopwatch.GetTimestamp();
         });
-        Task ftpServer = Task.Run(async () => {
+        Task<long> ftpServer = Task.Run(async () => {
             using TcpClient client = await ftpListener.AcceptTcpClientAsync();
+            return Stopwatch.GetTimestamp();
         });
 
         try {
@@ -50,13 +53,15 @@ public class TestCertificateInventoryCapture {
 
             Assert.Equal(1, result.ProbedMailCount);
             Assert.Equal(1, result.ProbedFtpTlsCount);
-            CertificateInventoryEntry mailEntry = Assert.Single(
+            Assert.Single(
                 result.Snapshot.Entries,
                 entry => string.Equals(entry.Scheme, "smtp", StringComparison.OrdinalIgnoreCase));
-            CertificateInventoryEntry ftpEntry = Assert.Single(
+            Assert.Single(
                 result.Snapshot.Entries,
                 entry => string.Equals(entry.Scheme, "ftps-explicit", StringComparison.OrdinalIgnoreCase));
-            TimeSpan phaseBoundaryGap = ftpEntry.ObservedAtUtc!.Value - mailEntry.ObservedAtUtc!.Value;
+            long mailProbeAcceptedAt = await mailServer;
+            long ftpProbeAcceptedAt = await ftpServer;
+            TimeSpan phaseBoundaryGap = Stopwatch.GetElapsedTime(mailProbeAcceptedAt, ftpProbeAcceptedAt);
             Assert.True(
                 phaseBoundaryGap >= TimeSpan.FromMilliseconds(350),
                 $"Expected the global probe-start interval across protocol phases; observed {phaseBoundaryGap}.");

--- a/Module/Build/Build-Module.ps1
+++ b/Module/Build/Build-Module.ps1
@@ -1,9 +1,24 @@
-﻿Import-Module PSPublishModule -Force
+param(
+    [ValidateSet('Manifest', 'Documentation', 'Build', 'Publish')]
+    [string] $ConfigurationGateMode = 'Build',
+
+    [bool] $SignModule = $false,
+
+    [string] $ProjectBuildConfigPath = '..\Build\project.build.json',
+
+    [string] $NuGetApiKeyPath = 'C:\Support\Important\NugetOrgEvotec.txt',
+
+    [string] $PowerShellGalleryApiKeyPath = 'C:\Support\Important\PowerShellGalleryAPI.txt',
+
+    [string] $GitHubApiKeyPath = 'C:\Support\Important\GitHubAPI.txt'
+)
+
+Import-Module PSPublishModule -MinimumVersion '3.0.130' -Force -ErrorAction Stop
 
 Build-Module -ModuleName 'DomainDetective' {
     # Usual defaults as per standard module
     $Manifest = [ordered] @{
-        ModuleVersion        = '1.0.0'
+        ModuleVersion        = '1.0.X'
         CompatiblePSEditions = @('Desktop', 'Core')
         GUID                 = 'a2986f0d-da11-43f5-a252-f9e1d1699776'
         Author               = 'Przemyslaw Klys'
@@ -65,11 +80,11 @@ Build-Module -ModuleName 'DomainDetective' {
 
     $newConfigurationBuildSplat = @{
         Enable                               = $true
-        SignModule                           = if ($Env:COMPUTERNAME -eq 'EVOMAGIC') { $true } else { $false }
+        SignModule                           = $SignModule
         MergeModuleOnBuild                   = $true
         MergeFunctionsFromApprovedModules    = $true
         CertificateThumbprint                = '92e95fb58effa6a4a75e77a33cdd6bfe6dd30f1a'
-        NETProjectPath                       = "$PSScriptRoot\..\..\DomainDetective.PowerShell"
+        NETProjectPath                       = '..\DomainDetective.PowerShell\DomainDetective.PowerShell.csproj'
         ResolveBinaryConflicts               = $true
         ResolveBinaryConflictsName           = 'DomainDetective.PowerShell'
         NETProjectName                       = 'DomainDetective.PowerShell'
@@ -81,16 +96,23 @@ Build-Module -ModuleName 'DomainDetective' {
         DotSourceLibraries                   = $true
         DotSourceClasses                     = $true
         DeleteTargetModuleBeforeBuild        = $true
-        RefreshPSD1Only                      = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $false } else { [bool]::Parse($Env:RefreshPSD1Only) }
         NETBinaryModuleDocumentation         = $true
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat
 
-    New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" -RequiredModulesPath "$PSScriptRoot\..\Artefacts\Unpacked\Modules"
-    New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName
+    $projectBuildOptions = @{
+        PublishApiKeyFilePath = $NuGetApiKeyPath
+    }
+    New-ConfigurationProjectBuild -Name 'DomainDetective' -ConfigPath $ProjectBuildConfigPath -Enabled -BuildBeforeModule -ProvideLocalNuGetFeed -PublishNuget -Options $projectBuildOptions
+    New-ConfigurationRelease -StageRoot 'Artefacts\UploadReady' -VersionSource Module -BuildOrder 'Packages', 'Module' -PublishOrder 'NuGet', 'PowerShellGallery', 'GitHub'
+
+    New-ConfigurationArtefact -Type Unpacked -Enable -Path 'Artefacts\Unpacked' -RequiredModulesPath 'Artefacts\Unpacked\Modules'
+    New-ConfigurationArtefact -Type Packed -Enable -Path 'Artefacts\Packed' -IncludeTagName -ArtefactName 'DomainDetective-PowerShellModule.<TagModuleVersionWithPreRelease>.zip' -ID 'ToGitHub'
 
     # global options for publishing to github/psgallery
-    #New-ConfigurationPublish -Type PowerShellGallery -FilePath 'C:\Support\Important\PowerShellGalleryAPI.txt' -Enabled:$false
-    #New-ConfigurationPublish -Type GitHub -FilePath 'C:\Support\Important\GitHubAPI.txt' -UserName 'EvotecIT' -Enabled:$false -GenerateReleaseNotes
-}
+    New-ConfigurationPublish -Type PowerShellGallery -FilePath $PowerShellGalleryApiKeyPath -Enabled:$false
+    New-ConfigurationPublish -Type GitHub -FilePath $GitHubApiKeyPath -UserName 'EvotecIT' -RepositoryName 'DomainDetective' -Enabled:$false -GenerateReleaseNotes -OverwriteTagName 'DomainDetective-PowerShellModule.<TagModuleVersionWithPreRelease>'
+
+    New-ConfigurationGate -Mode $ConfigurationGateMode
+} -ExitCode

--- a/Module/Docs/Invoke-DDCertificateInventory.md
+++ b/Module/Docs/Invoke-DDCertificateInventory.md
@@ -11,11 +11,11 @@ Captures and optionally persists a certificate inventory snapshot from domains a
 ## SYNTAX
 ### __AllParameterSets
 ```powershell
-Invoke-DDCertificateInventory [[-DomainName] <string[]>] [-DomainsFile <string>] [-CacheDirectory <string>] [-DnsEndpoint <DnsEndpoint>] [-NoApexHttps] [-NoWwwHttps] [-IncludeMxHttps] [-DisableMxDiscovery] [-DisableSmtpStartTls] [-DisableSubmissionStartTls] [-IncludeImapTls] [-IncludePop3Tls] [-IncludeCtSubdomains] [-VerifyCtSubdomains] [-MaxCtRowsPerDomain <int>] [-MaxCtSubdomainsPerDomain <int>] [-EnableNativeCtLogSubdomains] [-DisableNativeCtSharedIngestion] [-NativeCtLogOnly] [-EnablePassiveCtFallback] [-EnablePassiveCtMetadataFallback] [-NativeCtLogListUrl <string>] [-NativeCtLogUrl <string[]>] [-NativeCtMaxLogs <int>] [-NativeCtMaxEntriesPerLog <int>] [-NativeCtEntryBatchSize <int>] [-NativeCtInitialBackfillEntriesPerLog <int>] [-NativeCtCursorStatePath <string>] [-NativeCtIncludePendingLogs] [-NativeCtRequestDelayMilliseconds <int>] [-NativeCtRetryCount <int>] [-NativeCtRetryBaseDelayMilliseconds <int>] [-NativeCtRetryMaxDelayMilliseconds <int>] [-NativeCtCircuitBreakerFailureThreshold <int>] [-NativeCtCircuitBreakerDurationSeconds <int>] [-DisableNativeCtCatchUpMode] [-NativeCtCatchUpLagThreshold <int>] [-NativeCtCatchUpMaxEntriesPerLog <int>] [-NativeCtCatchUpBatchSize <int>] [-Endpoint <string[]>] [-MaxMxHostsPerDomain <int>] [-MaxParallelism <int>] [-DiscoveryParallelism <int>] [-MailTimeoutSeconds <int>] [-HttpsTimeoutSeconds <int>] [-MaxProbeErrorWarnings <int>] [-MaxTargets <int>] [-MaxProbeStartsPerSecond <int>] [-ReuseRecentResults] [-RecentResultTtlHours <int>] [-ReuseRecentFailureResults] [-RecentFailureResultTtlHours <int>] [-ReprobeExpiringWithinDays <int>] [-SkipRevocation] [-CtProfile <CertificateCtEnrichmentProfile>] [-DisableDefaultCtTemplate] [-CtApiTemplate <string[]>] [-EnableCensysCtSource] [-CensysApiId <string>] [-CensysApiSecret <string>] [-CensysApiSecretEnv <string>] [-CensysCtApiUrlTemplate <string>] [-EnableShodanCtSource] [-ShodanApiKey <string>] [-ShodanApiKeyEnv <string>] [-ShodanCtApiUrlTemplate <string>] [-NoPersist] [-FailOnWarningTargetDecisions] [<CommonParameters>]
+Invoke-DDCertificateInventory [[-DomainName] <string[]>] [-DomainsFile <string>] [-CacheDirectory <string>] [-DnsEndpoint <DnsEndpoint>] [-DetectServices] [-ProbeVantage <string>] [-AzureServiceTagsJsonPath <string>] [-DnsEnrichmentParallelism <int>] [-NoApexHttps] [-NoWwwHttps] [-IncludeMxHttps] [-DisableMxDiscovery] [-DisableSmtpStartTls] [-DisableSubmissionStartTls] [-IncludeImapTls] [-IncludePop3Tls] [-IncludeCtSubdomains] [-VerifyCtSubdomains] [-MaxCtRowsPerDomain <int>] [-MaxCtSubdomainsPerDomain <int>] [-EnableNativeCtLogSubdomains] [-DisableNativeCtSharedIngestion] [-NativeCtLogOnly] [-EnablePassiveCtFallback] [-EnablePassiveCtMetadataFallback] [-NativeCtLogListUrl <string>] [-NativeCtLogUrl <string[]>] [-NativeCtMaxLogs <int>] [-NativeCtMaxEntriesPerLog <int>] [-NativeCtEntryBatchSize <int>] [-NativeCtInitialBackfillEntriesPerLog <int>] [-NativeCtCursorStatePath <string>] [-NativeCtIncludePendingLogs] [-NativeCtRequestDelayMilliseconds <int>] [-NativeCtRetryCount <int>] [-NativeCtRetryBaseDelayMilliseconds <int>] [-NativeCtRetryMaxDelayMilliseconds <int>] [-NativeCtCircuitBreakerFailureThreshold <int>] [-NativeCtCircuitBreakerDurationSeconds <int>] [-DisableNativeCtCatchUpMode] [-NativeCtCatchUpLagThreshold <int>] [-NativeCtCatchUpMaxEntriesPerLog <int>] [-NativeCtCatchUpBatchSize <int>] [-Endpoint <string[]>] [-MaxMxHostsPerDomain <int>] [-MaxParallelism <int>] [-DiscoveryParallelism <int>] [-MailTimeoutSeconds <int>] [-FtpTlsTimeoutSeconds <int>] [-HttpsTimeoutSeconds <int>] [-MaxProbeErrorWarnings <int>] [-MaxTargets <int>] [-MaxProbeStartsPerSecond <int>] [-ReuseRecentResults] [-RecentResultTtlHours <int>] [-ReuseRecentFailureResults] [-RecentFailureResultTtlHours <int>] [-ReprobeExpiringWithinDays <int>] [-SkipRevocation] [-CtProfile <CertificateCtEnrichmentProfile>] [-DisableDefaultCtTemplate] [-CtApiTemplate <string[]>] [-EnableCensysCtSource] [-CensysApiId <string>] [-CensysApiSecret <string>] [-CensysApiSecretEnv <string>] [-CensysCtApiUrlTemplate <string>] [-EnableShodanCtSource] [-ShodanApiKey <string>] [-ShodanApiKeyEnv <string>] [-ShodanCtApiUrlTemplate <string>] [-NoPersist] [-FailOnWarningTargetDecisions] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Discovers HTTPS and mail TLS endpoints (for example MX-derived STARTTLS) and stores normalized certificate evidence in the inventory snapshot format used by certificate inventory analytics cmdlets.
+Discovers HTTPS, mail TLS, and explicit or implicit FTP TLS endpoints and stores normalized certificate and endpoint evidence in the inventory snapshot format used by certificate inventory analytics cmdlets.
 
 ## EXAMPLES
 
@@ -39,31 +39,31 @@ Invoke-DDCertificateInventory -DomainName example.com -CtProfile Extended -Enabl
 
 ### EXAMPLE 4
 ```powershell
-Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -VerifyCtSubdomains -MaxCtSubdomainsPerDomain 5000 -Verbose
+Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -VerifyCtSubdomains -MaxCtSubdomainsPerDomain 5000 -Verbose
 ```
 
 
 ### EXAMPLE 5
 ```powershell
-Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -EnableNativeCtLogSubdomains -NativeCtLogOnly -NativeCtInitialBackfillEntriesPerLog 5000 -Verbose
+Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -EnableNativeCtLogSubdomains -NativeCtLogOnly -NativeCtInitialBackfillEntriesPerLog 5000 -Verbose
 ```
 
 
 ### EXAMPLE 6
 ```powershell
-Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -Limit 150 -MaxProbeStartsPerSecond 20 -MaxProbeErrorWarnings 10 -Verbose
+Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -Limit 150 -MaxProbeStartsPerSecond 20 -MaxProbeErrorWarnings 10 -Verbose
 ```
 
 
 ### EXAMPLE 7
 ```powershell
-Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -ReuseRecentResults -RecentResultTtlHours 24 -ReprobeExpiringWithinDays 14
+Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -ReuseRecentResults -RecentResultTtlHours 24 -ReprobeExpiringWithinDays 14
 ```
 
 
 ### EXAMPLE 8
 ```powershell
-Invoke-DDCertificateInventory -DomainName eurofins.com -ReuseRecentFailureResults -RecentFailureResultTtlHours 1 -HttpsTimeoutSeconds 20
+Invoke-DDCertificateInventory -DomainName example.com -ReuseRecentFailureResults -RecentFailureResultTtlHours 1 -HttpsTimeoutSeconds 20
 ```
 
 
@@ -73,7 +73,29 @@ Invoke-DDCertificateInventory -DomainName example.com -Endpoint ftp://example.co
 ```
 
 
+### EXAMPLE 10
+```powershell
+Invoke-DDCertificateInventory -Endpoint ftps-explicit://ftp.example.com:21 -DetectServices -ProbeVantage branch-office -NoPersist
+```
+
+
 ## PARAMETERS
+
+### -AzureServiceTagsJsonPath
+Optional current Azure service-tag JSON file used for IP-based attribution.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -CacheDirectory
 Certificate monitor cache directory containing the inventory folder.
@@ -179,6 +201,22 @@ Type: CertificateCtEnrichmentProfile
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values: Default, Disabled, Public, Extended
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DetectServices
+Resolve endpoint DNS evidence and perform explainable provider/service attribution.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
 
 Required: False
 Position: named
@@ -315,6 +353,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -DnsEnrichmentParallelism
+Maximum concurrent DNS evidence lookups used by service detection.
+
+```yaml
+Type: Int32
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -DomainName
 Domain list to scan. Can be provided from pipeline.
 
@@ -428,7 +482,7 @@ Accept wildcard characters: False
 ```
 
 ### -Endpoint
-Additional endpoint(s) to probe (supports https:// and mail schemes).
+Additional endpoint(s) to probe (supports HTTPS, mail TLS, ftps://, and ftps-explicit:// schemes).
 
 ```yaml
 Type: String[]
@@ -448,6 +502,22 @@ When set, throw a terminating error when warning-level target-decision buckets a
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FtpTlsTimeoutSeconds
+FTP TLS timeout in seconds.
+
+```yaml
+Type: Int32
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:
@@ -652,7 +722,7 @@ Accept wildcard characters: False
 ```
 
 ### -MaxTargets
-Maximum total probe targets (HTTPS + mail) kept after discovery; useful for quick test runs (0 means unlimited).
+Maximum total probe targets (HTTPS + mail + FTP TLS) kept after discovery; useful for quick test runs (0 means unlimited).
 
 ```yaml
 Type: Int32
@@ -992,6 +1062,22 @@ Do not probe www.<domain> over HTTPS.
 
 ```yaml
 Type: SwitchParameter
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProbeVantage
+Label identifying the network vantage used for this observation.
+
+```yaml
+Type: String
 Parameter Sets: __AllParameterSets
 Aliases: None
 Possible values:

--- a/Module/Docs/Test-DDEmailImapTls.md
+++ b/Module/Docs/Test-DDEmailImapTls.md
@@ -11,7 +11,7 @@ Checks TLS configuration for a specific IMAP host.
 ## SYNTAX
 ### ServerName (Default)
 ```powershell
-Test-DDEmailImapTls [-HostName] <string> [[-Port] <int>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-DnsEndpoint <DnsEndpoint>] [-ShowChain] [<CommonParameters>]
+Test-DDEmailImapTls [-HostName] <string> [[-Port] <int>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-DnsEndpoint <DnsEndpoint>] [-ConnectAddress <ipaddress>] [-AddressFamily <MailTransportAddressFamily>] [-ShowChain] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,7 +25,29 @@ Test-DDEmailImapTls -HostName mail.example.com -Port 993
 ```
 
 
+### EXAMPLE 2
+```powershell
+Test-DDEmailImapTls -HostName mail.example.com -Port 993 -AddressFamily IPv6
+```
+
+
 ## PARAMETERS
+
+### -AddressFamily
+Network address family used by the connection.
+
+```yaml
+Type: MailTransportAddressFamily
+Parameter Sets: ServerName
+Aliases: None
+Possible values: Any, IPv4, IPv6
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ArtifactsDirectory
 Destination directory for artifacts when emitted.
@@ -34,6 +56,22 @@ Destination directory for artifacts when emitted.
 Type: String
 Parameter Sets: ServerName
 Aliases: ArtifactsPath
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectAddress
+Optional concrete address used for the TCP connection while HostName remains the TLS identity.
+
+```yaml
+Type: IPAddress
+Parameter Sets: ServerName
+Aliases: None
 Possible values:
 
 Required: False

--- a/Module/Docs/Test-DDEmailPop3Tls.md
+++ b/Module/Docs/Test-DDEmailPop3Tls.md
@@ -11,7 +11,7 @@ Checks TLS configuration for a specific POP3 host.
 ## SYNTAX
 ### ServerName (Default)
 ```powershell
-Test-DDEmailPop3Tls [-HostName] <string> [[-Port] <int>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-DnsEndpoint <DnsEndpoint>] [-ShowChain] [<CommonParameters>]
+Test-DDEmailPop3Tls [-HostName] <string> [[-Port] <int>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-DnsEndpoint <DnsEndpoint>] [-ConnectAddress <ipaddress>] [-AddressFamily <MailTransportAddressFamily>] [-ShowChain] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,7 +25,29 @@ Test-DDEmailPop3Tls -HostName mail.example.com -Port 995
 ```
 
 
+### EXAMPLE 2
+```powershell
+Test-DDEmailPop3Tls -HostName mail.example.com -Port 995 -ConnectAddress 192.0.2.10
+```
+
+
 ## PARAMETERS
+
+### -AddressFamily
+Network address family used by the connection.
+
+```yaml
+Type: MailTransportAddressFamily
+Parameter Sets: ServerName
+Aliases: None
+Possible values: Any, IPv4, IPv6
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ArtifactsDirectory
 Destination directory for artifacts when emitted.
@@ -34,6 +56,22 @@ Destination directory for artifacts when emitted.
 Type: String
 Parameter Sets: ServerName
 Aliases: ArtifactsPath
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectAddress
+Optional concrete address used for the TCP connection while HostName remains the TLS identity.
+
+```yaml
+Type: IPAddress
+Parameter Sets: ServerName
+Aliases: None
 Possible values:
 
 Required: False

--- a/Module/Docs/Test-DDEmailProtocolTls.md
+++ b/Module/Docs/Test-DDEmailProtocolTls.md
@@ -11,7 +11,7 @@ Checks SMTP/IMAP/POP3 TLS configuration for a domain.
 ## SYNTAX
 ### ServerName (Default)
 ```powershell
-Test-DDEmailProtocolTls [-DomainName] <string[]> [[-DnsEndpoint] <DnsEndpoint>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-Protocol <string[]>] [<CommonParameters>]
+Test-DDEmailProtocolTls [-DomainName] <string[]> [[-DnsEndpoint] <DnsEndpoint>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-Protocol <string[]>] [-AddressFamily <MailTransportAddressFamily>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -32,6 +32,22 @@ Test-DDEmailProtocolTls -DomainName example.com -Protocol Smtp
 
 
 ## PARAMETERS
+
+### -AddressFamily
+Network address family used when connecting to discovered mail hosts.
+
+```yaml
+Type: MailTransportAddressFamily
+Parameter Sets: ServerName
+Aliases: None
+Possible values: Any, IPv4, IPv6
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ArtifactsDirectory
 Destination directory for artifacts when emitted.

--- a/Module/Docs/Test-DDEmailSmtpTls.md
+++ b/Module/Docs/Test-DDEmailSmtpTls.md
@@ -11,7 +11,7 @@ Checks TLS configuration for a specific SMTP host.
 ## SYNTAX
 ### ServerName (Default)
 ```powershell
-Test-DDEmailSmtpTls [-HostName] <string> [[-Port] <int>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-DnsEndpoint <DnsEndpoint>] [-ShowChain] [-FullResponse] [<CommonParameters>]
+Test-DDEmailSmtpTls [-HostName] <string> [[-Port] <int>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-DnsEndpoint <DnsEndpoint>] [-ConnectAddress <ipaddress>] [-AddressFamily <MailTransportAddressFamily>] [-ShowChain] [-FullResponse] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,7 +25,29 @@ Test-DDEmailSmtpTls -HostName mail.example.com -Port 587
 ```
 
 
+### EXAMPLE 2
+```powershell
+Test-DDEmailSmtpTls -HostName mail.example.com -Port 587 -ConnectAddress 192.0.2.10 -AddressFamily IPv4
+```
+
+
 ## PARAMETERS
+
+### -AddressFamily
+Network address family used by the connection.
+
+```yaml
+Type: MailTransportAddressFamily
+Parameter Sets: ServerName
+Aliases: None
+Possible values: Any, IPv4, IPv6
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ArtifactsDirectory
 Destination directory for artifacts when emitted.
@@ -34,6 +56,22 @@ Destination directory for artifacts when emitted.
 Type: String
 Parameter Sets: ServerName
 Aliases: ArtifactsPath
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectAddress
+Optional concrete address used for the TCP connection while HostName remains the TLS identity.
+
+```yaml
+Type: IPAddress
+Parameter Sets: ServerName
+Aliases: None
 Possible values:
 
 Required: False

--- a/Module/Docs/Test-DDEmailStartTls.md
+++ b/Module/Docs/Test-DDEmailStartTls.md
@@ -9,9 +9,14 @@ schema: 2.0.0
 Checks SMTP STARTTLS support for a domain.
 
 ## SYNTAX
-### ServerName (Default)
+### DomainName (Default)
 ```powershell
-Test-DDEmailStartTls [-DomainName] <string[]> [[-DnsEndpoint] <DnsEndpoint>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-Port <int>] [-FullResponse] [<CommonParameters>]
+Test-DDEmailStartTls [-DomainName] <string[]> [[-DnsEndpoint] <DnsEndpoint>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-Port <int>] [-AddressFamily <MailTransportAddressFamily>] [-FullResponse] [<CommonParameters>]
+```
+
+### ServerName
+```powershell
+Test-DDEmailStartTls [-HostName] <string> [[-DnsEndpoint] <DnsEndpoint>] [-ExportFormat <ReportFormat[]>] [-ExportPath <string>] [-OpenInBrowser] [-ExportArtifacts] [-ArtifactsDirectory <string>] [-DisableParallel] [-ThrottleLimit <Int32>] [-MaxParallelism <Int32>] [-DnsParallelism <Int32>] [-DnsEndpoints <DnsEndpoint[]>] [-MultiResolverStrategy <MultiResolverStrategy>] [-MultiResolverMaxParallelism <Int32>] [-Port <int>] [-ConnectAddress <ipaddress>] [-AddressFamily <MailTransportAddressFamily>] [-FullResponse] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -25,15 +30,53 @@ Test-DDEmailStartTls -DomainName example.com -Port 587
 ```
 
 
+### EXAMPLE 2
+```powershell
+Test-DDEmailStartTls -HostName mail.example.com -Port 587 -ConnectAddress 192.0.2.10 -AddressFamily IPv4
+```
+
+
 ## PARAMETERS
+
+### -AddressFamily
+Network address family used by the connection.
+
+```yaml
+Type: MailTransportAddressFamily
+Parameter Sets: DomainName, ServerName
+Aliases: None
+Possible values: Any, IPv4, IPv6
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ArtifactsDirectory
 Destination directory for artifacts when emitted.
 
 ```yaml
 Type: String
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: ArtifactsPath
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConnectAddress
+Optional concrete address used for the TCP connection while HostName remains the reported logical endpoint.
+
+```yaml
+Type: IPAddress
+Parameter Sets: ServerName
+Aliases: None
 Possible values:
 
 Required: False
@@ -48,7 +91,7 @@ Disable parallel execution for cmdlet-level work.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -64,7 +107,7 @@ DNS server used for queries.
 
 ```yaml
 Type: DnsEndpoint
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
 
@@ -80,7 +123,7 @@ Optional list of resolver endpoints to use (multi-resolver).
 
 ```yaml
 Type: DnsEndpoint[]
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values: System, SystemTcp, Cloudflare, CloudflareSecurity, CloudflareFamily, CloudflareWireFormat, CloudflareWireFormatPost, CloudflareJsonPost, Google, GoogleWireFormat, GoogleWireFormatPost, GoogleJsonPost, Quad9, Quad9ECS, Quad9Unsecure, OpenDNS, OpenDNSFamily, CloudflareQuic, Quad9Http3, Quad9Quic, GoogleQuic, AdGuard, AdGuardFamily, AdGuardNonFiltering, NextDNS, DnsCryptCloudflare, DnsCryptQuad9, DnsCryptRelay, RootServer, CloudflareOdoh, Custom
 
@@ -96,7 +139,7 @@ DNS resolver concurrency hint for health checks.
 
 ```yaml
 Type: Int32
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -112,7 +155,7 @@ Domain(s) to test.
 
 ```yaml
 Type: String[]
-Parameter Sets: ServerName
+Parameter Sets: DomainName
 Aliases: None
 Possible values:
 
@@ -128,7 +171,7 @@ Emit artifacts (scan.json, metrics.json, progress.jsonl).
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: Artifacts
 Possible values:
 
@@ -144,7 +187,7 @@ Desired export format(s). Accepts one or many values.
 
 ```yaml
 Type: ReportFormat[]
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: Report
 Possible values: Html, Json, Word, Excel, Markdown, MarkdownHtml
 
@@ -160,7 +203,7 @@ Output file path for export.
 
 ```yaml
 Type: String
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -176,7 +219,7 @@ Return the full analysis object instead of per-server details.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -187,12 +230,28 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -HostName
+Logical SMTP hostname to test directly.
+
+```yaml
+Type: String
+Parameter Sets: ServerName
+Aliases: None
+Possible values:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -MaxParallelism
 Maximum concurrent health checks within a single domain run.
 
 ```yaml
 Type: Int32
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -208,7 +267,7 @@ Maximum number of resolvers to query in parallel (null = all).
 
 ```yaml
 Type: Int32
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -224,7 +283,7 @@ Strategy used when multiple DNS endpoints are provided.
 
 ```yaml
 Type: MultiResolverStrategy
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values: FirstSuccess, FastestWins, SequentialFallback, RoundRobin, Random
 
@@ -240,7 +299,7 @@ Open export in browser when applicable.
 
 ```yaml
 Type: SwitchParameter
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: OpenReport
 Possible values:
 
@@ -256,7 +315,7 @@ SMTP port number.
 
 ```yaml
 Type: Int32
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 
@@ -272,7 +331,7 @@ Maximum number of concurrent items for cmdlet-level parallel work.
 
 ```yaml
 Type: Int32
-Parameter Sets: ServerName
+Parameter Sets: DomainName, ServerName
 Aliases: None
 Possible values:
 

--- a/Module/Tests/AssemblyLoadContext.Tests.ps1
+++ b/Module/Tests/AssemblyLoadContext.Tests.ps1
@@ -9,7 +9,7 @@ Describe 'Packaged AssemblyLoadContext isolation' {
         }
 
         if (-not (Test-Path -LiteralPath $packagedLoader)) {
-            Set-ItResult -Skipped -Because 'packaged ALC artifact is not present; run Module\Build\Build-Module.ps1 with RefreshPSD1Only=false before this regression'
+            Set-ItResult -Skipped -Because 'packaged ALC artifact is not present; run Module\Build\Build-Module.ps1 -ConfigurationGateMode Build before this regression'
             return
         }
 
@@ -106,7 +106,7 @@ if (`$null -eq `$coreAssembly) {
         }
 
         if (-not (Test-Path -LiteralPath $packagedLoader)) {
-            Set-ItResult -Skipped -Because 'packaged ALC artifact is not present; run Module\Build\Build-Module.ps1 with RefreshPSD1Only=false before this regression'
+            Set-ItResult -Skipped -Because 'packaged ALC artifact is not present; run Module\Build\Build-Module.ps1 -ConfigurationGateMode Build before this regression'
             return
         }
 
@@ -180,7 +180,7 @@ if (`$null -eq `$coreAssembly) {
         $packagedModule = Join-Path $packagedModuleRoot 'DomainDetective'
         $packagedBinary = Join-Path $packagedModule 'Lib\Default\DomainDetective.PowerShell.dll'
         if (-not (Test-Path -LiteralPath $packagedBinary)) {
-            Set-ItResult -Skipped -Because 'packaged Windows PowerShell artifact is not present; run Module\Build\Build-Module.ps1 with RefreshPSD1Only=false before this regression'
+            Set-ItResult -Skipped -Because 'packaged Windows PowerShell artifact is not present; run Module\Build\Build-Module.ps1 -ConfigurationGateMode Build before this regression'
             return
         }
 

--- a/Module/en-US/DomainDetective-help.xml
+++ b/Module/en-US/DomainDetective-help.xml
@@ -12571,11 +12571,23 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
       </maml:description>
     </command:details>
     <maml:description>
-      <maml:para>Discovers HTTPS and mail TLS endpoints (for example MX-derived STARTTLS) and stores normalized certificate evidence in the inventory snapshot format used by certificate inventory analytics cmdlets.</maml:para>
+      <maml:para>Discovers HTTPS, mail TLS, and explicit or implicit FTP TLS endpoints and stores normalized certificate and endpoint evidence in the inventory snapshot format used by certificate inventory analytics cmdlets.</maml:para>
     </maml:description>
     <command:syntax>
       <command:syntaxItem parameterSetName="__AllParameterSets">
         <maml:name>Invoke-DDCertificateInventory</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AzureServiceTagsJsonPath</maml:name>
+          <maml:description>
+            <maml:para>Optional current Azure service-tag JSON file used for IP-based attribution.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>CacheDirectory</maml:name>
           <maml:description>
@@ -12662,6 +12674,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
           </command:parameterValueGroup>
           <dev:type>
             <maml:name>CertificateCtEnrichmentProfile</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DetectServices</maml:name>
+          <maml:description>
+            <maml:para>Resolve endpoint DNS evidence and perform explainable provider/service attribution.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -12795,6 +12819,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsEnrichmentParallelism</maml:name>
+          <maml:description>
+            <maml:para>Maximum concurrent DNS evidence lookups used by service detection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="None">
           <maml:name>DomainName</maml:name>
           <maml:description>
@@ -12882,7 +12918,7 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
         <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>Endpoint</maml:name>
           <maml:description>
-            <maml:para>Additional endpoint(s) to probe (supports https:// and mail schemes).</maml:para>
+            <maml:para>Additional endpoint(s) to probe (supports HTTPS, mail TLS, ftps://, and ftps-explicit:// schemes).</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
           <dev:type>
@@ -12899,6 +12935,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
           <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
           <dev:type>
             <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FtpTlsTimeoutSeconds</maml:name>
+          <maml:description>
+            <maml:para>FTP TLS timeout in seconds.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -13050,7 +13098,7 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Limit">
           <maml:name>MaxTargets</maml:name>
           <maml:description>
-            <maml:para>Maximum total probe targets (HTTPS + mail) kept after discovery; useful for quick test runs (0 means unlimited).</maml:para>
+            <maml:para>Maximum total probe targets (HTTPS + mail + FTP TLS) kept after discovery; useful for quick test runs (0 means unlimited).</maml:para>
           </maml:description>
           <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
@@ -13312,6 +13360,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ProbeVantage</maml:name>
+          <maml:description>
+            <maml:para>Label identifying the network vantage used for this observation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
           <maml:name>RecentFailureResultTtlHours</maml:name>
           <maml:description>
             <maml:para>How old persisted stable failure entries can be to qualify for reuse.</maml:para>
@@ -13435,6 +13495,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
     </command:syntax>
     <command:parameters>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AzureServiceTagsJsonPath</maml:name>
+        <maml:description>
+          <maml:para>Optional current Azure service-tag JSON file used for IP-based attribution.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>CacheDirectory</maml:name>
         <maml:description>
           <maml:para>Certificate monitor cache directory containing the inventory folder.</maml:para>
@@ -13520,6 +13592,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
         </command:parameterValueGroup>
         <dev:type>
           <maml:name>CertificateCtEnrichmentProfile</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DetectServices</maml:name>
+        <maml:description>
+          <maml:para>Resolve endpoint DNS evidence and perform explainable provider/service attribution.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -13653,6 +13737,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>DnsEnrichmentParallelism</maml:name>
+        <maml:description>
+          <maml:para>Maximum concurrent DNS evidence lookups used by service detection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="True (ByValue, ByPropertyName)" position="0" aliases="None">
         <maml:name>DomainName</maml:name>
         <maml:description>
@@ -13740,7 +13836,7 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
       <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>Endpoint</maml:name>
         <maml:description>
-          <maml:para>Additional endpoint(s) to probe (supports https:// and mail schemes).</maml:para>
+          <maml:para>Additional endpoint(s) to probe (supports HTTPS, mail TLS, ftps://, and ftps-explicit:// schemes).</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
         <dev:type>
@@ -13757,6 +13853,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
         <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
         <dev:type>
           <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FtpTlsTimeoutSeconds</maml:name>
+        <maml:description>
+          <maml:para>FTP TLS timeout in seconds.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -13908,7 +14016,7 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Limit">
         <maml:name>MaxTargets</maml:name>
         <maml:description>
-          <maml:para>Maximum total probe targets (HTTPS + mail) kept after discovery; useful for quick test runs (0 means unlimited).</maml:para>
+          <maml:para>Maximum total probe targets (HTTPS + mail + FTP TLS) kept after discovery; useful for quick test runs (0 means unlimited).</maml:para>
         </maml:description>
         <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
@@ -14170,6 +14278,18 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ProbeVantage</maml:name>
+        <maml:description>
+          <maml:para>Label identifying the network vantage used for this observation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>RecentFailureResultTtlHours</maml:name>
         <maml:description>
           <maml:para>How old persisted stable failure entries can be to qualify for reuse.</maml:para>
@@ -14333,35 +14453,35 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
       </command:example>
       <command:example>
         <maml:title>Capture snapshot including CT-discovered subdomains</maml:title>
-        <dev:code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -VerifyCtSubdomains -MaxCtSubdomainsPerDomain 5000 -Verbose</dev:code>
+        <dev:code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -VerifyCtSubdomains -MaxCtSubdomainsPerDomain 5000 -Verbose</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>Use native CT log polling without crt.sh fallback</maml:title>
-        <dev:code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -EnableNativeCtLogSubdomains -NativeCtLogOnly -NativeCtInitialBackfillEntriesPerLog 5000 -Verbose</dev:code>
+        <dev:code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -EnableNativeCtLogSubdomains -NativeCtLogOnly -NativeCtInitialBackfillEntriesPerLog 5000 -Verbose</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>Run a throttled test capture</maml:title>
-        <dev:code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -Limit 150 -MaxProbeStartsPerSecond 20 -MaxProbeErrorWarnings 10 -Verbose</dev:code>
+        <dev:code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -Limit 150 -MaxProbeStartsPerSecond 20 -MaxProbeErrorWarnings 10 -Verbose</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>Reuse recent captured endpoints to reduce repeated probing</maml:title>
-        <dev:code>Invoke-DDCertificateInventory -DomainName eurofins.com -IncludeCtSubdomains -ReuseRecentResults -RecentResultTtlHours 24 -ReprobeExpiringWithinDays 14</dev:code>
+        <dev:code>Invoke-DDCertificateInventory -DomainName example.com -IncludeCtSubdomains -ReuseRecentResults -RecentResultTtlHours 24 -ReprobeExpiringWithinDays 14</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
       <command:example>
         <maml:title>Reuse recent stable failures for short-lived verification lanes</maml:title>
-        <dev:code>Invoke-DDCertificateInventory -DomainName eurofins.com -ReuseRecentFailureResults -RecentFailureResultTtlHours 1 -HttpsTimeoutSeconds 20</dev:code>
+        <dev:code>Invoke-DDCertificateInventory -DomainName example.com -ReuseRecentFailureResults -RecentFailureResultTtlHours 1 -HttpsTimeoutSeconds 20</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -14369,6 +14489,13 @@ $views | Export-DDSecurityReport -ExportFormat Markdown -ExportPath ".\\Reports"
       <command:example>
         <maml:title>Fail automation when warning-level target decisions are detected</maml:title>
         <dev:code>Invoke-DDCertificateInventory -DomainName example.com -Endpoint ftp://example.com -FailOnWarningTargetDecisions</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Probe explicit FTPS and attach explainable service attribution evidence</maml:title>
+        <dev:code>Invoke-DDCertificateInventory -Endpoint ftps-explicit://ftp.example.com:21 -DetectServices -ProbeVantage branch-office -NoPersist</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -68199,6 +68326,23 @@ Notes:&#xD;
     <command:syntax>
       <command:syntaxItem parameterSetName="ServerName">
         <maml:name>Test-DDEmailImapTls</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddressFamily</maml:name>
+          <maml:description>
+            <maml:para>Network address family used by the connection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MailTransportAddressFamily</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
           <maml:name>ArtifactsDirectory</maml:name>
           <maml:description>
@@ -68207,6 +68351,18 @@ Notes:&#xD;
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectAddress</maml:name>
+          <maml:description>
+            <maml:para>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+          <dev:type>
+            <maml:name>IPAddress</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -68475,6 +68631,23 @@ Notes:&#xD;
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AddressFamily</maml:name>
+        <maml:description>
+          <maml:para>Network address family used by the connection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>MailTransportAddressFamily</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
         <maml:name>ArtifactsDirectory</maml:name>
         <maml:description>
@@ -68483,6 +68656,18 @@ Notes:&#xD;
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectAddress</maml:name>
+        <maml:description>
+          <maml:para>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+        <dev:type>
+          <maml:name>IPAddress</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -68766,6 +68951,13 @@ Notes:&#xD;
       <command:example>
         <maml:title>Test IMAP TLS.</maml:title>
         <dev:code>Test-DDEmailImapTls -HostName mail.example.com -Port 993</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Test only the IPv6 path for an IMAP host.</maml:title>
+        <dev:code>Test-DDEmailImapTls -HostName mail.example.com -Port 993 -AddressFamily IPv6</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -70465,6 +70657,23 @@ Notes:&#xD;
     <command:syntax>
       <command:syntaxItem parameterSetName="ServerName">
         <maml:name>Test-DDEmailPop3Tls</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddressFamily</maml:name>
+          <maml:description>
+            <maml:para>Network address family used by the connection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MailTransportAddressFamily</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
           <maml:name>ArtifactsDirectory</maml:name>
           <maml:description>
@@ -70473,6 +70682,18 @@ Notes:&#xD;
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectAddress</maml:name>
+          <maml:description>
+            <maml:para>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+          <dev:type>
+            <maml:name>IPAddress</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -70741,6 +70962,23 @@ Notes:&#xD;
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AddressFamily</maml:name>
+        <maml:description>
+          <maml:para>Network address family used by the connection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>MailTransportAddressFamily</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
         <maml:name>ArtifactsDirectory</maml:name>
         <maml:description>
@@ -70749,6 +70987,18 @@ Notes:&#xD;
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectAddress</maml:name>
+        <maml:description>
+          <maml:para>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+        <dev:type>
+          <maml:name>IPAddress</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -71036,6 +71286,13 @@ Notes:&#xD;
           <maml:para></maml:para>
         </dev:remarks>
       </command:example>
+      <command:example>
+        <maml:title>Test a specific POP3 backend without changing the certificate hostname.</maml:title>
+        <dev:code>Test-DDEmailPop3Tls -HostName mail.example.com -Port 995 -ConnectAddress 192.0.2.10</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
     </command:examples>
     <command:relatedLinks />
   </command:command>
@@ -71054,6 +71311,23 @@ Notes:&#xD;
     <command:syntax>
       <command:syntaxItem parameterSetName="ServerName">
         <maml:name>Test-DDEmailProtocolTls</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddressFamily</maml:name>
+          <maml:description>
+            <maml:para>Network address family used when connecting to discovered mail hosts.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MailTransportAddressFamily</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
           <maml:name>ArtifactsDirectory</maml:name>
           <maml:description>
@@ -71323,6 +71597,23 @@ Notes:&#xD;
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AddressFamily</maml:name>
+        <maml:description>
+          <maml:para>Network address family used when connecting to discovered mail hosts.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>MailTransportAddressFamily</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
         <maml:name>ArtifactsDirectory</maml:name>
         <maml:description>
@@ -73069,6 +73360,23 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
     <command:syntax>
       <command:syntaxItem parameterSetName="ServerName">
         <maml:name>Test-DDEmailSmtpTls</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddressFamily</maml:name>
+          <maml:description>
+            <maml:para>Network address family used by the connection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MailTransportAddressFamily</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
           <maml:name>ArtifactsDirectory</maml:name>
           <maml:description>
@@ -73077,6 +73385,18 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
           <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
           <dev:type>
             <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectAddress</maml:name>
+          <maml:description>
+            <maml:para>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+          <dev:type>
+            <maml:name>IPAddress</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -73357,6 +73677,23 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
       </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AddressFamily</maml:name>
+        <maml:description>
+          <maml:para>Network address family used by the connection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>MailTransportAddressFamily</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
         <maml:name>ArtifactsDirectory</maml:name>
         <maml:description>
@@ -73365,6 +73702,18 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectAddress</maml:name>
+        <maml:description>
+          <maml:para>Optional concrete address used for the TCP connection while HostName remains the TLS identity.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+        <dev:type>
+          <maml:name>IPAddress</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -73660,6 +74009,13 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
       <command:example>
         <maml:title>Test mail server TLS.</maml:title>
         <dev:code>Test-DDEmailSmtpTls -HostName mail.example.com -Port 587</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Test a specific backend while preserving the public SMTP hostname for TLS validation.</maml:title>
+        <dev:code>Test-DDEmailSmtpTls -HostName mail.example.com -Port 587 -ConnectAddress 192.0.2.10 -AddressFamily IPv4</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>
@@ -74221,8 +74577,25 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
       <maml:para>Part of the DomainDetective project.</maml:para>
     </maml:description>
     <command:syntax>
-      <command:syntaxItem parameterSetName="ServerName">
+      <command:syntaxItem parameterSetName="DomainName">
         <maml:name>Test-DDEmailStartTls</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddressFamily</maml:name>
+          <maml:description>
+            <maml:para>Network address family used by the connection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MailTransportAddressFamily</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
         <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
           <maml:name>ArtifactsDirectory</maml:name>
           <maml:description>
@@ -74497,8 +74870,330 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
           <dev:defaultValue>None</dev:defaultValue>
         </command:parameter>
       </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ServerName">
+        <maml:name>Test-DDEmailStartTls</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddressFamily</maml:name>
+          <maml:description>
+            <maml:para>Network address family used by the connection.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MailTransportAddressFamily</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
+          <maml:name>ArtifactsDirectory</maml:name>
+          <maml:description>
+            <maml:para>Destination directory for artifacts when emitted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ConnectAddress</maml:name>
+          <maml:description>
+            <maml:para>Optional concrete address used for the TCP connection while HostName remains the reported logical endpoint.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+          <dev:type>
+            <maml:name>IPAddress</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DisableParallel</maml:name>
+          <maml:description>
+            <maml:para>Disable parallel execution for cmdlet-level work.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="1" aliases="None">
+          <maml:name>DnsEndpoint</maml:name>
+          <maml:description>
+            <maml:para>DNS server used for queries.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsEndpoints</maml:name>
+          <maml:description>
+            <maml:para>Optional list of resolver endpoints to use (multi-resolver).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">DnsEndpoint[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">System</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SystemTcp</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareSecurity</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Google</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormat</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleWireFormatPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleJsonPost</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9ECS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Unsecure</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">OpenDNSFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Http3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Quad9Quic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">GoogleQuic</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuard</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardFamily</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">AdGuardNonFiltering</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">NextDNS</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptCloudflare</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptQuad9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DnsCryptRelay</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RootServer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">CloudflareOdoh</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Custom</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>DnsEndpoint[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>DnsParallelism</maml:name>
+          <maml:description>
+            <maml:para>DNS resolver concurrency hint for health checks.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Artifacts">
+          <maml:name>ExportArtifacts</maml:name>
+          <maml:description>
+            <maml:para>Emit artifacts (scan.json, metrics.json, progress.jsonl).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="Report">
+          <maml:name>ExportFormat</maml:name>
+          <maml:description>
+            <maml:para>Desired export format(s). Accepts one or many values.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">ReportFormat[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Html</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Json</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Word</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Excel</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Markdown</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MarkdownHtml</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>ReportFormat[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ExportPath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for export.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FullResponse</maml:name>
+          <maml:description>
+            <maml:para>Return the full analysis object instead of per-server details.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+          <maml:name>HostName</maml:name>
+          <maml:description>
+            <maml:para>Logical SMTP hostname to test directly.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Maximum concurrent health checks within a single domain run.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MultiResolverMaxParallelism</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of resolvers to query in parallel (null = all).</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>MultiResolverStrategy</maml:name>
+          <maml:description>
+            <maml:para>Strategy used when multiple DNS endpoints are provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">MultiResolverStrategy</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">FirstSuccess</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">FastestWins</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SequentialFallback</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RoundRobin</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Random</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>MultiResolverStrategy</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="OpenReport">
+          <maml:name>OpenInBrowser</maml:name>
+          <maml:description>
+            <maml:para>Open export in browser when applicable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Port</maml:name>
+          <maml:description>
+            <maml:para>SMTP port number.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThrottleLimit</maml:name>
+          <maml:description>
+            <maml:para>Maximum number of concurrent items for cmdlet-level parallel work.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
     </command:syntax>
     <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AddressFamily</maml:name>
+        <maml:description>
+          <maml:para>Network address family used by the connection.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">MailTransportAddressFamily</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Any</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">IPv6</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>MailTransportAddressFamily</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="ArtifactsPath">
         <maml:name>ArtifactsDirectory</maml:name>
         <maml:description>
@@ -74507,6 +75202,18 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
         <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
         <dev:type>
           <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ConnectAddress</maml:name>
+        <maml:description>
+          <maml:para>Optional concrete address used for the TCP connection while HostName remains the reported logical endpoint.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">IPAddress</command:parameterValue>
+        <dev:type>
+          <maml:name>IPAddress</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -74693,6 +75400,18 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
       </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="0" aliases="None">
+        <maml:name>HostName</maml:name>
+        <maml:description>
+          <maml:para>Logical SMTP hostname to test directly.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
       <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
         <maml:name>MaxParallelism</maml:name>
         <maml:description>
@@ -74790,6 +75509,13 @@ The returned view includes Assessments, Status, Counts, Recommendations, Referen
       <command:example>
         <maml:title>Verify STARTTLS.</maml:title>
         <dev:code>Test-DDEmailStartTls -DomainName example.com -Port 587</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>Test STARTTLS advertisement on a specific SMTP backend and retain the logical hostname in the evidence.</maml:title>
+        <dev:code>Test-DDEmailStartTls -HostName mail.example.com -Port 587 -ConnectAddress 192.0.2.10 -AddressFamily IPv4</dev:code>
         <dev:remarks>
           <maml:para></maml:para>
         </dev:remarks>


### PR DESCRIPTION
## Summary

- make `Module/Build/Build-Module.ps1` the single entry point for the DomainDetective NuGet packages and PowerShell module
- build packages before the module, provide the freshly built packages to the module build, and define the release order as NuGet, PowerShell Gallery, then GitHub
- replace the environment-variable manifest shortcut with explicit `Manifest`, `Documentation`, `Build`, and `Publish` gates
- keep ordinary runs safe: the default `Build` gate creates and verifies artifacts without publishing, while publication requires an explicit `Publish` invocation
- keep the existing package `0.2.X` version tracks independent from the module's `1.0.X` version track
- use the per-project package strategy to avoid colliding restore outputs in the unified package build
- refresh generated command help and MAML from the current module surface
- make the cross-protocol probe-rate regression measure actual accepted connections rather than protocol-specific certificate completion timestamps

## Usage

```powershell
# Build and verify all packages plus the PowerShell module; do not publish
.\Module\Build\Build-Module.ps1

# Refresh only manifest metadata
.\Module\Build\Build-Module.ps1 -ConfigurationGateMode Manifest

# Authorized release run, including module signing
.\Module\Build\Build-Module.ps1 -ConfigurationGateMode Publish -SignModule $true
```

The release command uses the configured credential-file paths. This PR does not publish packages, a PowerShell module, a GitHub release, or tags.

## Validation

- manifest gate completed without package, module artifact, or publication work
- full non-publishing build produced and verified all eight NuGet packages, the PowerShell module archive, release manifest, and checksums
- Debug solution build completed with zero warnings and zero errors
- module tests on Pester 6.1.0: 58 passed, 1 skipped, 0 failed
- corrected probe-rate regression passed 11 consecutive Windows `net8.0` runs
- PowerShell syntax, project-build JSON, generated MAML XML, and staged diff checks passed
- independent read-only review found no actionable issues

Remote credential acceptance, signing, publication ordering, and package/gallery/GitHub acceptance remain deliberate release-time gates.
