### PR TITLE
Add bounded DNS query Website Tool

### DIFF
--- a/.github/scripts/Test-WebsiteDeployContract.ps1
+++ b/.github/scripts/Test-WebsiteDeployContract.ps1
@@ -68,7 +68,7 @@ if (-not (Test-Path -LiteralPath $DeployWorkflowPath)) {
 }
 
 $deployWorkflowLines = @(Get-Content -LiteralPath $DeployWorkflowPath)
-$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977'
+$expectedDeployWorkflowUses = 'EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d'
 $deployWorkflowUses = $null
 $guardrailValue = $null
 $inDeployJob = $false

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   website-deploy:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-deploy.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
@@ -29,7 +29,7 @@ jobs:
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 01c8da4a9e9c5ab53b772e595c0abb514d36f977
+      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       # DomainDetective uses the PowerForge doctor audit step rather than the localized seo-doctor guardrail contract.
       require_seo_doctor_guardrail: false

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -53,13 +53,13 @@ jobs:
     needs:
       - website-tests
       - deploy-contract
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-ci.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 01c8da4a9e9c5ab53b772e595c0abb514d36f977
+      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-reports

--- a/.github/workflows/website-maintenance.yml
+++ b/.github/workflows/website-maintenance.yml
@@ -16,13 +16,13 @@ concurrency:
 
 jobs:
   website-maintenance:
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@01c8da4a9e9c5ab53b772e595c0abb514d36f977
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-website-maintenance.yml@2540d97039f41bae9bf79ae337f6be6bf8f7a44d
     with:
       website_root: Website
       pipeline_config: Website/pipeline.maintenance.json
       engine_mode: source
       runner_labels_json: ${{ github.event.repository.private && '["self-hosted","linux"]' || '["ubuntu-latest"]' }}
       powerforge_repository: EvotecIT/PSPublishModule
-      powerforge_ref: 01c8da4a9e9c5ab53b772e595c0abb514d36f977
+      powerforge_ref: 2540d97039f41bae9bf79ae337f6be6bf8f7a44d
       powerforge_web_tag: PowerForgeWeb-v1.0.0-preview-202604140746
       report_artifact_name: powerforge-website-maintenance-reports

--- a/DomainDetective.Website/wwwroot/index.html
+++ b/DomainDetective.Website/wwwroot/index.html
@@ -145,7 +145,10 @@
     <link rel="stylesheet" href="css/prism-theme.css" />
     <link rel="stylesheet" href="DomainDetective.Website.styles.css" />
 </head>
-<body>
+<body data-webmcp-page-tool
+      data-webmcp-tool-name="query_dns_records"
+      data-webmcp-tool-description="Resolve one bounded public DNS record query and leave the result visible in the DomainDetective playground."
+      data-webmcp-read-only="true">
     <div id="app">
         <div class="loading-screen">
             <div class="loading-brand">
@@ -170,7 +173,7 @@
     </div>
 
     <script src="js/app.js"></script>
-    <script src="js/raw-dns-query.js"></script>
+    <script src="js/raw-dns-query.js" data-powerforge-webmcp data-webmcp-tool-name="query_dns_records"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 </html>

--- a/DomainDetective.Website/wwwroot/js/raw-dns-query.js
+++ b/DomainDetective.Website/wwwroot/js/raw-dns-query.js
@@ -2,6 +2,15 @@
     'use strict';
 
     var controllers = new WeakMap();
+    var webMcpToolName = 'query_dns_records';
+    var activeWebMcpController = null;
+    var webMcpRegistered = false;
+    var webMcpRegistrationController = null;
+    var allowedToolRecordTypes = ['A', 'AAAA', 'CNAME', 'MX', 'TXT', 'NS', 'CAA', 'SRV', 'PTR', 'SOA', 'DS', 'DNSKEY', 'RRSIG', 'NSEC', 'NSEC3', 'TLSA', 'HTTPS', 'SVCB'];
+    var nonPublicDnsSuffixes = [
+        'localhost', 'localdomain', 'local', 'home.arpa', 'internal', 'intranet', 'lan', 'home', 'corp', 'private',
+        'test', 'invalid', 'example', 'onion'
+    ];
 
     var recordTypeMap = {
         0: 'Reserved',
@@ -75,6 +84,140 @@
 
     function getEffectiveName(name) {
         return name ? name : 'example.com';
+    }
+
+    function normalizePublicDnsName(value) {
+        var name = String(value == null ? '' : value).trim().toLowerCase().replace(/\.$/, '');
+        if (name.length < 3 || name.length > 253 || name.indexOf('.') < 1 || /^[0-9.]+$/.test(name)) {
+            return null;
+        }
+        var labels = name.split('.');
+        if (labels.some(function (label) {
+            return label.length < 1 || label.length > 63 || !/^_?[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/.test(label);
+        })) {
+            return null;
+        }
+        if (isNonPublicDnsName(name)) {
+            return null;
+        }
+        return name;
+    }
+
+    function isNonPublicDnsName(name) {
+        if (nonPublicDnsSuffixes.some(function (suffix) {
+            return name === suffix || name.endsWith('.' + suffix);
+        })) {
+            return true;
+        }
+
+        if (name.endsWith('.in-addr.arpa')) {
+            var reverseV4 = name.slice(0, -'.in-addr.arpa'.length).split('.');
+            if (reverseV4.length >= 1 && reverseV4.length <= 4 && reverseV4.every(function (part) { return /^\d{1,3}$/.test(part) && Number(part) <= 255; })) {
+                var octets = reverseV4.reverse().map(Number);
+                return octets[0] === 0 || octets[0] === 10 || octets[0] === 127 || octets[0] >= 224 ||
+                    (octets.length >= 2 && octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127) ||
+                    (octets.length >= 2 && octets[0] === 169 && octets[1] === 254) ||
+                    (octets.length >= 2 && octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
+                    (octets.length >= 2 && octets[0] === 192 && octets[1] === 168) ||
+                    (octets.length >= 2 && octets[0] === 198 && (octets[1] === 18 || octets[1] === 19));
+            }
+        }
+
+        if (name.endsWith('.ip6.arpa')) {
+            var reverseV6 = name.slice(0, -'.ip6.arpa'.length).split('.');
+            if (reverseV6.length >= 1 && reverseV6.length <= 32 && reverseV6.every(function (part) { return /^[0-9a-f]$/.test(part); })) {
+                var addressPrefix = reverseV6.reverse().join('');
+                return /^(?:fc|fd)/.test(addressPrefix) ||
+                    /^fe[89ab]/.test(addressPrefix) ||
+                    (addressPrefix.length === 32 && /^0{31}[01]$/.test(addressPrefix));
+            }
+        }
+
+        return false;
+    }
+
+    function trimToolText(value, maximum) {
+        var text = String(value == null ? '' : value).replace(/\s+/g, ' ').trim();
+        return text.length <= maximum ? text : text.slice(0, maximum - 1) + '…';
+    }
+
+    function buildWebMcpResult(state, payload, provider) {
+        var answers = (payload.Answer || []).map(function (row) {
+            return {
+                name: trimToolText(row.name || row.Name || '', 120),
+                type: trimToolText(getTypeLabel(row.type || row.Type || ''), 12),
+                ttl: Number(row.TTL == null ? (row.ttl == null ? 0 : row.ttl) : row.TTL),
+                data: trimToolText(row.data || row.Data || '', 240)
+            };
+        });
+        var result = {
+            success: true,
+            name: state.name,
+            type: state.type,
+            provider: provider.label,
+            status: rcodeMap[payload.Status] || String(payload.Status == null ? 'UNKNOWN' : payload.Status),
+            totalAnswers: answers.length,
+            answers: answers.slice(0, 10),
+            outputTruncated: answers.length > 10
+        };
+        while (result.answers.length > 0 && JSON.stringify(result).length > 1500) {
+            result.answers.pop();
+            result.outputTruncated = true;
+        }
+        return result;
+    }
+
+    async function registerWebMcpTool(controller) {
+        activeWebMcpController = controller;
+        if (webMcpRegistered || !document.modelContext || typeof document.modelContext.registerTool !== 'function') {
+            return;
+        }
+        try {
+            webMcpRegistrationController = new AbortController();
+            await document.modelContext.registerTool({
+                name: webMcpToolName,
+                description: 'Resolve one bounded public DNS record query and leave the result visible in the DomainDetective playground.',
+                inputSchema: {
+                    type: 'object',
+                    properties: {
+                        name: { type: 'string', minLength: 3, maxLength: 253, description: 'Public DNS name, for example example.com.' },
+                        type: { type: 'string', enum: allowedToolRecordTypes, default: 'A' }
+                    },
+                    required: ['name'],
+                    additionalProperties: false
+                },
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                    openWorldHint: true,
+                    untrustedContentHint: true
+                },
+                execute: async function (input, context) {
+                    if (!activeWebMcpController) {
+                        throw new Error('The Raw DNS Query playground is no longer available on this page.');
+                    }
+                    return activeWebMcpController.resolveFromWebMcp(input || {}, context && context.signal);
+                }
+            }, { signal: webMcpRegistrationController.signal });
+            webMcpRegistered = true;
+            document.body.setAttribute('data-webmcp-status', 'registered');
+        } catch (_) {
+            webMcpRegistrationController && webMcpRegistrationController.abort();
+            webMcpRegistrationController = null;
+            document.body.setAttribute('data-webmcp-status', 'failed');
+        }
+    }
+
+    async function unregisterWebMcpTool(controller) {
+        if (activeWebMcpController !== controller) {
+            return;
+        }
+        activeWebMcpController = null;
+        webMcpRegistrationController && webMcpRegistrationController.abort();
+        webMcpRegistrationController = null;
+        webMcpRegistered = false;
+        document.body.setAttribute('data-webmcp-status', 'disposed');
     }
 
     function buildSummaryCard(label, value, meta) {
@@ -514,25 +657,50 @@
             activeAbortController = null;
         }
 
-        async function resolveDns(state) {
+        function invalidateActiveRequest() {
+            latestRequestSequence = ++nextRequestSequence;
+            cancelActiveRequest();
+            elements.resolveButton.disabled = false;
+        }
+
+        function supersededResult(state) {
+            return {
+                success: false,
+                name: state.name,
+                type: state.type,
+                message: 'DNS query was superseded by a newer request.'
+            };
+        }
+
+        async function resolveDns(state, externalSignal) {
             if (!state.name) {
-                cancelActiveRequest();
+                invalidateActiveRequest();
                 elements.status.dataset.state = 'error';
                 elements.status.textContent = 'Enter a DNS name before resolving.';
                 elements.summary.innerHTML = '';
                 elements.records.innerHTML = '';
                 elements.jsonCode.textContent = '';
-                return;
+                return { success: false, message: 'Enter a DNS name before resolving.' };
             }
 
             if (!isValidEcsSubnet(state.ecs)) {
-                cancelActiveRequest();
+                invalidateActiveRequest();
                 elements.status.dataset.state = 'error';
                 elements.status.textContent = 'Use EDNS client subnet in IPv4 CIDR form, for example 203.0.113.0/24.';
                 elements.summary.innerHTML = '';
                 elements.records.innerHTML = '';
                 elements.jsonCode.textContent = '';
-                return;
+                return { success: false, message: 'Use EDNS client subnet in IPv4 CIDR form, for example 203.0.113.0/24.' };
+            }
+
+            if (externalSignal && externalSignal.aborted) {
+                invalidateActiveRequest();
+                elements.status.dataset.state = 'error';
+                elements.status.textContent = 'DNS query was cancelled.';
+                elements.summary.innerHTML = '';
+                elements.records.innerHTML = '';
+                elements.jsonCode.textContent = '';
+                return { success: false, name: state.name, type: state.type, message: elements.status.textContent };
             }
 
             writeStateToUrl(state);
@@ -544,18 +712,27 @@
             var requestSequence = ++nextRequestSequence;
             latestRequestSequence = requestSequence;
             cancelActiveRequest();
-            activeAbortController = new AbortController();
+            var requestAbortController = new AbortController();
+            var externallyAborted = false;
+            var handleExternalAbort = function () {
+                externallyAborted = true;
+                requestAbortController.abort();
+            };
+            activeAbortController = requestAbortController;
+            if (externalSignal) {
+                externalSignal.addEventListener('abort', handleExternalAbort, { once: true });
+            }
             elements.jsonCode.textContent = '';
             await highlight(root);
 
             try {
                 var response = await fetch(request.url.toString(), {
                     headers: request.provider.headers,
-                    signal: activeAbortController.signal
+                    signal: requestAbortController.signal
                 });
 
                 if (requestSequence !== latestRequestSequence) {
-                    return;
+                    return supersededResult(state);
                 }
 
                 if (!response.ok) {
@@ -564,7 +741,7 @@
 
                 var payload = await response.json();
                 if (requestSequence !== latestRequestSequence) {
-                    return;
+                    return supersededResult(state);
                 }
 
                 elements.status.dataset.state = 'success';
@@ -574,21 +751,38 @@
                 renderSections(payload, elements.records);
                 elements.jsonCode.textContent = JSON.stringify(payload, null, 2);
                 await highlight(root);
+                return buildWebMcpResult(state, payload, request.provider);
             } catch (error) {
                 if (requestSequence !== latestRequestSequence) {
-                    return;
+                    return supersededResult(state);
                 }
 
-                if (error && error.name === 'AbortError') {
-                    return;
+                if (error && error.name === 'AbortError' && !externallyAborted) {
+                    return {
+                        success: false,
+                        name: state.name,
+                        type: state.type,
+                        message: 'DNS query was cancelled.'
+                    };
                 }
 
                 elements.summary.innerHTML = '';
                 elements.records.innerHTML = '';
                 elements.jsonCode.textContent = '';
                 elements.status.dataset.state = 'error';
-                elements.status.textContent = error instanceof Error ? error.message : 'Failed to resolve DNS.';
+                elements.status.textContent = externallyAborted
+                    ? 'DNS query was cancelled.'
+                    : (error instanceof Error ? error.message : 'Failed to resolve DNS.');
+                return {
+                    success: false,
+                    name: state.name,
+                    type: state.type,
+                    message: trimToolText(elements.status.textContent, 300)
+                };
             } finally {
+                if (externalSignal) {
+                    externalSignal.removeEventListener('abort', handleExternalAbort);
+                }
                 if (requestSequence === latestRequestSequence) {
                     elements.resolveButton.disabled = false;
                     activeAbortController = null;
@@ -599,6 +793,38 @@
         function handleSubmit(event) {
             event.preventDefault();
             void resolveDns(getState());
+        }
+
+        async function resolveFromWebMcp(input, signal) {
+            var normalizedName = normalizePublicDnsName(input.name);
+            var requestedType = String(input.type || 'A').toUpperCase();
+            if (!normalizedName) {
+                invalidateActiveRequest();
+                elements.status.dataset.state = 'error';
+                elements.status.textContent = 'Enter a normalized public DNS name such as example.com.';
+                elements.summary.innerHTML = '';
+                elements.records.innerHTML = '';
+                elements.jsonCode.textContent = '';
+                return { success: false, message: elements.status.textContent };
+            }
+            if (allowedToolRecordTypes.indexOf(requestedType) < 0) {
+                invalidateActiveRequest();
+                elements.status.dataset.state = 'error';
+                elements.status.textContent = 'Choose one of the record types exposed by the Raw DNS Query playground.';
+                elements.summary.innerHTML = '';
+                elements.records.innerHTML = '';
+                elements.jsonCode.textContent = '';
+                return { success: false, name: normalizedName, message: elements.status.textContent };
+            }
+
+            elements.nameInput.value = normalizedName;
+            elements.typeInput.value = requestedType;
+            elements.providerInput.value = 'google';
+            elements.ecsInput.value = '';
+            elements.disableValidationInput.checked = false;
+            elements.showDnssecInput.checked = false;
+            syncDnssecControls(elements);
+            return resolveDns(getState(), signal);
         }
 
         function handleProviderChange() {
@@ -648,7 +874,7 @@
             void resolveDns(initialState);
         }
 
-        controllers.set(root, {
+        var controller = {
             form: elements.form,
             providerInput: elements.providerInput,
             nameInput: elements.nameInput,
@@ -660,8 +886,11 @@
             handleProviderChange: handleProviderChange,
             handleStateInput: handleStateInput,
             handleRootClick: handleRootClick,
-            cancelActiveRequest: cancelActiveRequest
-        });
+            cancelActiveRequest: invalidateActiveRequest,
+            resolveFromWebMcp: resolveFromWebMcp
+        };
+        controllers.set(root, controller);
+        void registerWebMcpTool(controller);
 
         return true;
     }
@@ -685,6 +914,7 @@
         controller.showDnssecInput.removeEventListener('change', controller.handleStateInput);
         root.removeEventListener('click', controller.handleRootClick);
         controller.cancelActiveRequest();
+        void unregisterWebMcpTool(controller);
         controllers.delete(root);
         return true;
     }

--- a/Website/content/docs/dns-resolvers.md
+++ b/Website/content/docs/dns-resolvers.md
@@ -43,3 +43,9 @@ healthCheck.DnsEndpoint = DnsEndpoint.CloudflareWireFormat;
 ## Browser Compatibility
 
 When running in a browser (Blazor WASM), only DNS-over-HTTPS endpoints work because browsers cannot make raw UDP/TCP DNS queries. The DomainDetective website currently keeps the browser-safe DNS workspace focused on `Google DNS` and `Cloudflare DNS`, while fuller resolver choice stays in the local DnsClientX workflows.
+
+## ChatGPT Website Tool
+
+The [Raw DNS Query playground](/tools/raw-dns-query/) exposes the read-only `query_dns_records` Website Tool in supported browsers. ChatGPT can request one public DNS name and one supported record type through the existing browser workflow. The page switches to the Google DNS-over-HTTPS resolver, clears EDNS client-subnet and DNSSEC options, and leaves the complete visible result in the playground.
+
+The tool rejects local names, IP-like inputs, malformed labels, and unsupported record types. Its machine-readable response is capped at ten answers and 1,500 characters; a larger DNS response remains available in the visible page and is marked as truncated in the tool result. A caller can cancel the active network request. No hosted DomainDetective analysis API or authenticated workflow is involved.

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -264,9 +264,25 @@
       "reportPath": "./_reports/tool-route-fallbacks.json"
     },
     {
+      "task": "exec",
+      "id": "test-webmcp-dns-tool",
+      "dependsOn": "generate-tool-route-fallbacks",
+      "skipModes": ["dev"],
+      "command": "pwsh",
+      "argsList": [
+        "-NoLogo",
+        "-NoProfile",
+        "-File",
+        "./scripts/Test-WebMcpDnsTool.ps1",
+        "-SiteRoot",
+        "./_site"
+      ],
+      "workingDirectory": "."
+    },
+    {
       "task": "verify",
       "id": "verify-ci-final",
-      "dependsOn": "generate-tool-route-fallbacks",
+      "dependsOn": "test-webmcp-dns-tool",
       "modes": ["ci"],
       "config": "./site.json",
       "baseline": "./.powerforge/verify-baseline.json",

--- a/Website/pipeline.json
+++ b/Website/pipeline.json
@@ -29,19 +29,6 @@
       "config": "./site.json"
     },
     {
-      "task": "verify",
-      "id": "verify-ci",
-      "dependsOn": "build-site",
-      "modes": ["ci"],
-      "config": "./site.json",
-      "baseline": "./.powerforge/verify-baseline.json",
-      "failOnNewWarnings": true,
-      "failOnNavLint": true,
-      "failOnThemeContract": true,
-      "warningPreviewCount": 10,
-      "errorPreviewCount": 10
-    },
-    {
       "task": "dotnet-build",
       "id": "build-library",
       "dependsOn": "verify-site",

--- a/Website/scripts/Test-WebMcpDnsTool.ps1
+++ b/Website/scripts/Test-WebMcpDnsTool.ps1
@@ -1,0 +1,114 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $SiteRoot,
+
+    [string] $BaseUrl
+)
+
+$ErrorActionPreference = 'Stop'
+$resolvedSiteRoot = (Resolve-Path -LiteralPath $SiteRoot).Path
+$runnerPath = Join-Path $PSScriptRoot 'webmcp-dns.playwright.js'
+$playwrightPackage = '@playwright/cli@0.1.17'
+$browserEngine = 'chromium'
+$server = $null
+$session = 'domaindetective-webmcp-dns-' + [Guid]::NewGuid().ToString('N')
+$serverStandardOutputPath = Join-Path ([System.IO.Path]::GetTempPath()) "$session-server.stdout.log"
+$serverStandardErrorPath = Join-Path ([System.IO.Path]::GetTempPath()) "$session-server.stderr.log"
+
+try {
+    if ([string]::IsNullOrWhiteSpace($BaseUrl)) {
+        $listener = [System.Net.Sockets.TcpListener]::new([System.Net.IPAddress]::Loopback, 0)
+        $listener.Start()
+        $port = ([System.Net.IPEndPoint] $listener.LocalEndpoint).Port
+        $listener.Stop()
+        $python = Get-Command python -ErrorAction Stop
+        $serverArguments = @{
+            FilePath = $python.Source
+            ArgumentList = @('-m', 'http.server', $port, '--bind', '127.0.0.1', '--directory', $resolvedSiteRoot)
+            PassThru = $true
+            RedirectStandardOutput = $serverStandardOutputPath
+            RedirectStandardError = $serverStandardErrorPath
+        }
+        if ($IsWindows) { $serverArguments.WindowStyle = 'Hidden' }
+        $server = Start-Process @serverArguments
+        $BaseUrl = "http://127.0.0.1:$port/tools/raw-dns-query/"
+        $ready = $false
+        for ($attempt = 0; $attempt -lt 50; $attempt++) {
+            try {
+                $response = Invoke-WebRequest -UseBasicParsing -Uri $BaseUrl -TimeoutSec 2
+                if ($response.StatusCode -eq 200) { $ready = $true; break }
+            } catch {
+                Start-Sleep -Milliseconds 200
+            }
+        }
+        if (-not $ready) { throw "Local DomainDetective server did not become ready at $BaseUrl." }
+    }
+
+    $npx = Get-Command npx -ErrorAction Stop
+    $installOutput = & $npx.Source --yes --package $playwrightPackage playwright-cli install-browser $browserEngine 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "Playwright could not install browser '$browserEngine'.`n$($installOutput -join [Environment]::NewLine)" }
+    $openOutput = & $npx.Source --yes --package $playwrightPackage playwright-cli "-s=$session" open $BaseUrl --browser $browserEngine 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "Playwright could not open the DNS tool.`n$($openOutput -join [Environment]::NewLine)" }
+    $rawResult = & $npx.Source --yes --package $playwrightPackage playwright-cli "-s=$session" run-code --filename $runnerPath
+    if ($LASTEXITCODE -ne 0) { throw 'Playwright WebMCP DNS run failed.' }
+    $rawText = $rawResult -join [Environment]::NewLine
+    $resultMatch = [regex]::Match($rawText, '(?ms)^### Result\r?\n(?<json>.+?)\r?\n### (?:Ran|Page|Error)')
+    if (-not $resultMatch.Success) { throw "Playwright did not emit a parseable result block.`n$rawText" }
+    $result = $resultMatch.Groups['json'].Value.Trim() | ConvertFrom-Json
+    if ($result -is [string]) { $result = $result | ConvertFrom-Json }
+
+    if ('query_dns_records' -notin @($result.registeredTools)) { throw 'The query_dns_records Website Tool was not registered.' }
+    if (-not [bool] $result.annotations.readOnlyHint -or -not [bool] $result.annotations.untrustedContentHint) {
+        throw 'The DNS Website Tool must declare read-only and untrusted-content annotations.'
+    }
+    if ([int] $result.schema.properties.name.maxLength -ne 253 -or @($result.schema.properties.type.enum).Count -gt 20) {
+        throw 'The DNS Website Tool input schema is not explicitly bounded.'
+    }
+    if (-not [bool] $result.valid.success -or [string] $result.valid.name -ne 'example.com' -or [string] $result.valid.type -ne 'A') {
+        throw 'The DNS Website Tool did not normalize and resolve the representative public query.'
+    }
+    if ([long] $result.validOutputCharacters -gt 1500) {
+        throw "The DNS Website Tool returned $($result.validOutputCharacters) characters; the limit is 1500."
+    }
+    if ([string]::IsNullOrWhiteSpace([string] $result.visible.records) -or [string] $result.visible.status -notmatch '^Resolved via ') {
+        throw 'The DNS Website Tool response was not left visible in the playground.'
+    }
+    if ([bool] $result.invalid.success -or [string] $result.invalidVisibleStatus -notmatch 'normalized public DNS name' -or -not [string]::IsNullOrWhiteSpace([string] $result.invalidVisibleRecords)) {
+        throw 'The DNS Website Tool did not fail closed and synchronize the visible invalid-input state.'
+    }
+    if ([bool] $result.unsupported.success -or -not [string]::IsNullOrWhiteSpace([string] $result.unsupportedVisibleRecords)) {
+        throw 'The DNS Website Tool did not clear stale records for an unsupported record type.'
+    }
+    if ([bool] $result.cancelled.success -or [string] $result.cancelledVisibleStatus -ne 'DNS query was cancelled.') {
+        throw 'The DNS Website Tool did not honor a caller cancellation before network activity.'
+    }
+    $forwardedSpecialUse = @($result.specialUse | Where-Object { [bool] $_.output.success })
+    if ($forwardedSpecialUse.Count -gt 0) {
+        throw "The DNS Website Tool forwarded local or special-use names to the public resolver: $($forwardedSpecialUse.name -join ', ')."
+    }
+    if ([bool] $result.raceInvalid.success -or [bool] $result.superseded.success -or [string] $result.superseded.message -notmatch 'superseded' -or -not [string]::IsNullOrWhiteSpace([string] $result.raceVisible.records)) {
+        throw 'The DNS Website Tool allowed a superseded request to replace the visible fail-closed state.'
+    }
+    if ([bool] $result.manuallySuperseded.success -or [string] $result.manuallySuperseded.message -notmatch 'superseded') {
+        throw 'A manual invalid form submission did not return a structured superseded result to the pending Website Tool call.'
+    }
+    if (-not [bool] $result.lifecycle.disposed -or -not [bool] $result.lifecycle.removedAfterDispose -or -not [bool] $result.lifecycle.initialized -or -not [bool] $result.lifecycle.restoredAfterInit) {
+        throw 'The DNS Website Tool did not follow the raw-query page lifecycle through its registration signal.'
+    }
+    if (@($result.consoleErrors).Count -gt 0) {
+        throw "The DNS Website Tool emitted console errors: $($result.consoleErrors -join ' | ')"
+    }
+
+    Write-Output "DomainDetective WebMCP DNS tool verified at $BaseUrl ($($result.valid.totalAnswers) answers, $($result.validOutputCharacters) characters)."
+} finally {
+    $npxCommand = Get-Command npx -ErrorAction SilentlyContinue
+    if ($npxCommand) { & $npxCommand.Source --yes --package $playwrightPackage playwright-cli "-s=$session" close 2>$null | Out-Null }
+    if ($server -and -not $server.HasExited) {
+        Stop-Process -Id $server.Id -Force
+        $server.WaitForExit(5000) | Out-Null
+    }
+    if ($server) { $server.Dispose() }
+    [System.IO.File]::Delete($serverStandardOutputPath)
+    [System.IO.File]::Delete($serverStandardErrorPath)
+}

--- a/Website/scripts/webmcp-dns.playwright.js
+++ b/Website/scripts/webmcp-dns.playwright.js
@@ -1,0 +1,124 @@
+async (page) => {
+  const consoleErrors = [];
+  page.on('console', message => {
+    if (message.type() === 'error') consoleErrors.push(message.text());
+  });
+  page.on('pageerror', error => consoleErrors.push(error.message));
+
+  await page.addInitScript(() => {
+    const tools = Object.create(null);
+    Object.defineProperty(window, '__domainDetectiveWebMcpTools', { value: tools, configurable: true });
+    Object.defineProperty(document, 'modelContext', {
+      configurable: true,
+      value: {
+        registerTool: async (tool, options) => {
+          tools[tool.name] = tool;
+          options?.signal?.addEventListener('abort', () => { delete tools[tool.name]; }, { once: true });
+        }
+      }
+    });
+  });
+  await page.reload({ waitUntil: 'networkidle' });
+  await page.waitForFunction(() => Boolean(window.__domainDetectiveWebMcpTools?.query_dns_records), null, { timeout: 60000 });
+
+  const result = await page.evaluate(async () => {
+    const tool = window.__domainDetectiveWebMcpTools.query_dns_records;
+    const valid = await tool.execute({ name: 'example.com.', type: 'A' }, { signal: new AbortController().signal });
+    await new Promise(resolve => setTimeout(resolve, 250));
+    const visible = {
+      name: document.querySelector('.js-dns-name')?.value || '',
+      type: document.querySelector('.js-dns-type')?.value || '',
+      provider: document.querySelector('.js-dns-provider')?.value || '',
+      status: document.querySelector('.js-dns-status')?.textContent || '',
+      records: document.querySelector('.js-dns-records')?.textContent || ''
+    };
+    const invalid = await tool.execute({ name: 'localhost', type: 'A' });
+    await new Promise(resolve => setTimeout(resolve, 100));
+    const invalidVisibleStatus = document.querySelector('.js-dns-status')?.textContent || '';
+    const invalidVisibleRecords = document.querySelector('.js-dns-records')?.textContent || '';
+    const unsupported = await tool.execute({ name: 'example.com', type: 'BOGUS' });
+    const unsupportedVisibleRecords = document.querySelector('.js-dns-records')?.textContent || '';
+    const cancelledSignal = new AbortController();
+    cancelledSignal.abort();
+    const cancelled = await tool.execute({ name: 'example.com', type: 'A' }, { signal: cancelledSignal.signal });
+    const cancelledVisibleStatus = document.querySelector('.js-dns-status')?.textContent || '';
+    const specialUse = [];
+    for (const name of [
+      'printer.local',
+      'host.localhost',
+      'service.home.arpa',
+      'example.test',
+      '10.in-addr.arpa',
+      '0.10.in-addr.arpa',
+      '1.0.0.10.in-addr.arpa',
+      '8.e.f.ip6.arpa',
+      'c.f.ip6.arpa'
+    ]) {
+      specialUse.push({ name, output: await tool.execute({ name, type: 'A' }) });
+    }
+
+    const originalFetch = window.fetch;
+    let markFetchStarted;
+    const fetchStarted = new Promise(resolve => { markFetchStarted = resolve; });
+    window.fetch = (url, options) => {
+      if (!String(url).startsWith('https://dns.google/resolve')) return originalFetch(url, options);
+      return new Promise((_resolve, reject) => {
+        markFetchStarted();
+        options?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+      });
+    };
+    const pending = tool.execute({ name: 'openai.com', type: 'A' });
+    await fetchStarted;
+    const raceInvalid = await tool.execute({ name: 'printer.local', type: 'A' });
+    const superseded = await pending;
+
+    let markManualFetchStarted;
+    const manualFetchStarted = new Promise(resolve => { markManualFetchStarted = resolve; });
+    markFetchStarted = markManualFetchStarted;
+    const manuallyCancelledPending = tool.execute({ name: 'openai.com', type: 'A' });
+    await manualFetchStarted;
+    document.querySelector('.js-dns-name').value = '';
+    document.querySelector('.js-dns-query-form').requestSubmit();
+    const manuallySuperseded = await manuallyCancelledPending;
+    window.fetch = originalFetch;
+    const raceVisible = {
+      status: document.querySelector('.js-dns-status')?.textContent || '',
+      records: document.querySelector('.js-dns-records')?.textContent || ''
+    };
+
+    let root = document.querySelector('.js-dns-query-form');
+    let disposed = false;
+    while (root && !disposed) {
+      disposed = window.domainDetectiveTools.disposeRawDnsQueryTool(root);
+      if (!disposed) root = root.parentElement;
+    }
+    await Promise.resolve();
+    const removedAfterDispose = !window.__domainDetectiveWebMcpTools.query_dns_records;
+    const initialized = Boolean(root && window.domainDetectiveTools.initRawDnsQueryTool(root));
+    await Promise.resolve();
+    const restoredAfterInit = Boolean(window.__domainDetectiveWebMcpTools.query_dns_records);
+    return {
+      registeredTools: Object.keys(window.__domainDetectiveWebMcpTools).sort(),
+      schema: tool.inputSchema,
+      annotations: tool.annotations,
+      valid,
+      validOutputCharacters: JSON.stringify(valid).length,
+      visible,
+      invalid,
+      invalidVisibleStatus,
+      invalidVisibleRecords,
+      unsupported,
+      unsupportedVisibleRecords,
+      cancelled,
+      cancelledVisibleStatus,
+      specialUse,
+      raceInvalid,
+      superseded,
+      raceVisible,
+      manuallySuperseded,
+      lifecycle: { disposed, removedAfterDispose, initialized, restoredAfterInit }
+    };
+  });
+
+  return JSON.stringify({ ...result, consoleErrors });
+}

--- a/Website/site.json
+++ b/Website/site.json
@@ -172,7 +172,16 @@
     "A2AAgentCard": { "Enabled": false },
     "McpServerCard": { "Enabled": false },
     "OpenApi": { "Enabled": false },
-    "WebMcp": false,
+    "WebMcp": true,
+    "WebMcpTools": [
+      {
+        "Name": "query_dns_records",
+        "Route": "/tools/raw-dns-query/",
+        "Description": "Resolve one bounded public DNS record query and leave the result visible in the DomainDetective playground.",
+        "Kind": "page-tool",
+        "ReadOnly": true
+      }
+    ],
     "MarkdownNegotiation": false
   },
   "Cloudflare": {


### PR DESCRIPTION
## Summary

- expose `query_dns_records` on the existing Raw DNS Query playground
- reuse the visible playground's public DNS providers and rendering path instead of adding a second resolver implementation
- allow one bounded query from an explicit record-type allowlist, reject non-public/reserved names, cap answers and output, and leave the result visible
- propagate cancellation, unregister on disposal, associate the adapter explicitly with its tool, and pin website workflows to the merged PowerForge.Web owner

## Ownership and dependency

DomainDetective owns DNS behavior; PowerForge.Web owns Website Tool discovery and readiness verification. [EvotecIT/PSPublishModule#870](https://github.com/EvotecIT/PSPublishModule/pull/870) is merged, and this PR consumes commit `2540d97039f41bae9bf79ae337f6be6bf8f7a44d`.

## Safety boundary

This pilot is read-only and restricted to public DNS names. It adds no arbitrary URL fetch, private-network probe, authenticated operation, DNS mutation, or administrative action.

## Validation

- cold 28-step website pipeline passed against the exact PowerForge revision after removing all generated site, cache, report, and synced-source state
- strict navigation verification now runs only after API docs and toolbox routes exist, preventing fresh-clone false failures while retaining the final gate
- generated agent readiness: 40 checks, 0 failures
- audit and doctor passed
- Playwright resolved the representative public query with 2 visible answers in a 288-character response
- record allowlist, private/reserved-name rejection, abbreviated reverse-zone handling, cancellation, lifecycle, output bounds, and visible synchronization passed
- deployment-contract test passed
